### PR TITLE
fix(actions): expand flat bracketed keys so model-scoped forms feed nested params (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Model-scoped form fields feed a nested param (issue #21).** A Rails
+  `Form(model: @invoice)` posts flat bracketed keys (`invoice[date]`,
+  `invoice[status]`) because the client keeps each input's `name` verbatim. The
+  server did exact-key matching, so a nested schema (`params: { invoice: { date:
+  :string } }`) looked for the literal key `"invoice"`, never found it, and
+  dropped the whole param. Param normalization now expands bracket notation
+  before coercion — `invoice[date]` nests under `invoice`, and
+  `items_attributes[0][qty]` becomes the Rails index-hash form the array coercer
+  already understands. A nested schema matches a normal Rails form with zero
+  field renaming, which is what makes the issue #16 nested-param types useful for
+  real forms. Pre-nested objects, plain scalars, and non-string values (a
+  checkbox boolean) pass through unchanged.
 - **Nested reactive roots no longer leak fields (issue #15).** When a reactive
   component is rendered inside another (both are `data-controller="reactive"`
   roots), an action on the outer root previously swept *every* descendant named

--- a/README.md
+++ b/README.md
@@ -294,6 +294,18 @@ end
 Nested coercion recurses per field, drops undeclared nested keys, and accepts an
 array as either a JSON array or a Rails index hash (`{ "0" => …, "1" => … }`).
 
+**Model-scoped form fields just work.** A standard Rails `Form(model: @invoice)`
+names its inputs `invoice[date]`, `invoice[status]`, … and the client posts those
+names verbatim. A nested schema matches them with zero field renaming — the
+endpoint expands bracket notation before coercion, so `invoice[date]` nests under
+`invoice` and `invoice_items_attributes[0][qty]` becomes the index-hash form
+above:
+
+```ruby
+action :save, params: {invoice: {date: :string, status: :string}}
+# client posts { "invoice[date]": "…", "invoice[status]": "…" }  → save(invoice: { date:, status: })
+```
+
 **Nested reactive components compose.** A reactive component rendered inside
 another is its own root — field collection stops at nested
 `data-controller="reactive"` roots, so an outer action collects only *its own*

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -201,12 +201,63 @@ module Phlex
       end
 
       # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed
-      # Hash so coercion can index it uniformly.
+      # Hash so coercion can index it uniformly, then expand bracket notation so
+      # a model-scoped Rails form's flat keys nest (issue #21).
       def to_param_hash(value)
-        return value.to_unsafe_h.stringify_keys if value.respond_to?(:to_unsafe_h)
-        return value.stringify_keys if value.is_a?(Hash)
+        flat =
+          if value.respond_to?(:to_unsafe_h)
+            value.to_unsafe_h.stringify_keys
+          elsif value.is_a?(Hash)
+            value.stringify_keys
+          else
+            return {}
+          end
 
-        {}
+        expand_bracket_keys(flat)
+      end
+
+      # The client's #collectFields keeps a form input's name verbatim, so a
+      # Rails Form(model: @invoice) posts FLAT bracketed keys like
+      # "invoice[date]". Coercion does exact-key matching, so without this a
+      # nested schema (params: { invoice: { date: … } }) never finds "invoice"
+      # and drops everything. Expand "invoice[date]" => "2026-01-02" into
+      # { "invoice" => { "date" => "2026-01-02" } } — and "items[0][qty]" into
+      # the Rails index-hash form coerce_array already understands — deep-merging
+      # so sibling keys (invoice[date], invoice[status]) coalesce. Keys WITHOUT
+      # brackets and already-nested values pass through untouched, so a
+      # pre-nested object (issue #16) and plain scalars still work. Value types
+      # (a checkbox boolean, an explicit array) are preserved verbatim — unlike a
+      # round-trip through parse_nested_query, which only handles strings.
+      def expand_bracket_keys(flat)
+        flat.each_with_object({}) do |(key, value), out|
+          path = bracket_path(key)
+          if path.length == 1
+            out[path.first] = value
+          else
+            deep_assign(out, path, value)
+          end
+        end
+      end
+
+      # "invoice[items_attributes][0][qty]" => ["invoice", "items_attributes",
+      # "0", "qty"]. A key with no brackets is a single-element path.
+      def bracket_path(key)
+        return [key] unless key.include?("[")
+
+        head, rest = key.split("[", 2)
+        [head, *rest.scan(/[^\[\]]+/)]
+      end
+
+      # Walk/create nested hashes along `path` and assign `value` at the leaf.
+      # If a node is already present but not a Hash (a bracket key colliding with
+      # a flat key of the same name), the later bracket assignment wins.
+      def deep_assign(hash, path, value)
+        *parents, leaf = path
+        node = parents.reduce(hash) do |acc, segment|
+          acc[segment] = {} unless acc[segment].is_a?(Hash)
+          acc[segment]
+        end
+        node[leaf] = value
       end
 
       # Only components that opt into Reactive may be resolved. The signature

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -230,12 +230,7 @@ module Phlex
       # round-trip through parse_nested_query, which only handles strings.
       def expand_bracket_keys(flat)
         flat.each_with_object({}) do |(key, value), out|
-          path = bracket_path(key)
-          if path.length == 1
-            out[path.first] = value
-          else
-            deep_assign(out, path, value)
-          end
+          deep_assign(out, bracket_path(key), value)
         end
       end
 
@@ -248,16 +243,27 @@ module Phlex
         [head, *rest.scan(/[^\[\]]+/)]
       end
 
-      # Walk/create nested hashes along `path` and assign `value` at the leaf.
-      # If a node is already present but not a Hash (a bracket key colliding with
-      # a flat key of the same name), the later bracket assignment wins.
+      # Walk/create nested hashes along `path`, then merge `value` at the leaf so
+      # a bracket key and a sibling pre-nested object coalesce regardless of which
+      # arrives first ({ "invoice[date]" => …, invoice: { status: … } } keeps
+      # both). #merge_value deep-merges hash/hash collisions and otherwise lets
+      # the later value win (a bracket key colliding with a flat scalar).
       def deep_assign(hash, path, value)
         *parents, leaf = path
         node = parents.reduce(hash) do |acc, segment|
           acc[segment] = {} unless acc[segment].is_a?(Hash)
           acc[segment]
         end
-        node[leaf] = value
+        node[leaf] = merge_value(node[leaf], value)
+      end
+
+      # Combine an existing leaf value with a new one. Two hashes deep-merge (so
+      # bracket-expanded fields and a pre-nested object for the same key both
+      # survive); any other collision takes the new value.
+      def merge_value(existing, value)
+        return value unless existing.is_a?(Hash) && value.is_a?(Hash)
+
+        existing.merge(value.stringify_keys) { |_k, old, new| merge_value(old, new) }
       end
 
       # Only components that opt into Reactive may be resolved. The signature

--- a/spec/dummy/app/components/nested_params_component.rb
+++ b/spec/dummy/app/components/nested_params_component.rb
@@ -17,6 +17,13 @@ class NestedParamsComponent < ApplicationComponent
     invoice_items_attributes: [{id: :integer, quantity: :float, price: :float, _destroy: :boolean}]
   }
 
+  # Issue #21: a model-scoped nested hash, matching what a Rails Form(model:)
+  # posts as flat bracketed keys (invoice[date], invoice[status], …).
+  action :save_invoice, params: {
+    date: :string,
+    invoice: {date: :string, status: :string, total: :float, active: :boolean}
+  }
+
   def initialize(received: nil)
     @received = received
   end
@@ -29,6 +36,10 @@ class NestedParamsComponent < ApplicationComponent
       bank_account_ids:,
       invoice_items_attributes:
     }
+  end
+
+  def save_invoice(date: nil, invoice: nil)
+    @received = {date:, invoice:}.compact
   end
 
   def view_template

--- a/spec/requests/bracket_params_spec.rb
+++ b/spec/requests/bracket_params_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #21: a model-scoped Rails form posts FLAT bracketed keys
+# (invoice[date]=…, invoice[status]=…) because #collectFields keeps the input's
+# `name` verbatim. The server's coerce_hash does exact-key matching, so a nested
+# schema (params: { invoice: { date: :string } }) looked for the literal key
+# "invoice" and dropped everything. to_param_hash now expands bracket notation
+# ("invoice[date]" => { "invoice" => { "date" => … } }) before coercion, so a
+# nested schema matches a normal Rails form with zero field renaming.
+RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
+  def token_for(klass, payload)
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  def post_action(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  def received(response)
+    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    JSON.parse(CGI.unescapeHTML(json))
+  end
+
+  let(:payload) { {"s" => {"received" => nil}} }
+
+  it "expands a model-scoped bracket key into the nested schema (the cosmos case)" do
+    # Exactly what a Rails Form(model: @invoice) posts via #collectFields.
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"invoice[date]" => "2026-01-02", "invoice[status]" => "open"})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
+  end
+
+  it "coerces nested types after bracket expansion (integer/float stay typed)" do
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"invoice[date]" => "2026-01-02", "invoice[total]" => "9.99"})
+
+    invoice = received(response)["invoice"]
+    expect(invoice["total"]).to eq(9.99)
+  end
+
+  it "drops undeclared bracketed keys (no mass assignment)" do
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"invoice[date]" => "2026-01-02", "invoice[admin]" => "true"})
+
+    expect(received(response)["invoice"].keys).to contain_exactly("date")
+  end
+
+  it "expands a bracketed array-of-hash key (Rails nested attributes)" do
+    post_action(NestedParamsComponent, payload:, act: "save",
+      params: {
+        "invoice_items_attributes[0][id]" => "10",
+        "invoice_items_attributes[0][quantity]" => "2",
+        "invoice_items_attributes[0][price]" => "5",
+        "invoice_items_attributes[0][_destroy]" => "false",
+        "invoice_items_attributes[1][id]" => "11",
+        "invoice_items_attributes[1][quantity]" => "3",
+        "invoice_items_attributes[1][price]" => "6",
+        "invoice_items_attributes[1][_destroy]" => "true"
+      })
+
+    items = received(response)["invoice_items_attributes"]
+    expect(items.map { |i| i["id"] }).to eq([10, 11])
+    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
+    expect(items.map { |i| i["_destroy"] }).to eq([false, true])
+  end
+
+  it "mixes a flat scalar with bracketed keys in one payload" do
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"date" => "2026-06-27", "invoice[date]" => "2026-01-02"})
+
+    parsed = received(response)
+    expect(parsed["date"]).to eq("2026-06-27")
+    expect(parsed["invoice"]["date"]).to eq("2026-01-02")
+  end
+
+  it "still accepts a PRE-NESTED object (backwards compatible with #16)" do
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {invoice: {date: "2026-01-02", status: "open"}})
+
+    expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
+  end
+
+  it "preserves a non-string value (checkbox boolean) through expansion" do
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"invoice[date]" => "2026-01-02", "invoice[active]" => true})
+
+    expect(received(response)["invoice"]["active"]).to be(true)
+  end
+end

