### PR TITLE
docs: document the combined record + state identity (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,20 @@ class Todos::Item < ApplicationComponent
 end
 ```
 
-### 2. State-backed (record-less widgets)
+### 2. State-backed (signed instance vars)
 
-No database row — e.g. a counter or a wizard step. The listed instance vars are
-signed into the token. Keep state small and JSON-serializable.
+Sign small, JSON-serializable instance vars into the token. Use it **alone** for
+a record-less widget (a counter, a wizard step), or **alongside `reactive_record`**
+to carry transient UI state — which field, what mode — next to the row. Both the
+record's GlobalID and the state are signed into one token and rebuilt on each
+action. Keep state small and JSON-serializable.
 
 ```ruby
 reactive_state :count, :step       # signed; rebuilt on each action
 ```
+
+The [inline edit example](docs/examples/inline_edit.md) combines both: a
+`reactive_record :record` plus `reactive_state :attribute, :editing`.
 
 ---
 
@@ -257,7 +263,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | Macro / helper | Use |
 |---|---|
 | `reactive_record :name` | Record-backed identity (GlobalID). State = the DB. |
-| `reactive_state :a, :b` | State-backed identity (signed instance vars). Record-less only. |
+| `reactive_state :a, :b` | Signed instance-var identity. Standalone, or combined with `reactive_record` to sign transient UI state alongside the row. |
 | `action :name, params: { x: :integer }` | Declare a client-invokable action + its param schema. **Default-deny.** |
 | `reactive_attrs` | Spread onto the root element: marks it reactive + carries the signed token. |
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
@@ -314,8 +320,10 @@ phlex-reactive is built so the easy path is the safe path — but the boundary i
 real, so read this once.
 
 - **State is never trusted from the client.** The DOM holds a `MessageVerifier`-
-  signed identity (`{component, gid}` or `{component, state}`), not raw state. A
-  tampered class, record, or state value fails signature verification → 400.
+  signed identity — `{component, gid}` (record-backed), `{component, state}`
+  (state-backed), or `{component, gid, state}` when a component declares both —
+  not raw state. A tampered class, record, or state value fails signature
+  verification → 400.
 - **Actions are default-deny.** Only methods declared with `action :name` are
   invokable. A public method without `action` is unreachable.
 - **You must authorize.** The signature proves the *token is yours*, not that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,9 +72,15 @@ Instead the DOM carries a **signed identity**:
   server re-finds the record from the database. State = the DB. The client can't
   forge the class or swap the record (signature), and can't see or change the
   record's columns (they're never in the token).
-- **State-backed**: `{ c: "Counter", s: { count: 3 } }`. For genuinely
-  record-less widgets. The state is signed, so the client can't tamper with it,
-  but keep it small and non-sensitive.
+- **State-backed**: `{ c: "Counter", s: { count: 3 } }`. For record-less
+  widgets. The state is signed, so the client can't tamper with it, but keep it
+  small and non-sensitive.
+- **Record + state**: `{ c: "Fields::InlineEdit", gid: "gid://app/User/7", s: { attribute: "name", editing: true } }`.
+  When a component declares both `reactive_record` and `reactive_state`, the
+  record's GlobalID **and** the declared state are signed into one token and
+  both are restored on each action — so transient mode (which field, edit/show)
+  is tamper-proof alongside the record. See the
+  [inline edit example](examples/inline_edit.md).
 
 The token is a Rails `MessageVerifier` token bound to the purpose
 `"phlex-reactive/identity"`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,13 +15,20 @@ The DOM token is a `MessageVerifier`-signed payload:
 
 - Record-backed: `{ "c" => "Todos::Item", "gid" => "gid://app/Todo/42" }`
 - State-backed: `{ "c" => "Counter", "s" => { "count" => 3 } }`
+- Record + state: `{ "c" => "Fields::InlineEdit", "gid" => "gid://app/User/7", "s" => { "attribute" => "name", "editing" => true } }`
+
+When a component declares both `reactive_record` and `reactive_state`, the
+record's GlobalID and the declared state are signed into **one** payload — so
+the transient mode (e.g. which column an inline edit may write) is tamper-proof
+alongside the record.
 
 **Guarantees** (tampering any of these fails verification → HTTP 400):
 
 - The component class can't be swapped (can't point a `Todo` token at an
   `AdminUser` component).
 - The record's GlobalID can't be swapped or forged.
-- State-backed values can't be edited.
+- State values can't be edited — including state signed alongside a record (the
+  client can't switch an inline edit's `attribute` to a column it shouldn't touch).
 
 **Does NOT guarantee**: that *this user* may act on this record. The signature
 proves the token is one **we** minted, not that the current session is allowed to


### PR DESCRIPTION
## Summary

Follow-up to #7 (issue #6). That PR made `reactive_record` and `reactive_state` **composable** — a component declaring both now signs the record's GlobalID **and** the declared state into one `MessageVerifier` token and restores both on every action. But #7 shipped no doc changes, so several published docs still framed the two identity modes as mutually exclusive and enumerated only the two old token shapes.

This corrects the three stale spots a reader would hit.

## Why it matters

The combined mode is the entire point of the `inline_edit` example (`reactive_record :record` + `reactive_state :attribute, :editing`). The docs said `reactive_state` was "**record-less only**" and that the signed identity was `{component, gid}` **or** `{component, state}` — both now factually wrong, and directly contradicting the documented example that the fix unbroke.

## Changes (docs only, no behavior change)

**`README.md`**
- "State-backed (record-less widgets)" section reframed: state vars can be signed **alone** or **alongside `reactive_record`**, with a cross-link to the inline edit example.
- API reference table: `reactive_state` row dropped the now-false "Record-less only".
- Security bullet: added the third `{component, gid, state}` token shape.

**`docs/architecture.md`**
- Added a **Record + state** identity bullet with a sample token and a link to the inline edit example.

**`docs/security.md`**
- Added the combined token shape under "What the signature guarantees".
- Extended the guarantees: state signed alongside a record is tamper-proof too (an inline edit's `attribute` can't be switched to a column it shouldn't touch — the security property #6 restored).

## Verification

- Surfaced by an adversarial multi-agent doc audit against the merged 0.2.3 runtime; every "the doc is already correct" candidate (the `inline_edit` example, the architecture HTML snippet, the CHANGELOG `false`/`nil` note) was **refuted** and left untouched. Only the genuinely-stale either/or framings are changed.
- `grep -rn "Record-less only" docs/ README.md` → no matches remain.
- All cross-links resolve (`docs/examples/inline_edit.md` exists).
- Example token class/keys (`Fields::InlineEdit`, `attribute`, `editing`) match `docs/examples/inline_edit.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how state-backed reactive components work when combined with record-backed identity.
  * Added guidance for signed identity formats that include record, state, or both.
  * Expanded security notes to explain that transient UI state is protected from tampering alongside the record, including inline editing scenarios.
  * Updated architecture documentation to describe the combined record + state identity model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->