### PR TITLE
fix(client): stop field collection at nested reactive roots (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nested reactive roots no longer leak fields (issue #15).** When a reactive
+  component is rendered inside another (both are `data-controller="reactive"`
+  roots), an action on the outer root previously swept *every* descendant named
+  input — including the nested roots' inputs — into its own params. Field
+  collection now stops at nested reactive roots: an action collects only the
+  inputs whose nearest `[data-controller~="reactive"]` ancestor is its own root.
+  Outer flat fields and per-row reactive editing compose cleanly, with no
+  name-disjointness workarounds.
+
 ## [0.2.6]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -272,6 +272,13 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
 
+**Nested reactive components compose.** A reactive component rendered inside
+another is its own root — field collection stops at nested
+`data-controller="reactive"` roots, so an outer action collects only *its own*
+named inputs, never a nested component's. An invoice editor's `save` sees its
+flat fields; each line-item row's `quantity`/`price` belong to that row's own
+action. No name-disjointness workarounds required.
+
 **Combining `on(...)` / `reactive_attrs` with your own attributes.** Both return
 a hash that includes a `data:` key. Spreading them *and* passing another `data:`
 (or `class:`, `id:`) would clobber it — use Phlex's `mix` to deep-merge:

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -145,10 +145,21 @@ export default class extends Controller {
     return match?.[1]
   }
 
+  // True when `el` is collected by THIS reactive root and not by a nested one.
+  // A reactive component can be rendered inside another (both are
+  // data-controller="reactive" roots). querySelectorAll() descends into nested
+  // roots, so without this guard an outer action would sweep the inner roots'
+  // inputs into its own params (issue #15). An element belongs to this root iff
+  // its nearest [data-controller~="reactive"] ancestor is this.element.
+  #ownsField(el) {
+    return el.closest('[data-controller~="reactive"]') === this.element
+  }
+
   #collectFields() {
     const fields = {}
-    // Standard form controls.
+    // Standard form controls owned by THIS root (not a nested reactive root).
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
+      if (!this.#ownsField(field)) return
       if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -167,6 +178,7 @@ export default class extends Controller {
     this.element
       .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
       .forEach((el) => {
+        if (!this.#ownsField(el)) return // skip editors owned by a nested reactive root (issue #15)
         // A plain element (e.g. a <div contenteditable>) has no `name` IDL
         // property — only the attribute — so read getAttribute, not el.name.
         const name = el.getAttribute("name")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,38 @@ from `on(:save, extra: ...)` always win over a collected field of the same name.
 > the standard controls left absent or empty, so it never clobbers a populated
 > input.
 
+#### Nested reactive roots collect independently
+
+A reactive component can be rendered **inside** another — each `**reactive_attrs`
+root is its own `data-controller="reactive"` element. Field collection stops at
+nested roots: an action collects only the named inputs whose nearest
+`[data-controller~="reactive"]` ancestor is *its own* root. A descendant
+reactive component's inputs belong to that component, not the outer one.
+
+```ruby
+# Outer editor (its own root) containing N reactive line-item rows (each a root).
+class InvoiceEditor < ApplicationComponent
+  # ... reactive_record :invoice; action :save, params: { notes: :string }
+  def view_template
+    div(id:, **reactive_attrs) do
+      input(name: "notes", value: @invoice.notes)         # collected by `save`
+      @invoice.items.each { render LineItem.new(item: it) } # each row is its own root
+      button(**on(:save)) { "Save" }
+    end
+  end
+end
+```
+
+A `save` on the editor receives `{ notes: }` only — never the rows' bare
+`quantity`/`price` inputs. A `quantity` change inside a row dispatches on *that
+row's* controller and updates only that row. So outer flat fields and per-row
+reactive editing compose without name-collision workarounds (issue #15).
+
+> Remember `mix` when a nested root needs its own `id`/`data`:
+> `div(**mix(reactive_attrs, id:, data: { testid: "row" }))`. A bare
+> `div(id:, **reactive_attrs, data: {...})` lets the extra `data:` clobber
+> `reactive_attrs`' `data-controller`, so the element never becomes a root.
+
 ## Why state isn't in the browser
 
 Livewire ships a *snapshot* of component state to the client and trusts it back

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,8 +104,8 @@ class InvoiceEditor < ApplicationComponent
   # ... reactive_record :invoice; action :save, params: { notes: :string }
   def view_template
     div(id:, **reactive_attrs) do
-      input(name: "notes", value: @invoice.notes)         # collected by `save`
-      @invoice.items.each { render LineItem.new(item: it) } # each row is its own root
+      input(name: "notes", value: @invoice.notes)              # collected by `save`
+      @invoice.items.each { |item| render LineItem.new(item:) } # each row is its own root
       button(**on(:save)) { "Save" }
     end
   end

--- a/spec/dummy/app/components/nested_editor_component.rb
+++ b/spec/dummy/app/components/nested_editor_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Outer reactive editor that CONTAINS nested reactive rows (issue #15). Its own
+# `notes` input is a sibling of the nested rows' `quantity` inputs in the DOM.
+# When `save` fires on the editor, field collection must stop at the nested
+# reactive roots: the editor must receive ONLY `notes`, never the rows' bare
+# `quantity`. To prove exactly which params arrived, `save` only accepts the
+# declared scalar `notes` and reflects whether it leaked by recording the keys
+# it actually got into a visible "saved" marker.
+class NestedEditorComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :notes, :saved
+  action :save, params: {notes: :string}
+
+  def initialize(notes: "", saved: nil)
+    @notes = notes
+    @saved = saved
+  end
+
+  def id = "editor"
+
+  def save(notes:)
+    @notes = notes
+    @saved = "saved:#{notes}"
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      input(name: "notes", value: @notes, data: {testid: "editor-notes"})
+      button(**mix(on(:save), data: {testid: "editor-save"})) { "Save editor" }
+      span(data: {testid: "editor-saved"}) { @saved.to_s }
+
+      # Two nested reactive roots, each owning a bare `quantity` input. Pre-fix,
+      # the editor's save swept BOTH rows' quantity (last one wins) into its own
+      # params and raised ArgumentError (unknown keyword :quantity) or silently
+      # collided. Post-fix they're invisible to the editor's save.
+      render NestedRowComponent.new(label: "a", quantity: "11")
+      render NestedRowComponent.new(label: "b", quantity: "22")
+    end
+  end
+end

--- a/spec/dummy/app/components/nested_row_component.rb
+++ b/spec/dummy/app/components/nested_row_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# A nested reactive root rendered INSIDE NestedEditorComponent (issue #15). It
+# owns a bare-named `quantity` input — the same name shape the cosmos line-item
+# rows used. An action on the OUTER editor must NOT collect this field.
+class NestedRowComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :label, :quantity
+  action :update, params: {quantity: :string}
+
+  def initialize(label:, quantity: "1")
+    @label = label
+    @quantity = quantity
+  end
+
+  def id = "row-#{@label}"
+
+  def update(quantity:)
+    @quantity = quantity
+  end
+
+  def view_template
+    div(**mix(reactive_attrs, id:, data: {testid: "row"})) do
+      input(**mix(on(:update, event: "change"), name: "quantity", value: @quantity, data: {testid: "row-qty-#{@label}"}))
+      span(data: {testid: "row-echo-#{@label}"}) { @quantity }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -27,6 +27,10 @@ class DemosController < ActionController::Base
     render_component FormSubmitComponent.new(todo: Todo.find(params[:id]))
   end
 
+  def nested_editor
+    render_component NestedEditorComponent.new
+  end
+
   # The page a non-intercepted form submit would navigate to (issue #11).
   def nav_probe
     render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "todos" => "demos#todos"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
+  get "nested_editor" => "demos#nested_editor"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
   match "nav_probe" => "demos#nav_probe", :via => [:get, :post]

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -145,10 +145,21 @@ export default class extends Controller {
     return match?.[1]
   }
 
+  // True when `el` is collected by THIS reactive root and not by a nested one.
+  // A reactive component can be rendered inside another (both are
+  // data-controller="reactive" roots). querySelectorAll() descends into nested
+  // roots, so without this guard an outer action would sweep the inner roots'
+  // inputs into its own params (issue #15). An element belongs to this root iff
+  // its nearest [data-controller~="reactive"] ancestor is this.element.
+  #ownsField(el) {
+    return el.closest('[data-controller~="reactive"]') === this.element
+  }
+
   #collectFields() {
     const fields = {}
-    // Standard form controls.
+    // Standard form controls owned by THIS root (not a nested reactive root).
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
+      if (!this.#ownsField(field)) return
       if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -167,6 +178,7 @@ export default class extends Controller {
     this.element
       .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
       .forEach((el) => {
+        if (!this.#ownsField(el)) return // skip editors owned by a nested reactive root (issue #15)
         // A plain element (e.g. a <div contenteditable>) has no `name` IDL
         // property — only the attribute — so read getAttribute, not el.name.
         const name = el.getAttribute("name")

--- a/spec/javascript/reactive_collect_fields.test.js
+++ b/spec/javascript/reactive_collect_fields.test.js
@@ -1,0 +1,177 @@
+// Unit test for #collectFields() field scoping across NESTED reactive roots.
+//
+// Issue #15: when one reactive component is rendered inside another (both are
+// data-controller="reactive" roots), an action dispatched on the OUTER root must
+// collect only the OUTER root's own named inputs — NOT the inner roots' inputs.
+// Before the fix, this.element.querySelectorAll(...) descended into nested
+// reactive roots and swept their inputs into the outer action's params (last
+// row wins, collides with the editor's own fields).
+//
+// #collectFields() is private, so we observe it through the POST body: stub
+// fetch to capture the request, dispatch on the outer root, and assert the
+// collected params contain only the outer root's fields.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A minimal DOM node faithful enough for #collectFields():
+//   - matches(selector) for the reactive-root predicate
+//   - closest(selector) walks parents (used to find the owning reactive root)
+//   - querySelectorAll(selector) returns descendant named fields
+// We only support the specific selectors #collectFields() actually issues.
+class FakeNode {
+  constructor({ tag = "div", name = null, type = null, value = "", checked = false, controller = null } = {}) {
+    this.tag = tag.toLowerCase()
+    this.name = name
+    this.type = type
+    this.value = value
+    this.checked = checked
+    this.parentNode = null
+    this.children = []
+    this.dataset = {}
+    if (controller) this.dataset.controller = controller
+  }
+
+  append(...nodes) {
+    for (const n of nodes) {
+      n.parentNode = this
+      this.children.push(n)
+    }
+    return this
+  }
+
+  #descendants() {
+    const out = []
+    for (const child of this.children) {
+      out.push(child, ...child.#descendants())
+    }
+    return out
+  }
+
+  getAttribute(attr) {
+    if (attr === "name") return this.name
+    return null
+  }
+
+  setAttribute() {}
+  removeAttribute() {}
+
+  // Only the two predicates #collectFields() uses.
+  matches(selector) {
+    if (selector === '[data-controller~="reactive"]') {
+      const c = this.dataset.controller
+      return !!c && c.split(/\s+/).includes("reactive")
+    }
+    if (selector.includes("input[name]")) {
+      return ["input", "select", "textarea"].includes(this.tag) && this.name != null
+    }
+    if (selector.includes("lexxy-editor")) {
+      return false // no rich editors in this fixture
+    }
+    return false
+  }
+
+  closest(selector) {
+    let node = this
+    while (node) {
+      if (node.matches(selector)) return node
+      node = node.parentNode
+    }
+    return null
+  }
+
+  querySelectorAll(selector) {
+    return this.#descendants().filter((n) => n.matches(selector))
+  }
+}
+
+function buildController(rootEl) {
+  const controller = new ReactiveController()
+  controller.element = rootEl
+  controller.tokenValue = "tok"
+  return controller
+}
+
+test("outer root action collects only its own fields, not nested reactive roots' (issue #15)", async () => {
+  // Outer reactive editor: a flat field `notes`, containing a nested reactive
+  // row with bare `quantity`/`price` inputs (the cosmos line-item shape).
+  const outer = new FakeNode({ tag: "div", controller: "reactive" })
+  const outerNotes = new FakeNode({ tag: "input", name: "notes", value: "editor notes" })
+
+  const innerRow = new FakeNode({ tag: "div", controller: "reactive" })
+  const rowQty = new FakeNode({ tag: "input", name: "quantity", value: "3" })
+  const rowPrice = new FakeNode({ tag: "input", name: "price", value: "9.99" })
+  innerRow.append(rowQty, rowPrice)
+
+  outer.append(outerNotes, innerRow)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = JSON.parse(opts.body)
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+
+  const controller = buildController(outer)
+  await controller.dispatch({
+    params: { action: "save", params: "{}" },
+    preventDefault: () => {},
+  })
+
+  // The outer save sees ONLY its own field. The nested row's quantity/price are
+  // owned by the inner reactive root, so they must not bleed into the editor's
+  // params.
+  expect(captured.params).toEqual({ notes: "editor notes" })
+  expect(captured.params).not.toHaveProperty("quantity")
+  expect(captured.params).not.toHaveProperty("price")
+})
+
+test("an action on the nested row still collects that row's own fields", async () => {
+  const outer = new FakeNode({ tag: "div", controller: "reactive" })
+  const outerNotes = new FakeNode({ tag: "input", name: "notes", value: "editor notes" })
+
+  const innerRow = new FakeNode({ tag: "div", controller: "reactive" })
+  const rowQty = new FakeNode({ tag: "input", name: "quantity", value: "3" })
+  innerRow.append(rowQty)
+  outer.append(outerNotes, innerRow)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = JSON.parse(opts.body)
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+
+  // Dispatch on the INNER row's controller — it owns rowQty, not outerNotes.
+  const controller = buildController(innerRow)
+  await controller.dispatch({
+    params: { action: "update", params: "{}" },
+    preventDefault: () => {},
+  })
+
+  expect(captured.params).toEqual({ quantity: "3" })
+  expect(captured.params).not.toHaveProperty("notes")
+})

--- a/spec/system/nested_roots_spec.rb
+++ b/spec/system/nested_roots_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #15: a reactive component rendered INSIDE another reactive component is
+# its own root. An action on the OUTER editor must collect only the editor's own
+# named inputs — NOT the nested rows' inputs. Pre-fix, the editor's save swept
+# every descendant input (including each row's bare `quantity`), so the editor
+# received row fields it never declared.
+RSpec.describe "Nested reactive roots (issue #15)", type: :system do
+  it "the outer editor's save collects only its own fields, not nested rows'" do
+    visit "/nested_editor"
+
+    # Marker proves no full-page navigation happened.
+    page.execute_script("window.__noReload = 'alive'")
+
+    find("[data-testid='editor-notes']").set("editor only")
+    find("[data-testid='editor-save']").click
+
+    # The save ran (no 403 from an undeclared `quantity`, no collision) and
+    # recorded ONLY the editor's own notes — the nested rows never bled in.
+    expect(page).to have_css("[data-testid='editor-saved']", text: "saved:editor only")
+
+    # The nested rows are untouched by the editor's save.
+    expect(page).to have_css("[data-testid='row-echo-a']", text: "11")
+    expect(page).to have_css("[data-testid='row-echo-b']", text: "22")
+
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "an action on a nested row still collects that row's own fields" do
+    visit "/nested_editor"
+    page.execute_script("window.__noReload = 'alive'")
+
+    field = find("[data-testid='row-qty-a']")
+    field.set("99")
+    # Set the value AND fire change explicitly so the row's own update dispatches
+    # (Capybara's blur alone proved flaky under Playwright here).
+    field.native.evaluate("el => { el.value = '99'; el.dispatchEvent(new Event('change', { bubbles: true })) }")
+
+    # Row A updated to its own field's value; Row B is unaffected; the editor is
+    # unaffected.
+    expect(page).to have_css("[data-testid='row-echo-a']", text: "99")
+    expect(page).to have_css("[data-testid='row-echo-b']", text: "22")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

When one reactive component is rendered **inside** another (both have `reactive_attrs`, so both are `data-controller="reactive"` roots), an action dispatched on the **outer** root collected the **inner** roots' named inputs too. `#collectFields()` queried `this.element.querySelectorAll("input[name], …")`, and because `this.element` is the outer root the query descended into nested reactive roots and swept their inputs into the outer action's params — sibling rows collided (last one wins) and bled into the outer component's own fields. The only workaround was keeping every nested field name disjoint from the outer schema.

## The fix

`#collectFields()` now keeps a field only when its nearest `[data-controller~="reactive"]` ancestor **is** `this.element`. Inputs owned by a nested reactive root are skipped. The same `#ownsField` guard is applied to the rich-text / `[contenteditable]` collection pass. Nested reactive components now compose cleanly: each action collects only its own root's fields.

This is a client-only change — existing single-root components are unaffected.

## Test plan

| Layer | What it proves |
|-------|----------------|
| `spec/javascript/reactive_collect_fields.test.js` | RED→GREEN bun unit test: an outer action collects only its own field; a nested row collects only its own. Faithful DOM stub with `closest()`/`querySelectorAll`. |
| `spec/system/nested_roots_spec.rb` | Browser proof: an editor with two nested reactive rows — the editor's `save` records only its `notes` (no 403 from an undeclared nested `quantity`), and each row updates independently with no full reload. |

New dummy fixtures: `NestedEditorComponent`, `NestedRowComponent`, and the `/nested_editor` route.

## Verification

- `bundle exec standardrb` — clean
- `bun test spec/javascript` — 7/7
- `bundle exec rspec` (incl. all system specs) — **77 examples, 0 failures**
- Vendored client controller re-synced (drift guard green)

## Docs

- `docs/architecture.md` — new "Nested reactive roots collect independently" section (with the `mix(reactive_attrs, …)` reminder).
- `README.md` — nested-components note under the Component API.
- `CHANGELOG.md` — `Unreleased → Fixed`.

Closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field collection in nested reactive components so actions only receive inputs from their own reactive root.
  * Prevented nested rich-text/custom editor values from being mixed into outer component requests.
* **New Features**
  * Added safe composition for reactive components rendered inside other reactive components.
  * Included a new nested-editor demo page showcasing outer vs. inner action scoping.
* **Documentation**
  * Updated the changelog, README, and architecture docs with nested root behavior and guidance.
* **Tests**
  * Added JavaScript unit coverage and a system spec for nested reactive root scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->