### PR TITLE
feat: action response control via Phlex::Reactive::Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.6]
+
+### Added
+
+- **Action response control via `Phlex::Reactive::Response`.** An action MAY now
+  return a `Response` to govern the actor's HTTP reply, instead of only the
+  implicit single re-render. Returning anything else keeps the legacy default
+  (re-render the component in place), so existing actions are unaffected.
+  - `Response.replace(self)` / `.update(self)` — explicit re-render.
+  - `Response.replace(self).flash(:error, msg_or_component)` — surface a
+    validation error / notice (the `#1` driver). `.flash` is additive on a
+    self-replace, so the component's signed token always refreshes. Flash
+    content is supplied explicitly (the render context is off-request — there is
+    no Rails `flash`); pass a string or a Phlex component. Target container is
+    `Phlex::Reactive.flash_target` (default `flash`).
+  - `Response.remove(self)` — drop the element (e.g. a moderation queue). New
+    instance helper `Streamable#to_stream_remove` backs it.
+  - `Response.redirect(url)` — client-side `Turbo.visit` for when the current
+    URL is dead (e.g. a slug rename). Rides a 200 turbo-stream carrying a
+    `reactive:visit` custom action (registered in the client), **not** an HTTP
+    3xx (which the client bails on). Pass a `*_url`.
+  - `Response.with(*streams)` / `#stream(*more)` — multi-stream (replace self +
+    a sibling component).
+- The endpoint guarantees the component's own replace is present (token refresh)
+  for non-remove/redirect responses, and never double-prepends when the action
+  already included a self-targeted stream.
+
+## [0.2.5]
+
 ### Fixed
 
 - **Form submit navigated instead of running the reactive action.** A component

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ hand-picking Turbo Stream targets.
 4. **Re-render through a real view context** — go through `Phlex::Reactive.renderer` / the controller, never a fabricated context (dom_id/url_for/t()/csrf must work)
 5. **Capability-detect pgbus features at runtime** — probe the actual keyword (`broadcast.parameters` includes `:exclude`), never `defined?(Pgbus)` alone or a version string
 6. **Degrade gracefully** — every pgbus-only feature must no-op or fall back when pgbus is absent
+7. **Control the reply via the return value** — return a `Phlex::Reactive::Response` (`replace`/`update`/`remove`/`redirect`/`with`, chain `.flash(level, content)` / `.stream(...)`) to govern the actor's HTTP reply; returning anything else keeps the implicit single replace. See the README "Controlling the action's reply" section and `lib/phlex/reactive/response.rb`.
 
 ## Commands
 
@@ -60,10 +61,11 @@ bundle exec rake                             # spec + standard
 
 ```
 Layer 4: Client runtime    app/javascript/phlex/reactive/reactive_controller.js (ONE generic Stimulus controller)
-Layer 3: Endpoint          app/controllers/phlex/reactive/actions_controller.rb (verify token → run action → re-render)
+Layer 3: Endpoint          app/controllers/phlex/reactive/actions_controller.rb (verify token → run action → render the returned Response, else re-render)
 Layer 2: Component mixin    lib/phlex/reactive/component.rb (reactive_record/reactive_state, action, reactive_attrs, on)
-Layer 1: Streamable mixin   lib/phlex/reactive/streamable.rb (#id, replace/append/..., broadcast_*_to, to_stream_replace)
-Layer 0: Core + config      lib/phlex/reactive.rb (verifier, renderer, base_controller_name, authorization_errors, action_path)
+Layer 1: Streamable mixin   lib/phlex/reactive/streamable.rb (#id, replace/append/..., broadcast_*_to, to_stream_replace, to_stream_remove)
+Layer 1: Response           lib/phlex/reactive/response.rb (replace/update/remove/redirect/with, flash, stream)
+Layer 0: Core + config      lib/phlex/reactive.rb (verifier, renderer, base_controller_name, authorization_errors, action_path, flash_target)
          Engine             lib/phlex/reactive/engine.rb (mounts the endpoint, pins the client controller)
 ```
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,35 @@ div(**mix(reactive_attrs, id:, class: "card")) { ... }
 button(**on(:increment), data: { testid: "inc" }) { "+" }
 ```
 
+### `Phlex::Reactive::Response` — controlling the action's reply
+
+By default an action re-renders its component in place. **Return** a `Response`
+to do more (it governs only the actor's HTTP reply — cross-tab updates still use
+`broadcast_*_to(..., exclude: reactive_connection_id)`). Returning anything else
+keeps the default, so existing actions are unaffected.
+
+```ruby
+def rename(title:)
+  return Response.replace(self).flash(:error, @todo.errors.full_messages.to_sentence) unless @todo.update(title:)
+  Response.replace(self)
+end
+
+def approve   = (@row.approve!; Response.remove(self))          # drop the element
+def publish   = (@article.publish!; Response.redirect(article_url(@article)))  # slug changed → Turbo.visit
+def add(item:) = Response.replace(self).stream(Totals.update(@order))           # multi-stream
+```
+
+| Builder | Reply |
+|---|---|
+| `Response.replace(self)` / `.update(self)` | re-render in place (explicit default) |
+| `.flash(level, content, target: …)` | append a flash; `content` is a string or Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
+| `Response.remove(self)` | remove the element (backed by `Streamable#to_stream_remove`) |
+| `Response.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
+| `Response.with(*streams)` / `#stream(*more)` | multi-stream |
+
+`.flash`/`.stream` are additive on a self-replace, so the component's signed
+token always refreshes.
+
 ### Configuration (`config/initializers/phlex_reactive.rb`)
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ for broadcasting.
    │                                          verify signed token (no state trusted)
    │                                          rebuild component (record from DB)
    │                                          run the whitelisted action
-   │                                          re-render → <turbo-stream replace id>
+   │                                          re-render → <turbo-stream replace id>   (default; an action
+   │                                          may return a Response — see "Controlling the action's reply")
    └──────── Turbo morphs it in ◀───────────────────────────────┘
 
    ...and for OTHER tabs/users:
@@ -254,7 +255,7 @@ The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
 | `.update` / `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
 | `.broadcast_replace_to(*streamables, model:)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable) |
 | `.broadcast_append_to(*streamables, target:, model:)` / `_update_` / `_prepend_` / `_remove_` | The broadcast variants |
-| `#to_stream_replace` / `#to_stream_update` | Stream the *already-built* instance (used internally after an action) |
+| `#to_stream_replace` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `Response`) |
 
 Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 

