### PR TITLE
fix(component): sign + restore reactive_state alongside record (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Record-backed components silently lost `reactive_state` every action.** When
+  a component declared BOTH `reactive_record` and `reactive_state`, the state
+  branch was dead: `reactive_token` signed only the record GID and
+  `from_identity` rebuilt with only the record — so the listed instance vars
+  (e.g. `attribute`, `editing`) reset to their `initialize` defaults on every
+  action. This broke the documented `inline_edit` example (clicking "edit"
+  couldn't stay in edit mode; `save` wrote the wrong/blank column) and quietly
+  voided the docs' promise that `@attribute` is signed/tamper-proof.
+  `reactive_token` now signs the record GID AND the declared state into one
+  `MessageVerifier` payload, and `from_identity` restores both — record + state
+  are composable, and the state stays tamper-proof. Record-only (`{c, gid}`) and
+  state-only (`{c, s}`) token shapes are unchanged; a signed `false` survives the
+  round trip (only a genuinely absent value falls back to the `initialize`
+  default). No API changes. Closes #6.
+
 - **Record-backed component built with a different init keyword by the action
   endpoint vs the broadcast path.** The click path (`Component.from_identity`)
   builds with `reactive_record_key` (the `reactive_record :name`), but the

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -124,10 +124,13 @@ module Phlex
           if reactive_state_keys.any?
             state = payload.fetch("s", {})
             reactive_state_keys.each do |key|
-              value = state[key.to_s]
-              # Skip only a genuinely absent value (nil) so the component's own
-              # initialize default applies; a signed `false` must survive.
-              kwargs[key] = value unless value.nil?
+              # Use key presence, not the value: a signed `nil` (nullable state)
+              # must round-trip distinctly. Only a genuinely absent key falls
+              # back to the component's initialize default; `false` and `nil`
+              # both survive.
+              next unless state.key?(key.to_s)
+
+              kwargs[key] = state[key.to_s]
             end
           end
 

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -20,8 +20,12 @@ module Phlex
     #     can neither forge the component class nor swap the record. State =
     #     the database.
     #   * State-backed (record-less, e.g. a counter): reactive_state :count
-    #     signs the listed instance variables. Use only when there is genuinely
-    #     no record to re-find.
+    #     signs the listed instance variables. Use when there is genuinely no
+    #     record to re-find.
+    #   * Both (the inline_edit pattern): reactive_record :record plus
+    #     reactive_state :attribute, :editing signs the record's GlobalID AND
+    #     the transient mode in one token, so "which field / what mode" survives
+    #     every action round trip and stays tamper-proof.
     #
     # Actions are DEFAULT-DENY: only methods declared with `action :name` may be
     # invoked. The signature proves the token is ours, NOT that this user may
@@ -102,17 +106,32 @@ module Phlex
 
         # Rebuild a component instance from a verified identity payload. Called
         # by the action endpoint after the token signature is verified.
+        #
+        # A component may carry a record (re-found via GlobalID), signed state
+        # (instance vars listed in reactive_state), or BOTH (the inline_edit
+        # pattern: a record plus "which field / what mode"). We assemble the
+        # init kwargs from whichever identity pieces are declared.
         def from_identity(payload)
+          kwargs = {}
+
           if reactive_record_key
             record = GlobalID::Locator.locate(payload.fetch("gid"))
             raise(ActiveRecord::RecordNotFound, "reactive record missing") unless record
 
-            new(reactive_record_key => record)
-          else
-            state = payload.fetch("s", {})
-            kwargs = reactive_state_keys.to_h { |k| [k, state[k.to_s]] }.compact
-            new(**kwargs)
+            kwargs[reactive_record_key] = record
           end
+
+          if reactive_state_keys.any?
+            state = payload.fetch("s", {})
+            reactive_state_keys.each do |key|
+              value = state[key.to_s]
+              # Skip only a genuinely absent value (nil) so the component's own
+              # initialize default applies; a signed `false` must survive.
+              kwargs[key] = value unless value.nil?
+            end
+          end
+
+          new(**kwargs)
         end
       end
 
@@ -164,18 +183,25 @@ module Phlex
 
       private
 
-      # Signed { c, gid } (record-backed) or { c, s } (state-backed).
+      # Signed identity payload: the class name plus whichever identity pieces
+      # the component declares — a record GlobalID (`gid`), signed state (`s`),
+      # or both. Keeping them in ONE MessageVerifier payload makes the state
+      # (e.g. which column an inline_edit may write) tamper-proof alongside the
+      # record. Record-only ({c, gid}) and state-only ({c, s}) shapes are
+      # unchanged.
       def reactive_token
-        payload =
-          if self.class.reactive_record_key
-            record = instance_variable_get(:"@#{self.class.reactive_record_key}")
-            {"c" => self.class.name, "gid" => record.to_gid.to_s}
-          else
-            state = self.class.reactive_state_keys.to_h do |k|
-              [k.to_s, instance_variable_get(:"@#{k}").as_json]
-            end
-            {"c" => self.class.name, "s" => state}
+        payload = {"c" => self.class.name}
+
+        if self.class.reactive_record_key
+          record = instance_variable_get(:"@#{self.class.reactive_record_key}")
+          payload["gid"] = record.to_gid.to_s
+        end
+
+        if self.class.reactive_state_keys.any?
+          payload["s"] = self.class.reactive_state_keys.to_h do |k|
+            [k.to_s, instance_variable_get(:"@#{k}").as_json]
           end
+        end
 
         Phlex::Reactive.sign(payload)
       end

--- a/spec/dummy/app/components/inline_edit_component.rb
+++ b/spec/dummy/app/components/inline_edit_component.rb
@@ -34,7 +34,11 @@ class InlineEditComponent < ApplicationComponent
   def view_template
     span(id:, **reactive_attrs) do
       if @editing
-        input(**mix(on(:save), name: "value", value: current_value, data: {testid: "field"}))
+        # The input only holds the value — the form fields it collects travel
+        # with whichever action fires. `on(:save)` lives on the Save button, not
+        # the input, so focusing the field doesn't dispatch save and collapse
+        # edit mode (matches docs/examples/inline_edit.md).
+        input(name: "value", value: current_value, data: {testid: "field"})
         button(**mix(on(:save), data: {testid: "save"})) { "Save" }
         button(**mix(on(:cancel), data: {testid: "cancel"})) { "Cancel" }
       else

--- a/spec/dummy/app/components/inline_edit_component.rb
+++ b/spec/dummy/app/components/inline_edit_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Record-backed reactive component that ALSO carries transient mode as signed
+# state (issue #6 / docs/examples/inline_edit.md). `record` is re-found via
+# GlobalID; `attribute` (which column) and `editing` (the mode) are signed
+# state that must survive every action round trip.
+class InlineEditComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :record
+  reactive_state :attribute, :editing
+
+  action :edit
+  action :cancel
+  action :save, params: {value: :string}
+
+  def initialize(record:, attribute:, editing: false)
+    @record = record
+    @attribute = attribute.to_sym
+    @editing = editing
+  end
+
+  def id = dom_id(@record, "inline_#{@attribute}")
+
+  def edit = @editing = true
+  def cancel = @editing = false
+
+  def save(value:)
+    @record.update!(@attribute => value)
+    @editing = false
+  end
+
+  def view_template
+    span(id:, **reactive_attrs) do
+      if @editing
+        input(**mix(on(:save), name: "value", value: current_value, data: {testid: "field"}))
+        button(**mix(on(:save), data: {testid: "save"})) { "Save" }
+        button(**mix(on(:cancel), data: {testid: "cancel"})) { "Cancel" }
+      else
+        span(**mix(on(:edit), data: {testid: "display"})) { current_value.presence || "—" }
+      end
+    end
+  end
+
+  private
+
+  def current_value = @record.public_send(@attribute).to_s
+end

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -116,6 +116,34 @@ RSpec.describe Phlex::Reactive::Component do
       expect(rebuilt.editing).to be(false)
     end
 
+    it "round-trips a signed nil distinctly from an absent key" do
+      # A nullable state key: its initialize default is a non-nil sentinel, so a
+      # signed `nil` must override it (key presence, not value, decides restore).
+      nullable_klass = Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "NullableThing"
+
+        reactive_record :record
+        reactive_state :filter
+
+        def initialize(record:, filter: :unset)
+          @record = record
+          @filter = filter
+        end
+
+        attr_reader :filter
+
+        def id = "nullable-#{@record.object_id}"
+      end
+
+      token = nullable_klass.new(record:, filter: nil).send(:reactive_token)
+      rebuilt = nullable_klass.from_identity(Phlex::Reactive.verify(token))
+
+      expect(rebuilt.filter).to be_nil # the signed nil wins, not the :unset default
+    end
+
     it "the state cannot be tampered without breaking the signature" do
       token = record_state_klass.new(record:, attribute: :name, editing: false).send(:reactive_token)
       # Re-encode a payload that switches the editable column to "ssn" onto the

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -53,6 +53,82 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "record + state identity (issue #6)" do
+    # A record-backed component that ALSO carries transient state (which field,
+    # what mode) — exactly the documented inline_edit pattern. Before the fix,
+    # the state branch was dead whenever a record was present: `attribute`/
+    # `editing` were never signed and never restored, so the mode reset to its
+    # initialize default on every action.
+    let(:record_state_klass) do
+      Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "InlineThing"
+
+        reactive_record :record
+        reactive_state :attribute, :editing
+
+        def initialize(record:, attribute:, editing: false)
+          @record = record
+          @attribute = attribute.to_sym
+          @editing = editing
+        end
+
+        attr_reader :record, :attribute, :editing
+
+        def id = "inline-#{@record.object_id}"
+      end
+    end
+
+    # A stand-in record that round-trips through GlobalID without a DB.
+    let(:record) { Struct.new(:gid_string).new("gid://app/Article/1") }
+
+    before do
+      allow(record).to receive(:to_gid).and_return(
+        instance_double(GlobalID, to_s: record.gid_string)
+      )
+      allow(GlobalID::Locator).to receive(:locate).with(record.gid_string).and_return(record)
+    end
+
+    it "signs BOTH the record gid and the declared state into one token" do
+      component = record_state_klass.new(record:, attribute: :name, editing: true)
+      payload = Phlex::Reactive.verify(component.send(:reactive_token))
+
+      expect(payload["c"]).to eq("InlineThing")
+      expect(payload["gid"]).to eq(record.gid_string)
+      expect(payload["s"]).to eq({"attribute" => "name", "editing" => true})
+    end
+
+    it "restores the record AND the state on rebuild (round trip)" do
+      token = record_state_klass.new(record:, attribute: :name, editing: true).send(:reactive_token)
+      rebuilt = record_state_klass.from_identity(Phlex::Reactive.verify(token))
+
+      expect(rebuilt.record).to be(record)
+      expect(rebuilt.attribute).to eq(:name) # not nil — survives the round trip
+      expect(rebuilt.editing).to be(true)    # not the initialize default (false)
+    end
+
+    it "preserves a false state value rather than dropping to the default" do
+      token = record_state_klass.new(record:, attribute: :name, editing: false).send(:reactive_token)
+      rebuilt = record_state_klass.from_identity(Phlex::Reactive.verify(token))
+
+      expect(rebuilt.editing).to be(false)
+    end
+
+    it "the state cannot be tampered without breaking the signature" do
+      token = record_state_klass.new(record:, attribute: :name, editing: false).send(:reactive_token)
+      # Re-encode a payload that switches the editable column to "ssn" onto the
+      # ORIGINAL signature — the signed digest no longer matches the data.
+      data, sig = token.split("--", 2)
+      decoded = JSON.parse(Base64.urlsafe_decode64(data))
+      decoded["_rails"]["data"]["s"]["attribute"] = "ssn"
+      forged = "#{Base64.urlsafe_encode64(decoded.to_json, padding: false)}--#{sig}"
+
+      expect(Phlex::Reactive.verify(forged)).to be_nil
+    end
+  end
+
   describe "model_param_name unification (issue #4)" do
     # A record-backed component whose demodulized class name (`bar`) differs
     # from its reactive_record name (`baz`). The action endpoint builds it with

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -79,6 +79,65 @@ RSpec.describe "Reactive actions", type: :request do
     end
   end
 
+  describe "record + state component (InlineEditComponent, issue #6)" do
+    let!(:todo) { Todo.create!(title: "original", done: false) }
+
+    # Mint a token exactly as the component would after a render: it signs the
+    # record gid AND the declared state (attribute, editing).
+    def state_payload(attribute:, editing:)
+      {"gid" => todo.to_gid.to_s, "s" => {"attribute" => attribute.to_s, "editing" => editing}}
+    end
+
+    it "restores the signed state so the mode survives an action" do
+      # We are in edit mode (editing: true was signed by the prior render). The
+      # endpoint must rebuild WITH editing: true — not the initialize default.
+      post_action(InlineEditComponent,
+        payload: state_payload(attribute: :title, editing: true),
+        act: "cancel")
+
+      expect(response).to have_http_status(:ok)
+      # cancel flips editing -> false, so the response renders display mode.
+      expect(response.body).to include('data-testid="display"')
+    end
+
+    it "save writes the SIGNED attribute, not a nil/blank column" do
+      post_action(InlineEditComponent,
+        payload: state_payload(attribute: :title, editing: true),
+        act: "save",
+        params: {value: "renamed"})
+
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("renamed") # the correct column, not nil
+      expect(response.body).to include("renamed")
+    end
+
+    it "edit flips into edit mode and re-renders the input" do
+      post_action(InlineEditComponent,
+        payload: state_payload(attribute: :title, editing: false),
+        act: "edit")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-testid="field"')
+      expect(response.body).to include('value="original"') # the signed attribute's value
+    end
+
+    it "rejects a token whose signed attribute was tampered" do
+      token = token_for(InlineEditComponent, state_payload(attribute: :title, editing: true))
+      # Re-encode the payload to switch the editable column onto the original
+      # signature — verification must fail (the digest no longer matches).
+      data, sig = token.split("--", 2)
+      decoded = JSON.parse(Base64.urlsafe_decode64(data))
+      decoded["_rails"]["data"]["s"]["attribute"] = "done"
+      forged = "#{Base64.urlsafe_encode64(decoded.to_json, padding: false)}--#{sig}"
+
+      post "/reactive/actions",
+        params: {token: forged, act: "save", params: {value: "x"}}.to_json,
+        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
   describe "tampering" do
     it "rejects a forged token" do
       post "/reactive/actions",


### PR DESCRIPTION
## Summary

Fixes #6. When a component declared **both** `reactive_record` and `reactive_state`, the state branch was dead code — the listed instance vars were never signed and never restored, so transient mode (`editing`, `attribute`) reset to its `initialize` default on every action.

Both the token mint and the rebuild branched `if reactive_record_key … else <state> … end`, so for a record-backed component `reactive_state_keys` was collected but never used. This broke the documented `inline_edit` example as written:

- Click "edit" → `@editing = true`, re-render the input ✅ (this one response looked right)
- Click Save/Cancel → `from_identity` rebuilt with **no** `editing`/`attribute` → `@editing` reverted to `false`, `@attribute` came back `nil`, so `save` wrote the wrong/blank column.

It also voided the docs' security promise that `@attribute` is signed/tamper-proof — for record-backed components it simply came back `nil`.

## The fix

`reactive_token` and `from_identity` now assemble their payload / init-kwargs **incrementally** instead of branching:

- always `c`
- add `gid` when `reactive_record_key` is set
- add `s` when `reactive_state_keys.any?`

Record + state are signed into **one** `MessageVerifier` payload, so the state stays tamper-proof alongside the record GID, and both are restored on rebuild.

### Backwards compatible

- Record-only (`{c, gid}`) and state-only (`{c, s}`) token shapes are byte-identical to before — existing components and any in-flight tokens keep working verbatim.
- A signed `false` survives the round trip; only a genuinely absent (`nil`) value falls back to the `initialize` default.
- No API changes. The documented `inline_edit` example now works exactly as written.

## Test plan

New coverage across two layers (TDD — written RED first, confirmed failing with `ArgumentError: missing keyword: :attribute`, then GREEN):

**Unit** (`spec/phlex/reactive/component_spec.rb`)
- signs BOTH the record gid and the declared state into one token
- restores the record AND the state on rebuild (`attribute`/`editing` survive — not nil, not the default)
- preserves a signed `false` rather than dropping to the default
- a re-encoded (tampered) state onto the original signature fails verification

**Request** (`spec/requests/reactive_actions_spec.rb`, via a new `InlineEditComponent` dummy mirroring `docs/examples/inline_edit.md`)
- the signed mode survives an action (`cancel` from edit mode renders display)
- `save` writes the **signed** attribute (`title`), not a nil/blank column
- `edit` flips into edit mode and re-renders the input with the signed attribute's value
- a tampered signed attribute is rejected with 400

## Verification

- [x] `bundle exec standardrb` — clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 39 examples, 0 failures
- [x] Backwards compatible — record-only and state-only paths unchanged (existing specs green)
- [x] pgbus optionality untouched (server-side identity signing only; no transport change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed record-backed reactive components so inline edit mode and other saved state persist correctly across actions, including `false` values and signed `nil`.
  * Strengthened identity verification so tampered token payloads are rejected, preventing altered state updates.
* **New Features**
  * Inline editing now round-trips record identity plus transient state in a single secure payload, keeping display/edit mode consistent.
* **Documentation**
  * Updated the security model documentation to describe the inline edit identity behavior.
* **Tests**
  * Added component and request coverage for record+state round-trips and token rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->