### PR TITLE
fix(streamable): unify model_param_name with reactive_record_key (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Record-backed component built with a different init keyword by the action
+  endpoint vs the broadcast path.** The click path (`Component.from_identity`)
+  builds with `reactive_record_key` (the `reactive_record :name`), but the
+  broadcast path (`Streamable.build` → `model_param_name`) built with the
+  demodulized, underscored class name. They only agreed when the class name
+  happened to equal the record name — otherwise one path worked and the other
+  raised `ArgumentError: missing keyword`. The README's own `Todos::Item`
+  (`reactive_record :todo`, `Item` ≠ `todo`) hit this on broadcast.
+  `model_param_name` now prefers `reactive_record_key` when set, so a single
+  `initialize(<record>:)` satisfies both clicks and broadcasts. `Streamable`-only
+  components (no `reactive_record`) keep the demodulized-class-name default, and
+  an explicit `def self.model_param_name` override still wins. No API changes.
+  Closes #4.
+
 ## [0.2.1]
 
 ### Fixed

--- a/docs/broadcasting.md
+++ b/docs/broadcasting.md
@@ -51,6 +51,37 @@ parts. The simplest rule: **use the same raw `*streamables` on both sides.**
 | `.broadcast_prepend_to(*streamables, target:, model:)` | Prepend into `target` |
 | `.broadcast_remove_to(*streamables, model:)` | Remove the element with id `component.id` |
 
+### How `model:` maps to the init keyword
+
+The positional `model:` is passed to the component's `initialize` under the
+keyword `model_param_name`. For a **record-backed** component (`reactive_record`),
+that keyword is the record name — the SAME keyword the action endpoint uses to
+rebuild the component on a click. So a single `initialize(<record>:)` satisfies
+both clicks and broadcasts:
+
+```ruby
+class Todos::Item < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+  reactive_record :todo
+  def initialize(todo:) = @todo = todo   # the keyword must match `reactive_record :todo`
+end
+
+Todos::Item.broadcast_replace_to(@list, :todos, model: @todo) # builds new(todo: @todo)
+```
+
+For a **`Streamable`-only** component (broadcast-only, no `reactive_record`),
+`model_param_name` defaults to the demodulized, underscored class name. When the
+init keyword differs from that, override it:
+
+```ruby
+class NotificationsBadge < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  def initialize(user:) = @user = user
+  def self.model_param_name = :user   # class name would be :notifications_badge
+end
+```
+
 ## Broadcasting from inside a reactive action
 
 The acting user gets the action's HTTP response (a replace of the component).

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -27,11 +27,19 @@ module Phlex
       extend ActiveSupport::Concern
 
       class_methods do
-        # The keyword the positional model maps to in `initialize`. Convention:
-        # demodulized, underscored class name (Invoice -> :invoice,
-        # InvoiceItem -> :invoice_item). Override when it differs.
+        # The keyword the positional model maps to in `initialize`. For a
+        # record-backed component (Component#reactive_record), this is the SAME
+        # keyword the action endpoint uses in `from_identity` — so one
+        # `initialize(<record>:)` satisfies BOTH the click path and the
+        # broadcast path. Otherwise it falls back to the demodulized, underscored
+        # class name (Invoice -> :invoice, InvoiceItem -> :invoice_item).
+        # Override when it differs.
         def model_param_name
-          name.demodulize.underscore.to_sym
+          if respond_to?(:reactive_record_key) && reactive_record_key
+            reactive_record_key
+          else
+            name.demodulize.underscore.to_sym
+          end
         end
 
         def component_args(model, options)

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -15,7 +15,8 @@ class TodoItemComponent < ApplicationComponent
   end
 
   def id = dom_id(@todo) # Streamable#dom_id is render-context-free
-  def self.model_param_name = :todo
+  # No model_param_name override needed: reactive_record :todo makes the
+  # broadcast path build with the same `todo:` keyword the action endpoint uses.
 
   def toggle
     @todo.update!(done: !@todo.done?)

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -53,6 +53,80 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "model_param_name unification (issue #4)" do
+    # A record-backed component whose demodulized class name (`bar`) differs
+    # from its reactive_record name (`baz`). The action endpoint builds it with
+    # `reactive_record_key` (:baz); the broadcast path builds it via
+    # `model_param_name`. Both MUST agree, or one path raises
+    # `ArgumentError: missing keyword`.
+    let(:record_klass) do
+      Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "Foo::Bar"
+
+        reactive_record :baz
+
+        def initialize(baz:) = @baz = baz
+        attr_reader :baz
+        def id = "foo-bar-#{@baz.object_id}"
+      end
+    end
+
+    it "broadcasts and clicks build with the same init keyword" do
+      expect(record_klass.model_param_name).to eq(:baz)
+    end
+
+    it "build(model) constructs with reactive_record_key, not the class name" do
+      record = Object.new
+      built = record_klass.send(:build, record, {})
+      expect(built.baz).to be(record)
+    end
+
+    it "falls back to the demodulized class name when no reactive_record is set" do
+      state_backed = Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "Foo::Widget"
+
+        reactive_state :count
+        def initialize(count: 0) = @count = count
+      end
+
+      expect(state_backed.model_param_name).to eq(:widget)
+    end
+
+    it "falls back to the demodulized class name for Streamable-only components" do
+      streamable_only = Class.new do
+        include Phlex::Reactive::Streamable
+
+        def self.name = "Foo::Row"
+
+        def initialize(row:) = @row = row
+      end
+
+      expect(streamable_only.model_param_name).to eq(:row)
+    end
+
+    it "honors an explicit model_param_name override" do
+      overridden = Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "Foo::Bar"
+        def self.model_param_name = :explicit
+
+        reactive_record :baz
+
+        def initialize(explicit:) = @explicit = explicit
+      end
+
+      expect(overridden.model_param_name).to eq(:explicit)
+    end
+  end
+
   describe "inheritance" do
     it "inherits actions and state keys from a parent" do
       child = Class.new(state_klass) do

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "turbo/broadcastable/test_helper"
 
 RSpec.describe "Reactive actions", type: :request do
+  include Turbo::Broadcastable::TestHelper
+
   # Mint a token exactly as a component would, using the app's verifier.
   def token_for(klass, payload)
     Phlex::Reactive.sign(payload.merge("c" => klass.name))
@@ -52,6 +55,27 @@ RSpec.describe "Reactive actions", type: :request do
       todo.destroy!
       post_action(TodoItemComponent, payload: {"gid" => gid}, act: "toggle")
       expect(response).to have_http_status(:not_found)
+    end
+
+    # Regression for issue #4: the action endpoint builds via reactive_record_key
+    # (:todo) while the broadcast path used the demodulized class name
+    # (:todo_item_component) — so the broadcast raised
+    # `ArgumentError: missing keyword: :todo`. The component class name
+    # (TodoItemComponent) differs from its reactive_record name (:todo), and it
+    # carries no model_param_name override, so both paths must now agree.
+    it "broadcasts a replace without raising ArgumentError (issue #4)" do
+      stream = "todos"
+
+      expect {
+        broadcasts = capture_turbo_stream_broadcasts(stream) do
+          TodoItemComponent.broadcast_replace_to(stream, model: todo)
+        end
+
+        html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+        expect(html).to include('action="replace"')
+        expect(html).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+        expect(html).to include("write specs")
+      }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #4 — a record-backed component was constructed with **different init keywords** on its two paths:

| Path | Keyword used | Source |
|------|-------------|--------|
| `from_identity` (clicks) | `reactive_record_key` | `reactive_record :name` |
| `build` / `broadcast_*_to` | `name.demodulize.underscore` | the class name |

They only agreed when the class name happened to equal the `reactive_record` name. Any component where those differ could handle clicks **or** broadcasts, but not both — one path raised `ArgumentError: missing keyword`. The README's own `Todos::Item` (`reactive_record :todo`, `Item` ≠ `todo`) hit this on the broadcast path.

## The fix

`Streamable.model_param_name` now prefers `reactive_record_key` when the component responds to it and it is set, falling back to the demodulized class name otherwise:

```ruby
def model_param_name
  if respond_to?(:reactive_record_key) && reactive_record_key
    reactive_record_key
  else
    name.demodulize.underscore.to_sym
  end
end
```

So a single `initialize(<record>:)` satisfies both the click path and the broadcast path.

## Backwards compatibility

- **Record-backed** components no longer need `def self.model_param_name` — the broadcast path now uses the same keyword the endpoint already uses.
- **`Streamable`-only** components (broadcast-only, no `reactive_record`) keep the demodulized-class-name default unchanged. Their overrides (e.g. `ChatMessageComponent`, the chat/notifications doc examples) stay as-is and still work.
- An explicit `def self.model_param_name` override **still wins**.
- pgbus optionality is untouched — broadcasts still route through `Turbo::StreamsChannel`.

Removed the now-redundant override from the dummy `TodoItemComponent` so it relies on the fix, demonstrating the unification end-to-end.

## Test Coverage

**`spec/phlex/reactive/component_spec.rb`** (unit):
- `model_param_name` resolves to `reactive_record_key` for a class whose name ≠ record name (`Foo::Bar` + `reactive_record :baz`)
- `build(model)` constructs with that keyword (no `ArgumentError`)
- falls back to the demodulized class name for state-backed and `Streamable`-only components
- an explicit `model_param_name` override is still honored

**`spec/requests/reactive_actions_spec.rb`** (request/broadcast):
- `TodoItemComponent.broadcast_replace_to(model:)` no longer raises `ArgumentError` — the dummy component's class name (`TodoItemComponent`) ≠ its record name (`:todo`) and it carries no override, so both paths must agree

**RED verified:** reverting only the fix (keeping the override removed) reproduces `ArgumentError: missing keyword: :todo` through `Streamable#build` at the request layer.

## Verification

- [x] `bundle exec standardrb` passes
- [x] `bundle exec rspec spec/phlex spec/requests` passes (31 examples, 0 failures)
- [x] Backwards compatible — `Streamable`-only and overridden components unchanged
- [x] pgbus optionality preserved (broadcasts route through `Turbo::StreamsChannel`)

Also updated `docs/broadcasting.md` with a note on how `model:` maps to the init keyword, and added a CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reactive components could use different initialization parameters in different update paths, which could cause a missing keyword error.
  * Broadcast updates now initialize consistently for record-backed components, while existing behavior remains unchanged for other components.

* **Documentation**
  * Added guidance on how model arguments map to component initialization keywords, with examples.

* **Tests**
  * Added coverage for consistent component initialization and broadcast behavior, plus a regression test for the reported issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->