### PR TITLE
feat(client): debounce option on on(:action) for live-as-you-type (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Debounce option on `on(...)` (issue #17).** A trigger can declare
+  `on(:update, event: "input", debounce: 300)` (milliseconds) to coalesce rapid
+  events — typically keystrokes — into a SINGLE action round trip fired after the
+  quiet period, instead of one POST per keystroke. A `blur` flushes a pending
+  dispatch so the last edit is never dropped, `preventDefault` still fires
+  synchronously (a debounced `submit` won't navigate), and the debounced round
+  trip still goes through the per-component queue so token threading holds.
+  Omitting `debounce:` keeps the immediate-dispatch default.
+
 ## [0.2.6]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -268,9 +268,21 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `action :name, params: { x: :integer }` | Declare a client-invokable action + its param schema. **Default-deny.** |
 | `reactive_attrs` | Spread onto the root element: marks it reactive + carries the signed token. |
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
+| `on(:action, event: "input", debounce: 300)` | Coalesce rapid events into one round trip after a quiet period (live-as-you-type). |
 
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
+
+**Debounced triggers (live-as-you-type).** Pass `debounce:` (milliseconds) to
+coalesce rapid events — typically keystrokes on an `"input"` trigger — into a
+single action round trip fired after the quiet period, instead of one POST per
+keystroke. A blur flushes a pending dispatch so the last edit is never dropped.
+Omit `debounce:` for the immediate-dispatch default.
+
+```ruby
+# Recompute a total live as the user types, without hammering the endpoint.
+input(**mix(on(:update, event: "input", debounce: 300), name: "quantity", value: @item.quantity))
+```
 
 **Combining `on(...)` / `reactive_attrs` with your own attributes.** Both return
 a hash that includes a `data:` key. Spreading them *and* passing another `data:`

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -47,6 +47,14 @@ export default class extends Controller {
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
 
+  // Tear down any pending debounce timers when the controller leaves the DOM
+  // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't
+  // fired yet would later call #enqueue on a disconnected controller — a round
+  // trip against a detached element / stale token (issue #17 follow-up).
+  disconnect() {
+    this.#clearAllDebounces()
+  }
+
   // Serialize requests per component. Each round trip rewrites the signed
   // token in the DOM (state lives in the token, not the client). If events
   // fire faster than round trips complete, concurrent requests would all read
@@ -104,6 +112,13 @@ export default class extends Controller {
     clearTimeout(pending.timer)
     target?.removeEventListener?.("blur", pending.flush)
     this.#debounceTimers.delete(target)
+  }
+
+  // Clear every pending debounce timer (used on disconnect). Reuses
+  // #clearDebounce so all timer/listener teardown stays in one place. Snapshot
+  // the keys first — #clearDebounce mutates the map as it goes.
+  #clearAllDebounces() {
+    for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
   }
 
   async #perform(action, params) {

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
   }
 
   #tokenCache // freshest token, threaded synchronously across queued requests
+  #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
 
   // Serialize requests per component. Each round trip rewrites the signed
   // token in the DOM (state lives in the token, not the client). If events
@@ -53,7 +54,7 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params } = event.params
+    const { action, params, debounce } = event.params
     if (!action) return
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
@@ -61,13 +62,48 @@ export default class extends Controller {
     // still being handled — deferring it into the request-queue microtask (below)
     // is too late: a `submit` trigger would natively POST the form and navigate
     // before the reactive round trip runs (issue #11). For a `click` trigger
-    // there's no default to miss, so this was previously invisible.
+    // there's no default to miss, so this was previously invisible. This holds
+    // for debounced triggers too — the round trip is deferred, but the native
+    // default must still be prevented now.
     event.preventDefault()
+
+    // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
+    // coalesce rapid events into ONE round trip after a quiet period, instead of
+    // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
+    const ms = Number(debounce) || 0
+    if (ms > 0) return this.#debounceDispatch(event.target, ms, action, params)
 
     // Capture action/params now; the queued work runs in a later microtask, by
     // which point the event object may have been reset by the browser.
+    return this.#enqueue(action, params)
+  }
+
+  #enqueue(action, params) {
     this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
     return this.queue
+  }
+
+  // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
+  // Also flush immediately on blur so leaving the field never drops the last
+  // edit (a long debounce shouldn't swallow a value the user tabbed away from).
+  #debounceDispatch(target, ms, action, params) {
+    this.#clearDebounce(target)
+
+    const flush = () => {
+      this.#clearDebounce(target)
+      this.#enqueue(action, params)
+    }
+    const timer = setTimeout(flush, ms)
+    target?.addEventListener?.("blur", flush, { once: true })
+    this.#debounceTimers.set(target, { timer, flush })
+  }
+
+  #clearDebounce(target) {
+    const pending = this.#debounceTimers.get(target)
+    if (!pending) return
+    clearTimeout(pending.timer)
+    target?.removeEventListener?.("blur", pending.flush)
+    this.#debounceTimers.delete(target)
   }
 
   async #perform(action, params) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,6 +141,21 @@ requests in flight at once would both read the *old* token and clobber each othe
 
 Result: click `+` five times fast → `5`, never `1` or `2`.
 
