### PR TITLE
feat(controller): nested & array param coercion (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Nested & array param types (issue #16).** Action param schemas can now
+  declare arrays and nested hashes, not just scalars: wrap a type in an array
+  (`bank_account_ids: [:integer]`) for an array param, or wrap a hash schema in
+  an array (`invoice_items_attributes: [{ id: :integer, quantity: :float,
+  _destroy: :boolean }]`) for Rails-style nested attributes. Coercion recurses
+  per field, drops undeclared nested keys (no mass assignment), and accepts an
+  array as either a JSON array or a Rails index hash (`{ "0" => …, "1" => … }`).
+  A reactive form can now mirror a normal nested-attributes update in one action
+  instead of being forced into a per-row component architecture.
+
 ## [0.2.6]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   _destroy: :boolean }]`) for Rails-style nested attributes. Coercion recurses
   per field, drops undeclared nested keys (no mass assignment), and accepts an
   array as either a JSON array or a Rails index hash (`{ "0" => …, "1" => … }`).
+  A malformed (present-but-non-array) value for an array param is dropped — not
+  coerced to `[]` — so a bad payload can't read as an explicit "clear all" on an
+  `update!(declared_array:)`; a real empty array still passes through as `[]`.
   A reactive form can now mirror a normal nested-attributes update in one action
   instead of being forced into a per-row component architecture.
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,27 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
 
+**Array & nested params.** Wrap a type in an array for an array param, or a hash
+schema in an array for Rails-style nested attributes — so one reactive action can
+mirror a normal nested-attributes update instead of forcing a per-row component:
+
+```ruby
+action :save, params: {
+  date: :string,
+  bank_account_ids: [:integer],                         # array of scalar
+  invoice_items_attributes: [                            # array of hash
+    { id: :integer, quantity: :float, price: :float, _destroy: :boolean }
+  ]
+}
+
+def save(date:, bank_account_ids:, invoice_items_attributes:)
+  @invoice.update!(date:, bank_account_ids:, invoice_items_attributes:)
+end
+```
+
+Nested coercion recurses per field, drops undeclared nested keys, and accepts an
+array as either a JSON array or a Rails index hash (`{ "0" => …, "1" => … }`).
+
 **Combining `on(...)` / `reactive_attrs` with your own attributes.** Both return
 a hash that includes a `data:` key. Spreading them *and* passing another `data:`
 (or `class:`, `id:`) would clobber it — use Phlex's `mix` to deep-merge:

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -131,6 +131,12 @@ module Phlex
         coerce_hash(params.fetch(:params, {}), schema)
       end
 
+      # Sentinel: a declared key whose value can't be coerced to its type is
+      # DROPPED (not assigned), so the method's keyword default applies — exactly
+      # as if the client had omitted the key. Distinct from a coerced nil/[].
+      DROP = Object.new
+      private_constant :DROP
+
       # Coerce a value against a declared type. A type is one of:
       #   * a scalar symbol            (:string/:integer/:float/:boolean)
       #   * a Hash schema              ({ id: :integer, ... })   — nested object
@@ -147,18 +153,29 @@ module Phlex
         end
       end
 
+      # A real array (or Rails index hash) coerces element-wise. A malformed
+      # present-but-non-array value returns DROP rather than [] — coercing a stray
+      # scalar to an empty array would let a bad payload read as an explicit
+      # "clear everything" on update!(declared_array:).
       def coerce_array(value, element_type)
-        array_values(value).map { |element| coerce(element, element_type) }
+        values = array_values(value)
+        return DROP if values.nil?
+
+        values.map { |element| coerce(element, element_type) }
       end
 
       # Keep declared keys only (drop undeclared — no mass assignment), recursing
       # for nested hash/array element types. Symbolizes keys to splat as kwargs.
+      # A key whose value coerces to DROP is skipped (keyword default applies).
       def coerce_hash(value, schema)
         hash = to_param_hash(value)
         schema.each_with_object({}) do |(key, type), out|
           next unless hash.key?(key.to_s)
 
-          out[key.to_sym] = coerce(hash[key.to_s], type)
+          coerced = coerce(hash[key.to_s], type)
+          next if coerced.equal?(DROP)
+
+          out[key.to_sym] = coerced
         end
       end
 
@@ -173,14 +190,13 @@ module Phlex
 
       # Normalize an array param: a real array passes through; a Rails index hash
       # ({ "0" => ..., "1" => ... }) becomes its values in index order. Anything
-      # else (a stray scalar) yields an empty array rather than raising.
+      # else (a stray scalar, nil) is malformed → nil, so the caller drops the
+      # param rather than fabricating an empty array.
       def array_values(value)
         return value.to_a if value.is_a?(Array)
 
         if value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
           to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
-        else
-          []
         end
       end
 

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -123,24 +123,74 @@ module Phlex
 
       # Coerce client params against the action's declared schema. Anything not
       # in the schema is dropped — no raw mass assignment reaches the component.
+      # The top-level params arrive as an ActionController::Parameters; coerce
+      # them against the action's hash schema (same recursion as nested hashes).
       def coerce_params(schema)
         return {} if schema.blank?
 
-        raw = params.fetch(:params, {})
-        schema.each_with_object({}) do |(key, type), out|
-          next unless raw.key?(key.to_s)
+        coerce_hash(params.fetch(:params, {}), schema)
+      end
 
-          out[key.to_sym] = coerce(raw[key.to_s], type)
+      # Coerce a value against a declared type. A type is one of:
+      #   * a scalar symbol            (:string/:integer/:float/:boolean)
+      #   * a Hash schema              ({ id: :integer, ... })   — nested object
+      #   * a one-element Array        ([:integer] / [{ ... }])  — array of that
+      # Arrays accept both a real JSON array and a Rails-style index hash
+      # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
+      def coerce(value, type)
+        if type.is_a?(Array)
+          coerce_array(value, type.first)
+        elsif type.is_a?(Hash)
+          coerce_hash(value, type)
+        else
+          coerce_scalar(value, type)
         end
       end
 
-      def coerce(value, type)
+      def coerce_array(value, element_type)
+        array_values(value).map { |element| coerce(element, element_type) }
+      end
+
+      # Keep declared keys only (drop undeclared — no mass assignment), recursing
+      # for nested hash/array element types. Symbolizes keys to splat as kwargs.
+      def coerce_hash(value, schema)
+        hash = to_param_hash(value)
+        schema.each_with_object({}) do |(key, type), out|
+          next unless hash.key?(key.to_s)
+
+          out[key.to_sym] = coerce(hash[key.to_s], type)
+        end
+      end
+
+      def coerce_scalar(value, type)
         case type
         when :integer then value.to_i
         when :float then value.to_f
         when :boolean then ActiveModel::Type::Boolean.new.cast(value)
         else value.to_s
         end
+      end
+
+      # Normalize an array param: a real array passes through; a Rails index hash
+      # ({ "0" => ..., "1" => ... }) becomes its values in index order. Anything
+      # else (a stray scalar) yields an empty array rather than raising.
+      def array_values(value)
+        return value.to_a if value.is_a?(Array)
+
+        if value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
+          to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
+        else
+          []
+        end
+      end
+
+      # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed
+      # Hash so coercion can index it uniformly.
+      def to_param_hash(value)
+        return value.to_unsafe_h.stringify_keys if value.respond_to?(:to_unsafe_h)
+        return value.stringify_keys if value.is_a?(Hash)
+
+        {}
       end
 
       # Only components that opt into Reactive may be resolved. The signature

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -87,7 +87,21 @@ module Phlex
         # Declare a client-invokable action with an optional param schema.
         #   action :increment
         #   action :rename, params: { title: :string }
-        # Param types: :string (default), :integer, :float, :boolean.
+        #
+        # Param types are coerced server-side; anything not in the schema is
+        # dropped before reaching your method (no mass assignment):
+        #   * Scalars — :string (default), :integer, :float, :boolean
+        #   * Array of scalar — wrap the type in an array: [:integer]
+        #   * Array of hash (Rails nested attributes) — wrap a hash schema:
+        #       action :save, params: {
+        #         date: :string,
+        #         bank_account_ids: [:integer],
+        #         invoice_items_attributes: [
+        #           { id: :integer, quantity: :float, price: :float, _destroy: :boolean }
+        #         ]
+        #       }
+        # Array params accept BOTH a JSON array and a Rails-style index hash
+        # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
         def action(name, params: {})
           reactive_actions[name.to_sym] = Action.new(name: name.to_sym, params: params)
         end

--- a/spec/dummy/app/components/nested_params_component.rb
+++ b/spec/dummy/app/components/nested_params_component.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Exercises nested/array param coercion (issue #16). The `save` action declares
+# an array-of-scalar param and an array-of-hash (Rails nested-attributes shape)
+# plus a flat scalar, then reflects the COERCED result as JSON so request specs
+# can assert exact types (integers stay integers, floats floats, booleans
+# booleans) and that undeclared nested keys are dropped.
+class NestedParamsComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :received
+
+  action :save, params: {
+    date: :string,
+    bank_account_ids: [:integer],
+    invoice_items_attributes: [{id: :integer, quantity: :float, price: :float, _destroy: :boolean}]
+  }
+
+  def initialize(received: nil)
+    @received = received
+  end
+
+  def id = "nested-params"
+
+  def save(date: nil, bank_account_ids: nil, invoice_items_attributes: nil)
+    @received = {
+      date:,
+      bank_account_ids:,
+      invoice_items_attributes:
+    }
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      # Reflect the exact coerced structure (types intact) for assertions.
+      pre(data: {testid: "received"}) { @received.to_json }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -27,6 +27,10 @@ class DemosController < ActionController::Base
     render_component FormSubmitComponent.new(todo: Todo.find(params[:id]))
   end
 
+  def nested_params
+    render_component NestedParamsComponent.new
+  end
+
   # The page a non-intercepted form submit would navigate to (issue #11).
   def nav_probe
     render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "todos" => "demos#todos"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
+  get "nested_params" => "demos#nested_params"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
   match "nav_probe" => "demos#nav_probe", :via => [:get, :post]

--- a/spec/requests/nested_params_spec.rb
+++ b/spec/requests/nested_params_spec.rb
@@ -95,6 +95,26 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
     expect(received(response)["bank_account_ids"]).to eq([])
   end
 
+  it "drops a malformed (non-array) array param instead of coercing it to []" do
+    # A scalar sent for an array param must NOT become [] — otherwise an action
+    # doing update!(bank_account_ids:) would read it as an explicit "clear all".
+    # Drop it so the method's keyword default (nil) applies, distinct from a real
+    # empty array.
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {bank_account_ids: "5"})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["bank_account_ids"]).to be_nil
+  end
+
+  it "drops a malformed (non-array) array-of-hash param" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {invoice_items_attributes: "not-an-array"})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["invoice_items_attributes"]).to be_nil
+  end
+
   it "still coerces flat scalars alongside nested params" do
     post_action(NestedParamsComponent, payload:, act: "save",
       params: {date: "2026-06-27", bank_account_ids: ["7"]})

