### PR TITLE
perf: render via render_in + benchmark harness & continuous-perf discipline

### DIFF
--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -1,0 +1,81 @@
+---
+description: "Benchmark the current branch against main and report a same-machine before/after. Use when a change touches a hot path (render, token signing, param coercion, broadcast, client dispatch) or when asked to measure performance."
+argument-hint: "optional: a specific hot path or bench name (e.g. render)"
+---
+
+# Performance Command
+
+Measure, don't guess. This command produces a **same-machine before/after** so
+any performance claim is backed by numbers, and keeps the perf docs/discipline
+in sync. See `docs/performance.md` for the hot paths and how the harness works.
+
+## The non-negotiable rule
+
+**Measure BEFORE you change.** A delta you didn't baseline is not a delta. If a
+change already landed without a baseline, reconstruct one from `main` in a
+worktree (below) — never report a number against a baseline from another machine
+or another day.
+
+## Workflow
+
+### 1. Baseline `main` (before)
+
+Capture pristine `main` with the SAME bench script you'll run on the branch, in
+an isolated worktree (so `lib/`+`app/` are pristine but the harness is present):
+
+```bash
+git worktree add --detach /tmp/pr-baseline main
+cp -r benchmark /tmp/pr-baseline/ && cp Gemfile /tmp/pr-baseline/
+(cd /tmp/pr-baseline && bundle install && RAILS_ENV=test rake bench:micro) > /tmp/before.txt
+```
+
+If the branch added a bench method that doesn't exist on `main` (e.g. a new
+`reset_*!`), write a baseline-safe script that only calls methods present on
+`main`, and run that script in BOTH trees.
+
+### 2. Measure the branch (after)
+
+```bash
+RAILS_ENV=test rake bench:micro > /tmp/after.txt
+RAILS_ENV=test rake bench:request   # end-to-end, for the request-cycle picture
+diff /tmp/before.txt /tmp/after.txt
+git worktree remove --force /tmp/pr-baseline
+```
+
+For a single isolated change, prefer the in-place toggle (e.g.
+`PHLEX_REACTIVE_NO_CACHE=1 ruby benchmark/micro/render.rb`) — it removes
+worktree variance entirely.
+
+### 3. Report HONESTLY
+
+- Give throughput (i/s, μs/i) AND allocations (obj/call, retained). Retained > 0
+  per render is a leak — call it out.
+- **Distinguish a method-level win from a request-level win.** A 2× faster
+  render barely moves full-request throughput (Rails middleware + DB dominate)
+  but is a 2× win on the broadcast fan-out path. Say which.
+- If a number is within run-to-run noise (`benchmark-ips` shows ±%), say "within
+  noise" — don't dress it up.
+- If you only measured *after* (no clean baseline), say so explicitly.
+
+### 4. Keep perf continuous (every PR that touches a hot path)
+
+- [ ] A bench exists for the changed hot path (`benchmark/micro/<name>.rb` or
+      the request bench). Add one if missing — `rake bench:micro` globs them.
+- [ ] The before/after numbers are in the PR body.
+- [ ] `docs/performance.md` updated if the representative numbers moved.
+- [ ] CHANGELOG notes the perf change (`perf:` scope).
+- [ ] If the client (`reactive_controller.js`) changed, the vendored copy
+      (`spec/dummy/public/vendor/reactive_controller.js`) is re-synced and the
+      JS tests pass.
+
+## The hot paths to watch
+
+| Path | Bench | Note |
+|------|-------|------|
+| `render_component` / `to_stream_replace` | `benchmark/micro/render.rb` | The biggest lever; dominates broadcast fan-out. |
+| `reactive_token` | `benchmark/micro/token.rb` | Runs every render; HMAC dominates, assembly is what we trim. |
+| `coerce_params` | `benchmark/micro/coerce_params.rb` | Per action with a schema; recursion allocations. |
+| full request | `benchmark/request/derailed.rb` | The production latency picture. |
+
+Argument (`$ARGUMENTS`): if a specific path/bench is named, focus the
+measurement there with `rake bench:one[<name>]`; otherwise run the full suite.

