### PR TITLE
feat(streamable): morph response preserves focus + in-progress input (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Morph response — focus-preserving re-render (issue #28).**
+  `Response.morph(self)` (and the opt-in `Response.replace(self, morph: true)`)
+  re-renders a component in place via Turbo 8's bundled Idiomorph
+  (`<turbo-stream action="replace" method="morph">`) instead of an outerHTML
+  swap. The focused `<input>` and its caret survive the save, making per-field
+  reactive editing — a "spreadsheet" grid where a debounced save fires while the
+  user is still typing/tabbing — actually viable. Backed by the new
+  `Streamable#to_stream_morph` primitive and a `morph:` flag on the
+  `.replace` / `.broadcast_replace_to` class builders and `Response#also_replace`
+  (live cross-tab updates can morph too). The default everywhere stays the plain
+  replace (no `method="morph"` attribute), so existing components are unchanged.
+  No new dependency — Idiomorph ships with `turbo-rails >= 2.0`.
 - **Input/select param-binding helpers (issue #23).** `reactive_input(:value,
   …)` and `reactive_select(:status, …) { … }` render a form control already bound
   to an action param — no hand-written `name: "value"` magic string to forget

--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
 | Method | Use |
 |---|---|
 | `#id` (you implement) | Stable DOM id == Turbo Stream target. Must match the root element's `id`. |
-| `.replace(model = nil, **opts)` | `<turbo-stream action=replace target=id>` of a freshly built component |
+| `.replace(model = nil, morph: false, **opts)` | `<turbo-stream action=replace target=id>` of a freshly built component; `morph: true` adds `method="morph"` |
 | `.update` / `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
-| `.broadcast_replace_to(*streamables, model:)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable) |
+| `.broadcast_replace_to(*streamables, model:, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
 | `.broadcast_append_to(*streamables, target:, model:)` / `_update_` / `_prepend_` / `_remove_` | The broadcast variants |
-| `#to_stream_replace` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `Response`) |
+| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `Response`); `#to_stream_morph` morphs in place |
 
 Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 
@@ -445,15 +445,21 @@ def approve   = (@row.approve!; Response.remove(self))          # drop the eleme
 def publish   = (@article.publish!; Response.redirect(article_url(@article)))  # slug changed → Turbo.visit
 def add(item:) = Response.replace(self).stream(Totals.update(@order))           # multi-stream
 
