### PR TITLE
feat: inline-edit ergonomics + integration guards (#23-26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Input/select param-binding helpers (issue #23).** `reactive_input(:value,
+  …)` and `reactive_select(:status, …) { … }` render a form control already bound
+  to an action param — no hand-written `name: "value"` magic string to forget
+  (which silently leaves the action with no params). `reactive_field(:param,
+  **attrs)` returns just the attribute hash to spread onto any control; an
+  explicit `name:` still wins as an escape hatch. The trigger stays on the
+  button, so focusing the field doesn't dispatch and collapse edit mode.
+- **`accepts_nested_attributes_for` helper (issue #24).** `nested_update!(:address,
+  address)` maps a declared nested param straight onto `<assoc>_attributes` and
+  carries the existing associated record's id, so `update_only:` matches it in
+  place instead of building a second `has_one` — replacing the per-editor
+  `*_attributes` + id-preservation boilerplate that was easy to get subtly wrong.
+  `nested_attributes(:address, address)` returns the id-merged hash without
+  updating, for combining with other attributes.
+- **`Response#also_update` / `#also_replace` (issue #25).** Re-render a companion
+  element alongside self without dropping to raw `turbo_stream_builder`:
+  `Response.replace(self).also_update("page_heading", html: @record.name)` adds an
+  update stream for an arbitrary DOM id (`html` is a string or a Phlex component,
+  rendered through the configured renderer), and `.also_replace(other_component)`
+  re-renders another Streamable component targeting its own `#id`. Both are
+  immutable and additive, so the self-replace still refreshes the signed token.
+- **Boot-time integration guards (issue #26).** Two silent first-run failures now
+  surface a clear warning. A host catch-all route (`match "*path", …`) that
+  shadows the engine's appended `POST /reactive/actions` (every reactive POST
+  404s) is detected at boot via a route-recognition check
+  (`Phlex::Reactive.action_route_ok?`), logging how to exempt the path. And when
+  `data-controller="reactive"` elements are on the page but no controller
+  connected — the `lazyLoadControllersFrom` case where the gem's controller was
+  never registered — the client runtime logs a console warning naming the fix.
+  The README gains an "Integration troubleshooting" section covering both.
 - **Nested & array param types (issue #16).** Action param schemas can now
   declare arrays and nested hashes, not just scalars: wrap a type in an array
   (`bank_account_ids: [:integer]`) for an array param, or wrap a hash schema in

--- a/README.md
+++ b/README.md
@@ -137,6 +137,47 @@ gem; point your bundler at the gem path or copy it in. See
 and a Phlex `ApplicationComponent` base class. pgbus is optional but recommended
 for broadcasting.
 
+### Integration troubleshooting (silent "nothing happens")
+
+Two host-app setups make the first reactive component *silently do nothing* —
+components render, but no action ever fires, with no error pointing at the cause.
+The gem now logs a warning for each, but here are the fixes:
+
+**A catch-all route shadows `POST /reactive/actions`.** The engine appends its
+route *after* everything in your `config/routes.rb`, so a bottom-of-file
+catch-all wins and every reactive POST 404s:
+
+```ruby
+# config/routes.rb — a catch-all like this shadows the engine's appended route
+match "*path", to: "errors#not_found", via: :all
+```
+
+Exempt the reactive path from the catch-all (or set
+`Phlex::Reactive.action_path` to an unshadowed path):
+
+```ruby
+match "*path", to: "errors#not_found", via: :all,
+  constraints: ->(req) { !req.path.start_with?("/reactive/") }
+```
+
+At boot the gem warns (`[phlex-reactive] POST /reactive/actions does not resolve
+to phlex/reactive/actions …`) when the route is shadowed.
+
+**The `reactive` controller isn't registered (`lazyLoadControllersFrom` apps).**
+`lazyLoadControllersFrom("controllers", application)` only registers controllers
+under `app/javascript/controllers/`. The gem's controller lives outside that dir,
+so `data-controller="reactive"` does nothing until you register it explicitly:
+
+```js
+// app/javascript/controllers/index.js (or your Stimulus entrypoint)
+import ReactiveController from "phlex/reactive/reactive_controller"
+application.register("reactive", ReactiveController)
+```
+
+If reactive elements are on the page but the controller never connected, the
+runtime logs a console warning (`[phlex-reactive] found N element(s) with
+data-controller="reactive" but the reactive controller never connected …`).
+
 ---
 
 ## The mental model in one picture
@@ -269,6 +310,9 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_attrs` | Spread onto the root element: marks it reactive + carries the signed token. |
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
 | `on(:action, event: "input", debounce: 300)` | Coalesce rapid events into one round trip after a quiet period (live-as-you-type). |
+| `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
+| `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
+| `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
 
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
@@ -337,6 +381,47 @@ div(**mix(reactive_attrs, id:, class: "card")) { ... }
 button(**on(:increment), data: { testid: "inc" }) { "+" }
 ```
 
+**Binding inputs to action params (drop the magic `name:`).** A field's value
+travels with an action only if its `name` equals the param. Hand-writing
+`name: "value"` on every input is easy to forget — the action then silently gets
+nothing. `reactive_input`/`reactive_select` emit the binding for you (the trigger
+stays on the button, so focusing the field doesn't dispatch and collapse edit
+mode):
+
+```ruby
+action :save, params: { value: :string, status: :string }
+
+def view_template
+  span(id:, **reactive_attrs) do
+    reactive_input(:value, value: @record.name)            # <input name="value" …>
+    reactive_select(:status) do                            # <select name="status">…</select>
+      %w[open closed].each { |s| option(value: s, selected: s == @record.status) { s } }
+    end
+    button(**mix(on(:save), data: { testid: "save" })) { "Save" }
+  end
+end
+```
+
+`reactive_field(:value, **attrs)` returns just the attribute hash if you'd rather
+spread it onto a control yourself. An explicit `name:` still wins (escape hatch).
+
+**Editing an associated record (`accepts_nested_attributes_for`).** `nested_update!`
+maps a declared nested param straight onto `<assoc>_attributes` and carries the
+existing record's id, so `update_only:` matches it in place instead of building a
+second `has_one` (the boilerplate that's easy to get subtly wrong):
+
+```ruby
+# Account has_one :address; accepts_nested_attributes_for :address, update_only: true
+action :save, params: { address: { street: :string, city: :string } }
+
+def save(address:)
+  nested_update!(:address, address)   # update!(address_attributes: address.merge(id: @account.address&.id))
+end
+```
+
+`nested_attributes(:address, address)` returns the id-merged hash without
+updating, if you need to combine it with other attributes.
+
 ### `Phlex::Reactive::Response` — controlling the action's reply
 
 By default an action re-renders its component in place. **Return** a
@@ -359,18 +444,23 @@ end
 def approve   = (@row.approve!; Response.remove(self))          # drop the element
 def publish   = (@article.publish!; Response.redirect(article_url(@article)))  # slug changed → Turbo.visit
 def add(item:) = Response.replace(self).stream(Totals.update(@order))           # multi-stream
+
+# Re-render a COMPANION element (a heading mirroring the edited name) alongside self:
+def rename(value:) = (@account.update!(name: value); Response.replace(self).also_update("page_heading", html: @account.name))
 ```
 
 | Builder | Reply |
 |---|---|
 | `Response.replace(self)` / `.update(self)` | re-render in place (explicit default) |
+| `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a string or Phlex component |
+| `.also_replace(component)` | also re-render another Streamable component, targeting its own `#id` |
 | `.flash(level, content, target: …)` | append a flash; `content` is a string or Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `Response.remove(self)` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `Response.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
 | `Response.with(*streams)` / `#stream(*more)` | multi-stream |
 
-`.flash`/`.stream` are additive on a self-replace, so the component's signed
-token always refreshes.
+`.flash`/`.stream`/`.also_*` are additive on a self-replace, so the component's
+signed token always refreshes.
 
 ### Configuration (`config/initializers/phlex_reactive.rb`)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Import and register it from your controllers entrypoint:
 
 ```js
 import { application } from "./application"
-import ReactiveController from "phlex-reactive/reactive_controller"
+import ReactiveController from "phlex/reactive/reactive_controller"
 application.register("reactive", ReactiveController)
 ```
 
@@ -452,15 +452,21 @@ def rename(value:) = (@account.update!(name: value); Response.replace(self).also
 | Builder | Reply |
 |---|---|
 | `Response.replace(self)` / `.update(self)` | re-render in place (explicit default) |
-| `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a string or Phlex component |
+| `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
 | `.also_replace(component)` | also re-render another Streamable component, targeting its own `#id` |
-| `.flash(level, content, target: …)` | append a flash; `content` is a string or Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
+| `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped) or a Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `Response.remove(self)` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `Response.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
 | `Response.with(*streams)` / `#stream(*more)` | multi-stream |
 
 `.flash`/`.stream`/`.also_*` are additive on a self-replace, so the component's
 signed token always refreshes.
+
+> **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
+> `html: @account.name` is safe even for user-supplied values. To emit intentional
+> markup, pass a **Phlex component** (`html: Heading.new(name: @record.name)`) —
+> rendered and auto-escaped through the renderer — or an `html_safe` string for
+> raw HTML you control.
 
 ### Configuration (`config/initializers/phlex_reactive.rb`)
 

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -36,6 +36,49 @@ if (typeof window !== "undefined") {
   else document.addEventListener("turbo:load", registerReactiveVisit, { once: true })
 }
 
+// --- Registration guard (issue #26 part 2) -------------------------------
+// In a `lazyLoadControllersFrom("controllers", application)` app, only
+// controllers under app/javascript/controllers/ are registered. This module
+// lives outside that dir, so importing it isn't enough — `data-controller=
+// "reactive"` does NOTHING until the host runs application.register("reactive",
+// ...). The failure is silent: components render, but no action ever fires.
+//
+// We can't warn from connect() in that case (connect never runs). Instead, once
+// the page is ready, if reactive elements exist but no controller has connected,
+// the controller wasn't registered — so we warn, pointing at the fix.
+let reactiveConnected = false
+
+export function checkReactiveRegistration() {
+  if (reactiveConnected) return
+  if (typeof document === "undefined") return
+  const els = document.querySelectorAll('[data-controller~="reactive"]')
+  if (!els || els.length === 0) return
+  console.warn(
+    "[phlex-reactive] found " + els.length + ' element(s) with data-controller="reactive" ' +
+      "but the reactive controller never connected. It is loaded but not registered — " +
+      'add `application.register("reactive", ReactiveController)` (importmap) or import it ' +
+      "into app/javascript/controllers/ for lazyLoadControllersFrom apps. See the README."
+  )
+}
+
+// Test seams (no-ops in production usage).
+export function __resetReactiveRegistrationForTest() {
+  reactiveConnected = false
+}
+export function __markReactiveConnectedForTest() {
+  reactiveConnected = true
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  // Defer past initial controller connection (a microtask/tick after ready).
+  const scheduleCheck = () => setTimeout(checkReactiveRegistration, 0)
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scheduleCheck, { once: true })
+  } else {
+    scheduleCheck()
+  }
+}
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.
@@ -46,6 +89,12 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+
+  // Mark that a reactive controller actually connected, so the registration
+  // guard above knows the controller was registered (issue #26 part 2).
+  connect() {
+    reactiveConnected = true
+  }
 
   // Tear down any pending debounce timers when the controller leaves the DOM
   // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ preloads the asset, so this adds no latency.
 ```js
 // app/javascript/controllers/index.js
 import { application } from "./application"
-import ReactiveController from "phlex-reactive/reactive_controller"
+import ReactiveController from "phlex/reactive/reactive_controller"
 application.register("reactive", ReactiveController)
 ```
 

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -133,7 +133,61 @@ module Phlex
         Thread.current[:phlex_reactive_connection_id] = previous
       end
 