--- a/README.md
+++ b/README.md
@@ -287,12 +287,18 @@ button(**on(:increment), data: { testid: "inc" }) { "+" }
 
 ### `Phlex::Reactive::Response` — controlling the action's reply
 
-By default an action re-renders its component in place. **Return** a `Response`
-to do more (it governs only the actor's HTTP reply — cross-tab updates still use
-`broadcast_*_to(..., exclude: reactive_connection_id)`). Returning anything else
-keeps the default, so existing actions are unaffected.
+By default an action re-renders its component in place. **Return** a
+`Phlex::Reactive::Response` to do more (it governs only the actor's HTTP reply —
+cross-tab updates still use `broadcast_*_to(..., exclude: reactive_connection_id)`).
+Returning anything else keeps the default, so existing actions are unaffected.
+
+The snippets below alias the constant for brevity (`Response.replace(self)` won't
+resolve to `Phlex::Reactive::Response` inside a namespaced component — fully
+qualify it, or add the alias shown):
 
 ```ruby
+Response = Phlex::Reactive::Response # or qualify each call below
+
 def rename(title:)
   return Response.replace(self).flash(:error, @todo.errors.full_messages.to_sentence) unless @todo.update(title:)
   Response.replace(self)

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -36,9 +36,9 @@ module Phlex
         component = component_class.from_identity(payload)
         coerced = coerce_params(action_def.params)
 
-        run_action(component, action_def, coerced)
+        result = run_action(component, action_def, coerced)
 
-        render turbo_stream: component.to_stream_replace
+        render turbo_stream: response_streams(result, component)
       rescue Phlex::Reactive::InvalidToken
         head :bad_request
       rescue ActiveRecord::RecordNotFound
@@ -67,6 +67,33 @@ module Phlex
             end
           end
         end
+      end
+
+      # Turn the action's return value into the turbo-stream(s) to render for
+      # the actor. A Phlex::Reactive::Response is honored explicitly; any other
+      # value (the legacy contract — return value ignored) falls back to the
+      # implicit single replace, so existing actions are unaffected.
+      def response_streams(result, component)
+        return [component.to_stream_replace] unless result.is_a?(Phlex::Reactive::Response)
+        return [redirect_stream(result.redirect_url)] if result.redirect?
+
+        streams = result.streams
+        # Guarantee the component's own replace is present (so its signed
+        # data-reactive-token-value refreshes) unless the Response opted out.
+        # Idempotent: only prepend when no self-targeted stream was supplied, so
+        # Response.replace(self).flash(...) isn't doubled.
+        if result.render_self? && streams.none? { |s| s.include?(%(target="#{component.id}")) }
+          streams = [component.to_stream_replace, *streams]
+        end
+        streams
+      end
+
+      # A 200 turbo-stream carrying a namespaced custom action the client turns
+      # into Turbo.visit — NOT an HTTP 3xx, which the client hard-bails on
+      # (response.redirected). The matching client handler is registered in
+      # reactive_controller.js.
+      def redirect_stream(url)
+        %(<turbo-stream action="reactive:visit" data-url="#{ERB::Util.html_escape(url)}"></turbo-stream>)
       end
 
       def transaction_wrapper(&block)

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -78,11 +78,17 @@ module Phlex
         return [redirect_stream(result.redirect_url)] if result.redirect?
 
         streams = result.streams
-        # Guarantee the component's own replace is present (so its signed
-        # data-reactive-token-value refreshes) unless the Response opted out.
-        # Idempotent: only prepend when no self-targeted stream was supplied, so
-        # Response.replace(self).flash(...) isn't doubled.
-        if result.render_self? && streams.none? { |s| s.include?(%(target="#{component.id}")) }
+        # Guarantee the component's signed identity token is refreshed unless the
+        # Response opted out (remove/redirect navigate away — handled above). The
+        # client reads the next token from the response body (#extractToken), so
+        # the real invariant is "a fresh data-reactive-token-value is present",
+        # NOT "some stream targets self". Checking the token directly is correct
+        # for replace AND update of self (both re-render the root via
+        # render_component, carrying the token), and still adds the fallback
+        # replace when a hand-built `with(...)` stream omits it. Idempotent: a
+        # Response.replace(self)/update(self) already carries the token, so we
+        # don't double the self-render.
+        if result.render_self? && streams.none? { |s| s.include?("data-reactive-token-value") }
           streams = [component.to_stream_replace, *streams]
         end
         streams

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -17,6 +17,25 @@ import { Controller } from "@hotwired/stimulus"
 // .broadcast_* methods — so a click and a background broadcast converge on
 // one re-render unit.
 //
+// Custom turbo-stream action: the server tells the actor to full-navigate
+// (e.g. the record's slug changed and the current URL is now dead). It rides a
+// 200 turbo-stream — NOT an HTTP 3xx — so it never trips the response.redirected
+// bail below (which still correctly catches real auth/CSRF redirects). Registered
+// once on the Turbo global (no @hotwired/turbo import — the gem uses window.Turbo
+// everywhere, and a named import is unreliable under importmap/esbuild).
+function registerReactiveVisit() {
+  const actions = window.Turbo?.StreamActions
+  if (!actions || actions["reactive:visit"]) return
+  actions["reactive:visit"] = function () {
+    const url = this.getAttribute("data-url")
+    if (url) window.Turbo.visit(url, { action: "advance" })
+  }
+}
+if (typeof window !== "undefined") {
+  if (window.Turbo) registerReactiveVisit()
+  else document.addEventListener("turbo:load", registerReactiveVisit, { once: true })
+}
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -23,7 +23,7 @@ import { Controller } from "@hotwired/stimulus"
 // bail below (which still correctly catches real auth/CSRF redirects). Registered
 // once on the Turbo global (no @hotwired/turbo import — the gem uses window.Turbo
 // everywhere, and a named import is unreliable under importmap/esbuild).
-function registerReactiveVisit() {
+export function registerReactiveVisit() {
   const actions = window.Turbo?.StreamActions
   if (!actions || actions["reactive:visit"]) return
   actions["reactive:visit"] = function () {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ A component that implements `#id` can render itself as a Turbo Stream:
 ```
 Counter.replace(c)            → <turbo-stream action="replace" target="<c.id>">…</turbo-stream>
 Counter.broadcast_replace_to(stream, model: c)  → same, pushed over the transport
+c.to_stream_remove            → <turbo-stream action="remove" target="<c.id>">    (backs Response.remove)
 ```
 
 Rendering goes through a real controller renderer (`Phlex::Reactive.renderer`),