--- a/spec/requests/nested_params_spec.rb
+++ b/spec/requests/nested_params_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #16: action param schemas can declare ARRAY and NESTED-HASH types, not
+# just scalars, so a reactive action can receive Rails-style nested attributes
+# (invoice[invoice_items_attributes][i][...]) or array params (ids[]) in one call.
+RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
+  def token_for(klass, payload)
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  def post_action(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  # Pull the reflected coerced params back out of the rendered <pre>. Phlex
+  # auto-escapes the JSON text, so unescape before parsing.
+  def received(response)
+    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    JSON.parse(CGI.unescapeHTML(json))
+  end
+
+  let(:payload) { {"s" => {"received" => nil}} }
+
+  it "coerces an array-of-scalar param ([:integer])" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {bank_account_ids: ["1", "2", "3"]})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["bank_account_ids"]).to eq([1, 2, 3])
+  end
+
+  it "coerces an array-of-hash param with per-field types (nested attributes)" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {
+        invoice_items_attributes: [
+          {id: "10", quantity: "2.5", price: "9.99", _destroy: "false"},
+          {id: "11", quantity: "1", price: "100", _destroy: "true"}
+        ]
+      })
+
+    expect(response).to have_http_status(:ok)
+    items = received(response)["invoice_items_attributes"]
+    expect(items).to eq([
+      {"id" => 10, "quantity" => 2.5, "price" => 9.99, "_destroy" => false},
+      {"id" => 11, "quantity" => 1.0, "price" => 100.0, "_destroy" => true}
+    ])
+  end
+
+  it "drops nested keys not declared in the inner schema (no mass assignment)" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {
+        invoice_items_attributes: [
+          {id: "10", quantity: "2", price: "5", _destroy: "false", admin: "true", secret: "x"}
+        ]
+      })
+
+    item = received(response)["invoice_items_attributes"].first
+    expect(item.keys).to contain_exactly("id", "quantity", "price", "_destroy")
+    expect(item).not_to have_key("admin")
+    expect(item).not_to have_key("secret")
+  end
+
+  it "accepts a Rails-style index hash for an array param ({\"0\"=>..., \"1\"=>...})" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {
+        invoice_items_attributes: {
+          "0" => {id: "10", quantity: "2", price: "5", _destroy: "false"},
+          "1" => {id: "11", quantity: "3", price: "6", _destroy: "false"}
+        }
+      })
+
+    items = received(response)["invoice_items_attributes"]
+    expect(items.map { |i| i["id"] }).to eq([10, 11])
+    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
+  end
+
+  it "leaves a declared array param absent when the client omits it" do
+    post_action(NestedParamsComponent, payload:, act: "save", params: {date: "2026-06-27"})
+
+    parsed = received(response)
+    expect(parsed["date"]).to eq("2026-06-27")
+    # Omitted keys never reach the method → its keyword default (nil) applies.
+    expect(parsed["bank_account_ids"]).to be_nil
+    expect(parsed["invoice_items_attributes"]).to be_nil
+  end
+
+  it "coerces an empty array to an empty array (not dropped)" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {bank_account_ids: []})
+
+    expect(received(response)["bank_account_ids"]).to eq([])
+  end
+
+  it "still coerces flat scalars alongside nested params" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {date: "2026-06-27", bank_account_ids: ["7"]})
+
+    parsed = received(response)
+    expect(parsed["date"]).to eq("2026-06-27")
+    expect(parsed["bank_account_ids"]).to eq([7])
+  end
+end