+### Debounced triggers
+
+A trigger may opt into a quiet-period debounce with
+`on(:update, event: "input", debounce: 300)`. The controller reads the debounce
+(a Stimulus `data-reactive-debounce-param`) in `dispatch` and, instead of
+enqueuing the round trip immediately, resets a **per-trigger-element** timer;
+only after `debounce` ms of quiet does it enqueue onto the same per-component
+queue (so token threading still holds). A `blur` on the element flushes a pending
+dispatch immediately, so tabbing away never drops the last edit. `preventDefault`
+still fires synchronously, so a debounced `submit` trigger won't navigate
+(issue #11). Without `debounce:`, dispatch is immediate — unchanged behavior.
+
+Result: type `c-a-t-s` fast into a debounced input → ONE search round trip, not
+four.
+
 ## What runs where
 
 | Concern | Where |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,10 @@ only after `debounce` ms of quiet does it enqueue onto the same per-component
 queue (so token threading still holds). A `blur` on the element flushes a pending
 dispatch immediately, so tabbing away never drops the last edit. `preventDefault`
 still fires synchronously, so a debounced `submit` trigger won't navigate
-(issue #11). Without `debounce:`, dispatch is immediate — unchanged behavior.
+(issue #11). On `disconnect` (the element leaves the DOM via a Turbo morph or
+navigation) every pending debounce timer is cleared, so a deferred round trip
+never fires against a detached controller. Without `debounce:`, dispatch is
+immediate — unchanged behavior.
 
 Result: type `c-a-t-s` fast into a debounced input → ONE search round trip, not
 four.

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -168,11 +168,18 @@ module Phlex
       # Attributes for an element that triggers an action.
       #   button(**on(:toggle)) { "○" }
       #   form(**on(:save, event: "submit")) { ... }
+      #   input(**on(:update, event: "input", debounce: 300))  # live-as-you-type
       #
       # Extra keyword args become explicit params merged over collected form
       # fields. For click triggers we force type="button" so a bare button
       # inside a <form> can't submit it and cause a full-page navigation.
-      def on(action_name, event: "click", **params)
+      #
+      # `debounce:` (milliseconds) coalesces rapid events (e.g. keystrokes on an
+      # "input" trigger) into ONE round trip fired after the quiet period — so
+      # live-update-as-you-type doesn't POST per keystroke. A blur flushes a
+      # pending dispatch so the last edit is never dropped. Omit it for the
+      # immediate-dispatch default.
+      def on(action_name, event: "click", debounce: nil, **params)
         attrs = {
           data: {
             action: "#{event}->reactive#dispatch",
@@ -180,6 +187,7 @@ module Phlex
             reactive_params_param: params.to_json
           }
         }
+        attrs[:data][:reactive_debounce_param] = debounce if debounce
         attrs[:type] = "button" if event == "click"
         attrs
       end

--- a/spec/dummy/app/components/debounce_component.rb
+++ b/spec/dummy/app/components/debounce_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Exercises the debounce option (issue #17). The `query` input dispatches a
+# debounced `search` action; each run bumps a `runs` counter and echoes the last
+# query. A burst of rapid input must coalesce into ONE run (one increment), not
+# one per keystroke.
+class DebounceComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :query, :runs
+
+  action :search, params: {query: :string}
+
+  def initialize(query: "", runs: 0)
+    @query = query
+    @runs = runs
+  end
+
+  def id = "debounce"
+
+  def search(query:)
+    @query = query
+    @runs += 1
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      input(**mix(on(:search, event: "input", debounce: 150),
+        name: "query", value: @query, data: {testid: "query"}))
+      span(data: {testid: "runs"}) { @runs.to_s }
+      span(data: {testid: "echo"}) { @query }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -27,6 +27,10 @@ class DemosController < ActionController::Base
     render_component FormSubmitComponent.new(todo: Todo.find(params[:id]))
   end
 
+  def debounce
+    render_component DebounceComponent.new
+  end
+
   # The page a non-intercepted form submit would navigate to (issue #11).
   def nav_probe
     render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get "todos" => "demos#todos"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
+  get "debounce" => "demos#debounce"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
   match "nav_probe" => "demos#nav_probe", :via => [:get, :post]

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -47,6 +47,14 @@ export default class extends Controller {
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
 
+  // Tear down any pending debounce timers when the controller leaves the DOM
+  // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't
+  // fired yet would later call #enqueue on a disconnected controller — a round
+  // trip against a detached element / stale token (issue #17 follow-up).
+  disconnect() {
+    this.#clearAllDebounces()
+  }
+
   // Serialize requests per component. Each round trip rewrites the signed
   // token in the DOM (state lives in the token, not the client). If events
   // fire faster than round trips complete, concurrent requests would all read
@@ -104,6 +112,13 @@ export default class extends Controller {
     clearTimeout(pending.timer)
     target?.removeEventListener?.("blur", pending.flush)
     this.#debounceTimers.delete(target)
+  }
+
+  // Clear every pending debounce timer (used on disconnect). Reuses
+  // #clearDebounce so all timer/listener teardown stays in one place. Snapshot
+  // the keys first — #clearDebounce mutates the map as it goes.
+  #clearAllDebounces() {
+    for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
   }
 
   async #perform(action, params) {

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
   }
 
   #tokenCache // freshest token, threaded synchronously across queued requests
+  #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
 
   // Serialize requests per component. Each round trip rewrites the signed
   // token in the DOM (state lives in the token, not the client). If events
@@ -53,7 +54,7 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params } = event.params
+    const { action, params, debounce } = event.params
     if (!action) return
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
@@ -61,13 +62,48 @@ export default class extends Controller {
     // still being handled — deferring it into the request-queue microtask (below)
     // is too late: a `submit` trigger would natively POST the form and navigate
     // before the reactive round trip runs (issue #11). For a `click` trigger
-    // there's no default to miss, so this was previously invisible.
+    // there's no default to miss, so this was previously invisible. This holds
+    // for debounced triggers too — the round trip is deferred, but the native
+    // default must still be prevented now.
     event.preventDefault()
+
+    // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
+    // coalesce rapid events into ONE round trip after a quiet period, instead of
+    // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
+    const ms = Number(debounce) || 0
+    if (ms > 0) return this.#debounceDispatch(event.target, ms, action, params)
 
     // Capture action/params now; the queued work runs in a later microtask, by
     // which point the event object may have been reset by the browser.
+    return this.#enqueue(action, params)
+  }
+
+  #enqueue(action, params) {
     this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
     return this.queue
+  }
+
+  // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
+  // Also flush immediately on blur so leaving the field never drops the last
+  // edit (a long debounce shouldn't swallow a value the user tabbed away from).
+  #debounceDispatch(target, ms, action, params) {
+    this.#clearDebounce(target)
+
+    const flush = () => {
+      this.#clearDebounce(target)
+      this.#enqueue(action, params)
+    }
+    const timer = setTimeout(flush, ms)
+    target?.addEventListener?.("blur", flush, { once: true })
+    this.#debounceTimers.set(target, { timer, flush })
+  }
+
+  #clearDebounce(target) {
+    const pending = this.#debounceTimers.get(target)
+    if (!pending) return
+    clearTimeout(pending.timer)
+    target?.removeEventListener?.("blur", pending.flush)
+    this.#debounceTimers.delete(target)
   }
 
   async #perform(action, params) {

