### PR TITLE
ci: test against Ruby 4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
           bundler-cache: true
       - name: Standard
         run: bundle exec standardrb
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "4.0"
           bundler-cache: true
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         ruby:
           - "3.3"
           - "3.4"
+          - "4.0"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now tests against Ruby 4.0** (added to the test matrix in `main.yml` and
+  the pre-release matrix in `release.yml`, alongside 3.2/3.3/3.4). Ruby 4.0
+  shipped December 2025 and is the current stable line. The gem requires no code
+  changes for 4.0 — its dependencies and the patterns it uses (ObjectSpace::WeakMap,
+  Data.define, Thread-locals, the MessageVerifier path) are stable across 3.4 → 4.0,
+  and it directly requires none of the gems 4.0 moved from default to bundled.
+  `required_ruby_version` stays `>= 3.2.0` (no upper bound, already permits 4.0).
+
 ### Added
 
 - **`reply.streams` — partial update with a token-only refresh (issue #30).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **CI now tests against Ruby 4.0** (added to the test matrix in `main.yml` and
-  the pre-release matrix in `release.yml`, alongside 3.2/3.3/3.4). Ruby 4.0
-  shipped December 2025 and is the current stable line. The gem requires no code
-  changes for 4.0 — its dependencies and the patterns it uses (ObjectSpace::WeakMap,
-  Data.define, Thread-locals, the MessageVerifier path) are stable across 3.4 → 4.0,
-  and it directly requires none of the gems 4.0 moved from default to bundled.
+  the pre-release matrix in `release.yml`, alongside 3.2/3.3/3.4; the lint and
+  browser-system jobs also run on 4.0 now). Ruby 4.0 shipped December 2025 and is
+  the current stable line. The gem requires no code changes for 4.0 — its
+  dependencies and the patterns it uses (ObjectSpace::WeakMap, Data.define,
+  Thread-locals, the MessageVerifier path) are stable across 3.4 → 4.0, and it
+  directly requires none of the gems 4.0 moved from default to bundled.
   `required_ruby_version` stays `>= 3.2.0` (no upper bound, already permits 4.0).
+  Verified empirically: the full unit/request/generator suite is green on Ruby
+  4.0.5 with zero deprecation or unbundled-gem warnings.
 
 ### Added
 


### PR DESCRIPTION
## Summary

Add **Ruby 4.0** to CI. It shipped Dec 2025 and is the current stable line
(4.0.5, June 2026) — there's no 3.5, the series went 3.4 → 4.0 — but our matrix
only tested 3.2/3.3/3.4, so the gem was never verified on the newest Ruby.

- `main.yml` test matrix → `3.2, 3.3, 3.4, 4.0`
- `release.yml` pre-release matrix → `3.3, 3.4, 4.0`

## Why no code/gemspec change

An audit of the gem's 4.0-sensitive patterns found **nothing breaks on 4.0**:

- `ObjectSpace::WeakMap` registry, `Data.define`, the `Struct` + `Thread.current`
  per-thread view-context cache, `**` kwarg splatting, `Mutex`, frozen literals,
  and the `MessageVerifier` JSON path are all stable across 3.4 → 4.0.
- The gem directly `require`s **none** of the 10 gems 4.0 moved from default to
  bundled (`logger`/`ostruct`/`base64`/…); its Rails deps supply them transitively.
- `required_ruby_version` stays `>= 3.2.0` — no upper bound, already permits 4.0.
- Deps allow 4.0: phlex/phlex-rails, turbo-rails, zeitwerk, globalid, railties
  (Rails 8.1 runs on 4.0). pgbus's floor is `>= 3.3.0` (no ceiling).

## The one thing to watch

The 4.0 job will install the optional dev-dep **pgbus** + native **pg** (the
Gemfile gate `>= 3.3` is true on 4.0). Left included for maximum coverage. If
`pg`'s native build fails on the 4.0 runner, the job reds for an optional dep —
not a phlex-reactive defect — and we'd cap pgbus at `< 4.0` then. The goal of
this PR is to learn whether the full stack works on 4.0.

## Test plan

- [x] Both workflow YAMLs validated; matrices confirmed
- [ ] CI green on the new 4.0 job (the actual verification — watching this run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI test coverage to include Ruby 4.0 alongside existing supported Ruby versions.
  * Updated lint and browser system checks, plus release-time test matrices, to run on Ruby 4.0.
* **Documentation**
  * Updated the changelog to note the expanded Ruby 4.0 CI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->