### PR TITLE
fix(client): collect rich-text / custom-editor fields on reactive save (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   byte-identical to source by a guard spec, so the browser tests never validate
   stale client code again. Closes #8.
 
+## [0.2.3] - 2026-06-24
+
+### Fixed
+
 - **Record-backed components silently lost `reactive_state` every action.** When
   a component declared BOTH `reactive_record` and `reactive_state`, the state
   branch was dead: `reactive_token` signed only the record GID and
@@ -37,6 +41,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   round trip (only a genuinely absent value falls back to the `initialize`
   default). No API changes. Closes #6.
 
+### Documentation
+
+- Documented the combined record + state identity (the `{c, gid, s}` token
+  shape): the README, `docs/architecture.md`, and `docs/security.md` no longer
+  frame `reactive_record` and `reactive_state` as mutually exclusive. (#9)
+
+## [0.2.2] - 2026-06-24
+
+### Fixed
+
 - **Record-backed component built with a different init keyword by the action
   endpoint vs the broadcast path.** The click path (`Component.from_identity`)
   builds with `reactive_record_key` (the `reactive_record :name`), but the
@@ -51,7 +65,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   an explicit `def self.model_param_name` override still wins. No API changes.
   Closes #4.
 
-## [0.2.1]
+## [0.2.1] - 2026-06-24
 
 ### Fixed
 
@@ -66,7 +80,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the gem eager-loads cleanly. Added a regression spec that calls
   `eager_load_all`. No API changes.
 
-## [0.2.0]
+## [0.2.0] - 2026-06-24
 
 ### Added
 
@@ -85,7 +99,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   helpers. phlex-reactive still works on Action Cable without pgbus; the
   `exclude:` argument is simply ignored there.
 
-## [0.1.0]
+## [0.1.0] - 2026-06-20
 
 ### Added
 
@@ -109,7 +123,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   scaffolds a reactive component (and an RSpec spec when the app uses RSpec),
   state-backed by default or record-backed with `--record`.
 
-[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.2...HEAD
+[0.2.3]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mhenrixon/phlex-reactive/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/mhenrixon/phlex-reactive/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Reactive save silently dropped rich-text / custom-editor fields.** The
+  client's field auto-collection (`#collectFields`) queried only
+  `input[name], select[name], textarea[name]`, so a named rich-text editor
+  (`lexxy-editor`, `trix-editor`) or any `[contenteditable]` was skipped — a
+  reactive `save` posted an empty value and silently wiped the field, with no
+  error. `#collectFields` now also reads named custom editors and contenteditable
+  elements (by `name` *attribute*, since a plain element has no `name` IDL
+  property), reading the serialized `.value` else the contenteditable text. It
+  only fills a name the standard controls left absent or empty, so a hidden input
+  a rich editor mirrors into (e.g. Trix) still wins when populated. The vendored
+  client copy the system suite runs (`spec/dummy/public/vendor/...`) is now kept
+  byte-identical to source by a guard spec, so the browser tests never validate
+  stale client code again. Closes #8.
+
 - **Record-backed components silently lost `reactive_state` every action.** When
   a component declared BOTH `reactive_record` and `reactive_state`, the state
   branch was dead: `reactive_token` signed only the record GID and

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -122,6 +122,7 @@ export default class extends Controller {
 
   #collectFields() {
     const fields = {}
+    // Standard form controls.
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (field.type === "checkbox") {
         fields[field.name] = field.checked
@@ -131,6 +132,25 @@ export default class extends Controller {
         fields[field.name] = field.value
       }
     })
+    // Named rich-text / custom editors (lexxy-editor, trix-editor) and bare
+    // [contenteditable]. These aren't input/select/textarea, so the query above
+    // skips them — without this, a reactive save posts an empty value and
+    // silently wipes the field (issue #8). Read whatever the element exposes:
+    // a custom editor's serialized `.value`, else its contenteditable text.
+    // Only fill a name the standard controls left absent or empty, so a synced
+    // hidden input (e.g. Trix mirrors into one) still wins when populated.
+    this.element
+      .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
+      .forEach((el) => {
+        // A plain element (e.g. a <div contenteditable>) has no `name` IDL
+        // property — only the attribute — so read getAttribute, not el.name.
+        const name = el.getAttribute("name")
+        if (!name) return
+        const existing = fields[name]
+        if (existing == null || existing === "") {
+          fields[name] = el.value ?? el.textContent ?? el.innerHTML ?? ""
+        }
+      })
     return fields
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,28 @@ Accept: text/vnd.turbo-stream.html
 The endpoint verifies the token, rebuilds the component, runs the action, and
 returns `component.to_stream_replace`. Turbo morphs it in.
 
+### What collected fields are
+
+On a button click or form submit, the controller auto-collects named fields
+inside the component so the action receives them without you wiring anything:
+
+- **Standard controls** — `input[name]`, `select[name]`, `textarea[name]`
+  (checkboxes send their `checked` state; radios send the checked value).
+- **Rich-text / custom editors** — named `lexxy-editor`, `trix-editor`, and any
+  `[contenteditable]` (with a `name` attribute). These aren't standard controls,
+  so they're read explicitly (serialized `.value`, else the contenteditable
+  text). Without this a reactive save would post an empty value and silently
+  wipe the field.
+
+Only fields that exist in the DOM are sent; a declared param with no matching
+field is simply absent (the action's keyword default applies). Explicit params
+from `on(:save, extra: ...)` always win over a collected field of the same name.
+
+> A rich editor that mirrors its value into a hidden `input[name]` (e.g. Trix)
+> is already covered by the standard query; the editor read only fills a name
+> the standard controls left absent or empty, so it never clobbers a populated
+> input.
+
 ## Why state isn't in the browser
 
 Livewire ships a *snapshot* of component state to the client and trusts it back

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,11 +67,13 @@ inside the component so the action receives them without you wiring anything:
 
 - **Standard controls** — `input[name]`, `select[name]`, `textarea[name]`
   (checkboxes send their `checked` state; radios send the checked value).
-- **Rich-text / custom editors** — named `lexxy-editor`, `trix-editor`, and any
-  `[contenteditable]` (with a `name` attribute). These aren't standard controls,
-  so they're read explicitly (serialized `.value`, else the contenteditable
-  text). Without this a reactive save would post an empty value and silently
-  wipe the field.
+- **Rich-text / custom editors** — named `lexxy-editor`, `trix-editor`, and
+  `[contenteditable]` elements with a `name` attribute (the editable ones:
+  `contenteditable`, `="true"`, or `="plaintext-only"` — an explicit
+  `contenteditable="false"` is skipped). These aren't standard controls, so
+  they're read explicitly (serialized `.value`, else the contenteditable text).
+  Without this a reactive save would post an empty value and silently wipe the
+  field.
 
 Only fields that exist in the DOM are sent; a declared param with no matching
 field is simply absent (the action's keyword default applies). Explicit params

--- a/docs/examples/inline_edit.md
+++ b/docs/examples/inline_edit.md
@@ -77,6 +77,10 @@ render Fields::InlineEdit.new(record: @user, attribute: :email)
   mutates, so it authorizes.
 - **The `span(**on(:edit))`** turns the display text into the click target. Add
   `tabindex` / keyboard handling if you need a11y on non-button triggers.
+- **Rich-text fields work too.** A named `lexxy-editor`, `trix-editor`, or
+  `[contenteditable]` is auto-collected on submit alongside plain inputs — so
+  `save` receives its value, not a blank. See
+  [what gets auto-collected](../architecture.md#what-collected-fields-are).
 
 ## Want it to update other viewers too?
 

--- a/spec/dummy/app/components/rich_editor_component.rb
+++ b/spec/dummy/app/components/rich_editor_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Reproduces issue #8: a reactive `save` whose value lives in a custom editor
+# element (a `[contenteditable]` here, standing in for lexxy-editor/trix-editor),
+# NOT an input/select/textarea. Before the fix, #collectFields skipped it and
+# `save` received an empty `title`, silently wiping the record.
+class RichEditorComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :save, params: {title: :string}
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, "rich")
+
+  def save(title:)
+    @todo.update!(title:) if title.present?
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      form(**on(:save, event: "submit")) do
+        # A named custom editor (contenteditable) — NOT input/select/textarea.
+        # Its text content is the value to collect.
+        div(
+          contenteditable: "true",
+          name: "title",
+          data: {testid: "editor"}
+        ) { @todo.title }
+        button(type: "submit", data: {testid: "save"}) { "Save" }
+      end
+      span(data: {testid: "current"}) { @todo.title }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -19,6 +19,10 @@ class DemosController < ActionController::Base
     render_component ChatRoomComponent.new(room:, messages: ChatMessage.for_room(room).last(50))
   end
 
+  def rich_editor
+    render_component RichEditorComponent.new(todo: Todo.find(params[:id]))
+  end
+
   private
 
   # Render a Phlex component as the layout's body. `render component, layout:`

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "counter" => "demos#counter"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
+  get "rich_editor/:id" => "demos#rich_editor"
 
   # The phlex-reactive engine appends POST /reactive/actions itself.
 end

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -60,13 +60,20 @@ export default class extends Controller {
     this.element.setAttribute("aria-busy", "true")
 
     try {
+      const headers = {
+        "Content-Type": "application/json",
+        Accept: "text/vnd.turbo-stream.html",
+        "X-CSRF-Token": this.#csrfToken(),
+      }
+      // Send the pgbus SSE connection id (if subscribed) so the server can
+      // exclude this connection from its own broadcast echo — the actor
+      // already gets the action's HTTP response. Harmless without pgbus.
+      const connectionId = this.#connectionId()
+      if (connectionId) headers["X-Pgbus-Connection"] = connectionId
+
       const response = await fetch(this.#actionPath(), {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "text/vnd.turbo-stream.html",
-          "X-CSRF-Token": this.#csrfToken(),
-        },
+        headers,
         body,
         credentials: "same-origin",
       })
@@ -115,6 +122,7 @@ export default class extends Controller {
 
   #collectFields() {
     const fields = {}
+    // Standard form controls.
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (field.type === "checkbox") {
         fields[field.name] = field.checked
@@ -124,6 +132,25 @@ export default class extends Controller {
         fields[field.name] = field.value
       }
     })
+    // Named rich-text / custom editors (lexxy-editor, trix-editor) and bare
+    // [contenteditable]. These aren't input/select/textarea, so the query above
+    // skips them — without this, a reactive save posts an empty value and
+    // silently wipes the field (issue #8). Read whatever the element exposes:
+    // a custom editor's serialized `.value`, else its contenteditable text.
+    // Only fill a name the standard controls left absent or empty, so a synced
+    // hidden input (e.g. Trix mirrors into one) still wins when populated.
+    this.element
+      .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
+      .forEach((el) => {
+        // A plain element (e.g. a <div contenteditable>) has no `name` IDL
+        // property — only the attribute — so read getAttribute, not el.name.
+        const name = el.getAttribute("name")
+        if (!name) return
+        const existing = fields[name]
+        if (existing == null || existing === "") {
+          fields[name] = el.value ?? el.textContent ?? el.innerHTML ?? ""
+        }
+      })
     return fields
   }
 
@@ -145,5 +172,18 @@ export default class extends Controller {
 
   #csrfToken() {
     return document.querySelector('meta[name="csrf-token"]')?.content ?? ""
+  }
+
+  // The pgbus SSE connection id, if the page is subscribed to a stream. pgbus
+  // reflects it onto the <pgbus-stream-source connection-id="…"> element (and
+  // apps may mirror it to <meta name="pgbus-connection-id">). Returns null
+  // when not present (e.g. no pgbus, or no active subscription) — the header
+  // is then simply omitted.
+  #connectionId() {
+    return (
+      document.querySelector("pgbus-stream-source[connection-id]")?.getAttribute("connection-id") ||
+      document.querySelector('meta[name="pgbus-connection-id"]')?.content ||
+      null
+    )
   }
 }

