### PR TITLE
feat(component): add reply builder as the action-reply surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`reply` — the action-reply builder.** Control an action's reply with
+  `reply.replace` / `reply.morph` / `reply.update` / `reply.remove` /
+  `reply.redirect(url)` / `reply.with(*)`, chaining `.flash` / `.stream` /
+  `.also_update` / `.also_replace` as before. `reply` is a subject-bound facade on
+  the component, so the two warts of the old form disappear: no `self` to thread
+  (`reply.morph`, not `Response.morph(self)`) and no constant to qualify — a
+  namespaced component no longer needs a per-file `Response = …` alias, because
+  `reply` is a method resolved on the component, not a lexical constant. It
+  returns the same immutable value object the endpoint reads, so the return-value
+  contract, immutability, and chaining are unchanged. `Phlex::Reactive::Response`
+  remains fully functional but is now an internal detail — `reply` is the
+  documented surface.
+
 - **Morph response — focus-preserving re-render (issue #28).**
-  `Response.morph(self)` (and the opt-in `Response.replace(self, morph: true)`)
+  `reply.morph` (and the opt-in `reply.replace(morph: true)`)
   re-renders a component in place via Turbo 8's bundled Idiomorph
   (`<turbo-stream action="replace" method="morph">`) instead of an outerHTML
   swap. The focused `<input>` and its caret survive the save, making per-field
   reactive editing — a "spreadsheet" grid where a debounced save fires while the
   user is still typing/tabbing — actually viable. Backed by the new
   `Streamable#to_stream_morph` primitive and a `morph:` flag on the
-  `.replace` / `.broadcast_replace_to` class builders and `Response#also_replace`
+  `.replace` / `.broadcast_replace_to` class builders and `#also_replace`
   (live cross-tab updates can morph too). The default everywhere stays the plain
   replace (no `method="morph"` attribute), so existing components are unchanged.
   No new dependency — Idiomorph ships with `turbo-rails >= 2.0`.

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ signed token always refreshes.
 > immutable value object the endpoint reads. You can build one directly
 > (`Phlex::Reactive::Response.replace(self)`) and it still works, but `reply` is
 > the preferred surface; treat `Response` as an internal detail.
-
+> **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
 > **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
 > `html: @account.name` is safe even for user-supplied values. To emit intentional
 > markup, pass a **Phlex component** (`html: Heading.new(name: @record.name)`) —

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ data-controller="reactive" but the reactive controller never connected …`).
    │                                          rebuild component (record from DB)
    │                                          run the whitelisted action
    │                                          re-render → <turbo-stream replace id>   (default; an action
-   │                                          may return a Response — see "Controlling the action's reply")
-   └──────── Turbo morphs it in ◀───────────────────────────────┘
+   │                                          may return reply.<verb> — see "Controlling the action's reply")
+   └──────── Turbo applies it in ◀──────────────────────────────┘
 
    ...and for OTHER tabs/users:
    model change → Component.broadcast_replace_to(stream) → pgbus SSE → same morph
@@ -296,7 +296,7 @@ The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
 | `.update` / `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
 | `.broadcast_replace_to(*streamables, model:, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
 | `.broadcast_append_to(*streamables, target:, model:)` / `_update_` / `_prepend_` / `_remove_` | The broadcast variants |
-| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `Response`); `#to_stream_morph` morphs in place |
+| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `reply`); `#to_stream_morph` morphs in place |
 
 Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 
@@ -313,6 +313,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
+| `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` | Return from an action to control the reply (flash, remove, redirect, multi-stream). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
 
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
@@ -422,51 +423,56 @@ end
 `nested_attributes(:address, address)` returns the id-merged hash without
 updating, if you need to combine it with other attributes.
 
-### `Phlex::Reactive::Response` — controlling the action's reply
+### `reply` — controlling the action's reply
 
-By default an action re-renders its component in place. **Return** a
-`Phlex::Reactive::Response` to do more (it governs only the actor's HTTP reply —
-cross-tab updates still use `broadcast_*_to(..., exclude: reactive_connection_id)`).
-Returning anything else keeps the default, so existing actions are unaffected.
+By default an action re-renders its component in place. To do more, **return**
+`reply.<verb>` — a subject-bound builder available in every component. It governs
+only the actor's HTTP reply (cross-tab updates still use
+`broadcast_*_to(..., exclude: reactive_connection_id)`). Returning anything else
+keeps the default, so existing actions are unaffected.
 