+      # The controller a correctly-mounted action path resolves to. Used by the
+      # route guard below.
+      ACTIONS_CONTROLLER = "phlex/reactive/actions"
+
+      # True when a POST to `path` resolves to the gem's ActionsController. A host
+      # catch-all route (match "*path", ...) appended above the engine's route
+      # SHADOWS it, so every reactive POST 404s and none of the controller runs —
+      # the opaque "is the endpoint even mounted?" failure (issue #26). A false
+      # here is the signal. Returns false (not raise) when nothing matches.
+      def action_route_ok?(path = action_path)
+        return false unless defined?(::Rails) && ::Rails.application
+
+        # At after_initialize (when the boot guard runs) the host's routes may not
+        # be drawn yet, so recognize_path would see an incomplete set and report a
+        # false shadow. Force-load routes first (idempotent — no-op if already
+        # loaded), so the check is correct whether it runs at boot or at runtime.
+        ensure_routes_loaded
+        recognized = ::Rails.application.routes.recognize_path(path, method: :post)
+        recognized[:controller] == ACTIONS_CONTROLLER
+      rescue ActionController::RoutingError, ActiveRecord::RecordNotFound
+        false
+      end
+
+      # Log a clear warning (once, at boot) when the action path doesn't resolve
+      # to the gem controller — pointing at the catch-all shadow rather than
+      # leaving an adopter to guess. Called from the engine's after_initialize.
+      def warn_unless_action_route_mounted!(path: action_path, logger: default_logger)
+        return if action_route_ok?(path)
+        return unless logger
+
+        logger.warn(
+          "[phlex-reactive] POST #{path} does not resolve to #{ACTIONS_CONTROLLER}. " \
+          "A host catch-all route (e.g. match \"*path\", ...) likely shadows it, so reactive " \
+          "actions will 404. Exempt #{path.sub(%r{\A/}, "")} from the catch-all, or set " \
+          "Phlex::Reactive.action_path to an unshadowed path. See the README integration section."
+        )
+      end
+
       private
