### PR TITLE
fix(client): preventDefault synchronously so form submit doesn't navigate (#11)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,8 @@ jobs:
           bun-version-file: ".bun-version"
       - name: Install JS dependencies
         run: bun install --frozen-lockfile
+      - name: JS unit tests (client controller)
+        run: bun test spec/javascript
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Form submit navigated instead of running the reactive action.** A component
+  wired with `on(:save, event: "submit")` on a real `<form>` let the browser
+  submit natively (full POST to the form's `action`), because
+  `dispatch()` deferred `event.preventDefault()` into the request-queue microtask
+  — too late, since `preventDefault()` only works synchronously within the event
+  dispatch. For `click` triggers there's no default to miss, so it was invisible;
+  for `submit` the form navigated (e.g. `POST /` → routing error). `dispatch()`
+  now calls `preventDefault()` synchronously (and captures the action/params up
+  front, so the deferred work never re-reads a reset event object). Guarded by a
+  bun unit test (`spec/javascript/reactive_controller.test.js`) that asserts the
+  synchronous call and fails on the pre-fix deferred code. Closes #11.
+
+## [0.2.4] - 2026-06-24
+
+### Fixed
+
 - **Reactive save silently dropped rich-text / custom-editor fields.** The
   client's field auto-collection (`#collectFields`) queried only
   `input[name], select[name], textarea[name]`, so a named rich-text editor
@@ -123,7 +139,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   scaffolds a reactive component (and an RSpec spec when the app uses RSpec),
   state-backed by default or record-backed with `--record`.
 
-[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.3...HEAD
+[0.2.4]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.0...v0.2.1

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -34,18 +34,24 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(event))
-    return this.queue
-  }
-
-  async #perform(event) {
     const { action, params } = event.params
     if (!action) return
 
-    // Stop native behavior (button submit / form navigation): the reactive
-    // round trip replaces it.
+    // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
+    // within the event dispatch. preventDefault() only works while the event is
+    // still being handled — deferring it into the request-queue microtask (below)
+    // is too late: a `submit` trigger would natively POST the form and navigate
+    // before the reactive round trip runs (issue #11). For a `click` trigger
+    // there's no default to miss, so this was previously invisible.
     event.preventDefault()
 
+    // Capture action/params now; the queued work runs in a later microtask, by
+    // which point the event object may have been reset by the browser.
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
+    return this.queue
+  }
+
+  async #perform(action, params) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style).
     // Explicit params (data-reactive-params-param) win over collected fields.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,6 +100,23 @@ For cross-tab, open two sessions (two `Capybara::Session`s or two browser
 contexts), act in one, and assert the morph appears in the other. Allow a beat
 for the SSE round trip.
 
+## 5. Client unit tests (bun)
+
+Some client-runtime contracts are timing-sensitive and a full browser can mask
+them — e.g. a `submit` trigger must `preventDefault()` **synchronously** during
+the event, which a system test in a minimal app can't reliably reproduce. Those
+are covered by fast bun unit tests against the controller in isolation:
+
+```bash
+bun test spec/javascript     # or: bun run test
+```
+
+They stub `@hotwired/stimulus` and assert behavior directly (e.g. `dispatch()`
+calls `preventDefault()` before its queued work). CI runs them in the System
+job, which already has bun set up. The system suite drives a **vendored copy** of
+the controller (`spec/dummy/public/vendor/reactive_controller.js`); a guard spec
+keeps it byte-identical to source, so edit the source and re-sync, never the copy.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "engines": {
     "bun": ">=1.1.0"
   },
+  "scripts": {
+    "test": "bun test spec/javascript"
+  },
   "devDependencies": {
     "playwright": "^1.50.0"
   }

--- a/spec/dummy/app/components/form_submit_component.rb
+++ b/spec/dummy/app/components/form_submit_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Issue #11: a reactive component whose action fires on a real <form> submit.
+# The form carries an explicit `action` to a DISTINCT page so that a native
+# (un-prevented) submit causes an observable navigation away from this page —
+# exactly the failure the reporter hit (their form action defaulted to "/").
+# The reactive controller must preventDefault() synchronously so the submit is
+# intercepted and the page never navigates.
+class FormSubmitComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :save, params: {title: :string}
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, "formsubmit")
+
+  def save(title:)
+    @todo.update!(title:) if title.present?
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      # Explicit action to a different route: a native submit would land on the
+      # nav-probe page. on(:save, event: "submit") must intercept it first.
+      form(action: "/nav_probe", method: "post", **mix(on(:save, event: "submit"))) do
+        input(name: "title", value: @todo.title, data: {testid: "title"})
+        button(type: "submit", data: {testid: "save"}) { "Save" }
+      end
+      span(data: {testid: "current"}) { @todo.title }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -23,6 +23,15 @@ class DemosController < ActionController::Base
     render_component RichEditorComponent.new(todo: Todo.find(params[:id]))
   end
 