--- a/spec/phlex/vendored_controller_sync_spec.rb
+++ b/spec/phlex/vendored_controller_sync_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The system suite drives the REAL browser via a vendored copy of the client
+# controller at spec/dummy/public/vendor/reactive_controller.js (importmap-pinned
+# in the dummy layout). If that copy drifts from the shipped source, the browser
+# specs validate stale code — exactly how the pgbus connection-id logic and, later,
+# the issue #8 rich-text collection fix could have gone untested. This guard makes
+# drift a hard failure: keep the vendored copy byte-identical to source.
+RSpec.describe "vendored client controller" do
+  root = File.expand_path("../..", __dir__)
+  source = File.join(root, "app/javascript/phlex/reactive/reactive_controller.js")
+  vendored = File.join(root, "spec/dummy/public/vendor/reactive_controller.js")
+
+  it "is byte-identical to the shipped source (no drift)" do
+    expect(File.read(vendored)).to eq(File.read(source)),
+      "spec/dummy/public/vendor/reactive_controller.js has drifted from the source " \
+      "app/javascript/phlex/reactive/reactive_controller.js. Re-sync it (the system " \
+      "suite runs the vendored copy):\n\n" \
+      "  cp app/javascript/phlex/reactive/reactive_controller.js " \
+      "spec/dummy/public/vendor/reactive_controller.js"
+  end
+end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -138,6 +138,22 @@ RSpec.describe "Reactive actions", type: :request do
     end
   end
 