+
+      # Materialize the route set if it hasn't been drawn yet (the engine appends
+      # POST /reactive/actions when routes are drawn, which may be after the boot
+      # guard's after_initialize). Idempotent; tolerant of older Rails.
+      def ensure_routes_loaded
+        reloader = ::Rails.application.routes_reloader
+        if reloader.respond_to?(:execute_unless_loaded)
+          reloader.execute_unless_loaded
+        elsif ::Rails.application.respond_to?(:reload_routes_unless_loaded)
+          ::Rails.application.reload_routes_unless_loaded
+        end
+      end
+
+      def default_logger
+        ::Rails.logger if defined?(::Rails) && ::Rails.respond_to?(:logger)
+      end
 
       def default_verifier
         unless defined?(::Rails) && ::Rails.application

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -206,7 +206,71 @@ module Phlex
         attrs
       end
 
+      # Bind a form control's `name` to an action param so its value travels with
+      # the action — instead of hand-writing the magic `name: "value"` on every
+      # input and silently getting no params when you forget it (issue #23).
+      # Returns a Phlex attributes hash to spread onto any control:
+      #   input(**reactive_field(:value, value: @record.name))
+      #   select(**reactive_field(:status)) { ... }
+      # Extra attrs merge over the binding; an explicit name: still wins (escape
+      # hatch). The trigger (on(:save)) stays on the button, not the field — so
+      # focusing the input doesn't dispatch and collapse edit mode.
+      def reactive_field(param, **attrs)
+        {name: param.to_s, **attrs}
+      end
+
+      # Render an <input> already bound to an action param (issue #23). Sugar for
+      # input(**reactive_field(param, **attrs)); the value/type/etc. pass through.
+      #   reactive_input(:value, value: @record.name, type: "text")
+      def reactive_input(param, **attrs)
+        input(**reactive_field(param, **attrs))
+      end
+
+      # Render a <select> bound to an action param (issue #23). The options block
+      # is the element's content, so the awkward FormBuilder positional split
+      # (where name: lands after the options/html-options args) goes away:
+      #   reactive_select(:status) { @statuses.each { |s| option(value: s, selected: s == @record.status) { s } } }
+      def reactive_select(param, **attrs, &block)
+        select(**reactive_field(param, **attrs), &block)
+      end
+
+      # Map a declared nested param onto Rails' <assoc>_attributes, carrying the
+      # existing associated record's id so accepts_nested_attributes_for matches
+      # it IN PLACE instead of building a second one (issue #24). Returns the
+      # update hash; pass it to update!:
+      #   def save(address:) = nested_update!(:address, address)
+      # The id is only added when the association already exists, so the first
+      # save (no associated record yet) creates one cleanly. The given attrs are
+      # not mutated.
+      def nested_attributes(association, attrs)
+        merged = attrs.dup
+        existing = reactive_record_for_nested.public_send(association)
+        merged[:id] = existing.id if existing
+
+        {"#{association}_attributes": merged}
+      end
+
+      # Map a nested param onto <assoc>_attributes (with id preservation) AND
+      # apply it to the component's record in one call (issue #24). Extra keyword
+      # attributes update alongside the association.
+      #   def save(address:, name:) = nested_update!(:address, address, name:)
+      def nested_update!(association, attrs, **extra)
+        reactive_record_for_nested.update!(**nested_attributes(association, attrs), **extra)
+      end
+
       private