--- a/spec/requests/bracket_params_spec.rb
+++ b/spec/requests/bracket_params_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
     expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
   end
 
+  it "merges a bracket key and a pre-nested object regardless of key order" do
+    # A bracket key processed BEFORE a sibling pre-nested object must not be
+    # clobbered by it (order-dependence): both fields survive the merge.
+    post_action(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {"invoice[date]" => "2026-01-02", "invoice" => {"status" => "open"}})
+
+    expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
+  end
+
   it "preserves a non-string value (checkbox boolean) through expansion" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
       params: {"invoice[date]" => "2026-01-02", "invoice[active]" => true})


### PR DESCRIPTION
## Summary

A standard Rails `Form(model: @invoice)` names its inputs `invoice[date]`, `invoice[status]`, … and the client's `#collectFields` keeps each name **verbatim**, so it posts flat bracketed string keys:

```json
{ "invoice[date]": "2026-01-02", "invoice[status]": "open" }
```

Server-side `coerce_hash` does exact-key matching (`hash.key?(key.to_s)`), so a nested schema looked for the literal key `"invoice"`, never found it (the keys were `"invoice[date]"` / `"invoice[status]"`), and **dropped the whole nested param**. JSON bodies mean Rails' own param parser doesn't expand the brackets either. Net: the issue #16 nested-param feature couldn't collect a real Rails form's fields without renaming them all to bare names.