@@ -57,8 +58,13 @@ POST /reactive/actions
 Accept: text/vnd.turbo-stream.html
 ```
 
-The endpoint verifies the token, rebuilds the component, runs the action, and
-returns `component.to_stream_replace`. Turbo morphs it in.
+The endpoint verifies the token, rebuilds the component, and runs the action. If
+the action returns a [`Phlex::Reactive::Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+(a replace/update, a remove, a redirect, or multiple streams — optionally with a
+flash), the endpoint renders that; otherwise it falls back to the implicit single
+`component.to_stream_replace` (the legacy contract). For any non-remove/redirect
+reply the component's own replace is guaranteed present so its token refreshes.
+Turbo morphs it in.
 
 ### What collected fields are
 

--- a/docs/broadcasting.md
+++ b/docs/broadcasting.md
@@ -84,8 +84,9 @@ end
 
 ## Broadcasting from inside a reactive action
 
-The acting user gets the action's HTTP response (a replace of the component).
-*Everyone else* gets the broadcast. Idiomorph dedupes a `replace` by DOM id, so
+The acting user gets the action's HTTP response (a replace of the component by
+default, or whatever [`Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+the action returns). *Everyone else* gets the broadcast. Idiomorph dedupes a `replace` by DOM id, so
 the actor doesn't double-apply — but for `append`/`prepend` (and animations or
 optimistic UI) the echo *would* double-apply. Suppress the actor's own echo with
 `exclude: reactive_connection_id`:
@@ -141,23 +142,24 @@ end
 ## Removing the actor's own element
 
 `destroy`-style actions are the one case where "replace the component by its id"
-doesn't fit (the element should vanish, not be replaced). Options:
-
-1. **Broadcast a remove and make the action response a remove too.** Override the
-   endpoint, or have the action render `to_stream_remove` (add a small helper),
-   so the actor's element is removed and everyone else's via broadcast.
-2. **Replace with an empty/tombstone state** if you want an "undo" affordance.
-
-Most apps add a tiny `to_stream_remove` to `Streamable` for this:
+doesn't fit — the element should vanish, not be replaced. Return
+`Response.remove(self)` from the action: the actor's element is removed via the
+built-in `Streamable#to_stream_remove` (no endpoint override, no helper to add),
+and other tabs get `broadcast_remove_to(..., exclude: reactive_connection_id)`.
 
 ```ruby
-def to_stream_remove
-  self.class.turbo_stream_builder.remove(id)
+def destroy
+  authorize! @todo, :destroy?
+  list = @todo.list
+  @todo.destroy!
+  Todos::Item.broadcast_remove_to(list, :todos, model: @todo, exclude: reactive_connection_id) # other tabs
+  Phlex::Reactive::Response.remove(self)                                                        # this tab
 end
 ```
 
-and return it from a destroy action via a custom endpoint hook. See
-[architecture.md](architecture.md) for the dispatch path.
+For an "undo" affordance, replace with a tombstone state instead of removing. See
+[`Phlex::Reactive::Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+for the full reply API.
 
 ## Presence (who's here / typing)
 

--- a/docs/examples/inline_edit.md
+++ b/docs/examples/inline_edit.md
@@ -82,6 +82,28 @@ render Fields::InlineEdit.new(record: @user, attribute: :email)
   `save` receives its value, not a blank. See
   [what gets auto-collected](../architecture.md#what-collected-fields-are).
 
+## Surfacing a validation error
+
+`save` above uses `update!`, which raises on invalid input. To show the error
+instead, use non-bang `update` and return a `Response` with a flash:
+
+```ruby
+def save(value:)
+  authorize! @record, :update?
+  if @record.update(@attribute => value)
+    @editing = false
+    Phlex::Reactive::Response.replace(self)
+  else
+    Phlex::Reactive::Response.replace(self).flash(:error, @record.errors.full_messages.to_sentence)
+  end
+end
+```
+
+The flash `content` is supplied explicitly (off-request — no Rails `flash`) and
+appends into `Phlex::Reactive.flash_target` (default `<div id="flash">`); pass a
+Phlex component instead of a string for rich markup. See
+[Response](../README.md#phlexreactiveresponse--controlling-the-actions-reply).
+
 ## Want it to update other viewers too?
 
 Broadcast on save:

--- a/docs/examples/todo_list.md
+++ b/docs/examples/todo_list.md
@@ -57,8 +57,8 @@ class Todos::Item < ApplicationComponent
     authorize! @todo, :destroy?
     list = @todo.list
     @todo.destroy!
-    # Remove from every other tab; this tab's own response also removes it.
-    Todos::Item.broadcast_remove_to(list, :todos, model: @todo)
+    Todos::Item.broadcast_remove_to(list, :todos, model: @todo) # other tabs
+    Phlex::Reactive::Response.remove(self)                       # this tab's element
   end
 
   def view_template
@@ -78,12 +78,10 @@ class Todos::Item < ApplicationComponent
 end
 ```
 
-Note `destroy` returns a *replace* of a now-deleted row in the action response.
-Render `to_stream_replace` of a tombstone, or override the endpoint to send a
-`remove` — the simplest path is to also handle removal client-side via the
-broadcast and let the action response be a no-op replace of an empty row. For
-clarity most apps make `destroy` an action whose response removes the element;
-see [docs/broadcasting.md](../broadcasting.md#removing-the-actors-own-element).
+`destroy` returns `Response.remove(self)`, so the actor's own row is removed (via
+the built-in `Streamable#to_stream_remove` — no tombstone, no endpoint override)
+and `broadcast_remove_to` removes it in every other tab. See
+[Response](../README.md#phlexreactiveresponse--controlling-the-actions-reply).
 
 ## The list + composer
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,8 +48,12 @@ route. No hand-picked target.**
 ## Why phlex-reactive
 
 - **Actions are Ruby methods.** Declare `action :increment`; the client calls it.
-- **Re-render is auto-targeted.** A component owns a stable `id`; the response
-  replaces it. You never pick a target.
+- **Re-render is auto-targeted.** A component owns a stable `id`; by default the
+  response replaces it — an action can return a `Response` to morph, remove,
+  redirect, or flash instead. You never pick a target.
+- **Actions control the reply.** Return a `Response` to morph, remove, redirect
+  (`Turbo.visit`), or attach a flash — or emit several streams at once. Returning
+  nothing keeps the auto-replace default.
 - **One unit for clicks AND broadcasts.** The same component re-renders for a
   local action and a server-pushed live update.
 - **State lives in your database**, behind a signed identity — no

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,6 +81,11 @@ cp "$(bundle show phlex-reactive)/app/javascript/phlex/reactive/reactive_control
 
 …and `import ReactiveController from "./reactive_controller"`.
 
+Importing `reactive_controller.js` also registers the `reactive:visit` Turbo
+`StreamAction` that powers `Response.redirect`. The `import ReactiveController`
+above covers this; if you vendor the file, make sure it's actually imported (not
+tree-shaken away) or redirects won't fire.
+
 ## bun (bun-rails)
 
 Same as esbuild. Point the import at the gem path or vendor the file.
@@ -104,6 +109,7 @@ Phlex::Reactive.renderer             = ApplicationController     # app helpers d
 Phlex::Reactive.authorization_errors = [Pundit::NotAuthorizedError]
 # Phlex::Reactive.action_path = "/_r/actions"                   # custom endpoint
 # Phlex::Reactive.verifier    = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
+# Phlex::Reactive.flash_target = "flash"                         # DOM id Response#flash appends into
 ```
 
 If you change `action_path`, expose it to the client:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,6 +76,32 @@ end
 For authorization, stub the current user / policy and assert `:forbidden` when
 the action's `authorize!` should deny.
 
+When an action returns a [`Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply),
+assert on the streams it produces:
+
+```ruby
+test "failed update keeps the replace and appends a flash" do
+  # POST a save action with invalid input
+  assert_response :success
+  assert_match %r{<turbo-stream action="replace" target="counter">}, response.body  # token refreshes
+  assert_match %r{<turbo-stream action="append" target="flash">}, response.body     # flash appended
+end
+
+test "remove action emits a remove and no replace" do
+  assert_response :success
+  assert_match %r{<turbo-stream action="remove" target="todo_42">}, response.body
+  refute_match %r{action="replace"}, response.body   # render_self? is false for remove
+end
+
+test "redirect rides a 200 reactive:visit, not a 3xx" do
+  assert_response :success            # NOT :redirect — the client bails on response.redirected
+  assert_match %r{<turbo-stream action="reactive:visit" data-url=".*/articles/}, response.body
+end
+```
+
+A `Response` is also a plain value object — unit-test it with no HTTP:
+`Response.remove(c).render_self?` is `false`; `Response.replace(c).flash(:x, "hi").streams.size` is `2`.
+
 ## 4. System / browser: the full loop & broadcasts
 
 Use a system test (Capybara) or a browser-automation CLI for the end-to-end loop

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -78,6 +78,26 @@ module Phlex
         @renderer ||= defined?(::ActionController::Base) ? ::ActionController::Base : nil
       end
 
+      # DOM id of the host-app container a Response#flash appends into.
+      # Default "flash"; override to match your layout's flash region.
+      def flash_target
+        @flash_target ||= "flash"
+      end
+
+      attr_writer :flash_target
+
+      # Render a Phlex component to HTML with a full (off-request) view context.
+      def render(component)
+        renderer.render(component, layout: false)
+      end
+
+      # A Turbo::Streams::TagBuilder bound to an off-request view context, used
+      # to build standalone streams (e.g. a Response flash append) not tied to a
+      # specific component's id.
+      def flash_builder
+        ::Turbo::Streams::TagBuilder.new(renderer.new.view_context)
+      end
+
       def base_controller_name
         @base_controller_name ||= "ActionController::Base"
       end

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # An explicit, immutable description of the ACTOR's HTTP response to a
+    # reactive action. An action MAY return one; if it returns anything else
+    # (the legacy contract — return value ignored), the endpoint falls back to
+    # the implicit single component.to_stream_replace.
+    #
+    # A Response governs ONLY the actor's HTTP reply. Cross-tab updates still go
+    # through Streamable's broadcast_*_to(..., exclude: reactive_connection_id).
+    #
+    #   Response.replace(self)                          # re-render in place (the default, explicit)
+    #   Response.replace(self).flash(:error, msg)       # surface a validation error
+    #   Response.remove(self)                           # drop the element (e.g. moderation queue)
+    #   Response.redirect(article_url(@article))        # slug changed -> Turbo.visit the new URL
+    #   Response.replace(self).stream(Totals.update(@order))  # multi-stream
+    class Response
+      attr_reader :streams, :redirect_url
+
+      class << self
+        # Re-render the component in place (explicit form of today's default).
+        def replace(component) = new(streams: [component.to_stream_replace])
+
+        # Morph only inner HTML (preserves the root element + its token attr).
+        def update(component) = new(streams: [component.to_stream_update])
+
+        # Remove the component's element from the DOM. Uses the instance
+        # to_stream_remove (the component already knows its own #id — no
+        # class-builder reconstruction; works for record- and state-backed).
+        def remove(component) = new(streams: [component.to_stream_remove], render_self: false)
+
+        # Client-side full navigation (Turbo.visit). Use when the current URL
+        # is dead (slug rename) or the outcome belongs on another page. Pass a
+        # *_url (the off-request render context has no request host for *_path).
+        def redirect(url) = new(redirect_url: url, render_self: false)
+
+        # Escape hatch / multi-stream root: zero or more raw turbo-stream strings.
+        def with(*strings) = new(streams: strings.flatten)
+
+        # Build a flash turbo-stream that appends `content` into a host-app
+        # container. `content` is a Phlex component instance (rendered through
+        # the configured renderer so t()/url_for work) or a ready HTML string —
+        # supplied by the caller because the render context is off-request
+        # (there is no Rails `flash`).
+        def flash_stream(_level, content, target:)
+          html = content.is_a?(::Phlex::SGML) ? Phlex::Reactive.render(content) : content.to_s
+          Phlex::Reactive.flash_builder.append(target, html: html)
+        end
+      end
+
+      # render_self: when true (default for replace/update/with), the endpoint
+      # GUARANTEES the component's own replace is present so its
+      # data-reactive-token-value refreshes (the client extracts the next token
+      # from the response HTML). remove/redirect set it false (nothing stays).
+      def initialize(streams: [], redirect_url: nil, render_self: true)
+        @streams = streams.freeze
+        @redirect_url = redirect_url
+        @render_self = render_self
+        freeze
+      end
+
+      # Append extra turbo-stream strings (a sibling component, a flash).
+      # Returns a NEW Response (immutable).
+      def stream(*more)
+        self.class.new(
+          streams: @streams + more.flatten,
+          redirect_url: @redirect_url,
+          render_self: @render_self
+        )
+      end
+
+      # Append a flash turbo-stream into a host-app container (default
+      # <div id="flash">, configurable via Phlex::Reactive.flash_target).
+      def flash(level, content, target: Phlex::Reactive.flash_target)
+        stream(self.class.flash_stream(level, content, target:))
+      end
+
+      def redirect? = !@redirect_url.nil?
+      def render_self? = @render_self
+    end
+  end
+end

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -187,6 +187,13 @@ module Phlex
       def to_stream_update
         self.class.turbo_stream_builder.update(id, html: self.class.render_component(self))
       end
+
+      # Render THIS instance as a remove stream. The component already knows its
+      # own #id, so no record/class reconstruction is needed (works for record-
+      # and state-backed components alike). Used by Response.remove.
+      def to_stream_remove
+        self.class.turbo_stream_builder.remove(id)
+      end
     end
   end
 end

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -11,6 +11,7 @@ class CounterComponent < ApplicationComponent
   action :decrement
   action :set, params: {count: :integer}
   action :reset_with_flash
+  action :bump_via_update
   action :go_home
 
   def initialize(count: 0)
@@ -29,6 +30,13 @@ class CounterComponent < ApplicationComponent
     Phlex::Reactive::Response.replace(self).flash(:notice, "Reset")
   end
 
+  # Response: morph inner HTML (update, not replace). The rendered template still
+  # carries the root's fresh data-reactive-token-value, so the token refreshes.
+  def bump_via_update
+    @count += 1
+    Phlex::Reactive::Response.update(self)
+  end
+
   # Response: client-side full navigation (no in-place stream). Targets a real
   # dummy route so the browser spec can assert the Turbo.visit landed.
   def go_home
@@ -40,7 +48,7 @@ class CounterComponent < ApplicationComponent
       button(**mix(on(:decrement), data: {testid: "dec"})) { "−" }
       span(id: "counter-value", data: {testid: "count"}) { @count.to_s }
       button(**mix(on(:increment), data: {testid: "inc"})) { "+" }
-      button(**mix(on(:set, count: 0), data: {testid: "reset"})) { "reset" }
+      button(**mix(on(:reset_with_flash), data: {testid: "reset"})) { "reset" }
       button(**mix(on(:go_home), data: {testid: "go-home"})) { "go home" }
     end
   end

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -48,6 +48,7 @@ class CounterComponent < ApplicationComponent
       button(**mix(on(:decrement), data: {testid: "dec"})) { "−" }
       span(id: "counter-value", data: {testid: "count"}) { @count.to_s }
       button(**mix(on(:increment), data: {testid: "inc"})) { "+" }
+      button(**mix(on(:bump_via_update), data: {testid: "bump-update"})) { "+1 (update)" }
       button(**mix(on(:reset_with_flash), data: {testid: "reset"})) { "reset" }
       button(**mix(on(:go_home), data: {testid: "go-home"})) { "go home" }
     end

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -10,6 +10,8 @@ class CounterComponent < ApplicationComponent
   action :increment
   action :decrement
   action :set, params: {count: :integer}
+  action :reset_with_flash
+  action :go_home
 
   def initialize(count: 0)
     @count = count
@@ -21,12 +23,25 @@ class CounterComponent < ApplicationComponent
   def decrement = @count -= 1
   def set(count:) = @count = count
 
+  # Response: replace self (token refresh) + append a flash.
+  def reset_with_flash
+    @count = 0
+    Phlex::Reactive::Response.replace(self).flash(:notice, "Reset")
+  end
+
+  # Response: client-side full navigation (no in-place stream). Targets a real
+  # dummy route so the browser spec can assert the Turbo.visit landed.
+  def go_home
+    Phlex::Reactive::Response.redirect("/todos")
+  end
+
   def view_template
     div(id:, **reactive_attrs) do
       button(**mix(on(:decrement), data: {testid: "dec"})) { "−" }
       span(id: "counter-value", data: {testid: "count"}) { @count.to_s }
       button(**mix(on(:increment), data: {testid: "inc"})) { "+" }
       button(**mix(on(:set, count: 0), data: {testid: "reset"})) { "reset" }
+      button(**mix(on(:go_home), data: {testid: "go-home"})) { "go home" }
     end
   end
 end

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -9,6 +9,8 @@ class TodoItemComponent < ApplicationComponent
   reactive_record :todo
   action :toggle
   action :rename, params: {title: :string}
+  action :archive
+  action :rename_strict, params: {title: :string}
 
   def initialize(todo:)
     @todo = todo
@@ -24,6 +26,20 @@ class TodoItemComponent < ApplicationComponent
 
   def rename(title:)
     @todo.update!(title:) if title.present?
+  end
+
+  # Response: remove self from the DOM (render_self false — no doomed re-render).
+  def archive
+    Phlex::Reactive::Response.remove(self)
+  end
+
+  # Response: surface a validation error as a flash while still refreshing the
+  # row's token (replace self + flash); on success, plain replace.
+  def rename_strict(title:)
+    return Phlex::Reactive::Response.replace(self).flash(:error, "blank") if title.blank?
+
+    @todo.update!(title:)
+    Phlex::Reactive::Response.replace(self)
   end
 
   def view_template

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -46,6 +46,11 @@ class TodoItemComponent < ApplicationComponent
     li(**mix(reactive_attrs, id:, data: {testid: "todo", done: @todo.done?.to_s})) do
       button(**mix(on(:toggle), data: {testid: "toggle"})) { @todo.done? ? "✓" : "○" }
       input(**mix(on(:rename, event: "change"), name: "title", value: @todo.title))
+      # archive returns Response.remove(self) — drops this row in place. (The
+      # rename_strict flash-on-blank path would need a second title input that
+      # collides with field collection above, so it's covered by the request
+      # specs rather than wired into this single-input demo row.)
+      button(**mix(on(:archive), data: {testid: "archive"})) { "archive" }
     end
   end
 end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     </script>
   </head>
   <body>
+    <div id="flash"></div> <%# Response#flash appends here (Phlex::Reactive.flash_target) %>
     <%= yield %>
   </body>
 </html>

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -17,6 +17,25 @@ import { Controller } from "@hotwired/stimulus"
 // .broadcast_* methods — so a click and a background broadcast converge on
 // one re-render unit.
 //
+// Custom turbo-stream action: the server tells the actor to full-navigate
+// (e.g. the record's slug changed and the current URL is now dead). It rides a
+// 200 turbo-stream — NOT an HTTP 3xx — so it never trips the response.redirected
+// bail below (which still correctly catches real auth/CSRF redirects). Registered
+// once on the Turbo global (no @hotwired/turbo import — the gem uses window.Turbo
+// everywhere, and a named import is unreliable under importmap/esbuild).
+function registerReactiveVisit() {
+  const actions = window.Turbo?.StreamActions
+  if (!actions || actions["reactive:visit"]) return
+  actions["reactive:visit"] = function () {
+    const url = this.getAttribute("data-url")
+    if (url) window.Turbo.visit(url, { action: "advance" })
+  }
+}
+if (typeof window !== "undefined") {
+  if (window.Turbo) registerReactiveVisit()
+  else document.addEventListener("turbo:load", registerReactiveVisit, { once: true })
+}
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -23,7 +23,7 @@ import { Controller } from "@hotwired/stimulus"
 // bail below (which still correctly catches real auth/CSRF redirects). Registered
 // once on the Turbo global (no @hotwired/turbo import — the gem uses window.Turbo
 // everywhere, and a named import is unreliable under importmap/esbuild).
-function registerReactiveVisit() {
+export function registerReactiveVisit() {
   const actions = window.Turbo?.StreamActions
   if (!actions || actions["reactive:visit"]) return
   actions["reactive:visit"] = function () {

--- a/spec/javascript/reactive_visit.test.js
+++ b/spec/javascript/reactive_visit.test.js
@@ -1,16 +1,20 @@
-// Unit test for the `reactive:visit` custom turbo-stream action registered by
-// the reactive controller module. Response.redirect(url) on the server emits a
-// <turbo-stream action="reactive:visit" data-url="…">; the client turns it into
-// Turbo.visit. We assert the handler is registered on window.Turbo.StreamActions
-// and navigates to data-url. (Separate file so the module imports fresh with
-// window.Turbo already present — module-scope registration runs once on import.)
+// Unit test for the `reactive:visit` custom turbo-stream action. Response.redirect(url)
+// on the server emits a <turbo-stream action="reactive:visit" data-url="…">; the client
+// turns it into Turbo.visit.
+//
+// We call the exported registerReactiveVisit() explicitly rather than relying on the
+// module's import-time side effect: bun runs all spec/javascript files in ONE process,
+// so the module may already be imported (and registration already attempted, possibly
+// against a window without Turbo) by the time this file's setup runs. Calling it
+// directly makes the test order-independent.
 //
 // Run with: bun test spec/javascript
-import { test, expect, mock, beforeAll } from "bun:test"
+import { test, expect, mock, beforeEach } from "bun:test"
 
+let registerReactiveVisit
 let visited
 
-beforeAll(async () => {
+beforeEach(async () => {
   mock.module("@hotwired/stimulus", () => ({ Controller: class {} }))
   visited = []
   globalThis.window = {
@@ -19,8 +23,8 @@ beforeAll(async () => {
       visit: (url, opts) => visited.push({ url, opts }),
     },
   }
-  // Importing the module runs registerReactiveVisit() against window.Turbo.
-  await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  ;({ registerReactiveVisit } = await import("../../app/javascript/phlex/reactive/reactive_controller.js"))
+  registerReactiveVisit()
 })
 
 test("registers a reactive:visit StreamAction on window.Turbo", () => {

--- a/spec/javascript/reactive_visit.test.js
+++ b/spec/javascript/reactive_visit.test.js
@@ -1,0 +1,42 @@
+// Unit test for the `reactive:visit` custom turbo-stream action registered by
+// the reactive controller module. Response.redirect(url) on the server emits a
+// <turbo-stream action="reactive:visit" data-url="…">; the client turns it into
+// Turbo.visit. We assert the handler is registered on window.Turbo.StreamActions
+// and navigates to data-url. (Separate file so the module imports fresh with
+// window.Turbo already present — module-scope registration runs once on import.)
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let visited
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({ Controller: class {} }))
+  visited = []
+  globalThis.window = {
+    Turbo: {
+      StreamActions: {},
+      visit: (url, opts) => visited.push({ url, opts }),
+    },
+  }
+  // Importing the module runs registerReactiveVisit() against window.Turbo.
+  await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+})
+
+test("registers a reactive:visit StreamAction on window.Turbo", () => {
+  expect(typeof window.Turbo.StreamActions["reactive:visit"]).toBe("function")
+})
+
+test("reactive:visit navigates to the element's data-url via Turbo.visit", () => {
+  const handler = window.Turbo.StreamActions["reactive:visit"]
+  // Stream actions run with `this` = the <turbo-stream> element.
+  handler.call({ getAttribute: (name) => (name === "data-url" ? "/todos" : null) })
+
+  expect(visited).toEqual([{ url: "/todos", opts: { action: "advance" } }])
+})
+
+test("reactive:visit with no data-url does nothing", () => {
+  const before = visited.length
+  window.Turbo.StreamActions["reactive:visit"].call({ getAttribute: () => null })
+  expect(visited.length).toBe(before)
+})

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The Response value object is unit-testable as a plain return value — no
+# controller/request boot. (to_stream_* and flash_builder render through the
+# configured renderer, so rails_helper provides the view context.)
+RSpec.describe Phlex::Reactive::Response do
+  let(:counter) { CounterComponent.new(count: 0) }
+  let(:todo) { Todo.create!(title: "t", done: false) }
+  let(:item) { TodoItemComponent.new(todo:) }
+
+  it "replace renders a self-targeted replace stream and keeps render_self" do
+    response = described_class.replace(counter)
+    expect(response.render_self?).to be(true)
+    expect(response.redirect?).to be(false)
+    expect(response.streams.size).to eq(1)
+    expect(response.streams.first).to include('action="replace"')
+    expect(response.streams.first).to include('target="counter"')
+  end
+
+  it "replace + flash composes two streams" do
+    response = described_class.replace(counter).flash(:notice, "hi")
+    expect(response.streams.size).to eq(2)
+    expect(response.streams.last).to include('action="append"')
+    expect(response.streams.last).to include('target="flash"')
+    expect(response.streams.last).to include("hi")
+  end
+
+  it "remove opts out of render_self and emits a remove stream" do
+    response = described_class.remove(item)
+    expect(response.render_self?).to be(false)
+    expect(response.streams.first).to include('action="remove"')
+    expect(response.streams.first).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+  end
+
+  it "redirect carries the url, opts out of render_self, and has no streams" do
+    response = described_class.redirect("/x")
+    expect(response.redirect?).to be(true)
+    expect(response.redirect_url).to eq("/x")
+    expect(response.render_self?).to be(false)
+    expect(response.streams).to be_empty
+  end
+
+  it "is immutable — stream/flash return new instances" do
+    base = described_class.replace(counter)
+    expect(base.stream("<turbo-stream></turbo-stream>")).not_to equal(base)
+    expect(base.streams.size).to eq(1) # original unchanged
+    expect(base).to be_frozen
+  end
+
+  it "flash accepts a Phlex component, rendered through the configured renderer" do
+    klass = Class.new(Phlex::HTML) do
+      def self.name = "FlashAlertProbe" # ActionView's render logger needs a name
+      def view_template = span { "rendered flash" }
+    end
+    response = described_class.with.flash(:error, klass.new)
+    expect(response.streams.first).to include("rendered flash")
+  end
+end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -154,6 +154,67 @@ RSpec.describe "Reactive actions", type: :request do
     end
   end
 
+  # Action response control: an action MAY return a Phlex::Reactive::Response to
+  # govern the actor's HTTP reply (flash / remove / redirect / multi-stream).
+  # Returning anything else keeps the legacy implicit single replace — proven by
+  # the back-compat specs above (increment/toggle never return a Response).
+  describe "Phlex::Reactive::Response control" do
+    let!(:todo) { Todo.create!(title: "moderate me", done: false) }
+
+    it "replace + flash: re-renders self (token refresh) AND appends a flash" do
+      post_action(CounterComponent, payload: {"s" => {"count" => 5}}, act: "reset_with_flash")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="replace"')
+      expect(response.body).to include('target="counter"') # self replace -> token refresh
+      expect(response.body).to include('action="append"')
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include("Reset")
+    end
+
+    it "replace + flash: contains exactly ONE self-target stream (no double-prepend)" do
+      post_action(CounterComponent, payload: {"s" => {"count" => 5}}, act: "reset_with_flash")
+      expect(response.body.scan('target="counter"').size).to eq(1)
+    end
+
+    it "remove: emits a remove stream for the element and NO self replace" do
+      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "archive")
+
+      dom = ActionView::RecordIdentifier.dom_id(todo)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(action="remove"))
+      expect(response.body).to include(%(target="#{dom}"))
+      expect(response.body).not_to include('action="replace"')
+    end
+
+    it "redirect: 200 turbo-stream carrying reactive:visit (NOT an HTTP 3xx)" do
+      post_action(CounterComponent, payload: {"s" => {"count" => 0}}, act: "go_home")
+
+      expect(response).to have_http_status(:ok)
+      expect(response).not_to be_redirect
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('action="reactive:visit"')
+      expect(response.body).to include('data-url="/todos"')
+    end
+
+    it "flash-on-error keeps the row's token (self replace + flash both present)" do
+      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename_strict", params: {title: ""})
+
+      dom = ActionView::RecordIdentifier.dom_id(todo)
+      expect(response.body).to include(%(target="#{dom}")) # fresh token
+      expect(response.body).to include('target="flash"')
+      expect(todo.reload.title).to eq("moderate me") # unchanged on the error path
+    end
+
+    it "valid rename_strict updates and single-replaces" do
+      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename_strict", params: {title: "renamed"})
+
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("renamed")
+      expect(response.body).not_to include('target="flash"')
+    end
+  end
+
   describe "tampering" do
     it "rejects a forged token" do
       post "/reactive/actions",

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -177,6 +177,21 @@ RSpec.describe "Reactive actions", type: :request do
       expect(response.body.scan('target="counter"').size).to eq(1)
     end
 
+    # Regression: an update(self) response refreshes the signed token. The
+    # endpoint guard keys off data-reactive-token-value (the invariant the client
+    # reads), NOT "some stream targets self" — so it must NOT prepend a second,
+    # contradictory replace when the update already carries a fresh token.
+    it "update: morphs self with a fresh token and is NOT doubled with a replace" do
+      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "bump_via_update")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="update"')
+      expect(response.body).to include('target="counter"')
+      expect(response.body).to include("data-reactive-token-value=") # token refreshed
+      expect(response.body).not_to include('action="replace"')       # no contradictory double-render
+      expect(response.body).to match(/>\s*2\s*</)                     # 1 -> 2
+    end
+
     it "remove: emits a remove stream for the element and NO self replace" do
       post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "archive")
 

--- a/spec/system/counter_spec.rb
+++ b/spec/system/counter_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe "Counter (state-backed reactive component)", type: :system do
     expect(page).to have_css("[data-testid='count']", text: "5")
   end
 
+  it "bump_via_update morphs inner HTML in place (update-style Response)" do
+    visit "/counter"
+    expect(page).to have_css("[data-testid='count']", text: "0")
+    page.execute_script("window.__noReload = 'alive'")
+
+    # bump_via_update returns Response.update(self) — an inner-HTML morph (not a
+    # replace). The count still updates in place and the token still refreshes.
+    find("[data-testid='bump-update']").click
+    expect(page).to have_css("[data-testid='count']", text: "1")
+
+    # A second click proves the token refreshed (a stale token would 400 and the
+    # count would stay at 1).
+    find("[data-testid='bump-update']").click
+    expect(page).to have_css("[data-testid='count']", text: "2")
+
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
   it "Response.redirect drives a Turbo.visit to the new URL" do
     visit "/counter"
     expect(page).to have_css("[data-testid='go-home']")

--- a/spec/system/counter_spec.rb
+++ b/spec/system/counter_spec.rb
@@ -24,8 +24,11 @@ RSpec.describe "Counter (state-backed reactive component)", type: :system do
     find("[data-testid='dec']").click
     expect(page).to have_css("[data-testid='count']", text: "2")
 
+    # reset is a Response.replace(self).flash(...) — count resets in place AND a
+    # flash is appended into #flash, all without a reload.
     find("[data-testid='reset']").click
     expect(page).to have_css("[data-testid='count']", text: "0")
+    expect(page).to have_css("#flash", text: "Reset")
 
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end

--- a/spec/system/counter_spec.rb
+++ b/spec/system/counter_spec.rb
@@ -42,4 +42,16 @@ RSpec.describe "Counter (state-backed reactive component)", type: :system do
 
     expect(page).to have_css("[data-testid='count']", text: "5")
   end
+
+  it "Response.redirect drives a Turbo.visit to the new URL" do
+    visit "/counter"
+    expect(page).to have_css("[data-testid='go-home']")
+
+    find("[data-testid='go-home']").click
+
+    # The reactive:visit custom stream action navigates the browser. Capybara
+    # waits for the new page (the todos demo) to load.
+    expect(page).to have_current_path("/todos")
+    expect(page).to have_css("[data-testid='new-todo']")
+  end
 end

--- a/spec/system/counter_spec.rb
+++ b/spec/system/counter_spec.rb
@@ -51,10 +51,22 @@ RSpec.describe "Counter (state-backed reactive component)", type: :system do
     expect(page).to have_css("[data-testid='count']", text: "0")
     page.execute_script("window.__noReload = 'alive'")
 
+    # Tag the reactive root and keep a handle to it. An update morphs the root's
+    # children, so this exact node survives; a replace would swap the root out,
+    # disconnecting this reference — that's how we distinguish update from replace.
+    page.execute_script(<<~JS)
+      const root = document.querySelector("[data-reactive-token-value]")
+      root.dataset.marker = "kept"
+      window.__reactiveRoot = root
+    JS
+
     # bump_via_update returns Response.update(self) — an inner-HTML morph (not a
     # replace). The count still updates in place and the token still refreshes.
     find("[data-testid='bump-update']").click
     expect(page).to have_css("[data-testid='count']", text: "1")
+    # The SAME root node is still connected (a replace would have swapped it).
+    expect(page.evaluate_script("window.__reactiveRoot.isConnected")).to be(true)
+    expect(page.evaluate_script("window.__reactiveRoot.dataset.marker")).to eq("kept")
 
     # A second click proves the token refreshed (a stale token would 400 and the
     # count would stay at 1).

--- a/spec/system/todos_spec.rb
+++ b/spec/system/todos_spec.rb
@@ -36,4 +36,19 @@ RSpec.describe "Todos (record-backed reactive components)", type: :system do
     expect(page).to have_field(with: "new name")
     expect(todo.reload.title).to eq("new name")
   end
+
+  it "archive removes the row in place via Response.remove" do
+    todo = Todo.create!(title: "archive me")
+    visit "/todos"
+    expect(page).to have_css("[data-testid='todo']", count: 1)
+
+    within("##{ActionView::RecordIdentifier.dom_id(todo)}") do
+      find("[data-testid='archive']").click
+    end
+
+    # Response.remove streams a <turbo-stream action="remove">, so the row leaves
+    # the DOM with no full-page reload.
+    expect(page).to have_no_css("##{ActionView::RecordIdentifier.dom_id(todo)}")
+    expect(page).to have_css("[data-testid='todo']", count: 0)
+  end
 end


### PR DESCRIPTION
## Summary

Lets a reactive action **return** a `Phlex::Reactive::Response` to govern the actor's HTTP reply — flash, remove, redirect, or multi-stream — instead of the hardcoded single re-render. Returning anything else keeps the legacy default (implicit replace), so **existing actions are 100% unaffected**.

```ruby
def rename(title:)
  return Response.replace(self).flash(:error, @todo.errors.full_messages.to_sentence) unless @todo.update(title:)
  Response.replace(self)
end

def approve  = (@row.approve!;  Response.remove(self))                          # drop the element
def publish  = (@article.publish!; Response.redirect(article_url(@article)))    # slug changed → Turbo.visit
def add(x:)  = Response.replace(self).stream(Totals.update(@order))             # multi-stream
```

Closes #13.

## What's in it

- **`Phlex::Reactive::Response`** (new) — immutable value object: `.replace`/`.update`/`.remove`/`.redirect`/`.with`, plus `#flash`/`#stream`.
- **`Streamable#to_stream_remove`** (new instance helper) backing `Response.remove`.
- **Endpoint** renders the action's `Response` (or falls back to the implicit replace); guarantees the component's own replace for token refresh on non-remove/redirect responses, without double-prepending a self stream.
- **Client**: registers a `reactive:visit` custom `Turbo.StreamActions` handler so `Response.redirect` rides a **200 turbo-stream** (not an HTTP 3xx, which the client bails on) → `Turbo.visit`. Vendored copy re-synced (drift guard).
- **Flash** content is supplied explicitly (off-request — no Rails `flash`): a string or a Phlex component, into `Phlex::Reactive.flash_target` (default `flash`).

## Design

API shape chosen via a proposal + adversarial-judge panel over three options (action-return-value, imperative buffer, result object). The immutable value object won on backward-compat safety and testability (a `Response` is a plain value you can assert on without booting the controller). The judges' fixes are folded in: instance `to_stream_remove` (no class-builder reconstruction) and the self-replace token-refresh guard.

## Test plan

- [x] **Request specs** — back-compat implicit replace unchanged; flash appended (+ no double self-stream); remove; redirect emits `reactive:visit` on a 200 (not a 3xx); flash-on-error keeps the row's token; valid path single-replaces.
- [x] **Response unit spec** — value object asserted without a request (`render_self?`, `streams`, `redirect?`, immutability, Phlex-component flash).
- [x] **JS unit tests** — `reactive:visit` registers on `window.Turbo.StreamActions` and navigates via `Turbo.visit`.
- [x] **Browser system spec** — clicking a `Response.redirect` button lands on the new URL (real Turbo.visit).

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests spec/generators` — 63 examples, 0 failures
- [x] `bundle exec rspec spec/system` — 9 examples, 0 failures
- [x] `bun test spec/javascript` — 5 pass
- [x] `bundle exec standardrb` — clean

Version bump deferred to `rake release[0.2.6]` (per maintainer's release flow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Phlex::Reactive::Response` so reactive actions can explicitly control outcomes: replace/update, flash, remove, and redirect (via `reactive:visit`), including multi-stream composition.
  * Added configurable flash rendering support and `Streamable#to_stream_remove`.
  * Added the `reactive:visit` Turbo Stream action and a `#flash` placeholder in the layout.
* **Bug Fixes**
  * The action endpoint now renders Turbo Streams based on the action return value, avoiding duplicate self-targeted refresh behavior and correctly handling remove/redirect.
* **Documentation**
  * Updated README and guides with the new response mental model and examples.
* **Tests**
  * Added/extended unit, request, and system tests covering `Response` and `reactive:visit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->