+
+      # The component's record, for the nested-attributes helpers. Requires a
+      # declared reactive_record (the nested helper only makes sense for a
+      # record-backed component).
+      def reactive_record_for_nested
+        key = self.class.reactive_record_key
+        unless key
+          raise Error, "#{self.class} must declare `reactive_record` to use nested_update!/nested_attributes"
+        end
+
+        instance_variable_get(:"@#{key}")
+      end
 
       # Signed identity payload: the class name plus whichever identity pieces
       # the component declares — a record GlobalID (`gid`), signed state (`s`),

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -40,6 +40,15 @@ module Phlex
           )
         end
       end
+
+      # Boot-time guard (issue #26): warn if the action path doesn't resolve to
+      # the gem controller. Runs after_initialize so the host's full route set
+      # (including a bottom-of-file catch-all that would shadow our appended
+      # route) is drawn. Turns the opaque "every reactive POST 404s" failure into
+      # a one-line log pointing at the cause. No-op when the route is fine.
+      config.after_initialize do
+        Phlex::Reactive.warn_unless_action_route_mounted!
+      end
     end
   end
 end

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -12,6 +12,7 @@ module Phlex
     #
     #   Response.replace(self)                          # re-render in place (the default, explicit)
     #   Response.replace(self).flash(:error, msg)       # surface a validation error
+    #   Response.replace(self).also_update("heading", html: @record.name)  # + a companion element
     #   Response.remove(self)                           # drop the element (e.g. moderation queue)
     #   Response.redirect(article_url(@article))        # slug changed -> Turbo.visit the new URL
     #   Response.replace(self).stream(Totals.update(@order))  # multi-stream
@@ -44,8 +45,20 @@ module Phlex
         # supplied by the caller because the render context is off-request
         # (there is no Rails `flash`).
         def flash_stream(_level, content, target:)
-          html = content.is_a?(::Phlex::SGML) ? Phlex::Reactive.render(content) : content.to_s
-          Phlex::Reactive.flash_builder.append(target, html: html)
+          Phlex::Reactive.flash_builder.append(target, html: render_html(content))
+        end
+
+        # Build a turbo-stream that updates an arbitrary target id with `content`
+        # (a Phlex component instance or an HTML string). Used by #also_update to
+        # re-render a companion element that isn't itself a Streamable component.
+        def update_stream(target, content)
+          Phlex::Reactive.flash_builder.update(target, html: render_html(content))
+        end
+
+        # A Phlex component renders through the configured renderer (so
+        # t()/url_for/CSRF work off-request); anything else is used as-is.
+        def render_html(content)
+          content.is_a?(::Phlex::SGML) ? Phlex::Reactive.render(content) : content.to_s
         end
       end
 
@@ -74,6 +87,24 @@ module Phlex
       # <div id="flash">, configurable via Phlex::Reactive.flash_target).
       def flash(level, content, target: Phlex::Reactive.flash_target)
         stream(self.class.flash_stream(level, content, target:))
+      end
+
+      # Also re-render a COMPANION element alongside self — a page heading, a
+      # summary card, a badge that recomputes from the saved value (issue #25).
+      # `target` is the sibling element's DOM id; `html` is a Phlex component
+      # instance (rendered through the configured renderer so t()/url_for work)
+      # or a ready HTML string. Returns a NEW Response (immutable). The common
+      # "re-render self + N siblings" case no longer needs raw turbo_stream_builder.
+      #   Response.replace(self).also_update("page_heading", html: @record.name)
+      def also_update(target, html:)
+        stream(self.class.update_stream(target, html))
+      end
+
+      # Like #also_update, but renders ANOTHER Streamable component and replaces
+      # it by its own #id — for a companion that is itself a component.
+      #   Response.replace(self).also_replace(SummaryCard.new(order: @order))
+      def also_replace(component)
+        stream(component.to_stream_replace)
       end
 
       def redirect? = !@redirect_url.nil?

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -55,8 +55,15 @@ module Phlex
           Phlex::Reactive.flash_builder.update(target, html: render_html(content))
         end
 
-        # A Phlex component renders through the configured renderer (so
-        # t()/url_for/CSRF work off-request); anything else is used as-is.
+        # Resolve `content` to the HTML for a turbo-stream's `html:`. Two forms,
+        # both SAFE against injection by default:
+        #   * a Phlex component instance — rendered through the configured
+        #     renderer, which auto-escapes interpolated values.
+        #   * any other value — coerced with to_s and handed to Turbo's
+        #     TagBuilder, which HTML-ESCAPES a plain String. So a model value
+        #     (`html: @record.name`) cannot inject markup. To emit intentional
+        #     raw HTML, pass an `html_safe` String (Turbo leaves those verbatim)
+        #     or a Phlex component. Same contract as the pre-existing flash_stream.
         def render_html(content)
           content.is_a?(::Phlex::SGML) ? Phlex::Reactive.render(content) : content.to_s
         end
@@ -91,11 +98,14 @@ module Phlex
 
       # Also re-render a COMPANION element alongside self — a page heading, a
       # summary card, a badge that recomputes from the saved value (issue #25).
-      # `target` is the sibling element's DOM id; `html` is a Phlex component
-      # instance (rendered through the configured renderer so t()/url_for work)
-      # or a ready HTML string. Returns a NEW Response (immutable). The common
-      # "re-render self + N siblings" case no longer needs raw turbo_stream_builder.
-      #   Response.replace(self).also_update("page_heading", html: @record.name)
+      # `target` is the sibling element's DOM id. `html` is either:
+      #   * a plain String — HTML-ESCAPED by Turbo, so a model value is safe:
+      #       Response.replace(self).also_update("page_heading", html: @record.name)
+      #   * a Phlex component — rendered + auto-escaped through the renderer (use
+      #     this when the companion has its own markup), or an `html_safe` String
+      #     for intentional raw HTML.
+      # Returns a NEW Response (immutable). The common "re-render self + N
+      # siblings" case no longer needs raw turbo_stream_builder.
       def also_update(target, html:)
         stream(self.class.update_stream(target, html))
       end