## Fix

Expand bracket notation in `to_param_hash` — the single chokepoint where every param hash is normalized before coercion:

- `invoice[date]` nests under `invoice`
- `invoice_items_attributes[0][qty]` becomes the Rails **index-hash** form the existing array coercer already understands
- sibling keys (`invoice[date]`, `invoice[status]`) deep-merge into one hash

Fixing it here (not client-only, not a `rescue`) means it holds regardless of the producer — `#collectFields`, explicit `data-reactive-params-param`, or any client. Value types are preserved verbatim (a checkbox boolean stays `true`, an explicit array stays an array) — unlike a round-trip through `parse_nested_query`, which only handles strings.

A nested schema now matches a normal Rails form with **zero field renaming**, which is what makes #16 useful for real forms.

```ruby
action :save, params: {invoice: {date: :string, status: :string}}
# client posts { "invoice[date]": "…", "invoice[status]": "…" }  → save(invoice: { date:, status: })
```

## Test Coverage

New `spec/requests/bracket_params_spec.rb`:

| spec | validates |
|------|-----------|
| model-scoped bracket key | `invoice[date]`/`invoice[status]` → `{ invoice: { … } }` (the cosmos case) |
| nested type coercion | integers/floats stay typed after expansion |
| undeclared-key drop | bracketed keys not in the inner schema are dropped (no mass assignment) |
| bracketed array-of-hash | `items_attributes[0][id]` … → array of coerced hashes |
| flat + bracketed mix | a flat scalar and a bracketed key coexist in one payload |
| pre-nested object | a `{ invoice: { … } }` object still works (backwards compatible with #16) |
| non-string value | a checkbox boolean survives expansion as `true` |

## Verification

- [x] `bundle exec standardrb` passes (clean)
- [x] `bundle exec rspec` passes — 99 examples (unit + request + generators + system), 0 failures
- [x] Backwards compatible — pre-nested objects, plain scalars, and Rails index hashes pass through unchanged
- [x] No client/JS change, so no vendored-controller resync needed
- [x] README + CHANGELOG updated

Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic support for Rails-style bracketed field names (e.g., `invoice[date]`, array-style bracket keys) to populate nested schemas.
  * Model-scoped forms now post bracketed names directly while still coercing into the declared nested structure.

* **Bug Fixes**
  * Nested bracket params are expanded into the expected nested shape before coercion/validation, preventing nested keys from being dropped.
  * Ensures undeclared nested fields are omitted and typed values (including booleans/numbers) remain correctly coerced.

* **Documentation**
  * Updated README with examples for bracket-notation and nested schema coercion.

* **Tests**
  * Added request coverage for bracket expansion, coercion, merge behavior, and array-style nested inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->