+# Per-field reactive editing (a "spreadsheet" grid): a debounced save fires
+# while the user is still typing/tabbing. Morph in place so the focused <input>
+# and its in-progress value survive the re-render (issue #28):
+def update(name:) = (@row.update!(name:); Response.morph(self))
+
 # Re-render a COMPANION element (a heading mirroring the edited name) alongside self:
 def rename(value:) = (@account.update!(name: value); Response.replace(self).also_update("page_heading", html: @account.name))
 ```
 
 | Builder | Reply |
 |---|---|
-| `Response.replace(self)` / `.update(self)` | re-render in place (explicit default) |
+| `Response.replace(self)` / `.update(self)` | re-render in place (explicit default; `replace` is an outerHTML swap, `update` morphs inner HTML) |
+| `Response.morph(self)` / `Response.replace(self, morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (issue #28) |
 | `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
-| `.also_replace(component)` | also re-render another Streamable component, targeting its own `#id` |
+| `.also_replace(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
 | `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped) or a Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `Response.remove(self)` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `Response.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -4,7 +4,8 @@ import { Controller } from "@hotwired/stimulus"
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
 // for interactive components. A component declares its actions in Ruby (via
 // Phlex::Reactive::Component); this controller binds DOM events to a single
-// HTTP round trip and lets Turbo morph the re-rendered component back in.
+// HTTP round trip and lets Turbo apply the re-rendered component back in
+// (replace by default; method="morph" — Response.morph — preserves focus).
 //
 // Wire format (client -> server), POST <action path>, turbo-stream Accept:
 //   { token: "<signed identity>", act: "<action>", params: {...} }
@@ -222,8 +223,10 @@ export default class extends Controller {
       // Capture the new token from the response synchronously, so the next
       // queued request uses it without waiting for the async DOM morph.
       this.#currentToken = this.#extractToken(html) ?? this.#currentToken
-      // Turbo applies the <turbo-stream> ops (replace/morph by id), preserving
-      // focus/scroll/listeners on unchanged nodes.
+      // Turbo applies the <turbo-stream> ops by id. A plain replace is an
+      // outerHTML swap (focus on the replaced subtree is lost); a method="morph"
+      // replace (Response.morph) or an update morphs in place, preserving the
+      // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
     } catch (error) {
       console.error("[phlex-reactive] action error", error)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,9 @@ the action returns a [`Phlex::Reactive::Response`](../README.md#phlexreactiveres
 flash), the endpoint renders that; otherwise it falls back to the implicit single
 `component.to_stream_replace` (the legacy contract). For any non-remove/redirect
 reply the component's own replace is guaranteed present so its token refreshes.
-Turbo morphs it in.
+Turbo applies it in: a plain `replace` is an outerHTML swap; `Response.morph(self)`
+(or `update`) morphs the subtree in place, preserving the focused input + caret
+for per-field editing (issue #28).
 
 ### What collected fields are
 

--- a/docs/examples/inline_edit.md
+++ b/docs/examples/inline_edit.md
@@ -104,6 +104,36 @@ appends into `Phlex::Reactive.flash_target` (default `<div id="flash">`); pass a
 Phlex component instead of a string for rich markup. See
 [Response](../README.md#phlexreactiveresponse--controlling-the-actions-reply).
 
+## Live-as-you-type (a spreadsheet-like grid)
+
+For per-field editing where a **debounced save fires while the user is still
+typing or tabbing**, a plain `Response.replace(self)` is wrong: it's an
+outerHTML swap that destroys the `<input>` you're typing in — focus and the
+in-progress value vanish. Return `Response.morph(self)` instead. It emits
+`<turbo-stream action="replace" method="morph">`, so Turbo 8's bundled Idiomorph
+morphs the subtree in place — the focused field and its caret survive the save.
+
+```ruby
+action :update, params: { name: :string }
+
+def update(name:)
+  authorize! @record, :update?
+  @record.update!(name:) if name.present?
+  Phlex::Reactive::Response.morph(self)   # morph in place — keep focus + caret
+end
+
+def view_template
+  div(id:, **reactive_attrs) do
+    # The field both holds the value AND triggers the debounced save.
+    input(**mix(on(:update, event: "input", debounce: 300),
+      name: "name", value: @record.name))
+  end
+end
+```
+
+`Response.replace(self, morph: true)` is the same thing via the opt-in flag; the
+morphed root still carries a fresh signed token, so the next edit verifies.
+
 ## Want it to update other viewers too?
 
 Broadcast on save:

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -5,8 +5,10 @@ module Phlex
     # Component turns a self-contained Phlex component into a Livewire-style
     # reactive unit: declare actions in Ruby, and the generic `reactive`
     # Stimulus controller wires clicks/inputs to an HTTP round trip that
-    # re-renders the component and morphs it back into the DOM. No per-feature
-    # Stimulus controllers, no hand-picked Turbo targets.
+    # re-renders the component and applies it back into the DOM (a plain replace
+    # by default; return Response.morph(self) to morph in place and keep the
+    # focused input — issue #28). No per-feature Stimulus controllers, no
+    # hand-picked Turbo targets.
     #
     # Include alongside Phlex::Reactive::Streamable (which provides #id and the
     # re-render machinery).

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -21,7 +21,19 @@ module Phlex
 
       class << self
         # Re-render the component in place (explicit form of today's default).
-        def replace(component) = new(streams: [component.to_stream_replace])
+        # `morph: true` morphs the subtree (preserves the focused input + caret)
+        # instead of an outerHTML swap — see .morph (issue #28).
+        def replace(component, morph: false)
+          new(streams: [morph ? component.to_stream_morph : component.to_stream_replace])
+        end
+
+        # Re-render the component in place via Idiomorph (issue #28). Emits
+        # `<turbo-stream action="replace" method="morph">`, so Turbo 8 morphs the
+        # subtree — the focused <input> + caret survive the save. Use this for
+        # per-field reactive editing (a "spreadsheet" grid where a debounced save
+        # fires while the user is still typing/tabbing). The morphed root still
+        # carries the fresh signed token, so the next action verifies.
+        def morph(component) = new(streams: [component.to_stream_morph])
 
         # Morph only inner HTML (preserves the root element + its token attr).
         def update(component) = new(streams: [component.to_stream_update])
@@ -113,8 +125,10 @@ module Phlex
       # Like #also_update, but renders ANOTHER Streamable component and replaces
       # it by its own #id — for a companion that is itself a component.
       #   Response.replace(self).also_replace(SummaryCard.new(order: @order))
-      def also_replace(component)
-        stream(component.to_stream_replace)
+      # `morph: true` morphs the companion in place (issue #28) — use it when the
+      # companion also holds focusable inputs that must survive the re-render.
+      def also_replace(component, morph: false)
+        stream(morph ? component.to_stream_morph : component.to_stream_replace)
       end
 
       def redirect? = !@redirect_url.nil?

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -64,9 +64,13 @@ module Phlex
           renderer.render(component, layout: false)
         end
 
-        def replace(model = nil, **options)
+        # `morph: true` emits `<turbo-stream action="replace" method="morph">` so
+        # Turbo 8's bundled Idiomorph morphs the subtree in place — preserving a
+        # focused <input> + caret — instead of an outerHTML swap (issue #28).
+        # Default (morph: false) is the unchanged plain replace.
+        def replace(model = nil, morph: false, **options)
           component = build(model, options)
-          turbo_stream_builder.replace(component.id, html: render_component(component))
+          turbo_stream_builder.replace(component.id, html: render_component(component), **morph_method(morph))
         end
 
         def update(model = nil, **options)
@@ -103,11 +107,15 @@ module Phlex
         # connection id — pass it to suppress the actor's own echo (the actor
         # already got the action's HTTP response). With Action Cable these are
         # ignored; with pgbus they reach the dispatcher. See docs/broadcasting.
-        def broadcast_replace_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
+        # `morph: true` makes the live cross-tab update morph in place (issue #28),
+        # so a peer tab keeps its focus/caret on the morphed row. The broadcast
+        # path takes EXTRA <turbo-stream> attributes via `attributes:` (not the
+        # TagBuilder's `method:` kwarg), so the morph flag rides there.
+        def broadcast_replace_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
           component = build(model, options)
           ::Turbo::StreamsChannel.broadcast_replace_to(
             *streamables, target: component.id, html: render_component(component),
-            **broadcast_transport_opts(exclude:, visible_to:)
+            **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
           )
         end
 
@@ -149,6 +157,20 @@ module Phlex
           new(**(model ? component_args(model, options) : options))
         end
 
+        # The TagBuilder (the .replace class builder + to_stream_morph) takes
+        # `method: :morph` to emit the `method="morph"` attribute. Pass it ONLY
+        # when morphing, so the default call produces today's plain replace.
+        def morph_method(morph)
+          morph ? {method: :morph} : {}
+        end
+
+        # The BROADCAST path renders extra <turbo-stream> attributes through
+        # `attributes:` (it has no `method:` kwarg — that would fall into the
+        # render args and be dropped). Same wire result: method="morph".
+        def morph_attributes(morph)
+          morph ? {attributes: {method: "morph"}} : {}
+        end
+
         # Only include transport opts that were actually given, so on Action
         # Cable (which doesn't accept them) the common no-opts call is unchanged.
         def broadcast_transport_opts(exclude:, visible_to:)
@@ -182,6 +204,16 @@ module Phlex
       # reactive action endpoint after an action mutated state).
       def to_stream_replace
         self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self))
+      end
+
+      # Render THIS instance as a MORPHING replace (issue #28):
+      # `<turbo-stream action="replace" method="morph">`. Turbo 8's bundled
+      # Idiomorph morphs the subtree in place — preserving the focused <input> +
+      # caret across the re-render — while still carrying the root's fresh
+      # data-reactive-token-value (so the signed token refreshes). Used by
+      # Response.morph / Response.replace(self, morph: true).
+      def to_stream_morph
+        self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph)
       end
 
       def to_stream_update

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -12,6 +12,7 @@ class CounterComponent < ApplicationComponent
   action :set, params: {count: :integer}
   action :reset_with_flash
   action :bump_via_update
+  action :bump_via_morph
   action :go_home
 
   def initialize(count: 0)
@@ -35,6 +36,15 @@ class CounterComponent < ApplicationComponent
   def bump_via_update
     @count += 1
     Phlex::Reactive::Response.update(self)
+  end
+
+  # Response: morph the whole element in place (issue #28). Emits
+  # action="replace" method="morph", so Idiomorph preserves a focused input +
+  # caret. The morphed root carries the fresh token, so it must NOT be doubled
+  # with a contradictory plain replace.
+  def bump_via_morph
+    @count += 1
+    Phlex::Reactive::Response.morph(self)
   end
 
   # Response: client-side full navigation (no in-place stream). Targets a real

--- a/spec/dummy/app/components/morph_grid_component.rb
+++ b/spec/dummy/app/components/morph_grid_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Issue #28: the "edit a row, it saves" grid. Each field fires a DEBOUNCED
+# `update` while the user is still typing/tabbing. The action returns
+# Response.morph(self), so the row re-renders via Idiomorph — the focused input
+# and its in-progress value survive the save. With a plain Response.replace this
+# row would outerHTML-swap, blur the field, and drop the just-typed value.
+class MorphGridComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :account
+
+  action :update, params: {name: :string}
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def id = dom_id(@account)
+
+  # Persist the edit and morph in place. The saved value reads back from the DB
+  # on the morphed render, so a Playwright test can prove the typed value
+  # actually persisted (the issue's failing assertion).
+  def update(name:)
+    @account.update!(name:) if name.present?
+    Phlex::Reactive::Response.morph(self)
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      # The field both holds the value AND triggers the debounced update — the
+      # canonical per-field reactive editing pattern from the issue.
+      input(**mix(on(:update, event: "input", debounce: 150),
+        name: "name", value: @account.name, data: {testid: "name"}))
+      span(data: {testid: "saved"}) { @account.name }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -39,6 +39,10 @@ class DemosController < ActionController::Base
     render_component DebounceComponent.new
   end
 
+  def morph_grid
+    render_component MorphGridComponent.new(account: Account.find(params[:id]))
+  end
+
   # The page a non-intercepted form submit would navigate to (issue #11).
   def nav_probe
     render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get "nested_editor" => "demos#nested_editor"
   get "nested_params" => "demos#nested_params"
   get "debounce" => "demos#debounce"
+  get "morph_grid/:id" => "demos#morph_grid"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
   match "nav_probe" => "demos#nav_probe", :via => [:get, :post]

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -4,7 +4,8 @@ import { Controller } from "@hotwired/stimulus"
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
 // for interactive components. A component declares its actions in Ruby (via
 // Phlex::Reactive::Component); this controller binds DOM events to a single
-// HTTP round trip and lets Turbo morph the re-rendered component back in.
+// HTTP round trip and lets Turbo apply the re-rendered component back in
+// (replace by default; method="morph" — Response.morph — preserves focus).
 //
 // Wire format (client -> server), POST <action path>, turbo-stream Accept:
 //   { token: "<signed identity>", act: "<action>", params: {...} }
@@ -222,8 +223,10 @@ export default class extends Controller {
       // Capture the new token from the response synchronously, so the next
       // queued request uses it without waiting for the async DOM morph.
       this.#currentToken = this.#extractToken(html) ?? this.#currentToken
-      // Turbo applies the <turbo-stream> ops (replace/morph by id), preserving
-      // focus/scroll/listeners on unchanged nodes.
+      // Turbo applies the <turbo-stream> ops by id. A plain replace is an
+      // outerHTML swap (focus on the replaced subtree is lost); a method="morph"
+      // replace (Response.morph) or an update morphs in place, preserving the
+      // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
     } catch (error) {
       console.error("[phlex-reactive] action error", error)

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -113,6 +113,51 @@ RSpec.describe Phlex::Reactive::Response do
     end
   end
 
+  # Issue #28: morph re-renders self in place via Idiomorph (method="morph"),
+  # preserving the focused input + caret. Response.morph(self) is the explicit
+  # builder; Response.replace(self, morph: true) is the opt-in flag; also_replace
+  # gains a morph: flag for companion components.
+  describe "morph (issue #28)" do
+    it "morph renders a self-targeted morphing replace and keeps render_self" do
+      response = described_class.morph(counter)
+      expect(response.render_self?).to be(true)
+      expect(response.redirect?).to be(false)
+      expect(response.streams.size).to eq(1)
+      expect(response.streams.first).to include('action="replace"')
+      expect(response.streams.first).to include('method="morph"')
+      expect(response.streams.first).to include('target="counter"')
+    end
+
+    it "replace(morph: true) emits the morph attribute" do
+      response = described_class.replace(counter, morph: true)
+      expect(response.streams.first).to include('method="morph"')
+    end
+
+    it "replace defaults to a plain swap (no morph attr) — back-compat" do
+      response = described_class.replace(counter)
+      expect(response.streams.first).not_to include("method=")
+    end
+
+    it "morph composes with flash (token still refreshes via the morph)" do
+      response = described_class.morph(counter).flash(:notice, "saved")
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.first).to include('method="morph"')
+      expect(response.streams.last).to include('action="append"')
+    end
+
+    it "also_replace(component, morph: true) morphs the companion component" do
+      response = described_class.morph(counter).also_replace(item, morph: true)
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.last).to include('method="morph"')
+      expect(response.streams.last).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "also_replace defaults to a plain replace (no morph attr)" do
+      response = described_class.replace(counter).also_replace(item)
+      expect(response.streams.last).not_to include("method=")
+    end
+  end
+
   it "flash accepts a Phlex component, rendered through the configured renderer" do
     klass = Class.new(Phlex::HTML) do
       def self.name = "FlashAlertProbe" # ActionView's render logger needs a name

--- a/spec/phlex/reactive/streamable_morph_spec.rb
+++ b/spec/phlex/reactive/streamable_morph_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #28: a morph stream re-renders a component in place via Turbo 8's
+# bundled Idiomorph (`<turbo-stream action="replace" method="morph">`), which
+# morphs the subtree instead of an outerHTML swap — preserving the focused
+# <input> + caret while still refreshing the signed token. These specs pin the
+# wire format (the `method="morph"` attribute) for the instance primitive and
+# the class builder's `morph:` flag — and prove the default (no morph:) is
+# byte-for-byte unchanged (backwards compat). The broadcast `morph:` flag is
+# covered in spec/requests (where Turbo's broadcast test helper is wired).
+RSpec.describe "Streamable morph (issue #28)" do
+  # A fresh component per example: a Phlex instance can only render once, and
+  # several of these stream the same component twice (once per assertion).
+  let(:todo) { Todo.create!(title: "t", done: false) }
+
+  describe "#to_stream_morph (instance primitive)" do
+    it "emits a replace action with method=\"morph\" targeting self" do
+      stream = CounterComponent.new(count: 0).to_stream_morph
+      expect(stream).to include('action="replace"')
+      expect(stream).to include('method="morph"')
+      expect(stream).to include('target="counter"')
+    end
+
+    it "carries the re-rendered root (fresh signed token)" do
+      stream = CounterComponent.new(count: 0).to_stream_morph
+      expect(stream).to include("data-reactive-token-value=")
+    end
+  end
+
+  describe "#to_stream_replace stays a plain swap (no morph attr) — back-compat" do
+    it "never emits method=\"morph\"" do
+      stream = CounterComponent.new(count: 0).to_stream_replace
+      expect(stream).to include('action="replace"')
+      expect(stream).not_to include("method=")
+    end
+  end
+
+  describe ".replace(model, morph:) class builder" do
+    it "adds method=\"morph\" when morph: true" do
+      stream = TodoItemComponent.replace(todo, morph: true)
+      expect(stream).to include('action="replace"')
+      expect(stream).to include('method="morph"')
+      expect(stream).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "omits method= by default (unchanged)" do
+      expect(TodoItemComponent.replace(todo)).not_to include("method=")
+    end
+  end
+end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe "Reactive actions", type: :request do
         expect(html).to include("write specs")
       }.not_to raise_error
     end
+
+    # Issue #28: a live cross-tab replace can morph in place so a peer tab keeps
+    # its focus/caret on the morphed row. Default broadcasts stay a plain swap.
+    it "broadcasts a morphing replace when morph: true (issue #28)" do
+      broadcasts = capture_turbo_stream_broadcasts("todos") do
+        TodoItemComponent.broadcast_replace_to("todos", model: todo, morph: true)
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="replace"')
+      expect(html).to include('method="morph"')
+    end
+
+    it "broadcasts a plain replace (no morph attr) by default" do
+      broadcasts = capture_turbo_stream_broadcasts("todos") do
+        TodoItemComponent.broadcast_replace_to("todos", model: todo)
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).not_to include("method=")
+    end
   end
 
   describe "record + state component (InlineEditComponent, issue #6)" do
@@ -190,6 +209,21 @@ RSpec.describe "Reactive actions", type: :request do
       expect(response.body).to include("data-reactive-token-value=") # token refreshed
       expect(response.body).not_to include('action="replace"')       # no contradictory double-render
       expect(response.body).to match(/>\s*2\s*</)                     # 1 -> 2
+    end
+
+    # Issue #28: Response.morph(self) re-renders the element via Idiomorph
+    # (action="replace" method="morph"). The morphed root carries a fresh token,
+    # so the endpoint must NOT prepend a second, contradictory plain replace.
+    it "morph: re-renders self with method=\"morph\" + a fresh token, not doubled" do
+      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "bump_via_morph")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="replace"')
+      expect(response.body).to include('method="morph"')
+      expect(response.body).to include('target="counter"')
+      expect(response.body).to include("data-reactive-token-value=")    # token refreshed
+      expect(response.body.scan('target="counter"').size).to eq(1)      # not doubled
+      expect(response.body).to match(/>\s*2\s*</)                       # 1 -> 2
     end
 
     it "remove: emits a remove stream for the element and NO self replace" do

--- a/spec/system/morph_grid_spec.rb
+++ b/spec/system/morph_grid_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #28: per-field reactive editing must NOT lose focus or drop the
+# in-progress value when the debounced save fires. Response.morph(self) emits
+# action="replace" method="morph", so Turbo 8's Idiomorph morphs the row in
+# place — the focused <input> and its caret survive. With the old plain
+# Response.replace this was a full outerHTML swap: the field was blurred and the
+# just-typed value vanished (the failing Playwright assertion in the issue).
+RSpec.describe "Morph grid — focus survives a save (issue #28)", type: :system do
+  it "keeps focus on the field and persists the typed value through a morph save" do
+    account = Account.create!(name: "old name")
+    visit "/morph_grid/#{account.id}"
+    page.execute_script("window.__noReload = 'alive'")
+
+    field = find("[data-testid='name']")
+    field.click # focus the field as a user would
+
+    # Type a new value; the debounced `update` fires while the field is focused,
+    # the action morphs the row in place.
+    field.set("renamed live")
+
+    # The morphed render reads the saved value back from the DB — proving the
+    # round trip landed AND the value persisted (not dropped on a hard swap).
+    expect(page).to have_css("[data-testid='saved']", text: "renamed live")
+    expect(account.reload.name).to eq("renamed live")
+
+    # The decisive morph assertion: after the save the field is STILL the active
+    # element. A plain replace (outerHTML swap) would have destroyed it and blurred
+    # focus to <body>; the morph preserves the live node.
+    active_testid = page.evaluate_script("document.activeElement && document.activeElement.dataset.testid")
+    expect(active_testid).to eq("name")
+
+    # ...and the input still carries the typed value (caret/value preserved).
+    expect(page).to have_field("name", with: "renamed live")
+
+    # No full-page reload happened.
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

`Response.replace(self)` re-rendered a component and emitted a plain `<turbo-stream action="replace">` — which Turbo applies as an **outerHTML swap of the whole element**. That destroyed and recreated every node inside, including the `<input>` the user was typing in: focus was lost and any keystroke not yet committed was dropped. Per-field reactive editing (the "edit a cell, it saves" grid with `on(:update, event: "input", debounce: 300)`) was unusable — the debounced save fired mid-typing, the row swapped, and focus + the in-progress value vanished.

This adds a first-class **morph re-render** that uses Turbo 8's bundled Idiomorph (`<turbo-stream action="replace" method="morph">`), morphing the subtree in place so the focused field and its caret survive the save.

The docs/comments that already *claimed* morph (`component.rb`, `reactive_controller.js`, `docs/architecture.md`) but didn't deliver it are corrected to match reality.

## API delta

| Builder | Reply |
|---|---|
| `Response.morph(self)` | re-render in place via Idiomorph (`method="morph"`) — preserves focus + caret |
| `Response.replace(self, morph: true)` | same, via an opt-in flag on the existing builder |
| `component.to_stream_morph` | the underlying Streamable primitive |
| `Klass.replace(model, morph: true)` | class builder gains the flag |
| `Klass.broadcast_replace_to(..., morph: true)` | live cross-tab updates can morph too (rides Turbo's `attributes:`) |
| `Response#also_replace(component, morph: true)` | companion components can morph |

The **default everywhere stays the plain replace** — no `method="morph"` attribute is emitted unless you opt in, so existing components are byte-for-byte unchanged. No client change was needed: the runtime already applies whatever stream op the server sends via `Turbo.renderStreamMessage`.

No new dependency — Idiomorph ships with `turbo-rails >= 2.0` (this repo's floor).

## Test plan

- **Unit** (`spec/phlex/reactive/streamable_morph_spec.rb`): `to_stream_morph` and `.replace(morph: true)` emit `method="morph"`; the default omits it (back-compat).
- **Unit** (`spec/phlex/reactive/response_spec.rb`): `Response.morph` / `replace(morph:)` / `also_replace(morph:)`; default carries no morph attr.
- **Request** (`spec/requests/reactive_actions_spec.rb`): the endpoint emits `method="morph"` and a fresh signed token without doubling the self-render; the broadcast morph rides `attributes:` (proven on the pgbus-absent Action Cable path).
- **System** (`spec/system/morph_grid_spec.rb`): typing into a field, the debounced morph save keeps focus (`document.activeElement` is still the field), preserves the typed value, persists to the DB, and does not reload the page. A plain replace fails this — it blurs to `<body>`.

## Verification

- `bundle exec standardrb` — clean
- `bundle exec rspec spec/phlex spec/requests` — 112 passing
- `bundle exec rspec spec/system` — 17 passing
- Backwards compatible — default replace path unchanged (no `method=` attribute)
- pgbus optionality preserved — `attributes:` is a standard turbo-rails kwarg, works on Action Cable AND pgbus

Closes #28