-The snippets below alias the constant for brevity (`Response.replace(self)` won't
-resolve to `Phlex::Reactive::Response` inside a namespaced component — fully
-qualify it, or add the alias shown):
+`reply` reads cleanly: the component is the implicit subject (no `self` to
+thread) and there's no constant to qualify (it's a method, so a namespaced
+component needs no alias):
 
 ```ruby
-Response = Phlex::Reactive::Response # or qualify each call below
-
 def rename(title:)
-  return Response.replace(self).flash(:error, @todo.errors.full_messages.to_sentence) unless @todo.update(title:)
-  Response.replace(self)
+  return reply.replace.flash(:error, @todo.errors.full_messages.to_sentence) unless @todo.update(title:)
+  reply.replace
 end
 
-def approve   = (@row.approve!; Response.remove(self))          # drop the element
-def publish   = (@article.publish!; Response.redirect(article_url(@article)))  # slug changed → Turbo.visit
-def add(item:) = Response.replace(self).stream(Totals.update(@order))           # multi-stream
+def approve   = (@row.approve!; reply.remove)          # drop the element
+def publish   = (@article.publish!; reply.redirect(article_url(@article)))  # slug changed → Turbo.visit
+def add(item:) = reply.replace.stream(Totals.update(@order))               # multi-stream
 
 # Per-field reactive editing (a "spreadsheet" grid): a debounced save fires
 # while the user is still typing/tabbing. Morph in place so the focused <input>
-# and its in-progress value survive the re-render (issue #28):
-def update(name:) = (@row.update!(name:); Response.morph(self))
+# and its in-progress value survive the re-render (issue #28). Note the action is
+# named `update`, yet `reply.morph` is unambiguous — the verb is on `reply`:
+def update(name:) = (@row.update!(name:); reply.morph)
 
 # Re-render a COMPANION element (a heading mirroring the edited name) alongside self:
-def rename(value:) = (@account.update!(name: value); Response.replace(self).also_update("page_heading", html: @account.name))
+def rename(value:) = (@account.update!(name: value); reply.replace.also_update("page_heading", html: @account.name))
 ```
 
 | Builder | Reply |
 |---|---|