+  def form_submit
+    render_component FormSubmitComponent.new(todo: Todo.find(params[:id]))
+  end
+
+  # The page a non-intercepted form submit would navigate to (issue #11).
+  def nav_probe
+    render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true
+  end
+
   private
 
   # Render a Phlex component as the layout's body. `render component, layout:`

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
   get "rich_editor/:id" => "demos#rich_editor"
+  get "form_submit/:id" => "demos#form_submit"
+  # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
+  # GET) so a native submit produces an observable navigation, not a 404.
+  match "nav_probe" => "demos#nav_probe", :via => [:get, :post]
 
   # The phlex-reactive engine appends POST /reactive/actions itself.
 end

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -34,18 +34,24 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(event))
-    return this.queue
-  }
-
-  async #perform(event) {
     const { action, params } = event.params
     if (!action) return
 
-    // Stop native behavior (button submit / form navigation): the reactive
-    // round trip replaces it.
+    // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
+    // within the event dispatch. preventDefault() only works while the event is
+    // still being handled — deferring it into the request-queue microtask (below)
+    // is too late: a `submit` trigger would natively POST the form and navigate
+    // before the reactive round trip runs (issue #11). For a `click` trigger
+    // there's no default to miss, so this was previously invisible.
     event.preventDefault()
 
+    // Capture action/params now; the queued work runs in a later microtask, by
+    // which point the event object may have been reset by the browser.
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
+    return this.queue
+  }
+
+  async #perform(action, params) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style).
     // Explicit params (data-reactive-params-param) win over collected fields.