--- a/spec/dummy/app/components/address_editor_component.rb
+++ b/spec/dummy/app/components/address_editor_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Exercises the accepts_nested_attributes_for helper (issue #24): a reactive
+# editor for an Account's has_one :address. save(address:) maps straight onto
+# address_attributes via nested_update!, which preserves the existing record id
+# so update_only matches in place instead of building a second association.
+class AddressEditorComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :account
+
+  action :save, params: {
+    address: {street: :string, city: :string, postal_code: :string, country: :string}
+  }
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def id = dom_id(@account, "address_editor")
+
+  def save(address:)
+    nested_update!(:address, address)
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      reactive_input(:"address[street]", value: @account.address&.street)
+      button(**mix(on(:save), data: {testid: "save"})) { "Save" }
+    end
+  end
+end

--- a/spec/dummy/app/components/address_editor_component.rb
+++ b/spec/dummy/app/components/address_editor_component.rb
@@ -20,6 +20,9 @@ class AddressEditorComponent < ApplicationComponent
 
   def id = dom_id(@account, "address_editor")
 
+  # Real apps authorize the record here (e.g. `authorize! @account, :update?` —
+  # see docs/security.md); the dummy app has no authz layer, like every other
+  # fixture, so the contract is demonstrated in the docs, not baked in here.
   def save(address:)
     nested_update!(:address, address)
   end

--- a/spec/dummy/app/components/reactive_input_component.rb
+++ b/spec/dummy/app/components/reactive_input_component.rb
@@ -21,9 +21,10 @@ class ReactiveInputComponent < ApplicationComponent
 
   def id = dom_id(@record, "reactive_input")
 
+  # `status` is rendered only to exercise reactive_select's name binding (the
+  # dummy Todo has no status column); the edited attribute is what we persist.
   def save(value: nil, status: nil)
     @record.update!(@attribute => value) if value
-    @record.update!(@attribute => status) if status
   end
 
   def view_template

--- a/spec/dummy/app/components/reactive_input_component.rb
+++ b/spec/dummy/app/components/reactive_input_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Exercises the reactive_input/reactive_select param-binding helpers (issue #23).
+# The edit-mode controls bind to the :save action's `value:`/`status:` params via
+# reactive_input/reactive_select — no hand-written `name: "value"` magic string.
+class ReactiveInputComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :record
+  reactive_state :attribute
+
+  action :save, params: {value: :string, status: :string}
+
+  STATUSES = %w[open closed].freeze
+
+  def initialize(record:, attribute: :title)
+    @record = record
+    @attribute = attribute.to_sym
+  end
+
+  def id = dom_id(@record, "reactive_input")
+
+  def save(value: nil, status: nil)
+    @record.update!(@attribute => value) if value
+    @record.update!(@attribute => status) if status
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      # name="value" emitted by the helper, not hand-written.
+      reactive_input(:value, value: @record.public_send(@attribute).to_s, data: {testid: "field"})
+
+      reactive_select(:status, data: {testid: "status"}) do
+        STATUSES.each { |s| option(value: s) { s } }
+      end
+
+      button(**mix(on(:save), data: {testid: "save"})) { "Save" }
+    end
+  end
+end

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Owner of a has_one :address, edited inline via the nested-attributes helper
+# (issue #24). update_only: true means Rails matches the existing address by id
+# rather than building a second one — which is exactly the id preservation the
+# nested_update! helper automates.
+class Account < ActiveRecord::Base
+  has_one :address, dependent: :destroy
+  accepts_nested_attributes_for :address, update_only: true
+
+  validates :name, presence: true
+end

--- a/spec/dummy/app/models/address.rb
+++ b/spec/dummy/app/models/address.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Address < ActiveRecord::Base
+  belongs_to :account
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -21,4 +21,20 @@ ActiveRecord::Schema.define(version: 1) do
     t.text :body, null: false
     t.timestamps
   end
+
+  # Owner + has_one association for the accepts_nested_attributes_for helper
+  # (issue #24): an Account that edits its Address inline via nested_update!.
+  create_table :accounts, force: true do |t|
+    t.string :name, null: false
+    t.timestamps
+  end
+
+  create_table :addresses, force: true do |t|
+    t.references :account, null: false
+    t.string :street
+    t.string :city
+    t.string :postal_code
+    t.string :country
+    t.timestamps
+  end
 end

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -36,6 +36,49 @@ if (typeof window !== "undefined") {
   else document.addEventListener("turbo:load", registerReactiveVisit, { once: true })
 }
 
+// --- Registration guard (issue #26 part 2) -------------------------------
+// In a `lazyLoadControllersFrom("controllers", application)` app, only
+// controllers under app/javascript/controllers/ are registered. This module
+// lives outside that dir, so importing it isn't enough — `data-controller=
+// "reactive"` does NOTHING until the host runs application.register("reactive",
+// ...). The failure is silent: components render, but no action ever fires.
+//
+// We can't warn from connect() in that case (connect never runs). Instead, once
+// the page is ready, if reactive elements exist but no controller has connected,
+// the controller wasn't registered — so we warn, pointing at the fix.
+let reactiveConnected = false
+
+export function checkReactiveRegistration() {
+  if (reactiveConnected) return
+  if (typeof document === "undefined") return
+  const els = document.querySelectorAll('[data-controller~="reactive"]')
+  if (!els || els.length === 0) return
+  console.warn(
+    "[phlex-reactive] found " + els.length + ' element(s) with data-controller="reactive" ' +
+      "but the reactive controller never connected. It is loaded but not registered — " +
+      'add `application.register("reactive", ReactiveController)` (importmap) or import it ' +
+      "into app/javascript/controllers/ for lazyLoadControllersFrom apps. See the README."
+  )
+}
+
+// Test seams (no-ops in production usage).
+export function __resetReactiveRegistrationForTest() {
+  reactiveConnected = false
+}
+export function __markReactiveConnectedForTest() {
+  reactiveConnected = true
+}
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  // Defer past initial controller connection (a microtask/tick after ready).
+  const scheduleCheck = () => setTimeout(checkReactiveRegistration, 0)
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scheduleCheck, { once: true })
+  } else {
+    scheduleCheck()
+  }
+}
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.
@@ -46,6 +89,12 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+
+  // Mark that a reactive controller actually connected, so the registration
+  // guard above knows the controller was registered (issue #26 part 2).
+  connect() {
+    reactiveConnected = true
+  }
 
   // Tear down any pending debounce timers when the controller leaves the DOM
   // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't