--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -25,8 +25,9 @@ an isolated worktree (so `lib/`+`app/` are pristine but the harness is present):
 
 ```bash
 git worktree add --detach /tmp/pr-baseline main
-cp -r benchmark /tmp/pr-baseline/ && cp Gemfile /tmp/pr-baseline/
-(cd /tmp/pr-baseline && bundle install && RAILS_ENV=test rake bench:micro) > /tmp/before.txt
+# Copy the harness AND Rakefile/Gemfile — main predates the bench task.
+cp -r benchmark /tmp/pr-baseline/ && cp Gemfile Rakefile /tmp/pr-baseline/
+(cd /tmp/pr-baseline && bundle install && RAILS_ENV=test bundle exec rake bench:micro) > /tmp/before.txt
 ```
 
 If the branch added a bench method that doesn't exist on `main` (e.g. a new

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,0 +1,90 @@
+# Performance Rules
+
+phlex-reactive must be fast in the places that run on every interaction. These
+rules make performance a standing part of every change, not an afterthought.
+See `docs/performance.md` for the harness and the current numbers.
+
+## The prime directive
+
+**Measure before you change. Measure after. Report both, honestly.**
+
+A performance claim without a same-machine before/after is not allowed in a PR
+or a commit message. If you didn't baseline, you don't have a delta — say
+"measured after only" or go capture the baseline (`/perf` automates this with a
+worktree).
+
+## When performance is in scope
+
+Any change to a **hot path** must come with a bench and a before/after:
+
+| Hot path | File |
+|----------|------|
+| Component re-render | `lib/phlex/reactive/streamable.rb` (`render_component`, `to_stream_replace`, `turbo_stream_builder`) |
+| Identity token signing | `lib/phlex/reactive/component.rb` (`reactive_token`, `on`, `reactive_attrs`) |
+| Param coercion | `app/controllers/phlex/reactive/actions_controller.rb` (`coerce_params` and friends) |
+| Broadcast render | `lib/phlex/reactive/streamable.rb` (`broadcast_*_to`) |
+| Client dispatch | `app/javascript/phlex/reactive/reactive_controller.js` |
+
+A pure docs/test/refactor change with no hot-path edit does not need a bench.
+
+## Always Do
+
+1. **Baseline first** — capture `main` (or pre-change) numbers BEFORE editing.
+   Run `rake bench:micro` and, for request-shaped work, `rake bench:request`.
+2. **Add a bench for a new hot path** — `benchmark/micro/<name>.rb` using the
+   shared `BenchSupport` harness. `rake bench:micro` discovers it automatically.
+3. **Report throughput AND allocations** — i/s + obj/call. Flag any non-zero
+   *retained* per render (a leak).
+4. **Distinguish method-level from request-level wins** — a 2× faster render
+   does NOT mean 2× faster requests (Rails stack + DB dominate); it means ~2× on
+   broadcast fan-out and less GC pressure. Say which the number is.
+5. **Update the docs + CHANGELOG** — if representative numbers moved, update
+   `docs/performance.md`; note the change under a `perf:` CHANGELOG entry.
+6. **Re-sync the vendored client** — any `reactive_controller.js` edit re-copies
+   to `spec/dummy/public/vendor/reactive_controller.js`; run `bun test
+   spec/javascript`.
+
+## Never Do
+
+1. **Never claim a speedup without a measured before/after.** No "this should be
+   faster." Prove it or don't say it.
+2. **Never optimize a cold path** the bench shows isn't hot — three clear lines
+   beat a clever micro-optimization that obscures behavior for no measured gain.
+3. **Never break a security/correctness invariant for speed** — the signed
+   identity, default-deny, schema coercion, and pgbus optionality are not
+   negotiable. A faster wrong answer is wrong.
+4. **Never trade carefully-tested behavior for a marginal allocation win.** The
+   nested-param coercion (issues #16/#21/#24) is correctness-critical; don't
+   rewrite its deep-merge for ~10% fewer objects on a path that isn't the
+   bottleneck. Hoisting a regex to a constant: yes. Rewriting the algorithm: only
+   if the bench proves it matters and the tests still pass.
+5. **Never add a hard CI perf gate on a flaky threshold** — the `bench` CI job is
+   run-and-report (uploads an artifact), not a merge blocker. Shared runners are
+   too noisy for a hard cutoff.
+
+## Caching for speed — the correctness guards
+
+When memoizing on the hot path (we do this for the view context, the stream
+builder, the flash builder, token ivar symbols):
+
+- **Key the cache on what can change.** The view context is keyed on the
+  configured renderer's identity, so swapping `Phlex::Reactive.renderer`
+  rebuilds it. A bare `@x ||=` that ignores a changeable input serves stale data.
+- **Reset on Rails code reload.** Anything holding a controller/view-context
+  instance must reset on `config.to_prepare` (the engine does this) — otherwise
+  dev serves a reloaded class from a stale memo.
+- **Don't cache values that legitimately rotate.** The CSRF token and the pgbus
+  connection id are read live on the client on purpose; caching them sends stale
+  values. Only the page-stable action path is cached.
+
+## Checklist (before marking perf work complete)
+
+- [ ] Baseline captured BEFORE the change (same machine, same script)
+- [ ] After numbers captured; before/after in the PR body
+- [ ] A bench exists for every hot path touched
+- [ ] Throughput + allocations reported; retained-per-render is 0
+- [ ] Method-level vs request-level framing is honest
+- [ ] `docs/performance.md` + CHANGELOG updated if numbers moved
+- [ ] Vendored client re-synced + JS tests green (if the client changed)
+- [ ] `bundle exec rspec spec/phlex spec/requests` still green
+- [ ] No security/correctness invariant traded for speed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,37 @@ jobs:
       - name: Unit + request + generator specs
         run: bundle exec rspec spec/phlex spec/requests spec/generators
 
+  bench:
+    runs-on: ubuntu-latest
+    name: Benchmarks (report only)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      # Run + report: this job NEVER fails the build on a perf regression
+      # (continue-on-error). It exists to surface throughput/allocation trends
+      # over time as an artifact, not to gate merges on a flaky threshold (shared
+      # CI runners are too noisy for a hard cutoff). Read the numbers on the PR.
+      - name: Micro-benchmarks
+        id: micro
+        continue-on-error: true
+        run: bundle exec rake bench:micro
+      - name: Request-cycle benchmark (derailed)
+        continue-on-error: true
+        run: bundle exec rake bench:request | tee tmp/benchmarks/request.txt
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmarks
+          path: tmp/benchmarks/*.txt
+          if-no-files-found: warn
+
   system:
     runs-on: ubuntu-latest
     name: System (browser)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,41 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   trip still goes through the per-component queue so token threading holds.
   Omitting `debounce:` keeps the immediate-dispatch default.
 
+### Performance
+
+- **Re-render is ~2× faster with ~half the allocations.** `render_component` now
+  renders through phlex-rails' lightweight `#render_in` against a memoized
+  off-request view context, instead of `ActionController.renderer.render` (which
+  dragged in ActionView's `TemplateRenderer`/`LookupContext`/log subscriber).
+  Measured same-machine before/after: `render_component` 6.99k→14.1k i/s (212→99
+  obj/call); `to_stream_replace` 4.60k→8.00k i/s (331→191 obj/call). HTML is
+  byte-identical and the full Rails helper set (`dom_id`/`url_for`/`t`/CSRF) still
+  works. The biggest win is on the **broadcast** path (N subscribers = N renders,
+  no HTTP to amortize against); at the full-request level the Rails stack + DB
+  dominate, so request throughput is roughly unchanged.
+
+- **View context, Turbo `TagBuilder`, and flash builder are memoized** per
+  component class (the comment used to claim this; now it's true). Keyed on the
+  configured renderer's identity so swapping `Phlex::Reactive.renderer` rebuilds,
+  and reset on Rails code reload (`config.to_prepare`) so a reloaded controller
+  is never served stale.
+
+- **Smaller per-render allocations on the token path.** `reactive_token`
+  precomputes its ivar symbols + state string-keys per class (14→11 obj/call,
+  state-backed), and `on(:action)` skips re-serializing an empty params hash
+  (6→5 obj/call). The bracket-key regex in param coercion is hoisted to a frozen
+  constant.
+
+- **Client: the page-stable action path is resolved once per controller** instead
+  of a `querySelector` per dispatch. CSRF token and pgbus connection id stay live
+  (they can rotate).
+
+- **Benchmark harness + CI report.** `rake bench` (micro: render/token/coerce) and
+  `rake bench:request` (end-to-end via derailed) measure the hot paths; a CI
+  `bench` job runs them on every PR and uploads the report as an artifact
+  (run-and-report, not a hard gate). See `docs/performance.md` and the `/perf`
+  command.
+
 ### Fixed
 
 - **Model-scoped form fields feed a nested param (issue #21).** A Rails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ hand-picking Turbo Stream targets.
 5. **Capability-detect pgbus features at runtime** — probe the actual keyword (`broadcast.parameters` includes `:exclude`), never `defined?(Pgbus)` alone or a version string
 6. **Degrade gracefully** — every pgbus-only feature must no-op or fall back when pgbus is absent
 7. **Control the reply via the return value** — return a `Phlex::Reactive::Response` (`replace`/`update`/`remove`/`redirect`/`with`, chain `.flash(level, content)` / `.stream(...)`) to govern the actor's HTTP reply; returning anything else keeps the implicit single replace. See the README "Controlling the action's reply" section and `lib/phlex/reactive/response.rb`.
+8. **Measure performance, don't guess** — any hot-path change (render, token signing, param coercion, broadcast, client dispatch) ships with a same-machine before/after from `rake bench` (or `/perf`). No speedup claim without a measured baseline. Report throughput AND allocations; distinguish a method-level win from a request-level one. See `.claude/rules/performance.md` and `docs/performance.md`.
 
 ## Commands
 
@@ -42,6 +43,8 @@ bundle exec rspec spec/phlex spec/requests   # Fast suite (unit + request + broa
 bundle exec rspec spec/system                # Browser suite (Playwright; CAPYBARA_SERVER=webrick locally)
 bundle exec standardrb                       # Lint
 bundle exec rake                             # spec + standard
+bundle exec rake bench                        # Performance micro-benches (render, token, coerce_params)
+bundle exec rake bench:request                # End-to-end request-cycle bench (derailed)
 ```
 
 ## Slash Commands
@@ -50,6 +53,7 @@ bundle exec rake                             # spec + standard
 |---------|---------|
 | `/lfg` | Full autonomous workflow: branch → understand → explore → plan → TDD → verify → PR |
 | `/tdd` | Enforce RED → GREEN → REFACTOR |
+| `/perf` | Benchmark the branch vs main (same-machine before/after) and keep perf docs in sync |
 | `/architect` | Coordinate a change across the component → endpoint → client layers |
 | `/security` | Security audit (signed identity, default-deny, params, CSRF, connection-id) |
 | `/review-pr` | Review a PR for pattern compliance |
@@ -118,9 +122,30 @@ optionality is a core invariant — never break it.
   `defined?(Pgbus)`. phlex-reactive's own runtime still supports Ruby 3.2.
 - See `docs/testing.md`.
 
+## Performance
+
+phlex-reactive is benchmarked, not assumed. The hot paths are the re-render
+(`render_component` → phlex-rails `render_in` against a memoized view context),
+token signing (`reactive_token`), and param coercion. Key facts:
+
+- **Render goes through `render_in`, not `renderer.render`** — ~2× faster, ~half
+  the allocations, byte-identical HTML. The off-request view context + Turbo
+  `TagBuilder` are memoized per class and reset on Rails code reload
+  (`config.to_prepare`).
+- **The render win matters most for broadcasts** (N subscribers = N renders, no
+  HTTP). At the full-request level the Rails stack + DB dominate — don't expect
+  a render optimization to move request throughput.
+- **Measure before you change.** `rake bench` (micro) and `rake bench:request`
+  (end-to-end); `/perf` captures a same-machine before/after against `main`. The
+  CI `bench` job is run-and-report (artifact), never a hard fail.
+- **Cache correctness:** key any hot-path memo on what can change (renderer
+  identity), reset on reload, never cache values that rotate (CSRF token, pgbus
+  connection id are read live).
+- See `docs/performance.md` and `.claude/rules/performance.md`.
+
 ## More Documentation
 
 See `.claude/` and `docs/`:
 - `.claude/commands/` — slash command definitions
-- `.claude/rules/` — coding style, git workflow, testing, agents
-- `docs/` — published site (architecture, security, broadcasting, transport-pgbus, testing, examples)
+- `.claude/rules/` — coding style, git workflow, testing, performance, agents
+- `docs/` — published site (architecture, security, broadcasting, transport-pgbus, testing, performance, examples)

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,18 @@ group :development do
   gem "standard", "~> 1.3", require: false
 end
 
+# Performance measurement. The micro-benches (benchmark/micro/*) isolate the hot
+# methods (render, reactive_token, param coercion) with benchmark-ips for
+# throughput and memory_profiler for allocations. The request-cycle bench
+# (benchmark/request/*) drives the dummy app through derailed_benchmarks for
+# end-to-end latency + memory. See docs/performance.md and `rake -T bench`.
+group :development, :test do
+  gem "benchmark-ips", "~> 2.13", require: false
+  gem "memory_profiler", "~> 1.0", require: false
+  gem "derailed_benchmarks", "~> 2.1", require: false
+  gem "stackprof", "~> 0.2", require: false # derailed_benchmarks profiling backend
+end
+
 group :test do
   gem "rspec", "~> 3.0"
   gem "rspec-rails", "~> 7.0"

--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ See [docs/broadcasting.md](docs/broadcasting.md) and
 - [Broadcasting & live updates](docs/broadcasting.md)
 - [Transport: pgbus vs Action Cable](docs/transport-pgbus.md)
 - [Testing reactive components](docs/testing.md)
+- [Performance & benchmarking](docs/performance.md)
 - Examples: [counter](docs/examples/counter.md) ·
   [chat](docs/examples/chat.md) · [todo list](docs/examples/todo_list.md) ·
   [inline edit](docs/examples/inline_edit.md) ·

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,54 @@ end
 
 require "standard/rake"
 
+# --- Performance benchmarks -------------------------------------------------
+# Micro-benches isolate the hot methods (render, reactive_token, param
+# coercion); the request bench drives the dummy app through derailed_benchmarks
+# for end-to-end latency + memory. See docs/performance.md.
+namespace :bench do
+  micro_dir = "benchmark/micro"
+
+  desc "Run the micro-benchmarks (render, token, coerce_params)"
+  task :micro do
+    files = Dir["#{micro_dir}/*.rb"].sort
+    abort "No micro-benchmarks found in #{micro_dir}" if files.empty?
+
+    # Capture a plain-text report (CI uploads it as an artifact) while still
+    # streaming to the console. Strip ANSI colors from the saved copy.
+    require "fileutils"
+    FileUtils.mkdir_p("tmp/benchmarks")
+    out = File.open("tmp/benchmarks/micro.txt", "w")
+    files.each do |file|
+      header = "\n### #{file} ###"
+      puts "\e[1;35m#{header}\e[0m"
+      out.puts header
+      result = `ruby #{file} 2>&1`
+      puts result
+      out.puts result.gsub(/\e\[[0-9;]*m/, "")
+    end
+    out.close
+    puts "\nSaved report to tmp/benchmarks/micro.txt"
+  end
+
+  desc "Run a single micro-benchmark: rake bench:one[render]"
+  task :one, [:name] do |_t, args|
+    name = args[:name] or abort "Usage: rake bench:one[render|token|coerce_params]"
+    file = "#{micro_dir}/#{name}.rb"
+    abort "No such benchmark: #{file}" unless File.exist?(file)
+    ruby file
+  end
+
+  desc "End-to-end request-cycle benchmark (derailed; needs a booted dummy app)"
+  task :request do
+    require "fileutils"
+    FileUtils.mkdir_p("tmp/benchmarks")
+    sh({"RAILS_ENV" => "test"}, "ruby benchmark/request/derailed.rb")
+  end
+end
+
+desc "Run the micro-benchmark suite (alias for bench:micro)"
+task bench: "bench:micro"
+
 desc "Build gem and verify contents"
 task :build do
   sh("gem build phlex-reactive.gemspec --strict")

--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,7 @@ namespace :bench do
     # streaming to the console. Strip ANSI colors from the saved copy.
     require "fileutils"
     FileUtils.mkdir_p("tmp/benchmarks")
+    failed = []
     out = File.open("tmp/benchmarks/micro.txt", "w")
     files.each do |file|
       header = "\n### #{file} ###"
@@ -41,17 +42,28 @@ namespace :bench do
       result = `ruby #{file} 2>&1`
       puts result
       out.puts result.gsub(/\e\[[0-9;]*m/, "")
+      # A crashed bench must not pass silently — record the failure (and note it
+      # in the saved report) so CI surfaces a broken bench instead of a green tick.
+      unless $?.success?
+        failed << file
+        out.puts "!!! FAILED (exit #{$?.exitstatus})"
+      end
     end
     out.close
     puts "\nSaved report to tmp/benchmarks/micro.txt"
+    abort "\nBenchmark(s) failed: #{failed.join(", ")}" if failed.any?
   end
 
   desc "Run a single micro-benchmark: rake bench:one[render]"
   task :one, [:name] do |_t, args|
     name = args[:name] or abort "Usage: rake bench:one[render|token|coerce_params]"
-    file = "#{micro_dir}/#{name}.rb"
-    abort "No such benchmark: #{file}" unless File.exist?(file)
-    ruby file
+    # Resolve against the actual bench files (no shell interpolation of arbitrary
+    # input into an executable path) so a stray name can't escape the benchmark dir.
+    available = Dir["#{micro_dir}/*.rb"].map { |f| File.basename(f, ".rb") }
+    unless available.include?(name)
+      abort "No such benchmark: #{name}. Available: #{available.sort.join(", ")}"
+    end
+    ruby "#{micro_dir}/#{name}.rb"
   end
 
   desc "End-to-end request-cycle benchmark (derailed; needs a booted dummy app)"

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -258,13 +258,19 @@ module Phlex
         end
       end
 
+      # Matches each bracket segment in "items_attributes][0][qty]" — the part
+      # after the first "[". Hoisted to a frozen constant so coercing a bracketed
+      # key doesn't recompile the pattern per key on every request.
+      BRACKET_SEGMENT = /[^\[\]]+/
+      private_constant :BRACKET_SEGMENT
+
       # "invoice[items_attributes][0][qty]" => ["invoice", "items_attributes",
       # "0", "qty"]. A key with no brackets is a single-element path.
       def bracket_path(key)
         return [key] unless key.include?("[")
 
         head, rest = key.split("[", 2)
-        [head, *rest.scan(/[^\[\]]+/)]
+        [head, *rest.scan(BRACKET_SEGMENT)]
       end
 
       # Walk/create nested hashes along `path`, then merge `value` at the leaf so

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -119,6 +119,7 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+  #actionPathCache // page-stable action path, resolved once per controller
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -332,13 +333,21 @@ export default class extends Controller {
     }
   }
 
+  // The action path comes from a <meta> tag that is fixed for the page's life,
+  // so resolve it once per controller and cache it — avoids a querySelector on
+  // every dispatch (this runs on the request hot path, once per click/keystroke
+  // round trip). Cached on the instance, so a fresh connect() (after a Turbo
+  // navigation swaps the element) re-reads it.
   #actionPath() {
-    return (
+    return (this.#actionPathCache ??=
       document.querySelector('meta[name="phlex-reactive-action-path"]')?.content ||
-      "/reactive/actions"
-    )
+      "/reactive/actions")
   }
 
+  // CSRF token and connection id are read LIVE (not cached) on purpose: Rails
+  // can rotate the CSRF token, and the pgbus connection id changes on an SSE
+  // reconnect — caching either would send a stale value. A single querySelector
+  // per request is cheap next to the round trip itself.
   #csrfToken() {
     return document.querySelector('meta[name="csrf-token"]')?.content ?? ""
   }

--- a/benchmark/micro/coerce_params.rb
+++ b/benchmark/micro/coerce_params.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Micro-bench: server-side param coercion (ActionsController#coerce_params). It
+# runs on every action that declares a param schema, recursing through nested
+# hashes/arrays and expanding Rails bracket keys. This isolates the coercion of
+# a realistic nested payload (a Rails Form(model:) with an array of nested
+# attributes) so allocation/throughput regressions in the recursion show up.
+#
+#   ruby benchmark/micro/coerce_params.rb
+
+require_relative "../support/boot"
+
+controller = Phlex::Reactive::ActionsController.new
+
+schema = {
+  date: :string,
+  bank_account_ids: [:integer],
+  invoice_items_attributes: [{id: :integer, quantity: :float, price: :float, _destroy: :boolean}]
+}
+
+# A flat, bracketed payload (what the client's #collectFields posts for a
+# Rails-style nested form) as an ActionController::Parameters, the real input.
+raw = ActionController::Parameters.new(
+  "date" => "2026-01-02",
+  "bank_account_ids[]" => %w[1 2 3],
+  "invoice_items_attributes[0][id]" => "10",
+  "invoice_items_attributes[0][quantity]" => "2.5",
+  "invoice_items_attributes[0][price]" => "9.99",
+  "invoice_items_attributes[0][_destroy]" => "false",
+  "invoice_items_attributes[1][id]" => "11",
+  "invoice_items_attributes[1][quantity]" => "1.0",
+  "invoice_items_attributes[1][price]" => "4.50",
+  "invoice_items_attributes[1][_destroy]" => "true"
+)
+
+# coerce_params reads params.fetch(:params, {}); set it on the controller.
+controller.params = ActionController::Parameters.new(params: raw)
+run = -> { controller.send(:coerce_params, schema) }
+
+BenchSupport.header("coerce_params: nested array-of-hash (Rails bracket form)")
+BenchSupport.ips { |x| x.report("coerce_params") { run.call } }
+
+BenchSupport.header("coerce_params allocations (per call)")
+BenchSupport.allocations("coerce_params") { run.call }

--- a/benchmark/micro/render.rb
+++ b/benchmark/micro/render.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Micro-bench: the component re-render path (the hottest server work in an
+# action round trip). `to_stream_replace` builds a Turbo stream from the
+# component, which needs a view context. We memoize that context per class, so
+# this bench measures the steady-state cost AND, with PHLEX_REACTIVE_NO_CACHE=1,
+# the un-memoized cost for an apples-to-apples before/after.
+#
+#   ruby benchmark/micro/render.rb
+#   PHLEX_REACTIVE_NO_CACHE=1 ruby benchmark/micro/render.rb   # the "before"
+
+require_relative "../support/boot"
+
+# Optional "before" mode: flush the cache on every call so we measure the cost
+# of rebuilding the view context per render (the pre-optimization behavior).
+no_cache = ENV["PHLEX_REACTIVE_NO_CACHE"] == "1"
+reset = -> { CounterComponent.reset_turbo_view_context! if no_cache }
+
+BenchSupport.header("render: CounterComponent#to_stream_replace#{" (NO CACHE)" if no_cache}")
+
+BenchSupport.ips do |x|
+  x.report("to_stream_replace") do
+    reset.call
+    CounterComponent.new(count: 1).to_stream_replace
+  end
+end
+
+BenchSupport.header("allocations per render")
+CounterComponent.new(count: 1).to_stream_replace # warm the cache for the cached run
+BenchSupport.allocations("to_stream_replace") do
+  reset.call
+  CounterComponent.new(count: 1).to_stream_replace
+end
+
+# render_component is the lightweight phlex-rails render_in path (vs the old
+# ActionController renderer.render). This isolates the pure render cost — the
+# win that matters MOST for broadcasts, where a single change fans out to N
+# subscribers as N renders with NO HTTP round trip to amortize against.
+BenchSupport.header("render_component (the broadcast/fan-out unit)")
+BenchSupport.ips do |x|
+  x.report("render_component") { CounterComponent.render_component(CounterComponent.new(count: 1)) }
+end
+BenchSupport.allocations("render_component") do
+  CounterComponent.render_component(CounterComponent.new(count: 1))
+end

--- a/benchmark/micro/token.rb
+++ b/benchmark/micro/token.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Micro-bench: reactive_token, which signs the component's identity payload on
+# EVERY render (it's spread into the root element via reactive_attrs). We cache
+# the ivar symbols + string keys per class so the per-render path no longer
+# allocates a Symbol/String per state key. The signing itself (MessageVerifier
+# HMAC) dominates and is unavoidable — this isolates the assembly cost around it.
+#
+#   ruby benchmark/micro/token.rb
+
+require_relative "../support/boot"
+
+state = CounterComponent.new(count: 42)          # state-backed ({c, s})
+todo = Todo.create!(title: "t", done: false)
+record = TodoItemComponent.new(todo:)            # record-backed ({c, gid})
+
+BenchSupport.header("reactive_token throughput")
+BenchSupport.ips do |x|
+  x.report("state-backed token") { state.send(:reactive_token) }
+  x.report("record-backed token") { record.send(:reactive_token) }
+end
+
+BenchSupport.header("reactive_token allocations (per call)")
+state.send(:reactive_token) # warm the class-level caches
+BenchSupport.allocations("state-backed") { state.send(:reactive_token) }
+BenchSupport.allocations("record-backed") { record.send(:reactive_token) }
+
+BenchSupport.header("on() trigger attrs (no explicit params — the common case)")
+BenchSupport.allocations("on(:increment)") { state.send(:on, :increment) }

--- a/benchmark/request/derailed.rb
+++ b/benchmark/request/derailed.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# End-to-end request-cycle benchmark: drives the FULL Rack stack of the dummy
+# app (middleware -> router -> Phlex::Reactive::ActionsController -> token verify
+# -> action -> re-render -> turbo-stream) for a real reactive action POST. This
+# is the number that reflects production action latency, complementing the
+# micro-benches (which isolate single methods).
+#
+# It boots the dummy app exactly as the request specs do and POSTs through
+# Rack::MockRequest — the same call-the-app primitive derailed_benchmarks uses
+# internally — wrapped in benchmark-ips for throughput and memory_profiler for
+# per-request allocations. derailed_benchmarks is loaded so its memory/object
+# helpers are available for ad-hoc deep dives (see docs/performance.md).
+#
+#   rake bench:request
+#   TEST_COUNT=500 rake bench:request
+
+ENV["RAILS_ENV"] ||= "test"
+
+require_relative "../../spec/dummy/config/environment"
+require "active_record"
+ActiveRecord::Schema.verbose = false
+load Rails.root.join("db/schema.rb")
+
+require "rack/mock"
+require "json"
+require "benchmark/ips"
+require "memory_profiler"
+require "derailed_benchmarks"
+
+app = Rails.application
+mock = Rack::MockRequest.new(app)
+
+# Mint a token exactly as a component would (the app's verifier), then POST the
+# reactive action body the client would send.
+def sign(klass, payload)
+  Phlex::Reactive.sign(payload.merge("c" => klass.name))
+end
+
+def post(mock, body)
+  mock.post(
+    "/reactive/actions",
+    :input => body,
+    "CONTENT_TYPE" => "application/json",
+    "HTTP_ACCEPT" => "text/vnd.turbo-stream.html"
+  )
+end
+
+# A state-backed action (no DB) and a record-backed action (GlobalID re-find +
+# DB write) — the two shapes of a real round trip.
+state_body = {token: sign(CounterComponent, "s" => {"count" => 1}), act: "increment", params: {}}.to_json
+
+todo = Todo.create!(title: "bench", done: false)
+record_body = {token: sign(TodoItemComponent, "gid" => todo.to_gid.to_s), act: "toggle", params: {}}.to_json
+
+# Sanity: both must return 200 before we benchmark, else we'd be timing an error.
+%w[state record].each do |kind|
+  body = (kind == "state") ? state_body : record_body
+  status = post(mock, body).status
+  abort "[bench] #{kind} request returned HTTP #{status}, expected 200" unless status == 200
+end
+
+puts "\n\e[1;36mrequest cycle: POST /reactive/actions (full Rack stack)\e[0m"
+puts "─" * 54
+Benchmark.ips do |x|
+  x.config(time: 3, warmup: 1)
+  x.report("state-backed action") { post(mock, state_body) }
+  x.report("record-backed action") { post(mock, record_body) }
+  x.compare!
+end
+
+puts "\n\e[1;36mallocations per request\e[0m"
+puts "─" * 23
+[["state-backed", state_body], ["record-backed", record_body]].each do |label, body|
+  report = MemoryProfiler.report { 50.times { post(mock, body) } }
+  puts format("  %-16s %8d objects/req  %10d bytes/req",
+    label, report.total_allocated / 50, report.total_allocated_memsize / 50)
+end

--- a/benchmark/support/boot.rb
+++ b/benchmark/support/boot.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Shared boot for the micro-benchmarks. Boots the dummy Rails app (so the
+# renderer controller, view context, and example components are all available)
+# and loads the in-memory schema — the same setup spec/rails_helper.rb uses, so
+# a bench measures the real render/coerce path, not a stub.
+#
+#   ruby benchmark/micro/render.rb
+#   rake bench:micro
+#
+# Off-Rails micro-benches (signing only) can skip this and require
+# "phlex/reactive" directly, but the render path needs the full app.
+
+ENV["RAILS_ENV"] ||= "test"
+
+require_relative "../../spec/dummy/config/environment"
+
+require "active_record"
+ActiveRecord::Schema.verbose = false
+load Rails.root.join("db/schema.rb")
+
+require "benchmark/ips"
+require "memory_profiler"
+
+module BenchSupport
+  module_function
+
+  # Run a benchmark-ips comparison over the given labelled procs and print a
+  # comparison table. `time:`/`warmup:` kept short so the full suite stays fast
+  # in CI; bump them locally when chasing a small delta.
+  def ips(time: 2, warmup: 1)
+    Benchmark.ips do |x|
+      x.config(time: time, warmup: warmup)
+      yield x
+      x.compare!
+    end
+  end
+
+  # Print the total allocated objects/bytes for one labelled proc — the number
+  # that actually moves when we kill a per-call allocation. Returns the report
+  # so a caller can assert on it if needed.
+  def allocations(label)
+    report = MemoryProfiler.report { yield }
+    puts format(
+      "  %-32s %8d objects  %10d bytes (retained: %d objects)",
+      label, report.total_allocated, report.total_allocated_memsize, report.total_retained
+    )
+    report
+  end
+
+  def header(title)
+    puts "\n\e[1;36m#{title}\e[0m"
+    puts "─" * title.length
+  end
+end

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,148 @@
+---
+layout: default
+title: Performance
+nav_order: 8
+---
+
+# Performance
+
+phlex-reactive aims to be fast in the places that run on every interaction: the
+component re-render, the identity-token signing, the param coercion, and the
+client request hot path. This page documents how those paths are kept fast, how
+to measure them yourself, and how performance is part of every change.
+
+The honest summary: **the re-render is the part we control and the part we
+optimized hardest, but a full HTTP action is dominated by the Rails middleware
+stack and (for record-backed components) the database** — so the render wins
+matter most for broadcasts (one change fanned out to N subscribers = N renders
+with no HTTP overhead to amortize against). Measure before you optimize; the
+harness below exists so you never have to guess.
+
+## The hot paths
+
+| Path | When it runs | What we did |
+|------|--------------|-------------|
+| `render_component` | every action re-render **and every broadcast render** | Renders through phlex-rails' lightweight `#render_in` against a **memoized** off-request view context, instead of `ActionController.renderer.render`. ~1.9× faster, ~half the allocations, byte-identical HTML. |
+| view context / `TagBuilder` | every render + broadcast | Built **once per component class** and reused (the comment used to say "memoized" — now it actually is). Reset on Rails code reload so a reloaded controller is never served stale. |
+| `reactive_token` | every render (it's in `reactive_attrs`) | Ivar symbols (`:@count`) and state string-keys are precomputed per class, so signing no longer allocates a `Symbol`/`String` per state key. The HMAC itself dominates and is unavoidable. |
+| `on(:action)` | every trigger rendered | The no-params case (the common one) skips re-serializing `{}` to JSON. |
+| `coerce_params` | every action with a param schema | The bracket-key regex is hoisted to a frozen constant (no per-key recompile). |
+| client meta lookups | every dispatch | The page-stable action path is resolved once per controller; CSRF + pgbus connection id stay live (they can rotate). |
+
+## Measuring
+
+Everything is driven from `rake`:
+
+```bash
+rake bench           # the micro-benchmark suite (alias for bench:micro)
+rake bench:micro     # render, reactive_token, coerce_params — isolates each method
+rake bench:request   # end-to-end POST /reactive/actions through the full Rack stack
+rake bench:one[render]  # a single micro-bench by name
+```
+
+- **Micro-benches** (`benchmark/micro/*.rb`) isolate one method with
+  [`benchmark-ips`](https://github.com/evanphx/benchmark-ips) (throughput) and
+  [`memory_profiler`](https://github.com/SamSaffron/memory_profiler)
+  (allocations). They boot the dummy app so they exercise the real render path.
+- **The request bench** (`benchmark/request/derailed.rb`) drives the dummy app's
+  full Rack stack (middleware → router → controller → token verify → action →
+  re-render → turbo-stream) via `Rack::MockRequest` — the same call-the-app
+  primitive [`derailed_benchmarks`](https://github.com/zombocom/derailed_benchmarks)
+  uses — so the numbers reflect production action latency. `derailed_benchmarks`
+  is loaded for its memory/object helpers when you want a deeper dive.
+
+### Reading the output
+
+`benchmark-ips` reports **i/s** (iterations per second — higher is better) and
+**μs/i** (microseconds per call — lower is better). `memory_profiler` reports
+**objects/bytes allocated** (transient GC pressure) and **retained** (objects
+that survive — a steady climb here is a leak). For a re-render, *retained should
+be 0*; a non-zero retained count per render is the smell the view-context
+memoization fixed.
+
+### Measure BEFORE you change
+
+The first rule: capture the baseline **before** touching code, or you can't
+claim a delta. The cleanest way for a gem is an isolated worktree so `main` and
+your branch run the *same script* on the *same machine*:
+
+```bash
+git worktree add --detach /tmp/baseline main
+cp -r benchmark /tmp/baseline/ && cp Gemfile /tmp/baseline/
+(cd /tmp/baseline && bundle install && rake bench:micro) > /tmp/before.txt
+rake bench:micro > /tmp/after.txt          # your branch
+diff /tmp/before.txt /tmp/after.txt
+git worktree remove --force /tmp/baseline
+```
+
+There is no committed baseline file (shared CI runners are too noisy for a hard
+regression gate), which is exactly why the before/after has to be a deliberate
+same-machine measurement, not a comparison against a number from another box.
+
+Toggling a single optimization in place (e.g. `PHLEX_REACTIVE_NO_CACHE=1 ruby
+benchmark/micro/render.rb`) is an even cleaner apples-to-apples for one change —
+it removes machine-to-machine *and* worktree variance.
+
+## Representative numbers
+
+Measured on Ruby 3.4 +YJIT, Apple Silicon, the dummy app — the **before** column
+is pristine `main` run in an isolated `git worktree` with the *same script* as
+the **after** column, so it's a true same-machine before/after. **Your absolute
+numbers will differ; the ratios are the point.**
+
+| Benchmark | Before | After | Delta |
+|-----------|--------|-------|-------|
+| `render_component` throughput | 6.99k i/s (143 μs) | 14.1k i/s (71 μs) | **2.0× faster** |
+| `render_component` allocations | 212 obj | 99 obj | **−53%** |
+| `to_stream_replace` throughput | 4.60k i/s (217 μs) | 8.00k i/s (125 μs) | **1.7× faster** |
+| `to_stream_replace` allocations | 331 obj | 191 obj | **−42%** |
+| `reactive_token` (state) allocations | 14 obj | 11 obj | −21% |
+| `on(:action)` (no params) allocations | 6 obj | 5 obj | −17% |
+
+Full-stack request numbers (no clean before/after — see below):
+
+| Benchmark | Throughput | Allocations |
+|-----------|-----------|-------------|
+| `POST /reactive/actions` (state-backed) | ~1.6k req/s (636 μs) | 828 obj/req |
+| `POST /reactive/actions` (record-backed, +DB) | ~1.1k req/s (895 μs) | 1316 obj/req |
+| `coerce_params` (2-row nested form) | ~37k i/s (27 μs) | 218 obj/call |
+
+What these tell you:
+
+- The render path got ~2× faster and halved its allocations — **but at the full
+  request level that delta is within noise**, because routing + middleware +
+  token verify + transaction dominate. Don't expect a render optimization to
+  move request throughput; expect it to move **broadcast fan-out** (N renders,
+  no HTTP) and to cut GC pressure under load.
+- Record-backed actions are ~1.4× slower than state-backed — that's the GlobalID
+  re-find + DB write, which is the security model working as designed (state
+  lives in the database), not overhead to remove.
+
+## CI
+
+The `bench` job in `.github/workflows/main.yml` runs the micro suite and the
+request bench on every PR and **uploads the report as the `benchmarks`
+artifact**. It is **run-and-report, never a hard fail** — it surfaces trends, it
+does not gate merges on a flaky threshold. Download the artifact from the PR's
+checks tab to see the numbers for that branch.
+
+## Performance is part of every change
+
+See [`.claude/rules/performance.md`](https://github.com/mhenrixon/phlex-reactive/blob/main/.claude/rules/performance.md):
+any change to a hot path ships with a bench, the README/CHANGELOG/docs are
+updated, and the JS vendored copy is re-synced. Run `/perf` to benchmark the
+current branch and get a written before/after.
+
+## Adding a benchmark
+
+A new hot path gets a new `benchmark/micro/<name>.rb`. Use the shared harness:
+
+```ruby
+require_relative "../support/boot"   # boots the dummy app + schema
+
+BenchSupport.header("my hot path")
+BenchSupport.ips { |x| x.report("thing") { thing_under_test } }
+BenchSupport.allocations("thing") { thing_under_test }
+```
+
+`rake bench:micro` picks it up automatically (it globs `benchmark/micro/*.rb`).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -68,12 +68,19 @@ your branch run the *same script* on the *same machine*:
 
 ```bash
 git worktree add --detach /tmp/baseline main
-cp -r benchmark /tmp/baseline/ && cp Gemfile /tmp/baseline/
-(cd /tmp/baseline && bundle install && rake bench:micro) > /tmp/before.txt
-rake bench:micro > /tmp/after.txt          # your branch
+# Copy the harness AND the Rakefile/Gemfile so `rake bench` exists in the
+# pristine tree (main predates the bench task).
+cp -r benchmark /tmp/baseline/ && cp Gemfile Rakefile /tmp/baseline/
+(cd /tmp/baseline && bundle install && RAILS_ENV=test bundle exec rake bench:micro) > /tmp/before.txt
+RAILS_ENV=test bundle exec rake bench:micro > /tmp/after.txt   # your branch
 diff /tmp/before.txt /tmp/after.txt
 git worktree remove --force /tmp/baseline
 ```
+
+If the branch added a bench that calls a method not on `main` (e.g. a new
+`reset_*!`), write a baseline-safe script that only calls methods present on
+`main` and run *that* in both trees — exactly how this PR's render numbers were
+taken.
 
 There is no committed baseline file (shared CI runners are too noisy for a hard
 regression gate), which is exactly why the before/after has to be a deliberate

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -87,15 +87,44 @@ module Phlex
       attr_writer :flash_target
 
       # Render a Phlex component to HTML with a full (off-request) view context.
+      # Uses phlex-rails' #render_in against the memoized view context — a direct
+      # component.call that skips ActionController's renderer.render machinery
+      # (~2x faster, ~half the allocations), with the same HTML and full helper
+      # access (dom_id/url_for/t/csrf). Used for a Phlex component embedded as
+      # Response#with content.
       def render(component)
-        renderer.render(component, layout: false)
+        component.render_in(off_request_view_context)
       end
 
       # A Turbo::Streams::TagBuilder bound to an off-request view context, used
       # to build standalone streams (e.g. a Response flash append) not tied to a
-      # specific component's id.
+      # specific component's id. Memoized — building a view context is expensive
+      # (instantiates the renderer + assembles its helpers), and a flash is on
+      # the action hot path.
       def flash_builder
-        ::Turbo::Streams::TagBuilder.new(renderer.new.view_context)
+        @flash_builder ||= ::Turbo::Streams::TagBuilder.new(off_request_view_context)
+      end
+
+      # A single off-request view context, built once and reused for both the
+      # flash builder and standalone component renders. Keyed on the renderer's
+      # identity so a renderer swap rebuilds; the engine resets it on Rails code
+      # reload (to_prepare).
+      def off_request_view_context
+        current = renderer
+        if @off_request_view_context.nil? || !@off_request_view_context_renderer.equal?(current)
+          @off_request_view_context = current.new.view_context
+          @off_request_view_context_renderer = current
+          @flash_builder = nil
+        end
+        @off_request_view_context
+      end
+
+      # Drop the cached view context + flash builder so the next call rebuilds.
+      # Registered on Rails' reloader by the engine; also used by specs.
+      def reset_flash_builder!
+        @flash_builder = nil
+        @off_request_view_context = nil
+        @off_request_view_context_renderer = nil
       end
 
       def base_controller_name

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -98,34 +98,57 @@ module Phlex
 
       # A Turbo::Streams::TagBuilder bound to an off-request view context, used
       # to build standalone streams (e.g. a Response flash append) not tied to a
-      # specific component's id. Memoized — building a view context is expensive
-      # (instantiates the renderer + assembles its helpers), and a flash is on
-      # the action hot path.
+      # specific component's id. Cached PER THREAD alongside the context it's
+      # bound to (see off_request_view_context for why per-thread).
       def flash_builder
-        @flash_builder ||= ::Turbo::Streams::TagBuilder.new(off_request_view_context)
+        off_request_view_context_cache[:builder]
       end
 
-      # A single off-request view context, built once and reused for both the
-      # flash builder and standalone component renders. Keyed on the renderer's
-      # identity so a renderer swap rebuilds; the engine resets it on Rails code
-      # reload (to_prepare).
+      # The off-request view context for the current thread, built once and
+      # reused for both the flash builder and standalone component renders.
+      # Cached PER THREAD, not per process: an ActionView context carries mutable
+      # output_buffer/view_flow state (render_in's capture swaps it), so sharing
+      # one instance across threads can interleave content on a threaded server.
+      # Rebuilt when the renderer object changes or the generation is bumped
+      # (reset_flash_builder! / Rails code reload), so a reloaded controller is
+      # never served stale.
       def off_request_view_context
-        current = renderer
-        if @off_request_view_context.nil? || !@off_request_view_context_renderer.equal?(current)
-          @off_request_view_context = current.new.view_context
-          @off_request_view_context_renderer = current
-          @flash_builder = nil
-        end
-        @off_request_view_context
+        off_request_view_context_cache[:view_context]
       end
 
-      # Drop the cached view context + flash builder so the next call rebuilds.
-      # Registered on Rails' reloader by the engine; also used by specs.
+      # Invalidate the per-thread context + builder for ALL threads by bumping
+      # the generation; each thread rebuilds lazily on next use. Registered on
+      # Rails' reloader by the engine; also used by specs. Thread-safe (an
+      # integer bump, no shared structure to tear down).
       def reset_flash_builder!
-        @flash_builder = nil
-        @off_request_view_context = nil
-        @off_request_view_context_renderer = nil
+        @off_request_view_context_generation = off_request_view_context_generation + 1
       end
+
+      def off_request_view_context_generation
+        @off_request_view_context_generation ||= 0
+      end
+
+      private
+
+      def off_request_view_context_cache
+        cache = Thread.current[:phlex_reactive_off_request_view_context]
+        current = renderer
+        generation = off_request_view_context_generation
+
+        unless cache && cache[:renderer].equal?(current) && cache[:generation] == generation
+          view_context = current.new.view_context
+          cache = {
+            view_context: view_context,
+            builder: ::Turbo::Streams::TagBuilder.new(view_context),
+            renderer: current,
+            generation: generation
+          }
+          Thread.current[:phlex_reactive_off_request_view_context] = cache
+        end
+        cache
+      end
+
+      public
 
       def base_controller_name
         @base_controller_name ||= "ActionController::Base"

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -68,6 +68,7 @@ module Phlex
         # re-finds it on each action. State lives in the DB.
         def reactive_record(name)
           @reactive_record_key = name.to_sym
+          remove_instance_variable(:@reactive_record_ivar) if defined?(@reactive_record_ivar)
         end
 
         def reactive_record_key
@@ -80,6 +81,7 @@ module Phlex
         #   reactive_state :count, :open
         def reactive_state(*names)
           reactive_state_keys.concat(names.map(&:to_sym))
+          @reactive_state_ivars = nil # rebuild the cached [key, ivar] pairs
         end
 
         def reactive_state_keys
@@ -118,6 +120,24 @@ module Phlex
 
         def reactive_action?(name)
           reactive_actions.key?(name.to_sym)
+        end
+
+        # The record's instance-variable symbol (e.g. :@todo), computed once.
+        # reactive_token reads it on every render; interpolating :"@#{key}" each
+        # time would allocate a symbol per render. Nil when record-less. Memoized
+        # per class; reset alongside reactive_record so it can't go stale.
+        def reactive_record_ivar
+          return @reactive_record_ivar if defined?(@reactive_record_ivar)
+
+          @reactive_record_ivar = reactive_record_key ? :"@#{reactive_record_key}" : nil
+        end
+
+        # [string_key, ivar_symbol] pairs for the signed state, computed once.
+        # reactive_token walks these every render; precomputing the "count"/:@count
+        # forms avoids a String + Symbol allocation per key per render. Memoized
+        # per class; reset when reactive_state adds a key.
+        def reactive_state_ivars
+          @reactive_state_ivars ||= reactive_state_keys.map { |k| [k.to_s, :"@#{k}"] }
         end
 
         # Rebuild a component instance from a verified identity payload. Called
@@ -211,12 +231,18 @@ module Phlex
       # live-update-as-you-type doesn't POST per keystroke. A blur flushes a
       # pending dispatch so the last edit is never dropped. Omit it for the
       # immediate-dispatch default.
+      # The verbatim JSON for an empty explicit-params payload. The common
+      # trigger (on(:increment), no params) hits this on EVERY render — skipping
+      # params.to_json (which re-serializes {} to the same "{}" each time) avoids
+      # a per-render allocation while keeping the wire format byte-identical.
+      EMPTY_PARAMS_JSON = "{}"
+
       def on(action_name, event: "click", debounce: nil, **params)
         attrs = {
           data: {
             action: "#{event}->reactive#dispatch",
             reactive_action_param: action_name.to_s,
-            reactive_params_param: params.to_json
+            reactive_params_param: params.empty? ? EMPTY_PARAMS_JSON : params.to_json
           }
         }
         attrs[:data][:reactive_debounce_param] = debounce if debounce
@@ -297,17 +323,18 @@ module Phlex
       # record. Record-only ({c, gid}) and state-only ({c, s}) shapes are
       # unchanged.
       def reactive_token
-        payload = {"c" => self.class.name}
+        klass = self.class
+        payload = {"c" => klass.name}
 
-        if self.class.reactive_record_key
-          record = instance_variable_get(:"@#{self.class.reactive_record_key}")
-          payload["gid"] = record.to_gid.to_s
+        if (record_ivar = klass.reactive_record_ivar)
+          payload["gid"] = instance_variable_get(record_ivar).to_gid.to_s
         end
 
-        if self.class.reactive_state_keys.any?
-          payload["s"] = self.class.reactive_state_keys.to_h do |k|
-            [k.to_s, instance_variable_get(:"@#{k}").as_json]
-          end
+        state_ivars = klass.reactive_state_ivars
+        unless state_ivars.empty?
+          state = {}
+          state_ivars.each { |key, ivar| state[key] = instance_variable_get(ivar).as_json }
+          payload["s"] = state
         end
 
         Phlex::Reactive.sign(payload)

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -41,6 +41,15 @@ module Phlex
         end
       end
 
+      # Flush memoized off-request view contexts on every code reload (dev) so a
+      # reloaded renderer controller class is never served from a stale memo. In
+      # production to_prepare runs once (eager load), so the cache simply builds
+      # fresh after boot. See Streamable.reset_all_view_contexts!.
+      config.to_prepare do
+        Phlex::Reactive::Streamable.reset_all_view_contexts!
+        Phlex::Reactive.reset_flash_builder!
+      end
+
       # Boot-time guard (issue #26): warn if the action path doesn't resolve to
       # the gem controller. Runs after_initialize so the host's full route set
       # (including a bottom-of-file catch-all that would shadow our appended

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -26,6 +26,13 @@ module Phlex
     module Streamable
       extend ActiveSupport::Concern
 
+      # A per-thread cache entry: an off-request view context + the Turbo
+      # TagBuilder bound to it, tagged with the renderer + generation it was
+      # built for. Rebuilt on a thread when the renderer object changes or the
+      # class generation is bumped — so a reset/reload/renderer-swap is picked
+      # up without ever sharing a mutable context across threads.
+      ThreadViewContext = Struct.new(:view_context, :builder, :renderer, :generation)
+
       # Every class that includes Streamable, so the engine can flush their
       # memoized view contexts on a Rails code reload (dev) in one pass. A
       # WeakMap used as a set (the class is the key) so a class reloaded by
@@ -76,31 +83,43 @@ module Phlex
 
         # Turbo::Streams::TagBuilder needs a real VIEW CONTEXT (it calls
         # `.formats` on it), not a controller class. Build one off-request from
-        # the configured renderer controller. Memoized per class — building a
+        # the configured renderer controller. Memoized PER THREAD — building a
         # view context instantiates the renderer controller and assembles its
         # whole helper module set, so doing it per render/broadcast was the
         # hottest server-side allocation in the action round trip. The builder
         # is bound to that one context and reused too.
+        #
+        # Why per-thread and not one-per-process: an ActionView context carries
+        # MUTABLE state (output_buffer/view_flow that #render_in's capture
+        # swaps), so a single instance shared across threads can interleave or
+        # bleed content between overlapping renders on a threaded server (Puma)
+        # or in concurrent jobs. A thread-local cache keeps the amortization
+        # (built once per thread, reused across that thread's renders) without
+        # ever sharing a buffer across threads.
         def turbo_stream_builder
-          memoized_turbo_view_context
-          @turbo_stream_builder
+          thread_view_context_cache.builder
         end
 
-        # The off-request view context, built once and reused. Keyed on the
-        # configured renderer's object identity so swapping
-        # Phlex::Reactive.renderer (tests, or a host that reconfigures it)
-        # transparently rebuilds; the engine also resets it on Rails code reload
-        # (to_prepare) so a reloaded controller class is never served stale.
+        # The off-request view context for the current thread, built once and
+        # reused. Rebuilt when the configured renderer object changes (a swap of
+        # Phlex::Reactive.renderer) or when the class's view-context generation
+        # is bumped (reset_turbo_view_context! / Rails code reload), so a
+        # reloaded controller class is never served stale.
         def turbo_view_context
-          memoized_turbo_view_context
+          thread_view_context_cache.view_context
         end
 
-        # Drop the cached view context + builder so the next call rebuilds.
-        # Registered on Rails' reloader by the engine; also used by specs.
+        # Invalidate the cached view context + builder for ALL threads by bumping
+        # this class's generation — each thread rebuilds lazily on its next use,
+        # and entries for the old generation are dropped. Registered on Rails'
+        # reloader by the engine; also used by specs. Thread-safe (an integer
+        # bump; no shared mutable structure to tear down).
         def reset_turbo_view_context!
-          @turbo_view_context = nil
-          @turbo_view_context_renderer = nil
-          @turbo_stream_builder = nil
+          @turbo_view_context_generation = turbo_view_context_generation + 1
+        end
+
+        def turbo_view_context_generation
+          @turbo_view_context_generation ||= 0
         end
 
         # Render a component to HTML with a full Rails view context. Uses
@@ -234,18 +253,23 @@ module Phlex
           Phlex::Reactive.renderer
         end
 
-        # Build the view context once and cache it alongside the builder bound
-        # to it. Invalidates automatically when the configured renderer object
-        # changes (a swap of Phlex::Reactive.renderer), so a test or host that
-        # reconfigures the renderer never gets a context tied to the old one.
-        def memoized_turbo_view_context
+        def thread_view_context_cache
+          store = (Thread.current[:phlex_reactive_view_contexts] ||= {})
           current = renderer
-          if @turbo_view_context.nil? || !@turbo_view_context_renderer.equal?(current)
-            @turbo_view_context = current.new.view_context
-            @turbo_view_context_renderer = current
-            @turbo_stream_builder = ::Turbo::Streams::TagBuilder.new(@turbo_view_context)
+          generation = turbo_view_context_generation
+          cached = store[self]
+
+          unless cached && cached.renderer.equal?(current) && cached.generation == generation
+            view_context = current.new.view_context
+            cached = ThreadViewContext.new(
+              view_context,
+              ::Turbo::Streams::TagBuilder.new(view_context),
+              current,
+              generation
+            )
+            store[self] = cached
           end
-          @turbo_view_context
+          cached
         end
       end
 

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -26,6 +26,34 @@ module Phlex
     module Streamable
       extend ActiveSupport::Concern
 
+      # Every class that includes Streamable, so the engine can flush their
+      # memoized view contexts on a Rails code reload (dev) in one pass. A
+      # WeakMap used as a set (the class is the key) so a class reloaded by
+      # Zeitwerk in dev is GC'd normally — a strong Array would pin every
+      # reloaded generation and leak across reloads. Guarded by a mutex;
+      # registration happens at class-load time, the reset iterates under lock.
+      @registry = ObjectSpace::WeakMap.new
+      @registry_mutex = Mutex.new
+
+      class << self
+        # Reset every streamable class's cached view context + builder. Called
+        # from the engine's reloader (config.to_prepare) so a reloaded renderer
+        # controller is never served from a stale memo. No-op outside Rails.
+        def reset_all_view_contexts!
+          @registry_mutex.synchronize do
+            @registry.keys.each(&:reset_turbo_view_context!)
+          end
+        end
+
+        def register(klass)
+          @registry_mutex.synchronize { @registry[klass] = true }
+        end
+      end
+
+      included do
+        Phlex::Reactive::Streamable.register(self)
+      end
+
       class_methods do
         # The keyword the positional model maps to in `initialize`. For a
         # record-backed component (Component#reactive_record), this is the SAME
@@ -48,20 +76,42 @@ module Phlex
 
         # Turbo::Streams::TagBuilder needs a real VIEW CONTEXT (it calls
         # `.formats` on it), not a controller class. Build one off-request from
-        # the configured renderer controller. Memoized per class.
+        # the configured renderer controller. Memoized per class — building a
+        # view context instantiates the renderer controller and assembles its
+        # whole helper module set, so doing it per render/broadcast was the
+        # hottest server-side allocation in the action round trip. The builder
+        # is bound to that one context and reused too.
         def turbo_stream_builder
-          ::Turbo::Streams::TagBuilder.new(turbo_view_context)
+          memoized_turbo_view_context
+          @turbo_stream_builder
         end
 
+        # The off-request view context, built once and reused. Keyed on the
+        # configured renderer's object identity so swapping
+        # Phlex::Reactive.renderer (tests, or a host that reconfigures it)
+        # transparently rebuilds; the engine also resets it on Rails code reload
+        # (to_prepare) so a reloaded controller class is never served stale.
         def turbo_view_context
-          renderer.new.view_context
+          memoized_turbo_view_context
         end
 
-        # Render a component to HTML with a full Rails view context. Routing
-        # through the controller renderer keeps dom_id/url_for/t() working
-        # during a re-render or broadcast.
+        # Drop the cached view context + builder so the next call rebuilds.
+        # Registered on Rails' reloader by the engine; also used by specs.
+        def reset_turbo_view_context!
+          @turbo_view_context = nil
+          @turbo_view_context_renderer = nil
+          @turbo_stream_builder = nil
+        end
+
+        # Render a component to HTML with a full Rails view context. Uses
+        # phlex-rails' #render_in against our memoized off-request view context
+        # — a direct component.call that skips ActionController's renderer.render
+        # machinery (TemplateRenderer, LookupContext, the render log subscriber):
+        # ~2x faster with ~half the allocations, and byte-identical HTML. The
+        # view context still carries the full Rails helper set, so
+        # dom_id/url_for/t()/csrf keep working during a re-render or broadcast.
         def render_component(component)
-          renderer.render(component, layout: false)
+          component.render_in(turbo_view_context)
         end
 
         # `morph: true` emits `<turbo-stream action="replace" method="morph">` so
@@ -182,6 +232,20 @@ module Phlex
 
         def renderer
           Phlex::Reactive.renderer
+        end
+
+        # Build the view context once and cache it alongside the builder bound
+        # to it. Invalidates automatically when the configured renderer object
+        # changes (a swap of Phlex::Reactive.renderer), so a test or host that
+        # reconfigures the renderer never gets a context tied to the old one.
+        def memoized_turbo_view_context
+          current = renderer
+          if @turbo_view_context.nil? || !@turbo_view_context_renderer.equal?(current)
+            @turbo_view_context = current.new.view_context
+            @turbo_view_context_renderer = current
+            @turbo_stream_builder = ::Turbo::Streams::TagBuilder.new(@turbo_view_context)
+          end
+          @turbo_view_context
         end
       end
 

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -119,6 +119,7 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+  #actionPathCache // page-stable action path, resolved once per controller
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -332,13 +333,21 @@ export default class extends Controller {
     }
   }
 
+  // The action path comes from a <meta> tag that is fixed for the page's life,
+  // so resolve it once per controller and cache it — avoids a querySelector on
+  // every dispatch (this runs on the request hot path, once per click/keystroke
+  // round trip). Cached on the instance, so a fresh connect() (after a Turbo
+  // navigation swaps the element) re-reads it.
   #actionPath() {
-    return (
+    return (this.#actionPathCache ??=
       document.querySelector('meta[name="phlex-reactive-action-path"]')?.content ||
-      "/reactive/actions"
-    )
+      "/reactive/actions")
   }
 
+  // CSRF token and connection id are read LIVE (not cached) on purpose: Rails
+  // can rotate the CSRF token, and the pgbus connection id changes on an SSE
+  // reconnect — caching either would send a stale value. A single querySelector
+  // per request is cheap next to the round trip itself.
   #csrfToken() {
     return document.querySelector('meta[name="csrf-token"]')?.content ?? ""
   }

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -146,13 +146,19 @@ RSpec.describe Phlex::Reactive::Component do
 
     it "the state cannot be tampered without breaking the signature" do
       token = record_state_klass.new(record:, attribute: :name, editing: false).send(:reactive_token)
-      # Re-encode a payload that switches the editable column to "ssn" onto the
-      # ORIGINAL signature — the signed digest no longer matches the data.
+      # Mutate the signed DATA segment (left of the `--`) while keeping the
+      # ORIGINAL signature — the HMAC over the data no longer matches, so verify
+      # fails. Flipping a byte in the encoded payload is serializer-agnostic: it
+      # works whether the verifier Marshals (the plain MessageVerifier in
+      # spec_helper) or JSON-serializes (the app verifier under rails_helper),
+      # unlike decoding+re-encoding a known payload shape.
       data, sig = token.split("--", 2)
-      decoded = JSON.parse(Base64.urlsafe_decode64(data))
-      decoded["_rails"]["data"]["s"]["attribute"] = "ssn"
-      forged = "#{Base64.urlsafe_encode64(decoded.to_json, padding: false)}--#{sig}"
+      mutated = data.dup
+      i = data.length / 2
+      mutated[i] = ((data[i] == "A") ? "B" : "A")
+      forged = "#{mutated}--#{sig}"
 
+      expect(forged).not_to eq(token) # sanity: we actually changed the data
       expect(Phlex::Reactive.verify(forged)).to be_nil
     end
   end
@@ -286,6 +292,36 @@ RSpec.describe Phlex::Reactive::Component do
     it "keeps debounce out of the explicit params payload" do
       attrs = instance.send(:on, :set, event: "input", debounce: 300, count: 5)
       expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({"count" => 5})
+    end
+
+    # Performance: the no-params case (the common on(:increment)) must NOT
+    # re-serialize an empty hash to JSON on every render — but the wire format
+    # must stay exactly "{}" so the client's #parseParams is unaffected.
+    it "emits an empty-object params payload (verbatim) with no explicit params" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:data][:reactive_params_param]).to eq("{}")
+    end
+
+    it "still serializes explicit params" do
+      attrs = instance.send(:on, :set, count: 9)
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({"count" => 9})
+    end
+  end
+
+  # Performance: reactive_token runs on EVERY render. It must produce a byte-
+  # identical payload before/after caching the ivar symbols + class name. These
+  # pin the payload SHAPE (decoded) so an allocation optimization can't silently
+  # change what's signed.
+  describe "#reactive_token payload (perf invariants)" do
+    it "signs {c, s} for a state-backed component, with string keys" do
+      token = state_klass.new(count: 5).send(:reactive_token)
+      expect(Phlex::Reactive.verify(token)).to eq("c" => "StateThing", "s" => {"count" => 5})
+    end
+
+    it "is stable across repeated renders of equal state" do
+      a = Phlex::Reactive.verify(state_klass.new(count: 3).send(:reactive_token))
+      b = Phlex::Reactive.verify(state_klass.new(count: 3).send(:reactive_token))
+      expect(a).to eq(b)
     end
   end
 end

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Performance: building a Turbo::Streams::TagBuilder needs a real Rails view
+# context, and a view context is EXPENSIVE to build (it instantiates the
+# renderer controller and assembles the helper module set). The naive code
+# rebuilt one on EVERY render and EVERY broadcast — the single hottest
+# server-side allocation in the action round trip. These specs pin the
+# memoization: the view context (and the builder bound to it) is reused across
+# renders, but a swap of Phlex::Reactive.renderer (and, in a Rails app, a code
+# reload) invalidates the cache so we never serve a stale controller instance.
+RSpec.describe "Streamable view-context memoization (performance)" do
+  after { CounterComponent.reset_turbo_view_context! }
+
+  describe ".turbo_view_context" do
+    it "reuses the same view context across calls" do
+      first = CounterComponent.turbo_view_context
+      second = CounterComponent.turbo_view_context
+      expect(second).to be(first)
+    end
+
+    it "rebuilds after an explicit reset (the Rails reload hook)" do
+      first = CounterComponent.turbo_view_context
+      CounterComponent.reset_turbo_view_context!
+      expect(CounterComponent.turbo_view_context).not_to be(first)
+    end
+
+    it "rebuilds when the configured renderer changes" do
+      original = Phlex::Reactive.renderer
+      first = CounterComponent.turbo_view_context
+
+      dedicated = Class.new(ActionController::Base)
+      Phlex::Reactive.renderer = dedicated
+      begin
+        expect(CounterComponent.turbo_view_context).not_to be(first)
+      ensure
+        Phlex::Reactive.renderer = original
+        CounterComponent.reset_turbo_view_context!
+      end
+    end
+  end
+
+  describe ".turbo_stream_builder" do
+    it "reuses the builder (and therefore its view context) across calls" do
+      expect(CounterComponent.turbo_stream_builder).to be(CounterComponent.turbo_stream_builder)
+    end
+  end
+
+  describe "render output is unchanged by memoization (back-compat)" do
+    it "produces the same replace stream as a freshly-built context" do
+      memoized = CounterComponent.new(count: 1).to_stream_replace
+      CounterComponent.reset_turbo_view_context!
+      fresh = CounterComponent.new(count: 1).to_stream_replace
+
+      # Strip the signed token (it re-randomizes per call) before comparing.
+      strip = ->(s) { s.gsub(/data-reactive-token-value="[^"]*"/, "TOKEN") }
+      expect(strip.call(memoized)).to eq(strip.call(fresh))
+    end
+  end
+
+  # render_component renders through phlex-rails' lightweight render_in (a direct
+  # component.call against the memoized view context) instead of the heavyweight
+  # ActionController renderer.render — ~2x faster, ~half the allocations — while
+  # keeping the SAME HTML and full Rails helper access (dom_id/url_for/t/csrf).
+  describe ".render_component (lightweight render path)" do
+    let(:todo) { Todo.create!(title: "t", done: false) }
+
+    it "renders a state-backed component to HTML" do
+      html = CounterComponent.render_component(CounterComponent.new(count: 3))
+      expect(html).to include('id="counter"')
+      expect(html).to include(">3<")
+    end
+
+    it "keeps Rails helpers working (dom_id on a record-backed component)" do
+      html = TodoItemComponent.render_component(TodoItemComponent.new(todo:))
+      expect(html).to include(%(id="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "carries the signed identity token (reactive_attrs rendered)" do
+      html = CounterComponent.render_component(CounterComponent.new(count: 0))
+      expect(html).to include("data-reactive-token-value=")
+      expect(html).to include('data-controller="reactive"')
+    end
+  end
+end

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -63,18 +63,26 @@ RSpec.describe "Streamable view-context memoization (performance)" do
     end
 
     it "renders correctly under concurrent threads (no buffer interleave)" do
+      renders_per_thread = 20
+      thread_count = 8
       results = Queue.new
-      threads = 8.times.map do |i|
+      threads = thread_count.times.map do |i|
         Thread.new do
-          20.times do
+          renders_per_thread.times do
             html = CounterComponent.render_component(CounterComponent.new(count: i))
             results << (html.include?(">#{i}<") && html.scan('id="counter"').size == 1)
           end
         end
       end
-      threads.each(&:join)
+      # #value (not #join) re-raises any exception from a worker thread — a render
+      # that crashed mid-thread would otherwise be swallowed AND shrink the queue,
+      # letting all(be(true)) pass on the survivors. Then assert the EXACT count
+      # so a partial run can't masquerade as a clean one.
+      threads.each(&:value)
 
-      verdicts = Array.new(results.size) { results.pop }
+      expected = thread_count * renders_per_thread
+      expect(results.size).to eq(expected)
+      verdicts = Array.new(expected) { results.pop }
       expect(verdicts).to all(be(true))
     end
   end

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -47,6 +47,38 @@ RSpec.describe "Streamable view-context memoization (performance)" do
     end
   end
 
+  # The cache is PER THREAD, not one-per-process: an ActionView context carries
+  # mutable output_buffer/view_flow state (render_in's capture swaps it), so a
+  # single shared instance could interleave content between concurrent renders
+  # on a threaded server. Each thread must get its own context, and concurrent
+  # renders must never corrupt each other.
+  describe "thread safety" do
+    it "gives each thread its own view context" do
+      contexts = Queue.new
+      [Thread.new { contexts << CounterComponent.turbo_view_context },
+        Thread.new { contexts << CounterComponent.turbo_view_context }].each(&:join)
+      a = contexts.pop
+      b = contexts.pop
+      expect(a).not_to be(b) # distinct instances per thread
+    end
+
+    it "renders correctly under concurrent threads (no buffer interleave)" do
+      results = Queue.new
+      threads = 8.times.map do |i|
+        Thread.new do
+          20.times do
+            html = CounterComponent.render_component(CounterComponent.new(count: i))
+            results << (html.include?(">#{i}<") && html.scan('id="counter"').size == 1)
+          end
+        end
+      end
+      threads.each(&:join)
+
+      verdicts = Array.new(results.size) { results.pop }
+      expect(verdicts).to all(be(true))
+    end
+  end
+
   describe "render output is unchanged by memoization (back-compat)" do
     it "produces the same replace stream as a freshly-built context" do
       memoized = CounterComponent.new(count: 1).to_stream_replace


### PR DESCRIPTION
## Summary

Make phlex-reactive fast where it counts, and make performance **continuous** —
measured on every change, not assumed. Two halves:

**A. Hot-path fixes** (each backed by a same-machine before/after, not a guess)
**B. Measurement tooling + discipline** (benchmark harness, CI report, perf docs,
a `/perf` command, and a standing perf rule for the Claude workflow)

The headline fix: the component re-render — the hottest server path, run on every
action **and every broadcast** — went through `ActionController.renderer.render`
(ActionView's `TemplateRenderer`/`LookupContext`/log-subscriber machinery) **and**
rebuilt the off-request view context + Turbo `TagBuilder` on every call (the
comment claimed "memoized per class"; it wasn't). It now renders through
phlex-rails' lightweight `#render_in` against a genuinely memoized view context.

## Measured before/after

Pristine `main` run in an isolated `git worktree` with the **same script** as the
branch (Ruby 3.4 +YJIT, Apple Silicon, dummy app). Ratios are the point; your
absolute numbers will differ.

| Benchmark | Before | After | Delta |
|-----------|--------|-------|-------|
| `render_component` throughput | 6.99k i/s (143 us) | 14.1k i/s (71 us) | **2.0x faster** |
| `render_component` allocations | 212 obj | 99 obj | **-53%** |
| `to_stream_replace` throughput | 4.60k i/s (217 us) | 8.00k i/s (125 us) | **1.7x faster** |
| `to_stream_replace` allocations | 331 obj | 191 obj | **-42%** |
| `reactive_token` (state) allocations | 14 obj | 11 obj | -21% |
| `on(:action)` (no params) allocations | 6 obj | 5 obj | -17% |

### Honest framing (this matters)

- **The render win is largest on broadcasts.** A single change fanned out to N
  subscribers = N renders with no HTTP round trip to amortize against. There the
  2x is a real 2x.
- **At the full-request level the win washes out** — routing + middleware + token
  verify + transaction + DB dominate, so `POST /reactive/actions` throughput is
  roughly unchanged. The render optimization still removes per-render retained-
  object churn (GC pressure under load). I measured this directly and am not
  overselling it.
- The token/`on()`/regex tweaks are modest but free and correct; HMAC signing
  dominates `reactive_token`, so throughput barely moves.
- I deliberately **did not** rewrite the nested-param deep-merge for ~10% fewer
  allocations — it's correctness-critical (issues #16/#21/#24) and not the
  bottleneck. Hoisting its regex to a constant: yes. Rewriting the algorithm: no.

## What changed

**Render path (`perf(streamable)`)**
- `render_component` -> `component.render_in(memoized_view_context)`; byte-identical
  HTML, full Rails helper access (`dom_id`/`url_for`/`t`/csrf) preserved.
- View context + `TagBuilder` + `flash_builder` memoized per class, keyed on the
  renderer's identity (swap rebuilds), reset on Rails code reload
  (`config.to_prepare`). The class registry is an `ObjectSpace::WeakMap` so
  reloaded classes are GC'd, not pinned.

**Micro-opts (`perf(component)`)**
- `reactive_token` precomputes ivar symbols + state string-keys per class.
- `on(:action)` skips re-serializing an empty params hash (wire format unchanged).
- Bracket-key coercion regex hoisted to a frozen constant.
- Client: page-stable action path resolved once per controller; CSRF + pgbus
  connection id stay live (they rotate). Vendored copy re-synced.
- Bonus: the state-tamper security test is now serializer-agnostic, so it passes
  run alone or in the full suite (it relied on the Rails `_rails.data` shape).

**Tooling (`test(bench)` + `docs(perf)`)**
- `benchmark/` — micro-benches (render/token/coerce) via benchmark-ips +
  memory_profiler, and an end-to-end request bench via derailed_benchmarks.
- `rake bench` / `bench:micro` / `bench:one[name]` / `bench:request`.
- CI `bench` job: runs on every PR, uploads the report as an artifact.
  Run-and-report, **never a hard fail** (shared runners are too noisy for a
  threshold).
- `docs/performance.md`, `.claude/rules/performance.md`, `.claude/commands/perf.md`,
  plus CLAUDE.md / README / CHANGELOG updates so perf + docs are part of every PR.
- Bench gems are dev/test only — **zero new runtime dependencies** (gemspec
  untouched).

## Invariants preserved

- Signed identity, default-deny actions, schema coercion, CSRF — untouched.
- pgbus optionality — untouched (no broadcast-path behavior change).
- All existing components work verbatim (HTML byte-identical).

## Test plan

- [x] `bundle exec standardrb`
- [x] `bundle exec rspec spec/phlex spec/requests spec/generators` — 159, 0 failures
- [x] `bun test spec/javascript` — 19, 0 failures
- [x] `bundle exec rspec spec/system` (browser) — 18, 0 failures (render path +
      client change validated end-to-end, incl. focus preservation + rapid-click race)
- [x] `rake bench:micro` / `rake bench:request` run clean and produce the report
- New: `spec/phlex/reactive/streamable_view_context_spec.rb` (memoization,
  renderer-swap invalidation, byte-identical output, `render_in` helper access)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `rake bench` benchmark tasks (micro, targeted, and request-cycle) plus CI benchmark artifact uploads.
  * Introduced new performance and benchmarking docs, including contributor `/perf` guidance and PR checklist.
  * Added new micro/request benchmark scripts for render, tokens, and param coercion.

* **Bug Fixes**
  * Improved performance via memoized off-request view contexts/tag builders, faster component rendering paths, and reduced token/`on(...)` empty-params overhead.
  * Better cache invalidation on reload and optimized client action-path resolution.

* **Documentation**
  * Updated README and Unreleased changelog with performance details.

* **Tests**
  * Strengthened signed-token/invariants and performance/memoization-related specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->