+  describe "blank field reaches the action; the component guards (issue #8)" do
+    # The transport doesn't second-guess values: a genuinely-cleared field is
+    # sent as "" and reaches the action. Protecting the record from a blank
+    # write is the action's job (`if title.present?`), not the transport's. The
+    # issue #8 fix is about COLLECTING the right value from rich-text/custom
+    # editors in the first place — covered by spec/system/rich_editor_spec.rb.
+    let!(:todo) { Todo.create!(title: "keep me", done: false) }
+
+    it "passes an explicitly blank param through to the guarded action" do
+      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename", params: {title: ""})
+
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("keep me") # unchanged: guarded by `if title.present?`
+    end
+  end
+
   describe "tampering" do
     it "rejects a forged token" do
       post "/reactive/actions",

--- a/spec/system/rich_editor_spec.rb
+++ b/spec/system/rich_editor_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #8: a reactive `save` must collect named rich-text / custom-editor
+# fields (lexxy-editor, trix-editor, [contenteditable]) — not just
+# input/select/textarea. We stand in for a custom editor with a named
+# [contenteditable] element. Before the fix its value was dropped and the
+# record was silently wiped.
+RSpec.describe "Rich editor field collection (issue #8)", type: :system do
+  it "collects a named contenteditable value on a reactive save" do
+    todo = Todo.create!(title: "before")
+    visit "/rich_editor/#{todo.id}"
+
+    editor = find("[data-testid='editor']")
+    # Replace the editable content with new text (contenteditable, not an input).
+    editor.native.evaluate('el => { el.textContent = "after edit" }')
+
+    find("[data-testid='save']").click
+
+    # The re-rendered component shows the saved value; the DB has it too.
+    expect(page).to have_css("[data-testid='current']", text: "after edit")
+    expect(todo.reload.title).to eq("after edit")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #8. A reactive form action auto-collected only `input[name], select[name], textarea[name]`, so a named rich-text editor (`<lexxy-editor>`, `<trix-editor>`) or any `[contenteditable]` was skipped — a reactive `save` posted an **empty value and silently wiped the field**, with no error.