--- a/spec/javascript/reactive_registration_guard.test.js
+++ b/spec/javascript/reactive_registration_guard.test.js
@@ -1,0 +1,63 @@
+// Unit test for the registration guard (issue #26 part 2).
+//
+// In a `lazyLoadControllersFrom("controllers", application)` app, only
+// controllers under app/javascript/controllers/ get registered. The gem's
+// controller lives outside that dir, so `data-controller="reactive"` silently
+// does nothing — components render but no action ever fires, with no error.
+//
+// checkReactiveRegistration() detects exactly this: reactive elements present in
+// the DOM, but no reactive controller ever connected. It warns; otherwise stays
+// silent.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+
+let mod
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+})
+
+let warnings
+beforeEach(() => {
+  warnings = []
+  globalThis.console = { warn: (...a) => warnings.push(a.join(" ")), error: () => {} }
+  mod.__resetReactiveRegistrationForTest()
+})
+
+afterEach(() => {
+  delete globalThis.document
+})
+
+function docWithReactiveEls(count) {
+  return {
+    querySelectorAll: (sel) =>
+      sel.includes("reactive") ? new Array(count).fill({}) : [],
+  }
+}
+
+test("warns when reactive elements exist but no controller connected", () => {
+  globalThis.document = docWithReactiveEls(2)
+  mod.checkReactiveRegistration()
+  expect(warnings.length).toBe(1)
+  expect(warnings[0]).toContain("phlex-reactive")
+  expect(warnings[0].toLowerCase()).toContain("register")
+})
+
+test("stays silent when a controller has connected", () => {
+  globalThis.document = docWithReactiveEls(2)
+  mod.__markReactiveConnectedForTest()
+  mod.checkReactiveRegistration()
+  expect(warnings.length).toBe(0)
+})
+
+test("stays silent when there are no reactive elements at all", () => {
+  globalThis.document = docWithReactiveEls(0)
+  mod.checkReactiveRegistration()
+  expect(warnings.length).toBe(0)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -247,6 +247,27 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#reactive_field param binding (issue #23)" do
+    subject(:instance) { state_klass.new }
+
+    it "binds the field name to the action param (drops the magic name: string)" do
+      attrs = instance.send(:reactive_field, :count)
+      expect(attrs[:name]).to eq("count")
+    end
+
+    it "merges extra attributes over the bound name" do
+      attrs = instance.send(:reactive_field, :count, value: 7, data: {testid: "f"})
+      expect(attrs[:name]).to eq("count")
+      expect(attrs[:value]).to eq(7)
+      expect(attrs[:data]).to eq({testid: "f"})
+    end
+
+    it "lets an explicit name: override the param binding (escape hatch)" do
+      attrs = instance.send(:reactive_field, :count, name: "other")
+      expect(attrs[:name]).to eq("other")
+    end
+  end
+
   describe "#on trigger attributes (issue #17 debounce)" do
     subject(:instance) { state_klass.new }
 

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -49,6 +49,54 @@ RSpec.describe Phlex::Reactive::Response do
     expect(base).to be_frozen
   end
 
+  # Issue #25: re-render self + a companion element/component without dropping to
+  # raw turbo_stream_builder.
+  describe "also_update / also_replace (companion elements)" do
+    it "also_update appends an update stream for an arbitrary target id" do
+      response = described_class.replace(counter).also_update("page_heading", html: "New name")
+
+      expect(response.streams.size).to eq(2)
+      expect(response.render_self?).to be(true)
+      expect(response.streams.last).to include('action="update"')
+      expect(response.streams.last).to include('target="page_heading"')
+      expect(response.streams.last).to include("New name")
+    end
+
+    it "also_update HTML-escapes a plain string but renders a Phlex component" do
+      probe = Class.new(Phlex::HTML) do
+        def self.name = "HeadingProbe"
+        def view_template = strong { "Bold heading" }
+      end
+      response = described_class.with.also_update("page_heading", html: probe.new)
+
+      expect(response.streams.first).to include("<strong>Bold heading</strong>")
+    end
+
+    it "also_replace renders another Streamable component, targeting its own id" do
+      response = described_class.replace(counter).also_replace(item)
+
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.last).to include('action="replace"')
+      expect(response.streams.last).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "is immutable — also_* return new instances and keep render_self" do
+      base = described_class.replace(counter)
+      extended = base.also_update("h", html: "x")
+      expect(extended).not_to equal(base)
+      expect(base.streams.size).to eq(1) # original unchanged
+      expect(extended.render_self?).to be(true)
+    end
+
+    it "chains alongside flash and stream" do
+      response = described_class.replace(counter)
+        .also_update("heading", html: "n")
+        .flash(:notice, "saved")
+
+      expect(response.streams.size).to eq(3)
+    end
+  end
+
   it "flash accepts a Phlex component, rendered through the configured renderer" do
     klass = Class.new(Phlex::HTML) do
       def self.name = "FlashAlertProbe" # ActionView's render logger needs a name

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Phlex::Reactive::Response do
       expect(response.streams.last).to include("New name")
     end
 
-    it "also_update HTML-escapes a plain string but renders a Phlex component" do
+    it "also_update renders a Phlex component (auto-escaped) into the companion stream" do
       probe = Class.new(Phlex::HTML) do
         def self.name = "HeadingProbe"
         def view_template = strong { "Bold heading" }
@@ -70,6 +70,22 @@ RSpec.describe Phlex::Reactive::Response do
       response = described_class.with.also_update("page_heading", html: probe.new)
 
       expect(response.streams.first).to include("<strong>Bold heading</strong>")
+    end
+
+    it "also_update HTML-escapes a plain string (a model value is safe)" do
+      # Turbo's TagBuilder escapes a plain String passed to html:, so a model
+      # value can't inject markup. (Pass an html_safe string or a Phlex
+      # component to emit intentional raw HTML.)
+      response = described_class.with.also_update("page_heading", html: "<em>Live</em>")
+
+      expect(response.streams.first).to include("&lt;em&gt;Live&lt;/em&gt;")
+      expect(response.streams.first).not_to include("<em>Live</em>")
+    end
+
+    it "also_update emits an html_safe string as raw markup" do
+      response = described_class.with.also_update("page_heading", html: "<em>Live</em>".html_safe)
+
+      expect(response.streams.first).to include("<em>Live</em>")
     end
 
     it "also_replace renders another Streamable component, targeting its own id" do

--- a/spec/requests/integration_guard_spec.rb
+++ b/spec/requests/integration_guard_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #26 part 1: a host catch-all route can shadow POST /reactive/actions, so
+# every reactive POST 404s and none of the gem's controller runs — looking
+# exactly like "the endpoint isn't mounted." A boot-time check surfaces the
+# cause instead of leaving adopters to guess.
+RSpec.describe "Reactive action route guard (issue #26)", type: :request do
+  describe ".action_route_ok?" do
+    it "is true when the action path resolves to the gem controller" do
+      expect(Phlex::Reactive.action_route_ok?).to be(true)
+    end
+
+    it "is false when the path resolves to a DIFFERENT controller (shadowed)" do
+      # Simulate a catch-all by pointing the check at a POST path the dummy app
+      # routes elsewhere (nav_probe -> demos), not the gem controller.
+      expect(Phlex::Reactive.action_route_ok?("/nav_probe")).to be(false)
+    end
+
+    it "is false when no route matches the path at all" do
+      expect(Phlex::Reactive.action_route_ok?("/definitely/not/mounted/anywhere")).to be(false)
+    end
+  end
+
+  describe ".warn_unless_action_route_mounted!" do
+    it "logs a warning naming the path and the catch-all cause when shadowed" do
+      logger = instance_double(Logger)
+      expect(logger).to receive(:warn).with(
+        a_string_including("phlex-reactive").and(
+          a_string_including("/nav_probe").and(a_string_including("catch-all"))
+        )
+      )
+
+      Phlex::Reactive.warn_unless_action_route_mounted!(path: "/nav_probe", logger:)
+    end
+
+    it "stays silent when the route resolves correctly" do
+      logger = instance_double(Logger)
+      expect(logger).not_to receive(:warn)
+
+      Phlex::Reactive.warn_unless_action_route_mounted!(logger:)
+    end
+  end
+end

--- a/spec/requests/nested_attributes_helper_spec.rb
+++ b/spec/requests/nested_attributes_helper_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #24: nested_update! / nested_attributes map a declared nested param onto
+# <assoc>_attributes and carry the existing record id automatically, so an
+# accepts_nested_attributes_for editor doesn't re-derive the *_attributes + id
+# preservation boilerplate by hand (and risk a duplicate has_one build).
+RSpec.describe "accepts_nested_attributes_for helper (issue #24)", type: :request do
+  def token_for(klass, payload)
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  def post_action(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  let(:account) { Account.create!(name: "Acme") }
+  let(:component) { AddressEditorComponent.new(account:) }
+
+  describe "#nested_attributes (the id-preserving map)" do
+    it "builds <assoc>_attributes with no id when the association is absent" do
+      result = component.send(:nested_attributes, :address, {street: "1 Main"})
+
+      expect(result).to eq(address_attributes: {street: "1 Main"})
+    end
+
+    it "carries the existing record id when the association is present" do
+      addr = account.create_address!(street: "old")
+      result = component.send(:nested_attributes, :address, {street: "new"})
+
+      expect(result).to eq(address_attributes: {street: "new", id: addr.id})
+    end
+
+    it "does not mutate the params it was given" do
+      account.create_address!(street: "old")
+      params = {street: "new"}
+      component.send(:nested_attributes, :address, params)
+
+      expect(params).to eq({street: "new"}) # no id leaked in
+    end
+  end
+
+  describe "#nested_update! (end-to-end through the action)" do
+    it "creates the associated record on first save (no duplicate build)" do
+      post_action(AddressEditorComponent, payload: {"gid" => account.to_gid.to_s}, act: "save",
+        params: {address: {street: "1 Main", city: "Town"}})
+
+      expect(response).to have_http_status(:ok)
+      account.reload
+      expect(account.address).to be_present
+      expect(account.address.street).to eq("1 Main")
+      expect(Address.where(account_id: account.id).count).to eq(1)
+    end
+
+    it "UPDATES the existing record in place (id preserved, no second has_one)" do
+      addr = account.create_address!(street: "old", city: "Oldtown")
+
+      post_action(AddressEditorComponent, payload: {"gid" => account.to_gid.to_s}, act: "save",
+        params: {address: {street: "new", city: "Newtown"}})
+
+      expect(response).to have_http_status(:ok)
+      expect(addr.reload.street).to eq("new")
+      expect(addr.reload.city).to eq("Newtown")
+      # Crucial: still exactly ONE address — the id was preserved, not rebuilt.
+      expect(Address.where(account_id: account.id).count).to eq(1)
+      expect(account.reload.address.id).to eq(addr.id)
+    end
+  end
+end

--- a/spec/requests/reactive_input_spec.rb
+++ b/spec/requests/reactive_input_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #23: reactive_input/reactive_select emit the action-param `name`
+# binding, so the value travels with the action without a hand-written
+# `name: "value"` magic string. We assert BOTH the rendered markup carries the
+# right name AND the action actually receives the bound param end-to-end.
+RSpec.describe "reactive_input / reactive_select binding (issue #23)", type: :request do
+  def token_for(klass, payload)
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  def post_action(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  let!(:todo) { Todo.create!(title: "before", done: false) }
+  let(:payload) { {"gid" => todo.to_gid.to_s, "s" => {"attribute" => "title"}} }
+
+  it "renders an input whose name is the bound param (not a magic string)" do
+    html = Phlex::Reactive.render(ReactiveInputComponent.new(record: todo, attribute: :title))
+
+    expect(html).to include('name="value"')
+    expect(html).to include('value="before"')
+  end
+
+  it "renders a select bound to the param with the option block as content" do
+    html = Phlex::Reactive.render(ReactiveInputComponent.new(record: todo, attribute: :title))
+
+    expect(html).to match(/<select[^>]*name="status"/)
+    expect(html).to include("<option")
+    expect(html).to include(">open<")
+  end
+
+  it "delivers the bound value to the action end-to-end" do
+    post_action(ReactiveInputComponent, payload:, act: "save", params: {value: "after"})
+
+    expect(response).to have_http_status(:ok)
+    expect(todo.reload.title).to eq("after")
+  end
+end


### PR DESCRIPTION
Four cosmos-dogfooding ergonomics features from the inline-editing framework work, batched into one PR. Each is independent and additive — existing components are untouched.

## #23 — Input/select param-binding helpers

A field's value travels with an action only if its `name` equals the param. Hand-writing `name: "value"` on every input is easy to forget — the action then silently receives nothing.

```ruby
action :save, params: { value: :string, status: :string }

reactive_input(:value, value: @record.name)   # <input name="value" …>
reactive_select(:status) do                    # <select name="status">…</select>
  %w[open closed].each { |s| option(value: s, selected: s == @record.status) { s } }
end
```

`reactive_field(:param, **attrs)` returns just the attribute hash; an explicit `name:` still wins (escape hatch). The trigger stays on the button, so focusing the field doesn't dispatch and collapse edit mode.

## #24 — `accepts_nested_attributes_for` helper

`nested_update!` maps a declared nested param onto Rails `<assoc>_attributes` and carries the existing record's id, so `update_only:` matches it in place instead of building a second `has_one`:

```ruby
# Account has_one :address; accepts_nested_attributes_for :address, update_only: true
def save(address:)
  nested_update!(:address, address)   # update!(address_attributes: address.merge(id: @account.address&.id))
end
```

The spec proves the crucial invariant: after an update there is still **exactly one** address, id preserved, no duplicate build. `nested_attributes(:address, address)` returns the id-merged hash without updating.

## #25 — `Response#also_update` / `#also_replace`

Re-render a companion element (a heading, a summary card) alongside self without dropping to raw `turbo_stream_builder`:

```ruby
Response.replace(self).also_update("page_heading", html: @record.name)   # arbitrary DOM id; html: string or Phlex component
Response.replace(self).also_replace(SummaryCard.new(order: @order))      # another Streamable, by its own #id
```

Immutable and additive — the self-replace still refreshes the signed token.

## #26 — Boot-time integration guards

Two silent first-run failures now surface a clear warning:

**Catch-all route shadowing.** A host `match "*path", …` appended below the engine's route shadows `POST /reactive/actions`, so every reactive POST 404s and no controller runs. Detected at boot via `Phlex::Reactive.action_route_ok?`.

> Root-cause note: the first cut of the boot check false-warned in the dummy app because at `after_initialize` the host's appended routes weren't materialized yet. Fixed at the right place — `action_route_ok?` now force-loads routes (`routes_reloader.execute_unless_loaded`, idempotent) before recognizing, so the check is correct at boot *and* runtime. Verified: 0 warnings on the dummy app's clean boot.

**Stimulus controller not registered.** In `lazyLoadControllersFrom("controllers", application)` apps the gem's controller lives outside `app/javascript/controllers/`, so `data-controller="reactive"` does nothing until it's registered explicitly. The client runtime now logs a console warning when reactive elements exist but no controller ever connected.

README gains an "Integration troubleshooting" section covering both fixes.

## Test coverage

| Area | Spec |
|------|------|
| #23 param binding | `component_spec.rb` (reactive_field) + `reactive_input_spec.rb` (markup + end-to-end) |
| #24 nested attrs | `nested_attributes_helper_spec.rb` (id-preserving map, no duplicate build) |
| #25 companion streams | `response_spec.rb` (also_update/also_replace, immutability, chaining) |
| #26 route guard | `integration_guard_spec.rb` (ok / shadowed / unmounted / warning) |
| #26 JS registration | `reactive_registration_guard.test.js` (warn when unconnected, silent otherwise) |

## Verification

- [x] `bundle exec standardrb` — clean
- [x] `bundle exec rspec` — 105 unit/request/generator + 16 system, 0 failures
- [x] `bun test spec/javascript` — 15, 0 failures
- [x] Backwards compatible — all pre-existing tests pass; helpers are additive
- [x] pgbus optionality untouched (none of these touch the broadcast path)
- [x] Vendored `reactive_controller.js` re-synced after the JS edit
- [x] README + CHANGELOG updated

Closes #23
Closes #24
Closes #25
Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper methods for action-param binding to inputs, selects, and generic fields (with an explicit name override).
  * Added nested-attributes helpers for updating associated records, preserving existing IDs.
  * Added `also_update` / `also_replace` companion Turbo Stream actions to update multiple elements per response.
* **Bug Fixes**
  * Added boot-time warnings for “nothing happens” cases: shadowed reactive POST action route and missing reactive controller registration.
* **Documentation**
  * Expanded integration troubleshooting and usage examples for the new helpers and stream behavior.
* **Tests**
  * Added coverage for binding, nested updates, companion streams, and the startup/route guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->