--- a/spec/javascript/reactive_debounce.test.js
+++ b/spec/javascript/reactive_debounce.test.js
@@ -1,0 +1,129 @@
+// Unit test for the debounce option on reactive triggers (issue #17).
+//
+// on(:update, event: "input", debounce: 50) must coalesce rapid inputs into a
+// SINGLE action round trip fired after the quiet period — instead of one POST
+// per keystroke. A blur flushes a pending debounced dispatch immediately. With
+// no debounce declared, dispatch fires immediately (today's behavior).
+//
+// We count fetch() calls with REAL timers (small delays) so the coalescing is
+// observed deterministically without fake-timer/microtask interplay.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A trigger element stub that records blur listeners so the test can fire blur.
+function makeTarget() {
+  const listeners = {}
+  return {
+    addEventListener: (type, fn) => {
+      (listeners[type] ||= []).push(fn)
+    },
+    removeEventListener: (type, fn) => {
+      listeners[type] = (listeners[type] || []).filter((f) => f !== fn)
+    },
+    fire: (type) => (listeners[type] || []).slice().forEach((fn) => fn()),
+  }
+}
+
+function makeRoot() {
+  return {
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+function buildController() {
+  const controller = new ReactiveController()
+  controller.element = makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    calls++
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+test("debounced dispatches coalesce into ONE fetch after the quiet period (issue #17)", async () => {
+  const { controller, calls } = buildController()
+  const target = makeTarget()
+
+  // Five rapid "input" dispatches, 10ms apart, with a 50ms debounce.
+  for (let i = 0; i < 5; i++) {
+    controller.dispatch({
+      target,
+      params: { action: "update", params: "{}", debounce: 50 },
+      preventDefault: () => {},
+    })
+    await wait(10)
+  }
+
+  // Still inside the window right after the burst → nothing fired yet.
+  expect(calls()).toBe(0)
+
+  await wait(120) // cross the quiet period + let the round trip run
+  expect(calls()).toBe(1) // exactly ONE round trip for the whole burst
+})
+
+test("blur flushes a pending debounced dispatch immediately", async () => {
+  const { controller, calls } = buildController()
+  const target = makeTarget()
+
+  controller.dispatch({
+    target,
+    params: { action: "update", params: "{}", debounce: 5000 },
+    preventDefault: () => {},
+  })
+  expect(calls()).toBe(0)
+
+  target.fire("blur") // user tabs away before the long window elapses
+  await wait(20)
+  expect(calls()).toBe(1) // flushed, not lost
+})
+
+test("no debounce → dispatch fires immediately (unchanged behavior)", async () => {
+  const { controller, calls } = buildController()
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "save", params: "{}" }, // no debounce
+    preventDefault: () => {},
+  })
+
+  expect(calls()).toBe(1)
+})
+
+test("a debounced dispatch still preventDefaults synchronously (submit safety)", () => {
+  const { controller } = buildController()
+  const order = []
+  controller.dispatch({
+    target: makeTarget(),
+    params: { action: "save", params: "{}", debounce: 300 },
+    preventDefault: () => order.push("preventDefault"),
+  })
+  // preventDefault must fire NOW (during the event), not after the debounce
+  // timer — otherwise a debounced submit trigger would navigate (issue #11).
+  expect(order).toEqual(["preventDefault"])
+})