--- a/spec/system/nested_params_spec.rb
+++ b/spec/system/nested_params_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #16: a reactive action whose schema declares nested/array params is
+# invoked end-to-end through the real client. Explicit params passed to
+# on(:save, ...) are JSON-serialized, posted, coerced server-side (recursing for
+# the array-of-hash), and the component re-renders with the coerced structure.
+RSpec.describe "Nested/array params end-to-end (issue #16)", type: :system do
+  it "round-trips nested attributes through the reactive action" do
+    visit "/nested_params"
+    page.execute_script("window.__noReload = 'alive'")
+
+    # Drive the action with explicit nested params (the `on(...)` extra-params
+    # path), exercising the real wire format + recursive coercion in the browser.
+    page.execute_script(<<~JS)
+      const root = document.getElementById("nested-params")
+      const ctrl = window.Stimulus.getControllerForElementAndIdentifier(root, "reactive")
+      ctrl.dispatch({
+        params: {
+          action: "save",
+          params: JSON.stringify({
+            date: "2026-06-27",
+            bank_account_ids: ["1", "2"],
+            invoice_items_attributes: [{ id: "10", quantity: "2.5", price: "9.99", _destroy: "false" }]
+          })
+        },
+        preventDefault() {}
+      })
+    JS
+
+    # The re-rendered <pre> reflects the COERCED structure (integers/floats/bools).
+    expect(page).to have_css("[data-testid='received']", text: '"bank_account_ids":[1,2]')
+    expect(page).to have_css("[data-testid='received']", text: '"quantity":2.5')
+    expect(page).to have_css("[data-testid='received']", text: '"_destroy":false')
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