-| `Response.replace(self)` / `.update(self)` | re-render in place (explicit default; `replace` is an outerHTML swap, `update` morphs inner HTML) |
-| `Response.morph(self)` / `Response.replace(self, morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (issue #28) |
+| `reply.replace` / `reply.update` | re-render in place (default; `replace` is an outerHTML swap, `update` morphs inner HTML) |
+| `reply.morph` / `reply.replace(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (issue #28) |
 | `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
 | `.also_replace(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
 | `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped) or a Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
-| `Response.remove(self)` | remove the element (backed by `Streamable#to_stream_remove`) |
-| `Response.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
-| `Response.with(*streams)` / `#stream(*more)` | multi-stream |
+| `reply.remove` | remove the element (backed by `Streamable#to_stream_remove`) |
+| `reply.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
+| `reply.with(*streams)` / `#stream(*more)` | multi-stream |
 
 `.flash`/`.stream`/`.also_*` are additive on a self-replace, so the component's
 signed token always refreshes.
+
+> **Under the hood.** `reply.<verb>` returns a `Phlex::Reactive::Response` — the
+> immutable value object the endpoint reads. You can build one directly
+> (`Phlex::Reactive::Response.replace(self)`) and it still works, but `reply` is
+> the preferred surface; treat `Response` as an internal detail.
 
 > **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
 > `html: @account.name` is safe even for user-supplied values. To emit intentional

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ A component that implements `#id` can render itself as a Turbo Stream:
 ```
 Counter.replace(c)            → <turbo-stream action="replace" target="<c.id>">…</turbo-stream>
 Counter.broadcast_replace_to(stream, model: c)  → same, pushed over the transport
-c.to_stream_remove            → <turbo-stream action="remove" target="<c.id>">    (backs Response.remove)
+c.to_stream_remove            → <turbo-stream action="remove" target="<c.id>">    (backs reply.remove)
 ```
 
 Rendering goes through a real controller renderer (`Phlex::Reactive.renderer`),
@@ -59,14 +59,18 @@ Accept: text/vnd.turbo-stream.html
 ```
 
 The endpoint verifies the token, rebuilds the component, and runs the action. If
-the action returns a [`Phlex::Reactive::Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+the action returns [`reply.<verb>`](../README.md#reply--controlling-the-actions-reply)
 (a replace/update, a remove, a redirect, or multiple streams — optionally with a
 flash), the endpoint renders that; otherwise it falls back to the implicit single
 `component.to_stream_replace` (the legacy contract). For any non-remove/redirect
 reply the component's own replace is guaranteed present so its token refreshes.
-Turbo applies it in: a plain `replace` is an outerHTML swap; `Response.morph(self)`
-(or `update`) morphs the subtree in place, preserving the focused input + caret
-for per-field editing (issue #28).
+Turbo applies it in: a plain `replace` is an outerHTML swap; `reply.morph`
+(or `reply.update`) morphs the subtree in place, preserving the focused input +
+caret for per-field editing (issue #28).
+
+`reply.<verb>` returns a `Phlex::Reactive::Response` — the immutable value object
+the endpoint reads (`response_streams`). It's an internal detail; you build it
+through `reply`.
 
 ### What collected fields are
 

--- a/docs/broadcasting.md
+++ b/docs/broadcasting.md
@@ -85,7 +85,7 @@ end
 ## Broadcasting from inside a reactive action
 
 The acting user gets the action's HTTP response (a replace of the component by
-default, or whatever [`Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+default, or whatever [`reply`](../README.md#reply--controlling-the-actions-reply)
 the action returns). *Everyone else* gets the broadcast. Idiomorph dedupes a `replace` by DOM id, so
 the actor doesn't double-apply — but for `append`/`prepend` (and animations or
 optimistic UI) the echo *would* double-apply. Suppress the actor's own echo with
@@ -142,10 +142,10 @@ end
 ## Removing the actor's own element
 
 `destroy`-style actions are the one case where "replace the component by its id"
-doesn't fit — the element should vanish, not be replaced. Return
-`Response.remove(self)` from the action: the actor's element is removed via the
-built-in `Streamable#to_stream_remove` (no endpoint override, no helper to add),
-and other tabs get `broadcast_remove_to(..., exclude: reactive_connection_id)`.
+doesn't fit — the element should vanish, not be replaced. Return `reply.remove`
+from the action: the actor's element is removed via the built-in
+`Streamable#to_stream_remove` (no endpoint override, no helper to add), and other
+tabs get `broadcast_remove_to(..., exclude: reactive_connection_id)`.
 
 ```ruby
 def destroy
@@ -153,12 +153,12 @@ def destroy
   list = @todo.list
   @todo.destroy!
   Todos::Item.broadcast_remove_to(list, :todos, model: @todo, exclude: reactive_connection_id) # other tabs
-  Phlex::Reactive::Response.remove(self)                                                        # this tab
+  reply.remove                                                                                  # this tab
 end
 ```
 
 For an "undo" affordance, replace with a tombstone state instead of removing. See
-[`Phlex::Reactive::Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply)
+[Controlling the action's reply](../README.md#reply--controlling-the-actions-reply)
 for the full reply API.
 
 ## Presence (who's here / typing)

--- a/docs/examples/inline_edit.md
+++ b/docs/examples/inline_edit.md
@@ -85,16 +85,16 @@ render Fields::InlineEdit.new(record: @user, attribute: :email)
 ## Surfacing a validation error
 
 `save` above uses `update!`, which raises on invalid input. To show the error
-instead, use non-bang `update` and return a `Response` with a flash:
+instead, use non-bang `update` and return `reply` with a flash:
 
 ```ruby
 def save(value:)
   authorize! @record, :update?
   if @record.update(@attribute => value)
     @editing = false
-    Phlex::Reactive::Response.replace(self)
+    reply.replace
   else
-    Phlex::Reactive::Response.replace(self).flash(:error, @record.errors.full_messages.to_sentence)
+    reply.replace.flash(:error, @record.errors.full_messages.to_sentence)
   end
 end
 ```
@@ -102,14 +102,14 @@ end
 The flash `content` is supplied explicitly (off-request — no Rails `flash`) and
 appends into `Phlex::Reactive.flash_target` (default `<div id="flash">`); pass a
 Phlex component instead of a string for rich markup. See
-[Response](../README.md#phlexreactiveresponse--controlling-the-actions-reply).
+[Controlling the action's reply](../README.md#reply--controlling-the-actions-reply).
 
 ## Live-as-you-type (a spreadsheet-like grid)
 
 For per-field editing where a **debounced save fires while the user is still
-typing or tabbing**, a plain `Response.replace(self)` is wrong: it's an
-outerHTML swap that destroys the `<input>` you're typing in — focus and the
-in-progress value vanish. Return `Response.morph(self)` instead. It emits
+typing or tabbing**, a plain `reply.replace` is wrong: it's an outerHTML swap
+that destroys the `<input>` you're typing in — focus and the in-progress value
+vanish. Return `reply.morph` instead. It emits
 `<turbo-stream action="replace" method="morph">`, so Turbo 8's bundled Idiomorph
 morphs the subtree in place — the focused field and its caret survive the save.
 
@@ -119,7 +119,8 @@ action :update, params: { name: :string }
 def update(name:)
   authorize! @record, :update?
   @record.update!(name:) if name.present?
-  Phlex::Reactive::Response.morph(self)   # morph in place — keep focus + caret
+  reply.morph   # morph in place — keep focus + caret. The action is named
+                # `update`, but `reply.morph` is unambiguous (the verb is on reply).
 end
 
 def view_template
@@ -131,8 +132,8 @@ def view_template
 end
 ```
 
-`Response.replace(self, morph: true)` is the same thing via the opt-in flag; the
-morphed root still carries a fresh signed token, so the next edit verifies.
+`reply.replace(morph: true)` is the same thing via the opt-in flag; the morphed
+root still carries a fresh signed token, so the next edit verifies.
 
 ## Want it to update other viewers too?
 

--- a/docs/examples/todo_list.md
+++ b/docs/examples/todo_list.md
@@ -58,7 +58,7 @@ class Todos::Item < ApplicationComponent
     list = @todo.list
     @todo.destroy!
     Todos::Item.broadcast_remove_to(list, :todos, model: @todo) # other tabs
-    Phlex::Reactive::Response.remove(self)                       # this tab's element
+    reply.remove                                                 # this tab's element
   end
 
   def view_template
@@ -78,10 +78,10 @@ class Todos::Item < ApplicationComponent
 end
 ```
 
-`destroy` returns `Response.remove(self)`, so the actor's own row is removed (via
-the built-in `Streamable#to_stream_remove` — no tombstone, no endpoint override)
-and `broadcast_remove_to` removes it in every other tab. See
-[Response](../README.md#phlexreactiveresponse--controlling-the-actions-reply).
+`destroy` returns `reply.remove`, so the actor's own row is removed (via the
+built-in `Streamable#to_stream_remove` — no tombstone, no endpoint override) and
+`broadcast_remove_to` removes it in every other tab. See
+[Controlling the action's reply](../README.md#reply--controlling-the-actions-reply).
 
 ## The list + composer
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ route. No hand-picked target.**
 
 - **Actions are Ruby methods.** Declare `action :increment`; the client calls it.
 - **Re-render is auto-targeted.** A component owns a stable `id`; by default the
-  response replaces it — an action can return a `Response` to morph, remove,
-  redirect, or flash instead. You never pick a target.
-- **Actions control the reply.** Return a `Response` to morph, remove, redirect
+  response replaces it — an action can return `reply.morph` / `reply.remove` /
+  `reply.redirect` / `reply.replace.flash(...)` instead. You never pick a target.
+- **Actions control the reply.** Return `reply.<verb>` to morph, remove, redirect
   (`Turbo.visit`), or attach a flash — or emit several streams at once. Returning
   nothing keeps the auto-replace default.
 - **One unit for clicks AND broadcasts.** The same component re-renders for a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ cp "$(bundle show phlex-reactive)/app/javascript/phlex/reactive/reactive_control
 …and `import ReactiveController from "./reactive_controller"`.
 
 Importing `reactive_controller.js` also registers the `reactive:visit` Turbo
-`StreamAction` that powers `Response.redirect`. The `import ReactiveController`
+`StreamAction` that powers `reply.redirect`. The `import ReactiveController`
 above covers this; if you vendor the file, make sure it's actually imported (not
 tree-shaken away) or redirects won't fire.
 
@@ -109,7 +109,7 @@ Phlex::Reactive.renderer             = ApplicationController     # app helpers d
 Phlex::Reactive.authorization_errors = [Pundit::NotAuthorizedError]
 # Phlex::Reactive.action_path = "/_r/actions"                   # custom endpoint
 # Phlex::Reactive.verifier    = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
-# Phlex::Reactive.flash_target = "flash"                         # DOM id Response#flash appends into
+# Phlex::Reactive.flash_target = "flash"                         # DOM id reply…flash appends into
 ```
 
 If you change `action_path`, expose it to the client:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,7 +76,7 @@ end
 For authorization, stub the current user / policy and assert `:forbidden` when
 the action's `authorize!` should deny.
 
-When an action returns a [`Response`](../README.md#phlexreactiveresponse--controlling-the-actions-reply),
+When an action returns a [`reply.<verb>`](../README.md#reply--controlling-the-actions-reply),
 assert on the streams it produces:
 
 ```ruby
@@ -99,8 +99,8 @@ test "redirect rides a 200 reactive:visit, not a 3xx" do
 end
 ```
 
-A `Response` is also a plain value object — unit-test it with no HTTP:
-`Response.remove(c).render_self?` is `false`; `Response.replace(c).flash(:x, "hi").streams.size` is `2`.
+`reply.<verb>` is a plain value object — unit-test it with no HTTP:
+`c.reply.remove.render_self?` is `false`; `c.reply.replace.flash(:x, "hi").streams.size` is `2`.
 
 ## 4. System / browser: the full loop & broadcasts
 

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -169,6 +169,22 @@ module Phlex
         Phlex::Reactive.current_connection_id
       end
 
+      # Subject-bound reply builder — the preferred way to control an action's
+      # reply. `reply.replace.flash(:error, msg)` reads cleaner than
+      # `Phlex::Reactive::Response.replace(self).flash(:error, msg)`: the
+      # component is the implicit subject (no `self` to thread) and there's no
+      # constant to qualify (reply is a method, so a namespaced component needs
+      # no `Response = …` alias). It returns the same immutable Response the
+      # endpoint reads, so chaining and the legacy return-value contract are
+      # unchanged. See Phlex::Reactive::Reply.
+      #
+      #   def archive       = reply.remove
+      #   def go_home       = reply.redirect("/todos")
+      #   def update(name:) = (@account.update!(name:); reply.morph)
+      def reply
+        Phlex::Reactive::Reply.new(self)
+      end
+
       # Root-element attributes: marks the element reactive and carries the
       # signed identity token. Spread onto the root:
       #   div(id:, **reactive_attrs) { ... }

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # A component-bound facade over Response — the surface an action body uses to
+    # control its reply. Component#reply returns one, so an action writes
+    #
+    #   reply.replace.flash(:error, msg)
+    #
+    # instead of
+    #
+    #   Phlex::Reactive::Response.replace(self).flash(:error, msg)
+    #
+    # Two warts disappear: there is no constant to qualify (reply is a method,
+    # resolved on the component — so a namespaced component needs no
+    # `Response = …` alias) and no `self` to thread (the component is bound).
+    #
+    # Reply is NOT a Response and does NOT subclass one: each verb forwards to
+    # the Response class method, supplying the bound component as the subject, and
+    # returns the real, frozen Response value the endpoint already honors. So
+    # immutability, chaining (.flash/.stream/.also_update/.also_replace), and
+    # render_self? are inherited untouched — and there is no "verb after a chained
+    # Response" asymmetry, because the chain is plain Response all the way down.
+    #
+    # Response remains the public value object (it's what the endpoint reads); it
+    # is simply an internal detail you rarely name directly now.
+    class Reply
+      def initialize(component)
+        @component = component
+      end
+
+      # Self-targeting builders — the bound component is supplied implicitly.
+
+      # Re-render in place. `morph: true` morphs the subtree (preserves the
+      # focused input + caret) instead of an outerHTML swap — see #morph.
+      def replace(morph: false)
+        Response.replace(@component, morph:)
+      end
+
+      # Re-render in place via Idiomorph (method="morph") — keeps focus + caret.
+      def morph
+        Response.morph(@component)
+      end
+
+      # Morph only inner HTML (preserves the root element + its token attr).
+      def update
+        Response.update(@component)
+      end
+
+      # Remove the component's element from the DOM (render_self false).
+      def remove
+        Response.remove(@component)
+      end
+
+      # Subject-free builders — pass straight through so they read naturally.
+
+      # Client-side full navigation (Turbo.visit). Pass a *_url.
+      def redirect(url)
+        Response.redirect(url)
+      end
+
+      # Escape hatch / multi-stream root: zero or more raw turbo-stream strings.
+      def with(*strings)
+        Response.with(*strings)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -25,32 +25,32 @@ class CounterComponent < ApplicationComponent
   def decrement = @count -= 1
   def set(count:) = @count = count
 
-  # Response: replace self (token refresh) + append a flash.
+  # Reply: replace self (token refresh) + append a flash.
   def reset_with_flash
     @count = 0
-    Phlex::Reactive::Response.replace(self).flash(:notice, "Reset")
+    reply.replace.flash(:notice, "Reset")
   end
 
-  # Response: morph inner HTML (update, not replace). The rendered template still
+  # Reply: morph inner HTML (update, not replace). The rendered template still
   # carries the root's fresh data-reactive-token-value, so the token refreshes.
   def bump_via_update
     @count += 1
-    Phlex::Reactive::Response.update(self)
+    reply.update
   end
 
-  # Response: morph the whole element in place (issue #28). Emits
+  # Reply: morph the whole element in place (issue #28). Emits
   # action="replace" method="morph", so Idiomorph preserves a focused input +
   # caret. The morphed root carries the fresh token, so it must NOT be doubled
   # with a contradictory plain replace.
   def bump_via_morph
     @count += 1
-    Phlex::Reactive::Response.morph(self)
+    reply.morph
   end
 
-  # Response: client-side full navigation (no in-place stream). Targets a real
+  # Reply: client-side full navigation (no in-place stream). Targets a real
   # dummy route so the browser spec can assert the Turbo.visit landed.
   def go_home
-    Phlex::Reactive::Response.redirect("/todos")
+    reply.redirect("/todos")
   end
 
   def view_template

--- a/spec/dummy/app/components/morph_grid_component.rb
+++ b/spec/dummy/app/components/morph_grid_component.rb
@@ -21,10 +21,12 @@ class MorphGridComponent < ApplicationComponent
 
   # Persist the edit and morph in place. The saved value reads back from the DB
   # on the morphed render, so a Playwright test can prove the typed value
-  # actually persisted (the issue's failing assertion).
+  # actually persisted (the issue's failing assertion). NB: the action is named
+  # `update`, yet `reply.morph` is unambiguous — the verb lives on the reply
+  # facade, not the component, so there's no collision with this action name.
   def update(name:)
     @account.update!(name:) if name.present?
-    Phlex::Reactive::Response.morph(self)
+    reply.morph
   end
 
   def view_template

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -28,6 +28,11 @@ class TodoItemComponent < ApplicationComponent
     @todo.update!(title:) if title.present?
   end
 
+  # This component deliberately keeps the fully-qualified
+  # Phlex::Reactive::Response.* form (the others use the preferred reply.*) so the
+  # back-compat path stays covered by the live request/system suites: reply.* is
+  # sugar over Response.*, and Response.* must keep working verbatim.
+
   # Response: remove self from the DOM (render_self false — no doomed re-render).
   def archive
     Phlex::Reactive::Response.remove(self)

--- a/spec/phlex/reactive/reply_spec.rb
+++ b/spec/phlex/reactive/reply_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Component#reply returns a subject-bound facade over Response, so an action body
+# writes `reply.replace.flash(:error, msg)` instead of
+# `Phlex::Reactive::Response.replace(self).flash(:error, msg)` — no constant to
+# qualify (it's a method, resolved on the component) and no `self` to thread.
+#
+# Reply is sugar: every verb returns the SAME frozen Response the endpoint reads,
+# so these specs lock parity with Response.* on the observable surface (streams,
+# redirect?, render_self?) rather than via == (Response has no value equality).
+RSpec.describe Phlex::Reactive::Reply do
+  let(:counter) { CounterComponent.new(count: 0) }
+  let(:todo) { Todo.create!(title: "t", done: false) }
+  let(:item) { TodoItemComponent.new(todo:) }
+
+  describe "Component#reply" do
+    it "returns a Reply bound to the component" do
+      expect(counter.reply).to be_a(described_class)
+    end
+
+    it "resolves inside a namespaced component with no Response constant in scope" do
+      # The whole point: reply is method dispatch on self, not lexical constant
+      # lookup — so a namespaced component needs no `Response =` alias.
+      namespaced = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "Deeply::Nested::Widget"
+
+        reactive_state :n
+        action :noop
+        def initialize(n: 0) = @n = n
+        def id = "widget"
+        def noop = reply.replace # bare `reply`, no constant
+        def view_template = div(id:, **reactive_attrs) { @n.to_s }
+      end
+
+      expect { namespaced.new.noop }.not_to raise_error
+      expect(namespaced.new.noop).to be_a(Phlex::Reactive::Response)
+    end
+  end
+
+  describe "verbs return a real Response with the same surface as Response.*" do
+    it "replace mirrors Response.replace(self)" do
+      via_reply = counter.reply.replace
+      via_class = Phlex::Reactive::Response.replace(CounterComponent.new(count: 0))
+
+      expect(via_reply).to be_a(Phlex::Reactive::Response)
+      expect(via_reply.render_self?).to eq(via_class.render_self?)
+      expect(via_reply.streams.first).to include('action="replace"')
+      expect(via_reply.streams.first).not_to include("method=") # plain swap by default
+    end
+
+    it "replace(morph: true) mirrors Response.replace(self, morph: true)" do
+      stream = counter.reply.replace(morph: true).streams.first
+      expect(stream).to include('action="replace"')
+      expect(stream).to include('method="morph"')
+    end
+
+    it "morph mirrors Response.morph(self)" do
+      stream = counter.reply.morph.streams.first
+      expect(stream).to include('action="replace"')
+      expect(stream).to include('method="morph"')
+    end
+
+    it "update mirrors Response.update(self)" do
+      expect(counter.reply.update.streams.first).to include('action="update"')
+    end
+
+    it "remove mirrors Response.remove(self) — render_self false" do
+      response = item.reply.remove
+      expect(response.render_self?).to be(false)
+      expect(response.streams.first).to include('action="remove"')
+      expect(response.streams.first).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "redirect mirrors Response.redirect(url) — render_self false, carries url" do
+      response = counter.reply.redirect("/x")
+      expect(response.redirect?).to be(true)
+      expect(response.redirect_url).to eq("/x")
+      expect(response.render_self?).to be(false)
+    end
+
+    it "with mirrors Response.with(*streams)" do
+      response = counter.reply.with("<turbo-stream></turbo-stream>")
+      expect(response).to be_a(Phlex::Reactive::Response)
+      expect(response.streams).to eq(["<turbo-stream></turbo-stream>"])
+    end
+  end
+
+  describe "chaining works on the returned Response (immutability preserved)" do
+    it "reply.replace.flash composes two streams" do
+      response = counter.reply.replace.flash(:notice, "hi")
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.last).to include('action="append"')
+      expect(response.streams.last).to include("hi")
+    end
+
+    it "reply.replace.also_update appends a companion stream" do
+      response = counter.reply.replace.also_update("page_heading", html: "New")
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.last).to include('target="page_heading"')
+    end
+
+    it "reply.morph.flash chains a flash onto a morph" do
+      response = counter.reply.morph.flash(:notice, "saved")
+      expect(response.streams.first).to include('method="morph"')
+      expect(response.streams.last).to include('action="append"')
+    end
+
+    it "the returned Response is frozen" do
+      expect(counter.reply.replace).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Controlling an action's reply meant writing `Phlex::Reactive::Response.<verb>(self)` at every call site. That carried two distinct frictions:

1. **Constant mangling** — bare `Response` raises `NameError` inside a namespaced component (`Todos::Item`), so you fully-qualify it or add a per-file `Response = Phlex::Reactive::Response` alias (the README documented this as a wart).
2. **`self` threading** — `Response` is a free-standing builder, so every call passes `(self)`: `replace(self)`, `morph(self)`, `remove(self)`.

This adds **`Component#reply`**, a subject-bound facade that kills both at once.

## Before → after

```ruby
# BEFORE — per-file alias + self threaded everywhere
Response = Phlex::Reactive::Response

def reset_with_flash = (@count = 0; Phlex::Reactive::Response.replace(self).flash(:notice, "Reset"))
def archive          = Phlex::Reactive::Response.remove(self)
def go_home          = Phlex::Reactive::Response.redirect("/todos")
def update(name:)    = (@account.update!(name:); Phlex::Reactive::Response.morph(self))
```
```ruby
# AFTER — no constant, no (self)
def reset_with_flash = (@count = 0; reply.replace.flash(:notice, "Reset"))
def archive          = reply.remove
def go_home          = reply.redirect("/todos")
def update(name:)    = (@account.update!(name:); reply.morph)   # `def update` does NOT shadow reply.morph
```

`reply` is a method resolved on the component, so there's no constant to qualify (namespaced components need no alias) and no `self` to thread. Each verb (`replace` / `morph` / `update` / `remove` / `redirect(url)` / `with(*)`) forwards to the `Response` class method and returns the **same frozen `Response`** the endpoint reads — so the return-value contract, immutability, and chaining (`.flash` / `.stream` / `.also_update` / `.also_replace`) are all unchanged.

## Why a `reply` facade (and not the alternatives)

This was chosen after a design panel that scored four approaches. `reply` won because it's the only one with no fatal flaw:

- It's a **plain object, not a `Response` subclass** — sidesteps the `self.class.new` chain-link crash and the verb-after-chain asymmetry a subclass would introduce.
- The verbs live on `reply`, **not on the component** — so `reply.update` never collides with an action named `update`. This repo already has `def update(name:)` in `MorphGridComponent`; bare verbs would recurse, `reply.morph` is unambiguous.
- Nothing is injected into user namespaces (no `const_set`), so an app's own `::Response` is never shadowed.

## `Response` is now an internal detail

`Phlex::Reactive::Response` stays fully public and functional — `reply.<verb>` is sugar over it — but every doc, example, and the CHANGELOG now lead with `reply.*`. The README reply section was rewritten (the `Response =` alias guidance is gone), and the cross-doc anchor was renamed accordingly.

## Test plan

- **Unit** (`spec/phlex/reactive/reply_spec.rb`): each verb returns a real `Response` with the same observable surface as `Response.*` (`streams` / `redirect?` / `render_self?`); chaining + frozen immutability preserved; **resolves inside a namespaced component with no `Response` constant in scope** (the core win).
- **Parity by sweep**: `CounterComponent` and `MorphGridComponent` migrated to `reply.*`, so the existing request + system suites exercise `reply.*` end-to-end. `TodoItemComponent` deliberately kept on `Phlex::Reactive::Response.*` so the back-compat path stays covered by the live suites.

## Verification

- `bundle exec standardrb` — clean
- `bundle exec rspec spec/phlex spec/requests` — 125 passing
- `bundle exec rspec spec/system` — 17 passing
- Backwards compatible — `Phlex::Reactive::Response.*` works verbatim (TodoItem proves it live)
- pgbus optionality untouched (no transport code changed); no JS change (vendored sync guard still green)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `reply` action-response builder for components, with verbs like replace, morph, update, remove, redirect, and multi-stream chaining.
* **Documentation**
  * Updated guides, examples, and API references to use `reply.*` terminology and refreshed behavior descriptions for focus/caret preservation and streaming.
* **Tests**
  * Added coverage for the new reply builder and its parity with existing response behavior.
* **Bug Fixes**
  * Aligned sample actions with the newer reply-based flow across interactive examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->