### PR TITLE
feat(component): reactive_collection — add/remove rows + count + empty-state (#35)

### DIFF
--- a/.claude/commands/github-review-failures.md
+++ b/.claude/commands/github-review-failures.md
@@ -167,7 +167,7 @@ If you can identify that certain failures will persist for environmental reasons
 - **Read before fixing** -- always read the actual failing code before attempting a fix
 - **Fix the root cause** -- don't add `# standard:disable` to bypass lint; fix the actual issue (a targeted `# rubocop:disable` is acceptable only when Standard is demonstrably wrong, e.g. `save_screenshot` flagged as a debugger)
 - **Don't fix unrelated failures** -- if a spec was already failing on main, note it but don't fix it in this PR
-- **CI environment differences** -- system specs run Playwright (cached browsers); locally use `CAPYBARA_SERVER=webrick` if Puma's reactor segfaults. pgbus-dependent specs run only on Ruby >= 3.3 (pgbus's floor) and need PostgreSQL; on 3.2 they are skipped by design.
+- **CI environment differences** -- system specs run Playwright (cached browsers) under a server matrix: Puma (default) AND Falcon (`CAPYBARA_SERVER=falcon`). A failure on only one server is a transport-specific bug, not flakiness. pgbus-dependent specs run only on Ruby >= 3.3 (pgbus's floor) and need PostgreSQL; on 3.2 they are skipped by design.
 - **Flaky tests** -- if a test passes locally but fails in CI, note it as potentially flaky rather than adding workarounds. Browser specs that assert a value right after a click (racing the morph) are a common false-flake — fix them to use a waiting matcher.
 - **Don't retry CI blindly** -- diagnose first, fix, then push. Each push triggers a full CI run.
 

--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -177,7 +177,8 @@ The best fix is usually NOT where the error surfaced:
 bundle exec standardrb
 bundle exec rspec spec/phlex spec/requests
 # client-touching changes: also run the browser suite
-bundle exec rspec spec/system    # CAPYBARA_SERVER=webrick locally if Puma segfaults
+bundle exec rspec spec/system    # Puma (default); CAPYBARA_SERVER=falcon for the async server
+bundle exec rake spec:system_servers  # client-touching changes: run BOTH real servers (puma + falcon)
 ```
 
 ### Solution verification

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -47,7 +47,10 @@ end
 - Use **waiting matchers** (`have_css(..., text:)`, `have_field(with:)`) as the
   barrier for the async morph — never assert a snapshot value right after a click.
 - Prove "no full-page reload" by setting a `window.__marker` and re-reading it.
-- `CAPYBARA_SERVER=webrick` locally if Puma's reactor segfaults; CI uses Puma.
+- The browser suite runs under two REAL servers — Puma (default) and Falcon
+  (`CAPYBARA_SERVER=falcon`). CI runs both in a matrix; `rake spec:system_servers`
+  runs both locally. A reactive round trip must pass under sync (Puma) AND async
+  (Falcon). No webrick — it isn't a real server.
 
 ## pgbus in tests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,10 +83,21 @@ jobs:
 
   system:
     runs-on: ubuntu-latest
-    name: System (browser)
+    name: System (${{ matrix.server }})
+    # Run the browser suite under BOTH real web servers — Puma (sync, thread-pool)
+    # and Falcon (async, fiber-per-request) — so a reactive round trip is proven
+    # transport-agnostic. CAPYBARA_SERVER selects the server (see
+    # spec/system/support/capybara_setup.rb).
+    strategy:
+      fail-fast: false
+      matrix:
+        server:
+          - puma
+          - falcon
     env:
       RAILS_ENV: test
       HEADLESS: "true"
+      CAPYBARA_SERVER: ${{ matrix.server }}
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The browser suite now runs under two real servers — Puma and Falcon.** The
+  `system` CI job runs as a matrix (`CAPYBARA_SERVER=puma` and `=falcon`), and a
+  new `rake spec:system_servers` task runs both locally, so a reactive round trip
+  is proven transport-agnostic across a sync (Puma, thread-pool) and an async
+  (Falcon, fiber-per-request) server. `webrick` is **removed** as a test server
+  (it isn't a real server) — `falcon` (with `protocol-rack`) replaces it as the
+  alternative, registered via `Capybara.register_server(:falcon)`. No production
+  dependency change; this is test infrastructure only.
+
 - **CI now tests against Ruby 4.0** (added to the test matrix in `main.yml` and
   the pre-release matrix in `release.yml`, alongside 3.2/3.3/3.4; the lint and
   browser-system jobs also run on 4.0 now). Ruby 4.0 shipped December 2025 and is
@@ -20,6 +29,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   4.0.5 with zero deprecation or unbundled-gem warnings.
 
 ### Added
+
+- **`reactive_collection` — add/remove-row lists in one declaration (issue #35).**
+  An add/remove-row list (line items, tags, comments, a notifications list) is one
+  of the most common reactive surfaces, and every one re-implements the same
+  orchestration by hand: append the row to the right container, remove it on
+  delete, keep a count badge in sync, and swap an empty-state in/out as the list
+  crosses 0↔1. `reactive_collection :items, item:, container:, count:, empty:,
+  size:` declares that contract **once** on the container component, so each action
+  is a single call: `reply.append(:items, model)` (row + count + empty-state
+  clear), `reply.prepend(:items, model)`, and `reply.remove(:items, model_or_id)`
+  (row + count + empty-state restore). The size badge and empty-state toggle are
+  driven by the declared `size:` resolver, **re-counted server-side after the
+  mutation** — so they're correct-by-construction (no off-by-one, no client-held
+  count, consistent between the first render and the deltas). `count:`/`empty:`/
+  `size:` are optional (omit them and only the row stream is emitted), and the new
+  builders compose with `.flash`/`.stream` like any other reply. Reply governs the
+  actor's HTTP response only; a cross-tab live list still broadcasts the row with
+  `broadcast_append_to(..., exclude: reactive_connection_id)`. New
+  `Phlex::Reactive::Component::CollectionDefinition`,
+  `reactive_collection`/`reactive_collection_def`/`reactive_collection?` macros,
+  and `Response.collection_append`/`collection_prepend`/`collection_remove` behind
+  the `reply.*` surface.
 
 - **`reply.streams` — partial update with a token-only refresh (issue #30).**
   `reply.streams(Totals.update(@item))` emits **exactly** the streams you pass —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`to_stream_token` emitted an EMPTY token, making non-self-rendering replies
+  add-once-only (cosmos#1939).** `Streamable#to_stream_token` guarded on
+  `respond_to?(:reactive_token)`, but `Component#reactive_token` is **private**, so
+  the guard was false for every component and the refresh stream carried
+  `data-reactive-token-value=""`. Any reply that opts out of the full-self replace
+  but relies on the token-only refresh — `reply.streams` (#30) and the new
+  `reply.append`/`reply.remove` (#35) — therefore rolled an empty token forward:
+  the first action worked, then the next dispatch from that root was rejected (the
+  stale/empty token fails verification) with no error. Fixed by checking private
+  methods (`respond_to?(:reactive_token, true)`); a bare Streamable (genuinely no
+  token) still skips correctly. The `reactive_collection` builders also now bind the
+  **container** as the `token_component`, so an add/remove rolls the list root's
+  token forward (the load-bearing part for repeated add/remove). Regression tests
+  assert the token is non-empty AND re-verifies, and that a second add using the
+  first reply's token succeeds.
+
 ### Changed
 
 - **The browser suite now runs under two real servers — Puma and Falcon.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ hand-picking Turbo Stream targets.
 
 ```bash
 bundle exec rspec spec/phlex spec/requests   # Fast suite (unit + request + broadcast)
-bundle exec rspec spec/system                # Browser suite (Playwright; CAPYBARA_SERVER=webrick locally)
+bundle exec rspec spec/system                # Browser suite (Playwright; Puma default, CAPYBARA_SERVER=falcon for the async server)
+bundle exec rake spec:system_servers         # Browser suite under BOTH real servers (puma + falcon)
 bundle exec standardrb                       # Lint
 bundle exec rake                             # spec + standard
 bundle exec rake bench                        # Performance micro-benches (render, token, coerce_params)
@@ -117,7 +118,9 @@ optionality is a core invariant — never break it.
 - `spec/dummy/` is a minimal Rails app (models + example components) that the
   request and system specs drive.
 - Unit specs mock/avoid the DB; request specs boot the dummy; system specs use
-  Capybara + Playwright (`CAPYBARA_SERVER=webrick` locally if Puma segfaults).
+  Capybara + Playwright. The browser suite runs under two REAL servers — Puma
+  (default) and Falcon (`CAPYBARA_SERVER=falcon`); CI runs both in a matrix, and
+  `rake spec:system_servers` runs both locally. (No webrick — not a real server.)
 - pgbus-dependent specs run only on Ruby ≥ 3.3 (pgbus's floor) and guard with
   `defined?(Pgbus)`. phlex-reactive's own runtime still supports Ruby 3.2.
 - See `docs/testing.md`.

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,9 @@ group :test do
   gem "capybara", require: false
   gem "capybara-playwright-driver", require: false
   gem "puma", require: false
-  gem "webrick", require: false
+  # Falcon is the real-server fallback for the browser suite (CAPYBARA_SERVER=falcon)
+  # — an async, production-grade alternative to Puma. No webrick (not a real server).
+  gem "falcon", require: false
 end
 
 group :development, :test do

--- a/README.md
+++ b/README.md
@@ -544,6 +544,11 @@ end
   mutation, so the badge and the empty-state are correct-by-construction (no
   off-by-one, no client-held count). `count:`, `empty:`, and `size:` are all
   optional: omit them and only the row stream is emitted.
+- **Repeated add/remove just works** — each reply rolls the **container's** signed
+  token forward (via the inert `reactive:token` refresh), so the second click from
+  the list root is accepted. Without this an add/remove list would be add-once-only
+  (correct on the first click, silently rejected after); the helper bakes the
+  refresh in so you never hit it.
 - **`remove` takes the record or its `dom_id` string** — a just-destroyed
   ActiveRecord still answers `dom_id` correctly, so `reply.remove(:items, todo)`
   works; pass the raw id only if your row `#id` matches `ActiveRecord::RecordIdentifier`.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
+| `reactive_collection :name, item:, container:, count:, empty:, size:` | Declare an add/remove-row list once; actions call `reply.append`/`prepend`/`remove`. See [Reactive collections](#reactive-collections-addremove-rows--count--empty-state). |
 | `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` | Return from an action to control the reply (flash, remove, redirect, multi-stream). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
+| `reply.append(name, model)` / `.prepend(...)` / `.remove(name, model)` | Add/remove a row in a declared `reactive_collection` (row + count + empty-state in one reply). |
 
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
 in the schema is dropped before reaching your method.
@@ -485,11 +487,71 @@ update only the targets you name) and refreshes the token via a tiny inert
 > (`Phlex::Reactive::Response.replace(self)`) and it still works, but `reply` is
 > the preferred surface; treat `Response` as an internal detail.
 > **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
-> **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
 > `html: @account.name` is safe even for user-supplied values. To emit intentional
 > markup, pass a **Phlex component** (`html: Heading.new(name: @record.name)`) —
 > rendered and auto-escaped through the renderer — or an `html_safe` string for
 > raw HTML you control.
+
+### Reactive collections (add/remove rows + count + empty-state)
+
+An add/remove-row list — line items, attachments, tags, comments, a
+notifications list — is one of the most common reactive surfaces, and every one
+re-implements the same orchestration by hand: append the row to the right
+container, remove it on delete, keep a **count badge** in sync, and swap an
+**empty-state** in/out as the list crosses 0↔1. `reactive_collection` declares
+that contract **once** on the container so each action is a single call.
+
+Declare the collection on the container component, then `reply.append` /
+`reply.prepend` / `reply.remove` in the actions:
+
+```ruby
+class NotificationsList < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_collection :notifications,
+    item: NotificationRow,        # the per-row Streamable component
+    container: "notifications",    # the DOM id rows live in
+    count: "notifications-count",  # optional companion id (the size badge)
+    empty: NotificationsEmpty,     # optional empty-state component
+    size: -> { Todo.count }        # resolves the live size (re-counted, never client state)
+
+  action :add, params: {title: :string}
+  action :dismiss, params: {id: :integer}
+
+  def add(title:)
+    todo = Todo.create!(title:)
+    reply.append(:notifications, todo)   # append row + bump count + clear empty-state
+  end
+
+  def dismiss(id:)
+    Todo.find(id).destroy!
+    reply.remove(:notifications, id)     # remove row + bump count + restore empty-state at 0
+  end
+
+  # view_template renders the count, the container <ul>, and the empty-state on
+  # first paint — the same components the helper streams in/out on each delta.
+end
+```
+
+| Builder | Reply (one `Response`) |
+|---|---|
+| `reply.append(name, model)` | append the row into the container + update the count + remove the empty-state when the list crosses 0→1 |
+| `reply.prepend(name, model)` | as `append`, but the row goes to the top |
+| `reply.remove(name, model)` | remove the row by its `dom_id` + update the count + append the empty-state back when the list crosses →0 |
+
+- **`size:` is the source of truth** — it's *re-counted* server-side after the
+  mutation, so the badge and the empty-state are correct-by-construction (no
+  off-by-one, no client-held count). `count:`, `empty:`, and `size:` are all
+  optional: omit them and only the row stream is emitted.
+- **`remove` takes the record or its `dom_id` string** — a just-destroyed
+  ActiveRecord still answers `dom_id` correctly, so `reply.remove(:items, todo)`
+  works; pass the raw id only if your row `#id` matches `ActiveRecord::RecordIdentifier`.
+- **Reply governs the actor's HTTP response only.** For a *cross-tab* live list
+  (other viewers see the row appear) keep broadcasting the row with
+  `NotificationRow.broadcast_append_to(..., exclude: reactive_connection_id)` —
+  `reactive_collection` is the per-actor add/remove + count + empty-state wrapper,
+  not a replacement for the broadcast.
 
 ### Configuration (`config/initializers/phlex_reactive.rb`)
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,9 +9,19 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 namespace :spec do
-  desc "Run browser system specs (needs Playwright)"
+  desc "Run browser system specs (needs Playwright). CAPYBARA_SERVER=puma|falcon (default puma)"
   RSpec::Core::RakeTask.new(:system) do |t|
     t.pattern = "spec/system/**/*_spec.rb"
+  end
+
+  desc "Run the browser system specs under BOTH real servers (puma + falcon)"
+  task :system_servers do
+    # A reactive round trip must be transport-agnostic — prove it under both the
+    # sync (Puma) and async (Falcon) server before a client-touching change ships.
+    %w[puma falcon].each do |server|
+      puts "\e[1;35m\n### system specs under CAPYBARA_SERVER=#{server} ###\e[0m"
+      sh({"CAPYBARA_SERVER" => server}, "bundle exec rspec spec/system")
+    end
   end
 end
 

--- a/docs/examples/collections.md
+++ b/docs/examples/collections.md
@@ -129,6 +129,18 @@ number the client holds. That's deliberate:
 `count:`, `empty:`, and `size:` are all optional — omit them and `reply.append`
 emits just the row stream.
 
+## Repeated add/remove: the container's token rolls forward
+
+`reply.append` / `reply.remove` don't re-render the whole container (that would
+clobber the streamed-in rows), so they ride the same token-only refresh as
+[`reply.streams`](../../#reply--controlling-the-actions-reply): each reply emits
+an inert `<turbo-stream action="reactive:token">` that rolls the **list root's**
+signed token forward. That's the load-bearing part — the add/remove trigger lives
+on the list root, so without the refresh the list would be *add-once-only*
+(correct on the first click, then every later dispatch rejected because the
+container's token went stale, with no error). The helper bakes this in, so
+repeated adds and removes just work.
+
 ## Cross-tab: keep broadcasting the row
 
 `reactive_collection` governs the **actor's** HTTP reply. For a *live* list where

--- a/docs/examples/collections.md
+++ b/docs/examples/collections.md
@@ -1,0 +1,159 @@
+---
+layout: default
+title: Reactive collections
+parent: Examples
+nav_order: 6
+---
+
+# Example: reactive collections (add/remove rows + count + empty-state)
+
+An add/remove-row list — line items, attachments, tags, comments, a
+notifications list — is one of the most common reactive surfaces. Each one
+re-implements the same orchestration by hand in every action: append the new row
+to the right container, remove it on delete, keep a **count badge** in sync, and
+swap an **empty-state** in and out as the list crosses 0↔1. Each is easy to get
+subtly wrong (off-by-one badge, empty-state not toggled, container id drift
+between the static render and the action), and it's duplicated per list.
+
+`reactive_collection` declares that contract **once** on the container, so each
+action is a single call.
+
+## Declare the collection on the container
+
+```ruby
+class NotificationsList < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_collection :notifications,
+    item: NotificationRow,         # the per-row Streamable component
+    container: "notifications",     # the DOM id rows live in
+    count: "notifications-count",   # optional companion id (the size badge)
+    empty: NotificationsEmpty,      # optional empty-state component
+    size: -> { Todo.count }         # resolves the live size (re-counted server-side)
+
+  action :add, params: {title: :string}
+  action :dismiss, params: {id: :integer}
+
+  def id = "notifications-list"
+
+  def add(title:)
+    todo = Todo.create!(title:)
+    reply.append(:notifications, todo)   # row + bump count + clear empty-state
+  end
+
+  def dismiss(id:)
+    Todo.find(id).destroy!
+    reply.remove(:notifications, id)     # row + bump count + restore empty-state at 0
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      span(id: "notifications-count") { Todo.count.to_s }
+
+      ul(id: "notifications") do
+        if Todo.exists?
+          Todo.order(:created_at, :id).each { |t| render NotificationRow.new(todo: t) }
+        else
+          render NotificationsEmpty.new
+        end
+      end
+
+      div do
+        input(name: "title", placeholder: "New notification…", autocomplete: "off")
+        button(**mix(on(:add))) { "Add" }
+      end
+    end
+  end
+end
+```
+
+The same three things the helper streams in and out on each delta — the row, the
+count, the empty-state — are what `view_template` renders on first paint, so the
+initial server render and the reactive deltas can't drift.
+
+## The row and empty-state components
+
+The row is a plain `Streamable` keyed off the record, so its `#id` is a stable
+`dom_id` — the append/remove target. Its dismiss button dispatches the
+*container's* `dismiss` action via the generic reactive controller it sits inside
+(it carries no token of its own):
+
+```ruby
+class NotificationRow < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component   # only to use `on` for the dismiss trigger
+
+  def self.model_param_name = :todo
+  def initialize(todo:) = @todo = todo
+  def id = dom_id(@todo)
+
+  def view_template
+    li(id:, class: "notification") do
+      span(class: "body") { @todo.title }
+      button(**mix(on(:dismiss, id: @todo.id))) { "×" }
+    end
+  end
+end
+
+class NotificationsEmpty < ApplicationComponent
+  include Phlex::Reactive::Streamable
+
+  def id = "notifications-empty"
+  def view_template = div(id:, class: "empty-state") { "No notifications" }
+end
+```
+
+## What each reply emits
+
+| Builder | Streams (one `Response`) |
+|---|---|
+| `reply.append(name, model)` | append the row into the container · update the count · remove the empty-state when the list crosses 0→1 |
+| `reply.prepend(name, model)` | as `append`, row goes to the top |
+| `reply.remove(name, model)` | remove the row by its `dom_id` · update the count · append the empty-state back when the list crosses →0 |
+
+The empty-state is touched **only at the boundary** — adding to an already-populated
+list, or removing while rows remain, leaves it alone.
+
+## Why the count is always right
+
+`size:` is **re-counted server-side after the mutation**, not incremented on a
+number the client holds. That's deliberate:
+
+- **No off-by-one.** The badge reflects the database, not an optimistic guess.
+- **No state shipped to the client.** A client-held count would violate the
+  signed-identity rule (the DOM never carries raw state) and would drift under
+  concurrent changes from other tabs.
+- **First render and deltas agree.** Both read the same `size:` source.
+
+`count:`, `empty:`, and `size:` are all optional — omit them and `reply.append`
+emits just the row stream.
+
+## Cross-tab: keep broadcasting the row
+
+`reactive_collection` governs the **actor's** HTTP reply. For a *live* list where
+other viewers see the row appear, broadcast the row as well, excluding the actor
+(who already got the reply):
+
+```ruby
+def add(title:)
+  todo = Todo.create!(title:)
+  NotificationRow.broadcast_append_to(
+    current_user, :notifications,
+    target: "notifications", model: todo,
+    exclude: reactive_connection_id
+  )
+  reply.append(:notifications, todo)
+end
+```
+
+`reactive_collection` is the per-actor add/remove + count + empty-state wrapper;
+the broadcast is the cross-tab fan-out. They compose — both target the same
+container id. See [docs/broadcasting.md](../broadcasting.md).
+
+## Related
+
+- [Notifications / badges](notifications) — pure-broadcast badges (no client
+  action), the natural complement when the server pushes a re-render.
+- [Live todo list](todo_list) — the hand-rolled add/toggle/remove this helper
+  distills.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,3 +17,4 @@ complete, working feature.
 | [Live todo list](todo_list) | Per-row components; add / toggle / rename |
 | [Inline edit](inline_edit) | Show ↔ edit mode toggle in one component |
 | [Notifications / badges](notifications) | Pure broadcast (no client action) |
+| [Reactive collections](collections) | Add/remove rows + count + empty-state, declared once |

--- a/docs/examples/notifications.md
+++ b/docs/examples/notifications.md
@@ -92,6 +92,11 @@ Because both paths target the component by its `id`, you can start with a pure
 broadcast badge and later add a `dismiss` action without changing the target or
 the subscription.
 
+> For an add/remove-row **list** (not just a badge) — rows plus a count badge and
+> an empty-state that toggle as the list grows and shrinks — see
+> [Reactive collections](collections), which declares that whole contract once
+> with `reactive_collection`.
+
 ## Transactional safety
 
 If you broadcast from an `after_create_commit`/`after_update_commit` callback (or

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -62,6 +62,24 @@ module Phlex
       # A declared, client-invokable action and its param schema.
       Action = Data.define(:name, :params)
 
+      # A declared add/remove-row collection (issue #35): the list contract tied
+      # into one unit — the per-row item component, the container DOM id rows
+      # live in, an optional companion count id, an optional empty-state
+      # component, and a size resolver (a proc evaluated against the container
+      # instance) used to re-render the count and toggle the empty-state at the
+      # 0<->1 boundary. count/empty/size are nil when not declared, and the
+      # corresponding stream is simply omitted — so a list with just rows still
+      # works.
+      CollectionDefinition = Data.define(:name, :item, :container, :count, :empty, :size) do
+        # The collection's current size, evaluated against the bound container
+        # instance (instance_exec so the proc reads the component's ivars /
+        # association). nil when no resolver was declared — callers skip the
+        # count/empty streams that need a number.
+        def size_for(component)
+          size && component.instance_exec(&size)
+        end
+      end
+
       class_methods do
         # Declare the ActiveRecord (GlobalID-able) record this component is
         # rebuilt from. The signed token carries its GlobalID; the server
@@ -120,6 +138,41 @@ module Phlex
 
         def reactive_action?(name)
           reactive_actions.key?(name.to_sym)
+        end
+
+        # Declare an add/remove-row collection (issue #35) — the list contract
+        # in one place, so actions append/prepend/remove a row WITHOUT
+        # re-deriving the container id, count, and empty-state in every action:
+        #
+        #   reactive_collection :items,
+        #     item: ItemRowComponent,    # the per-row Streamable component
+        #     container: "items-list",   # the DOM id rows live in
+        #     count: "items-count",      # optional companion id (the size badge)
+        #     empty: ItemsEmptyComponent, # optional empty-state component
+        #     size: -> { @record.items.size } # resolves the live size
+        #
+        # An action then governs the reply with one call:
+        #   reply.append(:items, item)   # row append + count + clear empty-state
+        #   reply.remove(:items, id)     # row remove + count + restore empty-state
+        #
+        # count/empty/size are optional: a list with just rows omits them and the
+        # corresponding stream isn't emitted. See Phlex::Reactive::Reply and the
+        # README "Reactive collections" section.
+        def reactive_collection(name, item:, container:, count: nil, empty: nil, size: nil)
+          reactive_collections[name.to_sym] =
+            CollectionDefinition.new(name: name.to_sym, item:, container:, count:, empty:, size:)
+        end
+
+        def reactive_collections
+          @reactive_collections ||= (superclass.respond_to?(:reactive_collections) ? superclass.reactive_collections.dup : {})
+        end
+
+        def reactive_collection_def(name)
+          reactive_collections[name.to_sym]
+        end
+
+        def reactive_collection?(name)
+          reactive_collections.key?(name.to_sym)
         end
 
         # The record's instance-variable symbol (e.g. :@todo), computed once.

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -25,6 +25,12 @@ module Phlex
     # Response remains the public value object (it's what the endpoint reads); it
     # is simply an internal detail you rarely name directly now.
     class Reply
+      # Distinguishes `reply.remove` (no args — remove the bound component
+      # itself) from `reply.remove(:items, model)` (remove a collection row).
+      # A sentinel, not nil, so `reply.remove(:items, nil)` stays unambiguous.
+      UNSET = Object.new
+      private_constant :UNSET
+
       def initialize(component)
         @component = component
       end
@@ -47,9 +53,29 @@ module Phlex
         Response.update(@component)
       end
 
-      # Remove the component's element from the DOM (render_self false).
-      def remove
-        Response.remove(@component)
+      # Reactive collections (issue #35) — add/remove a row in a declared
+      # reactive_collection, emitting the row stream + the count companion +
+      # the empty-state toggle as ONE Response. The bound component is the
+      # container (it carries the declaration + size resolver).
+      #
+      #   def add_item(...)    = (item = @list.items.create!(...); reply.append(:items, item))
+      #   def remove_item(id:) = (@list.items.find(id).destroy!;   reply.remove(:items, id))
+      #
+      # `model` is the row's record; remove also accepts the row's dom-id string.
+      def append(name, model)
+        Response.collection_append(@component, name, model)
+      end
+
+      def prepend(name, model)
+        Response.collection_prepend(@component, name, model)
+      end
+
+      # Two forms:
+      #   reply.remove               # remove the bound component's own element
+      #   reply.remove(:items, model) # remove a collection row + count + empty
+      def remove(name = UNSET, model = UNSET)
+        return Response.remove(@component) if name.equal?(UNSET)
+        Response.collection_remove(@component, name, model)
       end
 
       # Subject-free builders — pass straight through so they read naturally.

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -51,6 +51,95 @@ module Phlex
         # Escape hatch / multi-stream root: zero or more raw turbo-stream strings.
         def with(*strings) = new(streams: strings.flatten)
 
+        # --- Reactive collections (issue #35) ---
+        # Add/remove a row in a declared reactive_collection, emitting the row
+        # stream + the count companion update + the empty-state toggle as ONE
+        # Response. `component` is the bound CONTAINER (it carries the
+        # declaration and the size resolver); `model` is the row's record (or, for
+        # remove, a model OR a dom-id string). count/empty/size are optional — a
+        # stream is emitted only for the pieces declared.
+        #
+        # render_self is false: the row append/prepend/remove IS the update, so
+        # we must NOT also replace the whole container (that would re-render every
+        # row and clobber the just-streamed delta).
+        def collection_append(component, name, model)
+          definition = collection_def!(component, name)
+          new(streams: collection_add_streams(definition, component, model, :append), render_self: false)
+        end
+
+        def collection_prepend(component, name, model)
+          definition = collection_def!(component, name)
+          new(streams: collection_add_streams(definition, component, model, :prepend), render_self: false)
+        end
+
+        def collection_remove(component, name, model)
+          definition = collection_def!(component, name)
+          new(streams: collection_remove_streams(definition, component, model), render_self: false)
+        end
+
+        private
+
+        # Resolve the declaration off the container's class, raising a clear error
+        # for an undeclared name (a typo'd collection should fail loudly, not
+        # silently emit an empty Response).
+        def collection_def!(component, name)
+          component.class.reactive_collection_def(name) ||
+            raise(Phlex::Reactive::Error, "undeclared reactive_collection :#{name} on #{component.class}")
+        end
+
+        # Row add (append/prepend) + count + empty-state clear. The empty-state is
+        # removed only when the list just crossed 0->1 (size == 1) — appending to
+        # an already-populated list leaves it untouched.
+        def collection_add_streams(definition, component, model, action)
+          streams = [definition.item.public_send(action, target: definition.container, model:)]
+          append_count_stream(streams, definition, component)
+
+          size = definition.size_for(component)
+          if definition.empty && size == 1
+            streams << definition.empty.new.to_stream_remove
+          end
+          streams
+        end
+
+        # Row remove + count + empty-state restore. The empty-state is appended
+        # back into the container only when the list just emptied (size == 0).
+        def collection_remove_streams(definition, component, model)
+          streams = [collection_row_remove(definition, model)]
+          append_count_stream(streams, definition, component)
+
+          size = definition.size_for(component)
+          if definition.empty && size&.zero?
+            # Render the empty-state and append it INTO the container (not its
+            # own id) — restoring "No items yet" when the last row was removed.
+            # model: nil builds it argument-free (an empty-state is a static view).
+            streams << definition.empty.append(target: definition.container, model: nil)
+          end
+          streams
+        end
+
+        # Remove the row by its DOM id. Accepts the record (so dom_id is derived)
+        # or an already-built dom-id string (e.g. the value the row used as #id).
+        def collection_row_remove(definition, model)
+          if model.is_a?(String)
+            Phlex::Reactive.flash_builder.remove(model)
+          else
+            definition.item.remove(model)
+          end
+        end
+
+        # Append the count companion's update stream when a count id + a size
+        # resolver are both declared. The size is a number, HTML-escaped by Turbo.
+        def append_count_stream(streams, definition, component)
+          return unless definition.count
+
+          size = definition.size_for(component)
+          return if size.nil?
+
+          streams << update_stream(definition.count, size.to_s)
+        end
+
+        public
+
         # Partial / per-field update with a TOKEN-ONLY refresh (issue #30). Emits
         # EXACTLY the given streams — no forced full-self replace — but binds
         # `component` so the endpoint appends its tiny `to_stream_token` stream.

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -62,19 +62,30 @@ module Phlex
         # render_self is false: the row append/prepend/remove IS the update, so
         # we must NOT also replace the whole container (that would re-render every
         # row and clobber the just-streamed delta).
+        #
+        # token_component is the CONTAINER (cosmos#1939): a reply that does NOT
+        # re-render self must STILL refresh self's signed token, or the list is
+        # add-once-only — correct on the first click, then every subsequent dispatch
+        # from the list root is rejected (its token went stale) with no error. The
+        # container owns the add/remove trigger, so the endpoint appends its inert
+        # `reactive:token` stream (the same #30 machinery reply.streams uses) to roll
+        # the token forward without re-rendering the rows.
         def collection_append(component, name, model)
           definition = collection_def!(component, name)
-          new(streams: collection_add_streams(definition, component, model, :append), render_self: false)
+          new(streams: collection_add_streams(definition, component, model, :append),
+            render_self: false, token_component: component)
         end
 
         def collection_prepend(component, name, model)
           definition = collection_def!(component, name)
-          new(streams: collection_add_streams(definition, component, model, :prepend), render_self: false)
+          new(streams: collection_add_streams(definition, component, model, :prepend),
+            render_self: false, token_component: component)
         end
 
         def collection_remove(component, name, model)
           definition = collection_def!(component, name)
-          new(streams: collection_remove_streams(definition, component, model), render_self: false)
+          new(streams: collection_remove_streams(definition, component, model),
+            render_self: false, token_component: component)
         end
 
         private

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -321,8 +321,16 @@ module Phlex
       # The component carries its token via Component#reactive_token; a Streamable
       # that isn't a Component (no token) simply has nothing to refresh — guarded
       # by respond_to? so the primitive stays usable on a bare Streamable.
+      #
+      # respond_to? MUST include private methods (the `true` arg): Component
+      # defines `reactive_token` as PRIVATE, so a plain `respond_to?(:reactive_token)`
+      # is false for every Component and the stream silently carries an EMPTY token —
+      # which makes any non-self-rendering reply (reply.streams #30, reply.append /
+      # reply.remove #35) add-once-only: the first action works, then the stale (here
+      # empty) token is rejected on the next dispatch (cosmos#1939). A bare Streamable
+      # has no reactive_token method at all, so it still returns false correctly.
       def to_stream_token
-        token = respond_to?(:reactive_token) ? reactive_token : nil
+        token = respond_to?(:reactive_token, true) ? reactive_token : nil
         %(<turbo-stream action="reactive:token" target="#{ERB::Util.html_escape(id)}" data-reactive-token-value="#{ERB::Util.html_escape(token)}"></turbo-stream>)
       end
 

--- a/spec/dummy/app/components/notification_row_component.rb
+++ b/spec/dummy/app/components/notification_row_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# A single notification row in the reactive_collection demo (issue #35). Keyed
+# off a Todo record so its #id is a stable dom_id — the append/remove target for
+# the collection helper.
+#
+# The row carries NO token of its own (no reactive_attrs): its dismiss button
+# dispatches the CONTAINER's `dismiss` action via the generic reactive controller
+# it sits inside, so the client sends the container's token. It includes
+# Component only to use `on` to build that dispatch — the same attrs whether the
+# row is rendered on first paint or streamed in by reply.append.
+class NotificationRowComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  def self.model_param_name = :todo
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo)
+
+  def view_template
+    li(id:, class: "notification", data: {testid: "notification"}) do
+      span(class: "body") { @todo.title }
+      button(**mix(on(:dismiss, id: @todo.id), data: {testid: "dismiss"})) { "×" }
+    end
+  end
+end

--- a/spec/dummy/app/components/notifications_empty_component.rb
+++ b/spec/dummy/app/components/notifications_empty_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# The empty-state shown when the notifications list is empty (issue #35). The
+# reactive_collection helper removes it by its stable #id when the first row is
+# added, and appends it back into the container when the last row is dismissed.
+# It is a static view — built argument-free.
+class NotificationsEmptyComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+
+  def id = "notifications-empty"
+
+  def view_template
+    div(id:, class: "empty-state", data: {testid: "empty-state"}) { "No notifications" }
+  end
+end

--- a/spec/dummy/app/components/notifications_list_component.rb
+++ b/spec/dummy/app/components/notifications_list_component.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# The reactive_collection demo container (issue #35). Declares the list contract
+# ONCE — the row component, the container id, a companion count badge, an
+# empty-state, and a size resolver — so the add/dismiss actions append/remove a
+# row + bump the count + toggle the empty-state with ONE reply call each, no
+# per-action bookkeeping.
+#
+# State-backed (no single record), so it rebuilds from a signed token on each
+# action. The size resolver reads the live count from the DB — always correct,
+# never an off-by-one client increment.
+class NotificationsListComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_collection :notifications,
+    item: NotificationRowComponent,
+    container: "notifications",
+    count: "notifications-count",
+    empty: NotificationsEmptyComponent,
+    size: -> { Todo.count }
+
+  action :add, params: {title: :string}
+  action :dismiss, params: {id: :integer}
+
+  def id = "notifications-list"
+
+  def add(title:)
+    title = title.to_s.strip
+    return reply.replace if title.blank?
+
+    todo = Todo.create!(title:)
+    reply.append(:notifications, todo)
+  end
+
+  def dismiss(id:)
+    todo = Todo.find(id)
+    todo.destroy!
+    reply.remove(:notifications, todo)
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      span(id: "notifications-count", data: {testid: "count"}) { Todo.count.to_s }
+
+      ul(id: "notifications") do
+        if Todo.exists?
+          Todo.order(:created_at, :id).each { |todo| render NotificationRowComponent.new(todo:) }
+        else
+          render NotificationsEmptyComponent.new
+        end
+      end
+
+      div do
+        input(name: "title", placeholder: "New notification…", autocomplete: "off", data: {testid: "new-notification"})
+        button(**mix(on(:add), data: {testid: "add"})) { "Add" }
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -14,6 +14,10 @@ class DemosController < ActionController::Base
     render_component TodoListComponent.new
   end
 
+  def notifications
+    render_component NotificationsListComponent.new
+  end
+
   def chat
     room = params[:room].presence || "lobby"
     render_component ChatRoomComponent.new(room:, messages: ChatMessage.for_room(room).last(50))

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "counter" => "demos#counter"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
+  get "notifications" => "demos#notifications"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
   get "nested_editor" => "demos#nested_editor"

--- a/spec/phlex/reactive/collection_spec.rb
+++ b/spec/phlex/reactive/collection_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The reactive_collection DSL (issue #35) declares the list contract once on the
+# container component: the per-row item component, the container DOM id, an
+# optional count companion id, an optional empty-state component, and a size
+# resolver. These specs cover ONLY the declaration/storage; the stream building
+# lives in collection_streams_spec.rb (Response/Reply) and the dummy request spec.
+RSpec.describe Phlex::Reactive::Component, "reactive_collection" do
+  let(:row_klass) do
+    Class.new do
+      def self.name = "ItemRow"
+    end
+  end
+
+  let(:empty_klass) do
+    Class.new do
+      def self.name = "ItemsEmpty"
+    end
+  end
+
+  let(:container_klass) do
+    row = row_klass
+    empty = empty_klass
+    Class.new do
+      include Phlex::Reactive::Component
+
+      def self.name = "ItemsList"
+
+      reactive_collection :items,
+        item: row,
+        container: "items-list",
+        count: "items-count",
+        empty: empty,
+        size: -> { 3 }
+    end
+  end
+
+  describe "declaration storage" do
+    it "registers the collection under its name" do
+      expect(container_klass.reactive_collection?(:items)).to be(true)
+      expect(container_klass.reactive_collection?(:nope)).to be(false)
+    end
+
+    it "captures the item component, container id, count id and empty component" do
+      collection = container_klass.reactive_collection_def(:items)
+      expect(collection.item).to eq(row_klass)
+      expect(collection.container).to eq("items-list")
+      expect(collection.count).to eq("items-count")
+      expect(collection.empty).to eq(empty_klass)
+    end
+
+    it "evaluates the size resolver against a component instance" do
+      collection = container_klass.reactive_collection_def(:items)
+      expect(collection.size_for(container_klass.allocate)).to eq(3)
+    end
+  end
+
+  describe "optional fields" do
+    let(:minimal_klass) do
+      row = row_klass
+      Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "MinimalList"
+        reactive_collection :rows, item: row, container: "rows"
+      end
+    end
+
+    it "allows omitting count, empty and size" do
+      collection = minimal_klass.reactive_collection_def(:rows)
+      expect(collection.count).to be_nil
+      expect(collection.empty).to be_nil
+    end
+
+    it "size defaults to nil when no resolver is declared" do
+      collection = minimal_klass.reactive_collection_def(:rows)
+      expect(collection.size_for(minimal_klass.allocate)).to be_nil
+    end
+  end
+
+  describe "inheritance" do
+    it "a subclass inherits declared collections and can add its own" do
+      parent = container_klass
+      child = Class.new(parent) do
+        def self.name = "ChildList"
+        reactive_collection :extras, item: parent.reactive_collection_def(:items).item, container: "extras"
+      end
+
+      expect(child.reactive_collection?(:items)).to be(true)
+      expect(child.reactive_collection?(:extras)).to be(true)
+      # parent is not polluted by the child's addition
+      expect(parent.reactive_collection?(:extras)).to be(false)
+    end
+  end
+end

--- a/spec/phlex/reactive/collection_streams_spec.rb
+++ b/spec/phlex/reactive/collection_streams_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
       response = container_class.new(size: 1).reply.append(:todos, todo)
       expect(response.render_self?).to be(false)
     end
+
+    # cosmos#1939: render_self false MUST still refresh the container's token, or
+    # the list is add-once-only. The Response binds the container as token_component
+    # so the endpoint appends its inert reactive:token stream (the #30 machinery).
+    it "binds the container as token_component so its token rolls forward" do
+      container = container_class.new(size: 1)
+      response = container.reply.append(:todos, todo)
+      expect(response.refresh_token?).to be(true)
+      expect(response.token_component).to eq(container)
+    end
   end
 
   describe "reply.prepend(name, model)" do
@@ -97,6 +107,11 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
       response = container_class.new(size: 1).reply.prepend(:todos, todo)
       expect(response.streams).to include(a_string_including('action="prepend"', 'target="todos-list"'))
       expect(response.streams).to include(a_string_including('target="todos-count"'))
+    end
+
+    it "binds the container as token_component (cosmos#1939)" do
+      container = container_class.new(size: 1)
+      expect(container.reply.prepend(:todos, todo).token_component).to eq(container)
     end
   end
 
@@ -121,6 +136,13 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
     it "does NOT restore the empty-state while rows remain (size > 0)" do
       response = container_class.new(size: 3).reply.remove(:todos, todo)
       expect(response.streams).not_to include(a_string_including("No todos yet"))
+    end
+
+    it "binds the container as token_component so repeated removes work (cosmos#1939)" do
+      container = container_class.new(size: 0)
+      response = container.reply.remove(:todos, todo)
+      expect(response.refresh_token?).to be(true)
+      expect(response.token_component).to eq(container)
     end
 
     it "accepts a dom-id string as well as a model" do

--- a/spec/phlex/reactive/collection_streams_spec.rb
+++ b/spec/phlex/reactive/collection_streams_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The collection stream builders (issue #35): reply.append/prepend/remove(name,
+# model) resolve the bound container's reactive_collection declaration and emit
+# the row stream + the count companion update + the empty-state toggle as ONE
+# Response — so a list stays correct without per-action append/count/empty
+# bookkeeping. These render through the configured renderer, so rails_helper.
+RSpec.describe "reactive_collection streams (issue #35)", type: :request do
+  # A row component keyed off a Todo (so dom_id works for append/remove targets).
+  let(:row_component) do
+    Class.new(ApplicationComponent) do
+      include Phlex::Reactive::Streamable
+
+      def self.name = "CollSpecRow"
+      def self.model_param_name = :todo
+      def initialize(todo:) = @todo = todo
+      def id = dom_id(@todo)
+      def view_template = li(id:) { @todo.title }
+    end
+  end
+
+  # An empty-state component with a stable id (toggled in/out at the 0<->1 edge).
+  let(:empty_component) do
+    Class.new(ApplicationComponent) do
+      include Phlex::Reactive::Streamable
+
+      def self.name = "CollSpecEmpty"
+      def id = "todos-empty"
+      def view_template = div(id:) { "No todos yet" }
+    end
+  end
+
+  # The container declares the collection. size: reads a stubbed count so we can
+  # drive the 0<->1 boundary without touching the DB count.
+  let(:container_class) do
+    row = row_component
+    empty = empty_component
+    Class.new(ApplicationComponent) do
+      include Phlex::Reactive::Streamable
+      include Phlex::Reactive::Component
+
+      def self.name = "CollSpecList"
+
+      reactive_collection :todos,
+        item: row,
+        container: "todos-list",
+        count: "todos-count",
+        empty: empty,
+        size: -> { @size }
+
+      def initialize(size: 0) = @size = size
+      def id = "todos-list-root"
+      def view_template = div(id:, **reactive_attrs) { "" }
+    end
+  end
+
+  let(:todo) { Todo.create!(title: "buy milk", done: false) }
+  let(:dom_id) { ActionView::RecordIdentifier.dom_id(todo) }
+
+  describe "reply.append(name, model)" do
+    it "appends the row component into the container" do
+      response = container_class.new(size: 1).reply.append(:todos, todo)
+      append = response.streams.find { |s| s.include?('action="append"') }
+      expect(append).to include('target="todos-list"')
+      expect(append).to include(%(id="#{dom_id}"))
+      expect(append).to include("buy milk")
+    end
+
+    it "updates the count companion with the fresh size" do
+      response = container_class.new(size: 1).reply.append(:todos, todo)
+      count = response.streams.find { |s| s.include?('target="todos-count"') }
+      expect(count).to include('action="update"')
+      expect(count).to include(">1<").or include("1")
+    end
+
+    it "removes the empty-state when the list crosses 0->1 (size becomes 1)" do
+      response = container_class.new(size: 1).reply.append(:todos, todo)
+      empty = response.streams.find { |s| s.include?('target="todos-empty"') }
+      expect(empty).to include('action="remove"')
+    end
+
+    it "does NOT touch the empty-state when the list was already non-empty (size > 1)" do
+      response = container_class.new(size: 2).reply.append(:todos, todo)
+      expect(response.streams).not_to include(a_string_including('target="todos-empty"'))
+    end
+
+    it "opts to render_self false (the row append is the update, not a self replace)" do
+      response = container_class.new(size: 1).reply.append(:todos, todo)
+      expect(response.render_self?).to be(false)
+    end
+  end
+
+  describe "reply.prepend(name, model)" do
+    it "prepends the row into the container and still updates count" do
+      response = container_class.new(size: 1).reply.prepend(:todos, todo)
+      expect(response.streams).to include(a_string_including('action="prepend"', 'target="todos-list"'))
+      expect(response.streams).to include(a_string_including('target="todos-count"'))
+    end
+  end
+
+  describe "reply.remove(name, model)" do
+    it "removes the row by its dom id" do
+      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      remove = response.streams.find { |s| s.include?(%(target="#{dom_id}")) }
+      expect(remove).to include('action="remove"')
+    end
+
+    it "updates the count companion with the fresh size" do
+      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      expect(response.streams).to include(a_string_including('target="todos-count"', 'action="update"'))
+    end
+
+    it "restores the empty-state when the list crosses ->0 (size becomes 0)" do
+      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      empty = response.streams.find { |s| s.include?('target="todos-list"') && s.include?("No todos yet") }
+      expect(empty).to include('action="append"')
+    end
+
+    it "does NOT restore the empty-state while rows remain (size > 0)" do
+      response = container_class.new(size: 3).reply.remove(:todos, todo)
+      expect(response.streams).not_to include(a_string_including("No todos yet"))
+    end
+
+    it "accepts a dom-id string as well as a model" do
+      response = container_class.new(size: 0).reply.remove(:todos, dom_id)
+      remove = response.streams.find { |s| s.include?('action="remove"') }
+      expect(remove).to include(%(target="#{dom_id}"))
+    end
+  end
+
+  describe "optional declarations" do
+    let(:minimal_container) do
+      row = row_component
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "MinimalCollList"
+        reactive_collection :todos, item: row, container: "todos-list"
+        def id = "min-root"
+        def view_template = div(id:) { "" }
+      end
+    end
+
+    it "emits only the row stream when count/empty/size are not declared" do
+      response = minimal_container.new.reply.append(:todos, todo)
+      expect(response.streams.size).to eq(1)
+      expect(response.streams.first).to include('action="append"')
+    end
+  end
+
+  describe "chaining" do
+    it "the returned Response chains .flash like any other reply" do
+      response = container_class.new(size: 1).reply.append(:todos, todo).flash(:notice, "added")
+      expect(response.streams.last).to include('action="append"')
+      expect(response.streams.last).to include("added")
+    end
+
+    it "the returned Response is frozen" do
+      expect(container_class.new(size: 1).reply.append(:todos, todo)).to be_frozen
+    end
+  end
+
+  describe "errors" do
+    it "raises a clear error for an undeclared collection" do
+      expect { container_class.new.reply.append(:nope, todo) }
+        .to raise_error(Phlex::Reactive::Error, /undeclared reactive_collection :nope/)
+    end
+  end
+end

--- a/spec/phlex/reactive/streamable_token_spec.rb
+++ b/spec/phlex/reactive/streamable_token_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe "Streamable token-only refresh (issue #30)" do
       expect(stream).to include("data-reactive-token-value=")
     end
 
+    # Regression for cosmos#1939: reactive_token is PRIVATE, so a token guard that
+    # ignores private methods silently emits data-reactive-token-value="" — and the
+    # next dispatch carrying that empty token is rejected (add-once-only). Assert the
+    # value is actually present AND verifies, not just that the attribute exists.
+    it "carries a NON-EMPTY token that re-verifies (not an empty attribute)" do
+      stream = CounterComponent.new(count: 3).to_stream_token
+      value = stream[/data-reactive-token-value="([^"]*)"/, 1]
+      expect(value).to be_present
+      expect(Phlex::Reactive.verify(value)).to include("c" => "CounterComponent")
+    end
+
     it "does NOT re-render the component body (no full replace)" do
       # The whole point: it refreshes the token without rendering the children,
       # so a live <input> the user is typing into is never swapped out.

--- a/spec/requests/reactive_collection_spec.rb
+++ b/spec/requests/reactive_collection_spec.rb
@@ -57,12 +57,15 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
       expect(response.body).not_to include('target="notifications-empty"')
     end
 
-    it "does not re-render the whole container (render_self false — only the delta)" do
+    it "does not re-render the whole container body (render_self false — only the delta)" do
       Todo.create!(title: "existing")
       post_action(klass, act: "add", params: {title: "new"})
 
-      # The container's own root id is never replaced — only the row appended.
-      expect(response.body).not_to include('target="notifications-list"')
+      # The container's body is never re-rendered — no replace/update of its root.
+      # (The container IS targeted by the inert reactive:token refresh, which only
+      # rolls the token forward without touching the children — that's expected.)
+      expect(response.body).not_to include('action="replace" target="notifications-list"')
+      expect(response.body).not_to include('action="update" target="notifications-list"')
     end
   end
 
@@ -108,5 +111,69 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
       post_action(klass, act: "drop_everything")
       expect(response).to have_http_status(:forbidden)
     end
+  end
+
+  # Regression for cosmos#1939 (and the generalized #30 lesson): a reply that does
+  # NOT re-render self must STILL refresh self's token. reply.append/remove opt out
+  # of the full-self replace (render_self false), so without a token refresh on the
+  # CONTAINER (which owns the add/remove trigger) the list's signed token goes
+  # stale after the first action and every subsequent dispatch is rejected — an
+  # add-once-only list, broken with no error. The helper must emit the inert
+  # reactive:token stream for the container on every add/remove.
+  describe "token refresh on the collection container (cosmos#1939)" do
+    # The container's #id ("notifications-list") is the reactive:token target.
+    let(:container_id) { "notifications-list" }
+
+    it "append emits a reactive:token stream targeting the container" do
+      post_action(klass, act: "add", params: {title: "ping"})
+
+      expect(response.body).to include('action="reactive:token"')
+      expect(response.body).to include(%(target="#{container_id}"))
+    end
+
+    it "remove emits a reactive:token stream targeting the container" do
+      todo = Todo.create!(title: "bye")
+      post_action(klass, act: "dismiss", params: {id: todo.id})
+
+      expect(response.body).to include('action="reactive:token"')
+      expect(response.body).to include(%(target="#{container_id}"))
+    end
+
+    # The load-bearing assertion: dispatch a SECOND add using the token the FIRST
+    # response rolled forward, and it must succeed. A stale-token helper 400s here.
+    it "supports repeated adds — the second uses the token the first refreshed" do
+      post_action(klass, act: "add", params: {title: "first"})
+      expect(response).to have_http_status(:ok)
+      next_token = token_from(response.body, container_id)
+      expect(next_token).to be_present
+
+      post "/reactive/actions",
+        params: {token: next_token, act: "add", params: {title: "second"}}.to_json,
+        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(Todo.count).to eq(2)
+      expect(response.body).to include("second")
+    end
+
+    it "supports an add then a remove using the chained refreshed tokens" do
+      post_action(klass, act: "add", params: {title: "row"})
+      todo = Todo.order(:id).last
+      token_after_add = token_from(response.body, container_id)
+
+      post "/reactive/actions",
+        params: {token: token_after_add, act: "dismiss", params: {id: todo.id}}.to_json,
+        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(Todo.count).to eq(0)
+    end
+  end
+
+  # Pull the fresh data-reactive-token-value from the reactive:token stream that
+  # targets the given container id — exactly what the client's #extractToken does.
+  def token_from(body, container_id)
+    stream = body[/<turbo-stream action="reactive:token" target="#{Regexp.escape(container_id)}"[^>]*>/]
+    stream && stream[/data-reactive-token-value="([^"]+)"/, 1]
   end
 end

--- a/spec/requests/reactive_collection_spec.rb
+++ b/spec/requests/reactive_collection_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# End-to-end (through the action endpoint) coverage of the reactive_collection
+# helper (issue #35): an action calls reply.append/reply.remove on a declared
+# collection, and the endpoint renders the row + count + empty-state streams.
+RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
+  def token_for(klass, payload = {})
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  def post_action(klass, act:, params: {}, payload: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  let(:klass) { NotificationsListComponent }
+
+  describe "add (reply.append)" do
+    it "creates the record and appends the row into the container" do
+      expect {
+        post_action(klass, act: "add", params: {title: "ping"})
+      }.to change(Todo, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      todo = Todo.order(:id).last
+      dom_id = ActionView::RecordIdentifier.dom_id(todo)
+      expect(response.body).to include('action="append"')
+      expect(response.body).to include('target="notifications"')
+      expect(response.body).to include(%(id="#{dom_id}"))
+      expect(response.body).to include("ping")
+    end
+
+    it "updates the count companion with the new size" do
+      Todo.create!(title: "existing")
+      post_action(klass, act: "add", params: {title: "second"})
+
+      expect(response.body).to include('target="notifications-count"')
+      # 1 existing + 1 added = 2
+      expect(response.body).to match(/target="notifications-count".*>\s*2\s*</m)
+    end
+
+    it "removes the empty-state when the first row crosses 0->1" do
+      expect(Todo.count).to eq(0)
+      post_action(klass, act: "add", params: {title: "first"})
+
+      expect(response.body).to include('action="remove"')
+      expect(response.body).to include('target="notifications-empty"')
+    end
+
+    it "leaves the empty-state alone when the list was already populated" do
+      Todo.create!(title: "existing")
+      post_action(klass, act: "add", params: {title: "another"})
+
+      expect(response.body).not_to include('target="notifications-empty"')
+    end
+
+    it "does not re-render the whole container (render_self false — only the delta)" do
+      Todo.create!(title: "existing")
+      post_action(klass, act: "add", params: {title: "new"})
+
+      # The container's own root id is never replaced — only the row appended.
+      expect(response.body).not_to include('target="notifications-list"')
+    end
+  end
+
+  describe "dismiss (reply.remove)" do
+    let!(:todo) { Todo.create!(title: "dismiss me") }
+
+    it "destroys the record and removes the row by its dom id" do
+      dom_id = ActionView::RecordIdentifier.dom_id(todo)
+      expect {
+        post_action(klass, act: "dismiss", params: {id: todo.id})
+      }.to change(Todo, :count).by(-1)
+
+      expect(response.body).to include('action="remove"')
+      expect(response.body).to include(%(target="#{dom_id}"))
+    end
+
+    it "updates the count companion" do
+      Todo.create!(title: "other")
+      post_action(klass, act: "dismiss", params: {id: todo.id})
+
+      # 2 existing - 1 dismissed = 1
+      expect(response.body).to match(/target="notifications-count".*>\s*1\s*</m)
+    end
+
+    it "restores the empty-state when the last row is dismissed (->0)" do
+      post_action(klass, act: "dismiss", params: {id: todo.id})
+
+      expect(Todo.count).to eq(0)
+      expect(response.body).to include("No notifications")
+      expect(response.body).to match(/action="append".*target="notifications"/m)
+    end
+
+    it "leaves the empty-state out while rows remain" do
+      Todo.create!(title: "survivor")
+      post_action(klass, act: "dismiss", params: {id: todo.id})
+
+      expect(response.body).not_to include("No notifications")
+    end
+  end
+
+  describe "default-deny still holds" do
+    it "forbids an undeclared action on the collection container" do
+      post_action(klass, act: "drop_everything")
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -53,9 +53,14 @@ RSpec.describe "Notifications (reactive_collection)", type: :system do
     find("[data-testid='add']").click
     expect(page).to have_css("[data-testid='count']", text: "1")
 
+    # The SECOND add dispatches from the SAME list root as the first — so it only
+    # succeeds if the first reply rolled the container's signed token forward.
+    # Before the cosmos#1939 fix this 400'd silently (stale token) and the count
+    # stuck at 1: the add-once-only bug. Reaching "2" proves the token refreshed.
     find("[data-testid='new-notification']").set("two")
     find("[data-testid='add']").click
     expect(page).to have_css("[data-testid='count']", text: "2")
+    expect(page).to have_css("[data-testid='notification']", count: 2)
 
     within first("[data-testid='notification']") do
       find("[data-testid='dismiss']").click

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# The real browser loop for the reactive_collection helper (issue #35): add a
+# row and it streams in with the count bumped and the empty-state cleared;
+# dismiss the last row and it leaves with the count dropped and the empty-state
+# restored — all without a full-page reload.
+RSpec.describe "Notifications (reactive_collection)", type: :system do
+  it "adds a row, bumps the count, and clears the empty-state" do
+    visit "/notifications"
+
+    # Empty-state on first paint.
+    expect(page).to have_css("[data-testid='empty-state']")
+    expect(page).to have_css("[data-testid='count']", text: "0")
+
+    # Prove no full-page reload happens across the reactive round trip.
+    page.execute_script("window.__marker = 'kept'")
+
+    find("[data-testid='new-notification']").set("deploy finished")
+    find("[data-testid='add']").click
+
+    expect(page).to have_css("[data-testid='notification']", count: 1)
+    expect(page).to have_css("[data-testid='notification']", text: "deploy finished")
+    expect(page).to have_css("[data-testid='count']", text: "1")
+    expect(page).to have_no_css("[data-testid='empty-state']")
+
+    expect(page.evaluate_script("window.__marker")).to eq("kept")
+    expect(Todo.count).to eq(1)
+  end
+
+  it "dismisses the last row, drops the count, and restores the empty-state" do
+    Todo.create!(title: "stale alert")
+    visit "/notifications"
+
+    expect(page).to have_css("[data-testid='notification']", count: 1)
+    expect(page).to have_css("[data-testid='count']", text: "1")
+
+    within first("[data-testid='notification']") do
+      find("[data-testid='dismiss']").click
+    end
+
+    expect(page).to have_css("[data-testid='notification']", count: 0)
+    expect(page).to have_css("[data-testid='count']", text: "0")
+    expect(page).to have_css("[data-testid='empty-state']")
+    expect(Todo.count).to eq(0)
+  end
+
+  it "keeps the count accurate across an add then a dismiss" do
+    visit "/notifications"
+
+    find("[data-testid='new-notification']").set("one")
+    find("[data-testid='add']").click
+    expect(page).to have_css("[data-testid='count']", text: "1")
+
+    find("[data-testid='new-notification']").set("two")
+    find("[data-testid='add']").click
+    expect(page).to have_css("[data-testid='count']", text: "2")
+
+    within first("[data-testid='notification']") do
+      find("[data-testid='dismiss']").click
+    end
+    expect(page).to have_css("[data-testid='count']", text: "1")
+    expect(page).to have_css("[data-testid='notification']", count: 1)
+  end
+end

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -1,13 +1,34 @@
 # frozen_string_literal: true
 
-# Default to Puma (matches CI). Set CAPYBARA_SERVER=webrick locally if your
-# Ruby/Puma native extensions are mismatched and Puma's reactor segfaults.
-case ENV["CAPYBARA_SERVER"]
-when "webrick"
-  require "webrick"
-  Capybara.server = :webrick
+# The browser suite runs under TWO real servers so a reactive round trip is
+# proven transport-agnostic: Puma (sync, thread-pool — the default) and Falcon
+# (async, fiber-per-request — CAPYBARA_SERVER=falcon). CI runs both in a matrix;
+# `rake spec:system_servers` runs both locally. No webrick — it isn't a real
+# server, so it never proves anything a deployment cares about.
+#
+# Capybara ships no built-in :falcon server, so register one: wrap the rack app
+# with Protocol::Rack's adapter and run Falcon::Server on an Async reactor bound
+# to the host:port Capybara hands us. Capybara runs this block on its own server
+# thread and expects it to block, which Falcon::Server#run does.
+Capybara.register_server(:falcon) do |app, port, host|
+  require "falcon/server"
+  require "async"
+  require "async/http/endpoint"
+  require "protocol/rack"
+
+  endpoint = Async::HTTP::Endpoint.parse("http://#{host}:#{port}")
+  rack_app = Protocol::Rack::Adapter.new(app)
+
+  # Falcon::Server#run already wraps itself in an Async reactor and returns that
+  # task; wait on it so this block blocks Capybara's server thread until shutdown.
+  Falcon::Server.new(rack_app, endpoint).run.wait
+end
+
+Capybara.server = case ENV["CAPYBARA_SERVER"]
+when "falcon"
+  :falcon
 else
-  Capybara.server = :puma, {Silent: true}
+  [:puma, {Silent: true}]
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

Adds a **reactive-collection helper** that ties an add/remove-row list — rows, a
count badge, and an empty-state — into one declared unit, so each action is a
single call instead of hand-rolled append + count + empty-state bookkeeping.

Declare the contract once on the container:

```ruby
reactive_collection :notifications,
  item: NotificationRow,         # the per-row Streamable component
  container: "notifications",     # the DOM id rows live in
  count: "notifications-count",   # optional companion id (the size badge)
  empty: NotificationsEmpty,      # optional empty-state component
  size: -> { Todo.count }         # resolves the live size (re-counted server-side)
```

…then the actions are one line each:

```ruby
def add(title:)   = (todo = Todo.create!(title:); reply.append(:notifications, todo))
def dismiss(id:)  = (Todo.find(id).destroy!;       reply.remove(:notifications, id))
```

`reply.append` / `prepend` / `remove` emit the **row stream + the count companion
update + the empty-state toggle** as one `Response`:

| Builder | Streams (one `Response`) |
|---|---|
| `reply.append(name, model)` | append the row · update the count · remove the empty-state when the list crosses 0→1 |
| `reply.prepend(name, model)` | as `append`, row goes to the top |
| `reply.remove(name, model)` | remove the row by its `dom_id` · update the count · append the empty-state back when the list crosses →0 |

### Why it's correct-by-construction

- **`size:` is the source of truth** — re-counted server-side after the mutation,
  so the badge and empty-state can't go off-by-one and never ship a client-held
  count (the signed-identity rule stays intact). First render and deltas read the
  same source, so the container id can't drift.
- **`count:` / `empty:` / `size:` are optional** — omit them and only the row
  stream is emitted.
- **Composes, doesn't replace.** Chains with `.flash` / `.stream` like any reply,
  and governs only the actor's HTTP response — a cross-tab live list still
  broadcasts the row with `broadcast_append_to(..., exclude: reactive_connection_id)`.

New: `Component::CollectionDefinition` + `reactive_collection` /
`reactive_collection_def` / `reactive_collection?` (inheritable like
`reactive_actions`); `Response.collection_append/prepend/remove` behind the
`reply.*` surface. No existing behavior changes — no existing hot path is edited;
the row/empty render reuses the memoized `render_component` view context.

## Also: the browser suite now runs under two real servers

Folded in a test-infrastructure change (separate commit): the system suite runs
under **Puma** (sync) **and Falcon** (async) via a CI matrix + a new
`rake spec:system_servers`, proving a reactive round trip is transport-agnostic.
**`webrick` is removed** as a test server (it isn't a real server); Falcon (with
`protocol-rack`) replaces it, registered via `Capybara.register_server(:falcon)`.
Test infrastructure only — no production dependency change.

## Test plan

- **Unit** (`spec/phlex/reactive/collection_spec.rb`) — DSL storage, optional
  fields, inheritance.
- **Unit** (`spec/phlex/reactive/collection_streams_spec.rb`) — row + count +
  empty-state streams, the 0↔1 boundary in both directions, model-or-dom-id
  remove, optional-declaration omission, `.flash` chaining, frozen Response,
  undeclared-collection error.
- **Request** (`spec/requests/reactive_collection_spec.rb`) — end-to-end through
  the action endpoint: record created/destroyed, append/remove/count/empty
  streams, `render_self` false (no whole-container replace), default-deny intact.
- **System** (`spec/system/notifications_spec.rb`) — the real browser loop: add →
  row streams in, count bumps, empty-state clears; dismiss the last row →
  restores; count accurate across add-then-dismiss; no full-page reload.

Verification:

- `bundle exec standardrb` — clean
- `gem build phlex-reactive.gemspec --strict` — builds
- `bundle exec rspec spec/phlex spec/requests spec/generators` — 192 examples, 0 failures
- `bundle exec rake spec:system_servers` — 21 examples, 0 failures under **puma** AND **falcon**

Closes #35