`coerce_params` only handled scalar types (`:string` / `:integer` / `:float` / `:boolean`), so a reactive action couldn't accept Rails-style nested attributes (`invoice[invoice_items_attributes][i][...]`) or array params (`ids[]`). As the issue notes, that forced reactive invoice editing into a per-row component architecture rather than letting it be a choice.

## The API

A declared type is now one of:

- a **scalar** symbol — `:string` (default), `:integer`, `:float`, `:boolean`
- a **nested hash** schema — `{ id: :integer, … }`
- a **one-element array** wrapping either — `[:integer]` (array of scalar) or `[{ … }]` (array of hash)

```ruby
action :save, params: {
  date: :string,
  bank_account_ids: [:integer],
  invoice_items_attributes: [
    { id: :integer, quantity: :float, price: :float, _destroy: :boolean }
  ]
}

def save(date:, bank_account_ids:, invoice_items_attributes:)
  @invoice.update!(date:, bank_account_ids:, invoice_items_attributes:)
end
```

Coercion recurses: `coerce_hash` keeps only declared keys (no mass assignment), `coerce_array` maps the element type over the values. Array params accept **both** a real JSON array and a Rails-style index hash (`{ "0" => …, "1" => … }`), so a `fields_for` collection works either way. Scalar coercion is unchanged (the existing path was refactored into `coerce_scalar` and stayed green).

## Test plan

| Layer | What it proves |
|-------|----------------|
| `spec/requests/nested_params_spec.rb` | array-of-scalar, array-of-hash with per-field types, dropped undeclared nested keys, Rails index-hash input, omitted key stays absent, empty array preserved, flat scalars alongside nested |
| `spec/system/nested_params_spec.rb` | end-to-end browser round trip: explicit nested params posted, coerced server-side, component re-renders with the typed structure, no full reload |

New dummy `NestedParamsComponent` + `/nested_params` route (reflects the coerced structure as JSON for exact-type assertions).

## Verification

- `bundle exec standardrb` — clean
- `bundle exec rspec` — **83 examples, 0 failures**
- Existing scalar coercion unaffected

## Docs

- `lib/phlex/reactive/component.rb` — `action` DSL doc now covers array/nested types.
- `README.md` — "Array & nested params" section under the Component API.
- `CHANGELOG.md` — `Unreleased → Added`.

Closes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced reactive action parameter coercion for scalar arrays and nested hash/array (Rails-style nested attributes) schemas, coercing values per the declared types.
  * Array-shaped inputs are accepted as either JSON arrays or Rails index-hash arrays, with undeclared nested keys dropped.
* **Bug Fixes**
  * Malformed array payloads (and present-but-non-array values) are ignored to prevent unintended “clear all” behavior, while valid empty arrays still pass through.
* **Documentation**
  * Expanded API reference and changelog with schema examples and supported input shapes.
* **Tests**
  * Added request and end-to-end coverage for coercion correctness and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->