--- a/spec/javascript/reactive_controller.test.js
+++ b/spec/javascript/reactive_controller.test.js
@@ -1,0 +1,81 @@
+// Unit test for the reactive Stimulus controller's dispatch() timing.
+//
+// Issue #11: event.preventDefault() must be called SYNCHRONOUSLY inside
+// dispatch(), while the browser is still handling the event. Deferring it into
+// the request-queue microtask (the .then(() => this.#perform(...)) chain) is too
+// late — a `submit` trigger natively POSTs the form and the page navigates
+// before the reactive round trip runs. The browser/Turbo race that surfaces
+// this isn't reproducible in the minimal dummy Rails app, so we assert the
+// contract directly here.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  // Stub @hotwired/stimulus so we can import the real controller in isolation
+  // (no Stimulus, no bundler). We only need a Controller base with `element`.
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {
+        this.element = makeElement()
+      }
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// Minimal element stub: querySelectorAll returns nothing, setAttribute is a
+// no-op. Enough for #collectFields() and the aria-busy toggle not to throw
+// before the (irrelevant-here) fetch.
+function makeElement() {
+  return {
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+function buildController() {
+  const controller = new ReactiveController()
+  controller.tokenValue = "tok"
+  // Avoid a real network call in the deferred #perform: stub fetch to reject.
+  globalThis.fetch = () => Promise.reject(new Error("no network in unit test"))
+  globalThis.document = { querySelector: () => null }
+  return controller
+}
+
+test("dispatch() calls preventDefault synchronously (issue #11)", () => {
+  const controller = buildController()
+  const calls = []
+  const event = {
+    params: { action: "save", params: "{}" },
+    preventDefault: () => calls.push("preventDefault"),
+  }
+
+  const queue = controller.dispatch(event)
+  // Swallow the deferred #perform rejection (fetch stubbed to reject); we only
+  // care that preventDefault already ran by this point — BEFORE any await.
+  if (queue && queue.catch) queue.catch(() => {})
+
+  // The decisive assertion: preventDefault fired during the synchronous call,
+  // not in a later microtask. Pre-fix (preventDefault inside #perform) this is
+  // empty here because #perform is deferred behind .then().
+  expect(calls).toEqual(["preventDefault"])
+})
+
+test("dispatch() ignores an event with no action (no preventDefault)", () => {
+  const controller = buildController()
+  const calls = []
+  const event = {
+    params: {},
+    preventDefault: () => calls.push("preventDefault"),
+  }
+
+  controller.dispatch(event)
+  // No action declared → nothing to do, and we must not preventDefault a trigger
+  // that isn't ours.
+  expect(calls).toEqual([])
+})

--- a/spec/system/form_submit_spec.rb
+++ b/spec/system/form_submit_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #11: a reactive component wired with form(**on(:save, event: "submit"))
+# must intercept the submit and run the reactive action, NOT navigate.
+#
+# This is an end-to-end SMOKE test (submit-triggered action works, page stays
+# put). It does NOT isolate the preventDefault-timing race itself: the Turbo-8
+# submit race that surfaces the bug isn't reproducible in the minimal dummy app
+# (a native submit here is suppressed regardless of the fix). The actual
+# regression guard for the synchronous-preventDefault contract is the bun unit
+# test at spec/javascript/reactive_controller.test.js, which fails on the
+# pre-fix (deferred) code.
+RSpec.describe "Reactive form submit (issue #11)", type: :system do
+  it "runs a submit-triggered reactive action without navigating away" do
+    todo = Todo.create!(title: "before")
+    visit "/form_submit/#{todo.id}"
+
+    find("[data-testid='title']").set("after submit")
+    find("[data-testid='save']").click
+
+    # The reactive re-render lands in place (waiting matcher = async barrier).
+    expect(page).to have_css("[data-testid='current']", text: "after submit")
+    # We never navigated to the form's action: the nav-probe sentinel is absent.
+    expect(page).to have_no_css("[data-testid='nav-probe']")
+    expect(todo.reload.title).to eq("after submit")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #11. A component wired with `on(:save, event: "submit")` on a real `<form>` let the browser **submit natively** (full POST to the form's `action`) instead of running the reactive action.

`dispatch()` deferred `event.preventDefault()` into the request-queue microtask:

```js
// before
dispatch(event) {
  this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(event))
  return this.queue
}
async #perform(event) {
  const { action, params } = event.params
  if (!action) return
  event.preventDefault()   // ← runs in a later microtask, after the event finished
  ...
}
```

`preventDefault()` only works **synchronously within the event dispatch**. By the time the microtask ran, the browser had already committed the submit. For `click` triggers there's no default to miss (invisible); for `submit` the form navigated (e.g. `POST /` → routing error).

## The fix

`dispatch()` now calls `preventDefault()` **synchronously**, gated on action presence, and captures `action`/`params` up front before queuing:

```js
dispatch(event) {
  const { action, params } = event.params
  if (!action) return
  event.preventDefault()   // synchronous — stops the submit/navigation
  this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
  return this.queue
}
async #perform(action, params) { ... }
```

Capturing `action`/`params` up front also addresses the reporter's secondary warning — the deferred `#perform` never re-reads a reset event object.

## Test plan — and an honest note on test fidelity

The Turbo-8 submit race that surfaces this bug **isn't reproducible in the minimal dummy Rails app** (a native submit there is suppressed regardless of the fix, so a browser test passes pre- and post-fix). So the real regression guard is a **bun unit test**:

| Layer | Spec | Guards |
|---|---|---|
| **JS unit (bun)** | `spec/javascript/reactive_controller.test.js` | `dispatch()` calls `preventDefault()` **synchronously** (not in the queued microtask), and ignores a no-action event. **Verified RED on the pre-fix deferred code, GREEN on the fix.** |
| System (smoke) | `spec/system/form_submit_spec.rb` | End-to-end: a `form(**on(:save, event: "submit"))` runs the reactive action and the page stays put. Documented as a smoke test, not the race guard. |
| Unit | `spec/phlex/vendored_controller_sync_spec.rb` | Vendored controller stays byte-identical to source (re-synced here). |

The bun test stubs `@hotwired/stimulus` and exercises `dispatch()` in isolation — fast, deterministic, and catches exactly the timing regression a browser can't.

## CI + tooling

- New **"JS unit tests"** step in the System job (which already sets up bun). No new dependency — uses bun's built-in test runner.
- `package.json`: added `"test": "bun test spec/javascript"`.
- `docs/testing.md`: new **"Client unit tests (bun)"** section.

## Docs (keeping the CHANGELOG honest)

- `#11` entry under `[Unreleased]`.
- Moved the **released** `#8` entry into a dated `[0.2.4]` section (the 0.2.4 bump hadn't created one) and added the compare-link footer — same release-hygiene cleanup pattern as the prior PR.

## Verification

- [x] `bun test spec/javascript` — 2 pass (RED on pre-fix, GREEN on fix)
- [x] `bundle exec standardrb` — clean
- [x] `bundle exec rspec spec/phlex spec/requests` — **42 examples, 0 failures**
- [x] `CAPYBARA_SERVER=webrick bundle exec rspec spec/system` — **8 examples, 0 failures**
- [x] Click triggers (counter/todos/chat) unchanged; pgbus optionality untouched (no transport change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where form submits could trigger unwanted browser navigation instead of staying in the app.
  * Improved handling of submit actions so changes are applied reliably and the page remains in place.

* **New Features**
  * Added an end-to-end demo and smoke test for reactive form submission.

* **Tests**
  * Added unit coverage for submit handling and a system test for the full browser flow.

* **Documentation**
  * Updated testing guidance and release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->