`#collectFields()` now also reads named custom editors and contenteditable elements.

## The non-obvious bug

While building the fix, a captured POST payload showed the value *was* collected but keyed as `"undefined"`:

```json
"params": { "undefined": "after edit" }
```

A plain element (a `<div contenteditable>`) has **no `name` IDL property** — only the attribute — so `el.name` is `undefined`. The fix reads `getAttribute("name")`. (A diagnostic spec caught this; without it the fix would have shipped broken.)

## What changed

- **`#collectFields`** — after standard controls, collect named `lexxy-editor`, `trix-editor`, and `[contenteditable]` (excluding `contenteditable="false"`). Value is `el.value` (custom editors expose serialized HTML) else the contenteditable text. The editor only fills a name the standard controls left **absent or empty**, so a hidden input a rich editor mirrors into (e.g. Trix) still wins when populated. Explicit `on(:save, x: …)` params still win over everything.
- **Vendored test copy re-synced + drift guard.** The system suite drives `spec/dummy/public/vendor/reactive_controller.js`, which had silently drifted from source (it predated the pgbus connection-id logic) — so the browser specs were validating *stale* client code. Re-synced it and added `spec/phlex/vendored_controller_sync_spec.rb`, which fails on any future drift.

## Test plan

| Layer | Spec | Proves |
|---|---|---|
| System | `spec/system/rich_editor_spec.rb` | Type into a named `[contenteditable]`, submit → the record gets the typed value. **RED before the fix** (stayed blank). |
| Request | `spec/requests/reactive_actions_spec.rb` | An explicitly-blank field reaches the action; the component's own `if title.present?` guard protects the record — the transport doesn't second-guess values. |
| Unit | `spec/phlex/vendored_controller_sync_spec.rb` | Vendored copy is byte-identical to source (negative-tested: it fails on drift). |

## Docs (per "keep docs updated moving forward")

- `docs/architecture.md` — new **"What collected fields are"** section: which shapes are auto-collected, explicit-params-win, omit-if-absent.
- `docs/examples/inline_edit.md` — note that rich-text fields are collected too, linking the architecture section.

## Verification

- [x] `bundle exec standardrb` — clean
- [x] `bundle exec rspec spec/phlex spec/requests` — **42 examples, 0 failures**
- [x] `CAPYBARA_SERVER=webrick bundle exec rspec spec/system` — **7 examples, 0 failures**
- [x] Backwards compatible — existing checkbox/radio/text collection unchanged; all existing browser specs pass.
- [x] pgbus optionality preserved — re-sync added the already-shipping pgbus header logic to the test copy; without pgbus `#connectionId()` returns null and the header is omitted.

## Note for the maintainer

The `save` of a **required** keyword param that maps to *no* DOM field still surfaces as an unhandled `ArgumentError` (500), because the server correctly omits absent params and the action then misses its keyword. That's pre-existing behavior, out of scope here, and arguably correct (loud failure) — flagging it in case you'd prefer a 400. The destructive *silent wipe* this issue reported is fully closed: we now send the real editor value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reactive saves to capture named rich-text/custom editors and `[contenteditable]` field values on submission.
  * Ensured rich-editor saves don’t wipe existing mirrored/hidden input values when already populated.
  * Updated reactive request headers to avoid echoing broadcasts to the originating SSE stream.
* **Documentation**
  * Clarified how collected fields and precedence work for rich editors and `contenteditable`.
  * Refreshed changelog release/compare links and related notes.
* **Tests**
  * Added system/regression coverage for rich-editor saving and blank-string parameter passthrough, plus a byte-identical vendored controller sync check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->