--- a/spec/javascript/reactive_debounce.test.js
+++ b/spec/javascript/reactive_debounce.test.js
@@ -103,6 +103,25 @@ test("blur flushes a pending debounced dispatch immediately", async () => {
   expect(calls()).toBe(1) // flushed, not lost
 })
 
+test("disconnect() cancels a pending debounced dispatch (no fetch after teardown)", async () => {
+  const { controller, calls } = buildController()
+  const target = makeTarget()
+
+  controller.dispatch({
+    target,
+    params: { action: "update", params: "{}", debounce: 50 },
+    preventDefault: () => {},
+  })
+  expect(calls()).toBe(0)
+
+  // The element leaves the DOM (Turbo morph/navigation) before the window
+  // elapses. A pending timer must not later POST against a detached controller.
+  controller.disconnect()
+
+  await wait(80) // past the debounce window
+  expect(calls()).toBe(0) // timer was cleared on disconnect — nothing fired
+})
+
 test("no debounce → dispatch fires immediately (unchanged behavior)", async () => {
   const { controller, calls } = buildController()
 
@@ -115,15 +134,20 @@ test("no debounce → dispatch fires immediately (unchanged behavior)", async ()
   expect(calls()).toBe(1)
 })
 
-test("a debounced dispatch still preventDefaults synchronously (submit safety)", () => {
+test("a debounced dispatch still preventDefaults synchronously (submit safety)", async () => {
   const { controller } = buildController()
   const order = []
+  const target = makeTarget()
   controller.dispatch({
-    target: makeTarget(),
+    target,
     params: { action: "save", params: "{}", debounce: 300 },
     preventDefault: () => order.push("preventDefault"),
   })
   // preventDefault must fire NOW (during the event), not after the debounce
   // timer — otherwise a debounced submit trigger would navigate (issue #11).
   expect(order).toEqual(["preventDefault"])
+  // Tear down the pending 300ms timer so the delayed fetch can't fire after the
+  // test exits (flush via blur, then drain the queue) — keeps the suite stable.
+  target.fire("blur")
+  await controller.queue
 })

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -246,4 +246,25 @@ RSpec.describe Phlex::Reactive::Component do
       expect(state_klass.reactive_action?(:decrement)).to be(false)
     end
   end
+
+  describe "#on trigger attributes (issue #17 debounce)" do
+    subject(:instance) { state_klass.new }
+
+    it "wires the action + event without a debounce by default" do
+      attrs = instance.send(:on, :increment, event: "input")
+      expect(attrs[:data][:action]).to eq("input->reactive#dispatch")
+      expect(attrs[:data][:reactive_action_param]).to eq("increment")
+      expect(attrs[:data]).not_to have_key(:reactive_debounce_param)
+    end
+
+    it "emits the debounce as a Stimulus param when given" do
+      attrs = instance.send(:on, :set, event: "input", debounce: 300)
+      expect(attrs[:data][:reactive_debounce_param]).to eq(300)
+    end
+
+    it "keeps debounce out of the explicit params payload" do
+      attrs = instance.send(:on, :set, event: "input", debounce: 300, count: 5)
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({"count" => 5})
+    end
+  end
 end

--- a/spec/system/debounce_spec.rb
+++ b/spec/system/debounce_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #17: on(:action, event: "input", debounce: ms) coalesces rapid input
+# events into ONE round trip after the quiet period, instead of one POST per
+# keystroke. A blur flushes a pending dispatch so the last edit is never lost.
+RSpec.describe "Debounced reactive input (issue #17)", type: :system do
+  it "coalesces a burst of rapid input into a single action run" do
+    visit "/debounce"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    # Fire a burst of input events faster than the 150ms debounce window. If the
+    # debounce works, exactly ONE search runs (runs -> 1); without it, each input
+    # would POST (runs -> 5).
+    page.execute_script(<<~JS)
+      const field = document.querySelector("[data-testid='query']")
+      const values = ["c", "ca", "cat", "cats", "catsx"]
+      values.forEach((v, i) => {
+        setTimeout(() => {
+          field.value = v
+          field.dispatchEvent(new Event("input", { bubbles: true }))
+        }, i * 20)
+      })
+    JS
+
+    # After the burst + quiet period, the single coalesced run lands.
+    expect(page).to have_css("[data-testid='echo']", text: "catsx")
+    expect(page).to have_css("[data-testid='runs']", text: "1")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "flushes the pending dispatch on blur" do
+    visit "/debounce"
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    # One input then an immediate blur (before the 150ms window). The blur must
+    # flush the pending dispatch rather than dropping the edit.
+    page.execute_script(<<~JS)
+      const field = document.querySelector("[data-testid='query']")
+      field.value = "flushed"
+      field.dispatchEvent(new Event("input", { bubbles: true }))
+      field.dispatchEvent(new Event("blur"))
+    JS
+
+    expect(page).to have_css("[data-testid='echo']", text: "flushed")
+    expect(page).to have_css("[data-testid='runs']", text: "1")
+  end
+end


### PR DESCRIPTION
## Summary

`on(:action, event: "input")` dispatched a server round trip on **every keystroke** — there was no debounce. A field meant to update live (recompute a total as the user types a quantity) hammered the endpoint, so the only safe option was `event: "change"`/blur, which loses the live-as-you-type feel the classic client-side JS gave for free.

## The API

```ruby
on(:update, event: "input", debounce: 300)  # ms; coalesce rapid input, fire once after the quiet period
```

`on` now accepts `debounce:` (milliseconds), emitted as a Stimulus `data-reactive-debounce-param`. In `dispatch` the controller reads it and, instead of enqueuing the round trip immediately, resets a **per-trigger-element** timer; only after the quiet period does it enqueue onto the same per-component queue — so the token-threading guarantee still holds. A `blur` flushes a pending dispatch so tabbing away never drops the last edit. `preventDefault` still fires synchronously, so a debounced `submit` trigger won't navigate (issue #11). Omitting `debounce:` keeps the immediate-dispatch default — existing triggers are unaffected.

## Test plan

| Layer | What it proves |
|-------|----------------|
| `spec/javascript/reactive_debounce.test.js` | RED→GREEN: a 5-event burst coalesces to ONE fetch after the quiet period; blur flushes a pending dispatch; no-debounce fires immediately; a debounced trigger still `preventDefault`s synchronously |
| `spec/phlex/reactive/component_spec.rb` | `#on` emits the debounce param only when given, and keeps it out of the explicit-params JSON payload |
| `spec/system/debounce_spec.rb` | browser proof: a rapid input burst runs the action exactly once (`runs → 1`, not 5); blur flushes the pending edit |

New dummy `DebounceComponent` + `/debounce` route.

## Verification

- `bundle exec standardrb` — clean
- `bun test spec/javascript` — 9/9
- `bundle exec rspec` (incl. system) — **80 examples, 0 failures**
- Vendored client controller re-synced (drift guard green)

## Docs

- `docs/architecture.md` — "Debounced triggers" subsection (timer reset, blur flush, queue interaction, preventDefault safety).
- `README.md` — debounce row + "live-as-you-type" note under the Component API.
- `lib/phlex/reactive/component.rb` — `on` doc covers `debounce:`.
- `CHANGELOG.md` — `Unreleased → Added`.

Closes #17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for debounced reactive actions, so rapid input events can be combined into a single update after typing pauses.
  * Existing immediate action behavior remains available when no debounce setting is used.

* **Bug Fixes**
  * Ensured the last pending input update is flushed when a field loses focus.
  * Kept default browser behavior prevention consistent for handled actions.

* **Documentation**
  * Updated the API and architecture docs with debounce examples and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->