### PR TITLE
feat(component): file/multipart params + nested-param fix + shared spec helpers (#34, #39, #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   params as fields, the file(s) appended — and the endpoint coerces `:file` to the
   `ActionDispatch::Http::UploadedFile`, passed through untouched. A non-file value
   sent to a `:file` param is dropped (the keyword default applies), consistent with
-  the #16 coercion rules. Token threading and the re-render/morph are identical;
-  only the request encoding changes when a file is present — so attaching a
-  document/receipt/image stays a reactive action instead of dropping out to a
-  bespoke controller + upload Stimulus controller. Covered end-to-end: server
-  coercion (request specs), the FormData wire shape (bun unit tests), and a real
-  browser upload under Puma + Falcon (system spec).
+  the #16 coercion rules — and for a `[:file]` array, a non-file *element* (a
+  forged/mixed payload) is rejected from the array too, so the internal coercion
+  sentinel never leaks to the action. A `<input type="file" multiple>` keeps its
+  array shape (`params[name][]`) even when the user picks exactly one file, so a
+  `[:file]` schema still coerces it. Token threading and the re-render/morph are
+  identical; only the request encoding changes when a file is present — so
+  attaching a document/receipt/image stays a reactive action instead of dropping
+  out to a bespoke controller + upload Stimulus controller. Covered end-to-end:
+  server coercion (request specs), the FormData wire shape (bun unit tests), and a
+  real browser upload under Puma + Falcon (system spec).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **File / multipart params in a reactive action (#34).** An action can now accept
+  an uploaded file: declare `params: { file: :file }` (or `[:file]` for multiple).
+  When the reactive root holds a populated `<input type="file">`, the client sends
+  the action as multipart `FormData` instead of JSON — `token` + `act` + scalar
+  params as fields, the file(s) appended — and the endpoint coerces `:file` to the
+  `ActionDispatch::Http::UploadedFile`, passed through untouched. A non-file value
+  sent to a `:file` param is dropped (the keyword default applies), consistent with
+  the #16 coercion rules. Token threading and the re-render/morph are identical;
+  only the request encoding changes when a file is present — so attaching a
+  document/receipt/image stays a reactive action instead of dropping out to a
+  bespoke controller + upload Stimulus controller. Covered end-to-end: server
+  coercion (request specs), the FormData wire shape (bun unit tests), and a real
+  browser upload under Puma + Falcon (system spec).
+
 ### Fixed
 
 - **`to_stream_token` emitted an EMPTY token, making non-self-rendering replies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Multipart path silently dropped an explicit nested-hash / array param (#39).**
+  When an action declared a `:file` param alongside an explicit nested (hash/array)
+  param, the nested param was dropped on the multipart path while the JSON path
+  handled it correctly — the two encodings were asymmetric. The client's
+  `#buildFormData` `JSON.stringify`'d a non-scalar param into one
+  `params[key]='<json>'` field, which the server received as an un-decodable
+  `String` leaf and dropped (nested hash → `{}`, array → key removed). Fixed
+  client-side: `#buildFormData` now bracket-expands a nested object/array into
+  `params[key][sub]` / `params[key][index][...]` fields (arrays use numeric
+  indices) — the same Rails-form shape the server's `expand_bracket_keys` /
+  `array_values` already parse, so a JSON body and a multipart body now coerce
+  identically. The server is unchanged. One intentional divergence: an empty
+  array/object as a whole param can't be carried by `FormData`, so the multipart
+  path omits the key (the action's keyword default applies) rather than sending an
+  explicit-clear `[]`/`{}`. Covered end-to-end: the bracketed multipart shape
+  coerces correctly (request specs), a `:file` alongside a nested param both
+  survive (request spec), and the FormData wire shape (bun unit tests).
+
 - **`to_stream_token` emitted an EMPTY token, making non-self-rendering replies
   add-once-only (cosmos#1939).** `Streamable#to_stream_token` guarded on
   `respond_to?(:reactive_token)`, but `Component#reactive_token` is **private**, so

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ group :development, :test do
   gem "actioncable", ">= 7.1", "< 9.0"
   gem "activejob", ">= 7.1", "< 9.0"
   gem "activerecord", ">= 7.1", "< 9.0"
+  # ActiveStorage backs the file/multipart upload fixture (issue #34). Dev/test
+  # only — phlex-reactive itself doesn't depend on it; the dummy app uses it to
+  # attach an uploaded file from a reactive action.
+  gem "activestorage", ">= 7.1", "< 9.0"
   gem "sqlite3", ">= 1.4"
 
   # pgbus is NOT a runtime dependency (it stays out of the gemspec — broadcasts

--- a/README.md
+++ b/README.md
@@ -324,12 +324,15 @@ Anything not in the schema is dropped before reaching your method.
 an uploaded file in a reactive action — attach a document/receipt/image to the
 record without dropping out to a bespoke controller. When the reactive root holds
 a populated `<input type="file">`, the client sends the action as multipart
-`FormData` (instead of JSON) — `token` + `act` + scalar params as fields, the
-file(s) appended; the endpoint coerces `:file` to the
-`ActionDispatch::Http::UploadedFile`, passed through untouched. A non-file value
-sent to a `:file` param is dropped (the keyword default applies — never a
-fabricated file). Token threading and the re-render/morph are identical; only the
-request encoding changes when a file is present.
+`FormData` (instead of JSON) — `token` + `act` as fields, scalar params as fields,
+any nested/array params bracket-expanded into `params[key][sub]` /
+`params[key][index]` fields (the same Rails-form shape, so a JSON body and a
+multipart body coerce identically — #39), and the file(s) appended; the endpoint
+coerces `:file` to the `ActionDispatch::Http::UploadedFile`, passed through
+untouched. A non-file value sent to a `:file` param is dropped (the keyword
+default applies — never a fabricated file). Token threading and the
+re-render/morph are identical; only the request encoding changes when a file is
+present.
 
 ```ruby
 reactive_record :document
@@ -349,6 +352,13 @@ def view_template
   end
 end
 ```
+
+> **One multipart caveat:** `FormData` can't carry an *empty* array or hash, so on
+> the multipart (file-present) path an empty `[]`/`{}` param is **omitted** and the
+> action's keyword default applies — it does **not** arrive as an explicit empty
+> collection the way it does over JSON. If you rely on sending `tags: []` to clear
+> a collection, send that action *without* a file (the JSON path). A non-empty
+> nested/array param rides along fine next to a file.
 
 **Array & nested params.** Wrap a type in an array for an array param, or a hash
 schema in an array for Rails-style nested attributes — so one reactive action can

--- a/README.md
+++ b/README.md
@@ -317,8 +317,38 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` | Return from an action to control the reply (flash, remove, redirect, multi-stream). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
 | `reply.append(name, model)` / `.prepend(...)` / `.remove(name, model)` | Add/remove a row in a declared `reactive_collection` (row + count + empty-state in one reply). |
 
-Param types: `:string` (default), `:integer`, `:float`, `:boolean`. Anything not
-in the schema is dropped before reaching your method.
+Param types: `:string` (default), `:integer`, `:float`, `:boolean`, `:file`.
+Anything not in the schema is dropped before reaching your method.
+
+**File uploads (`:file`).** Declare `:file` (or `[:file]` for multiple) to accept
+an uploaded file in a reactive action — attach a document/receipt/image to the
+record without dropping out to a bespoke controller. When the reactive root holds
+a populated `<input type="file">`, the client sends the action as multipart
+`FormData` (instead of JSON) — `token` + `act` + scalar params as fields, the
+file(s) appended; the endpoint coerces `:file` to the
+`ActionDispatch::Http::UploadedFile`, passed through untouched. A non-file value
+sent to a `:file` param is dropped (the keyword default applies — never a
+fabricated file). Token threading and the re-render/morph are identical; only the
+request encoding changes when a file is present.
+
+```ruby
+reactive_record :document
+action :upload, params: { file: :file, caption: :string } # single (has_one_attached)
+action :upload_pages, params: { pages: [:file] }           # multiple (has_many_attached)
+
+def upload(file: nil, caption: nil)
+  @document.file.attach(file) if file
+  @document.update!(title: caption) if caption.present?
+end
+
+def view_template
+  form(**on(:upload, event: "submit")) do
+    input(type: "file", name: "file")
+    input(name: "caption")
+    button(type: "submit") { "Upload" }
+  end
+end
+```
 
 **Array & nested params.** Wrap a type in an array for an array param, or a hash
 schema in an array for Rails-style nested attributes — so one reactive action can

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -200,11 +200,22 @@ module Phlex
       # present-but-non-array value returns DROP rather than [] — coercing a stray
       # scalar to an empty array would let a bad payload read as an explicit
       # "clear everything" on update!(declared_array:).
+      #
+      # An ELEMENT that coerces to DROP (e.g. a non-file in a [:file] array, a
+      # forged/mixed payload) is rejected from the result — the same rule
+      # coerce_hash applies to a dropped value, so the internal DROP sentinel
+      # never leaks into the action. A genuinely empty input array stays [] (an
+      # explicit empty collection), but an array whose every element drops
+      # returns DROP, so the keyword default applies rather than handing the
+      # action a surprise [].
       def coerce_array(value, element_type)
         values = array_values(value)
         return DROP if values.nil?
+        return [] if values.empty?
 
-        values.map { |element| coerce(element, element_type) }
+        coerced = values.map { |element| coerce(element, element_type) }
+        coerced.reject! { |element| element.equal?(DROP) }
+        coerced.empty? ? DROP : coerced
       end
 
       # Keep declared keys only (drop undeclared — no mass assignment), recursing

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -163,6 +163,7 @@ module Phlex
 
       # Coerce a value against a declared type. A type is one of:
       #   * a scalar symbol            (:string/:integer/:float/:boolean)
+      #   * :file                      — a multipart upload (issue #34)
       #   * a Hash schema              ({ id: :integer, ... })   — nested object
       #   * a one-element Array        ([:integer] / [{ ... }])  — array of that
       # Arrays accept both a real JSON array and a Rails-style index hash
@@ -172,9 +173,27 @@ module Phlex
           coerce_array(value, type.first)
         elsif type.is_a?(Hash)
           coerce_hash(value, type)
+        elsif type == :file
+          coerce_file(value)
         else
           coerce_scalar(value, type)
         end
+      end
+
+      # An uploaded file (issue #34) passes through UNTOUCHED — never .to_s'd,
+      # which would corrupt it into a string the action can't attach. Anything
+      # that isn't an uploaded file (a forged/malformed scalar, an empty input)
+      # returns DROP, so the method's keyword default applies — consistent with
+      # the #16 rule that a value that can't be coerced to its type is dropped,
+      # not fabricated. Duck-types on UploadedFile's interface (original_filename
+      # + a readable IO) rather than naming a class, so a Rack::Test upload, an
+      # ActionDispatch upload, and a Falcon multipart body all qualify.
+      def coerce_file(value)
+        uploaded_file?(value) ? value : DROP
+      end
+
+      def uploaded_file?(value)
+        value.respond_to?(:original_filename) && value.respond_to?(:read)
       end
 
       # A real array (or Rails index hash) coerces element-wise. A malformed

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -8,9 +8,12 @@ import { Controller } from "@hotwired/stimulus"
 // (replace by default; method="morph" — Response.morph — preserves focus).
 //
 // Wire format (client -> server), POST <action path>, turbo-stream Accept:
-//   { token: "<signed identity>", act: "<action>", params: {...} }
+//   { token: "<signed identity>", act: "<action>", params: {...} }   (JSON)
 // (`act`, not `action`: `action` is a reserved Rails routing param.)
 // The token is a MessageVerifier-signed { component, gid } — NO state is sent.
+// When the root holds a chosen <input type="file">, the SAME payload is sent as
+// multipart FormData instead (token/act flat, params bracketed, files appended)
+// so an upload reaches the action (issue #34) — only the encoding differs.
 // The response is a <turbo-stream> that replaces the component by its id.
 //
 // Server -> client live updates use the SAME element id, pushed over the
@@ -206,21 +209,31 @@ export default class extends Controller {
     // triggered action still receives sibling inputs (Livewire-style).
     // Explicit params (data-reactive-params-param) win over collected fields.
     const fieldParams = this.#collectFields()
+    const allParams = { ...fieldParams, ...this.#parseParams(params) }
+    const token = this.#currentToken
 
-    const body = JSON.stringify({
-      token: this.#currentToken,
-      act: action,
-      params: { ...fieldParams, ...this.#parseParams(params) },
-    })
+    // File/multipart path (issue #34): if THIS root has a populated
+    // <input type="file">, the action can't be JSON (JSON.stringify drops the
+    // File). Send FormData instead — token + act + scalar params as fields, each
+    // chosen file appended. The morph/token machinery downstream is identical;
+    // only the request ENCODING differs when files are present.
+    const files = this.#collectFiles()
+    const multipart = files.length > 0
+    const body = multipart
+      ? this.#buildFormData(token, action, allParams, files)
+      : JSON.stringify({ token, act: action, params: allParams })
 
     this.element.setAttribute("aria-busy", "true")
 
     try {
       const headers = {
-        "Content-Type": "application/json",
         Accept: "text/vnd.turbo-stream.html",
         "X-CSRF-Token": this.#csrfToken(),
       }
+      // For JSON we declare the content type; for multipart we must NOT — the
+      // browser sets `multipart/form-data; boundary=…` itself, and overriding it
+      // would strip the boundary and corrupt the body server-side.
+      if (!multipart) headers["Content-Type"] = "application/json"
       // Send the pgbus SSE connection id (if subscribed) so the server can
       // exclude this connection from its own broadcast echo — the actor
       // already gets the action's HTTP response. Harmless without pgbus.
@@ -293,7 +306,12 @@ export default class extends Controller {
     // Standard form controls owned by THIS root (not a nested reactive root).
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
-      if (field.type === "checkbox") {
+      if (field.type === "file") {
+        // A file input's `.value` is the useless "C:\fakepath\…" string — never
+        // a scalar param. Its chosen files travel via #collectFiles (multipart);
+        // skip it here so an empty picker doesn't post a phantom blank value
+        // (issue #34).
+      } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
         if (field.checked) fields[field.name] = field.value
@@ -322,6 +340,62 @@ export default class extends Controller {
         }
       })
     return fields
+  }
+
+  // Chosen files inside THIS reactive root (issue #34). Returns a flat list of
+  // { name, file } for every populated <input type="file"> the root owns —
+  // honoring `multiple` (every file in the picker) and the nested-root scoping
+  // (#ownsField) so an outer action never sweeps an inner root's file input. An
+  // empty list means "no files" → the JSON path stays in effect.
+  #collectFiles() {
+    const chosen = []
+    this.element.querySelectorAll('input[type="file"][name]').forEach((input) => {
+      if (!this.#ownsField(input)) return
+      const files = input.files
+      if (!files || files.length === 0) return
+      for (const file of files) chosen.push({ name: input.name, file })
+    })
+    return chosen
+  }
+
+  // Build the multipart body (issue #34). `token`/`act` are flat fields the
+  // endpoint reads from params[:token]/params[:act]; scalar params nest under
+  // params[<key>] (Rails parses the bracket into params[:params]); each file is
+  // appended under params[<name>] (single) — a second file with the same name
+  // (a `multiple` picker, several inputs sharing a name) is sent as
+  // params[<name>][] so Rails coerces it to an array for a [:file] schema.
+  #buildFormData(token, action, params, files) {
+    const fd = new FormData()
+    fd.append("token", token)
+    fd.append("act", action)
+    for (const [key, value] of Object.entries(params)) {
+      fd.append(`params[${key}]`, this.#scalarField(value))
+    }
+    const multiNames = this.#multiFileNames(files)
+    for (const { name, file } of files) {
+      const key = multiNames.has(name) ? `params[${name}][]` : `params[${name}]`
+      fd.append(key, file, file.name)
+    }
+    return fd
+  }
+
+  // FormData fields are strings; mirror the JSON wire shape — a boolean
+  // checkbox becomes "true"/"false" (the server's :boolean cast reads it), an
+  // array/object is JSON-encoded (the bracket-expansion path on the server
+  // handles the scalar leaves the same way it does for a JSON body).
+  #scalarField(value) {
+    if (value == null) return ""
+    if (typeof value === "object") return JSON.stringify(value)
+    return String(value)
+  }
+
+  // Names that appear more than once across the chosen files (a `multiple`
+  // picker, or several file inputs sharing a name) — those go to params[name][]
+  // so the server sees an array; a lone file stays params[name].
+  #multiFileNames(files) {
+    const counts = new Map()
+    for (const { name } of files) counts.set(name, (counts.get(name) ?? 0) + 1)
+    return new Set([...counts].filter(([, n]) => n > 1).map(([name]) => name))
   }
 
   #parseParams(raw) {

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -312,7 +312,10 @@ export default class extends Controller {
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
       if (field.type === "file") {
-        for (const file of field.files ?? []) files.push({ name: field.name, file })
+        // Carry the input's `multiple` flag so #buildFormData keeps the array
+        // shape (params[name][]) even when the user picked exactly one file —
+        // otherwise a [:file] schema would see a lone scalar upload and drop it.
+        for (const file of field.files ?? []) files.push({ name: field.name, file, multiple: field.multiple })
       } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -358,8 +361,11 @@ export default class extends Controller {
       this.#appendField(fd, `params[${key}]`, value)
     }
     const multiNames = this.#multiFileNames(files)
-    for (const { name, file } of files) {
-      const key = multiNames.has(name) ? `params[${name}][]` : `params[${name}]`
+    for (const { name, file, multiple } of files) {
+      // params[name][] when the input is `multiple` (array shape even for one
+      // file) OR the name repeats across inputs; otherwise a lone scalar file.
+      const asArray = multiple || multiNames.has(name)
+      const key = asArray ? `params[${name}][]` : `params[${name}]`
       fd.append(key, file, file.name)
     }
     return fd

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -206,10 +206,11 @@ export default class extends Controller {
 
   async #perform(action, params) {
     // Auto-collect named field values inside this component so a button-
-    // triggered action still receives sibling inputs (Livewire-style).
-    // Explicit params (data-reactive-params-param) win over collected fields.
-    const fieldParams = this.#collectFields()
-    const allParams = { ...fieldParams, ...this.#parseParams(params) }
+    // triggered action still receives sibling inputs (Livewire-style), plus any
+    // chosen file inputs in the SAME walk. Explicit params
+    // (data-reactive-params-param) win over collected fields.
+    const { fields, files } = this.#collectFields()
+    const allParams = { ...fields, ...this.#parseParams(params) }
     const token = this.#currentToken
 
     // File/multipart path (issue #34): if THIS root has a populated
@@ -217,7 +218,6 @@ export default class extends Controller {
     // File). Send FormData instead — token + act + scalar params as fields, each
     // chosen file appended. The morph/token machinery downstream is identical;
     // only the request ENCODING differs when files are present.
-    const files = this.#collectFiles()
     const multipart = files.length > 0
     const body = multipart
       ? this.#buildFormData(token, action, allParams, files)
@@ -301,16 +301,18 @@ export default class extends Controller {
     return el.closest('[data-controller~="reactive"]') === this.element
   }
 
+  // One walk over THIS root's named controls (not a nested reactive root's),
+  // returning both the scalar `fields` and any chosen `files`. A file input's
+  // `.value` is the useless "C:\fakepath\…" string, never a scalar — so its
+  // chosen files are collected separately (honoring `multiple`) and it adds no
+  // phantom blank value (issue #34). An empty `files` keeps the JSON path.
   #collectFields() {
     const fields = {}
-    // Standard form controls owned by THIS root (not a nested reactive root).
+    const files = []
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
       if (field.type === "file") {
-        // A file input's `.value` is the useless "C:\fakepath\…" string — never
-        // a scalar param. Its chosen files travel via #collectFiles (multipart);
-        // skip it here so an empty picker doesn't post a phantom blank value
-        // (issue #34).
+        for (const file of field.files ?? []) files.push({ name: field.name, file })
       } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -339,23 +341,7 @@ export default class extends Controller {
           fields[name] = el.value ?? el.textContent ?? el.innerHTML ?? ""
         }
       })
-    return fields
-  }
-
-  // Chosen files inside THIS reactive root (issue #34). Returns a flat list of
-  // { name, file } for every populated <input type="file"> the root owns —
-  // honoring `multiple` (every file in the picker) and the nested-root scoping
-  // (#ownsField) so an outer action never sweeps an inner root's file input. An
-  // empty list means "no files" → the JSON path stays in effect.
-  #collectFiles() {
-    const chosen = []
-    this.element.querySelectorAll('input[type="file"][name]').forEach((input) => {
-      if (!this.#ownsField(input)) return
-      const files = input.files
-      if (!files || files.length === 0) return
-      for (const file of files) chosen.push({ name: input.name, file })
-    })
-    return chosen
+    return { fields, files }
   }
 
   // Build the multipart body (issue #34). `token`/`act` are flat fields the

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -355,7 +355,7 @@ export default class extends Controller {
     fd.append("token", token)
     fd.append("act", action)
     for (const [key, value] of Object.entries(params)) {
-      fd.append(`params[${key}]`, this.#scalarField(value))
+      this.#appendField(fd, `params[${key}]`, value)
     }
     const multiNames = this.#multiFileNames(files)
     for (const { name, file } of files) {
@@ -365,14 +365,35 @@ export default class extends Controller {
     return fd
   }
 
-  // FormData fields are strings; mirror the JSON wire shape — a boolean
-  // checkbox becomes "true"/"false" (the server's :boolean cast reads it), an
-  // array/object is JSON-encoded (the bracket-expansion path on the server
-  // handles the scalar leaves the same way it does for a JSON body).
-  #scalarField(value) {
-    if (value == null) return ""
-    if (typeof value === "object") return JSON.stringify(value)
-    return String(value)
+  // Append a param leaf to FormData under its bracketed key. FormData carries
+  // only strings, so a NON-scalar param (a nested object or an array) is
+  // bracket-EXPANDED into params[key][sub] / params[key][index][...] fields —
+  // the SAME Rails-form shape the server's expand_bracket_keys / array_values
+  // already parse, so a JSON body and a multipart body coerce identically
+  // (issue #39). Previously a non-scalar was JSON.stringify'd into one
+  // params[key]='<json>' field, which the server received as an un-decodable
+  // String leaf and DROPPED (nested hash -> {}, array -> key removed).
+  //
+  // Arrays use NUMERIC indices (params[key][0], params[key][1]) — required for
+  // an array-of-hash so each element's sub-keys stay grouped and the server's
+  // index-hash sort rebuilds order; params[key][] would collapse them. A scalar
+  // (string/number/boolean) is one string field, mirroring the JSON wire shape
+  // (the server's :boolean/:integer casts read "true"/"42"). null/undefined is
+  // an empty field. An EMPTY array/object emits NOTHING — FormData can't carry
+  // []/{}, so the key is omitted and the action's keyword default applies (this
+  // differs from the JSON path, where an explicit [] coerces to an empty array).
+  #appendField(fd, key, value) {
+    if (value == null) {
+      fd.append(key, "")
+    } else if (Array.isArray(value)) {
+      value.forEach((element, index) => this.#appendField(fd, `${key}[${index}]`, element))
+    } else if (typeof value === "object") {
+      for (const [subKey, subValue] of Object.entries(value)) {
+        this.#appendField(fd, `${key}[${subKey}]`, subValue)
+      }
+    } else {
+      fd.append(key, String(value))
+    }
   }
 
   // Names that appear more than once across the chosen files (a `multiple`

--- a/docs/security.md
+++ b/docs/security.md
@@ -74,6 +74,16 @@ Anything not in the schema is dropped before reaching your method, so a maliciou
 `{ admin: true, title: "x" }` body can't mass-assign. Never do
 `@record.update!(params)` — take explicit, declared params.
 
+**File params (`:file` / `[:file]`).** A reactive action can accept an uploaded
+file (the client switches to multipart `FormData` when a file input is present).
+The multipart request runs through the *same* gates as a JSON one — the signed
+identity is still verified, the action is still default-deny, and the file is
+still schema-coerced: a `:file` param accepts only an actual uploaded file and is
+**dropped** for any non-file value (a forged string can't fabricate a file). Apply
+your own attachment rules in the action (content-type/size allow-lists,
+`authorize!` before attaching) exactly as you would in a plain controller — the
+schema proves the value is a file, not that this user may upload it.
+
 ### 4. Don't put secrets in state-backed tokens
 
 State-backed tokens are *signed* (tamper-proof) but **not encrypted** — the

--- a/spec/dummy/app/components/document_upload_component.rb
+++ b/spec/dummy/app/components/document_upload_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Issue #34: a reactive component that accepts a FILE in its action. When the
+# reactive root contains a populated <input type="file">, the client sends the
+# action as multipart FormData (not JSON) and the endpoint coerces the declared
+# `:file` param to the ActionDispatch::Http::UploadedFile, passed through
+# untouched. The action attaches it to the record via ActiveStorage — the rest
+# of the reactive flow (token threading, re-render/morph) is identical.
+class DocumentUploadComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :document
+
+  # Single-file path (has_one_attached). A caption rides alongside as a scalar
+  # field to prove multipart carries scalar params + the file together.
+  action :upload, params: {file: :file, caption: :string}
+  # Multiple-file path (has_many_attached): [:file] coerces an array of uploads.
+  action :upload_pages, params: {pages: [:file]}
+
+  def initialize(document:)
+    @document = document
+  end
+
+  def id = dom_id(@document)
+
+  def upload(file: nil, caption: nil)
+    @document.file.attach(file) if file
+    @document.update!(title: caption) if caption.present?
+  end
+
+  def upload_pages(pages: nil)
+    @document.pages.attach(pages) if pages.present?
+  end
+
+  def view_template
+    div(**mix(reactive_attrs, id:, data: {testid: "document"})) do
+      span(data: {testid: "title"}) { @document.title }
+      span(data: {testid: "filename"}) { @document.file.attached? ? @document.file.filename.to_s : "" }
+      span(data: {testid: "pages-count"}) { @document.pages.count.to_s }
+
+      form(**on(:upload, event: "submit")) do
+        input(type: "file", name: "file", data: {testid: "file"})
+        input(name: "caption", data: {testid: "caption"})
+        button(type: "submit", data: {testid: "save"}) { "Upload" }
+      end
+    end
+  end
+end

--- a/spec/dummy/app/components/document_upload_component.rb
+++ b/spec/dummy/app/components/document_upload_component.rb
@@ -17,6 +17,10 @@ class DocumentUploadComponent < ApplicationComponent
   action :upload, params: {file: :file, caption: :string}
   # Multiple-file path (has_many_attached): [:file] coerces an array of uploads.
   action :upload_pages, params: {pages: [:file]}
+  # Issue #39: a :file param alongside an explicit NESTED-hash param. The nested
+  # `meta` used to be dropped on the multipart path (the exact combination the
+  # issue flagged); it must now survive next to the file.
+  action :upload_with_meta, params: {file: :file, meta: {tag: :string, year: :integer}}
 
   def initialize(document:)
     @document = document
@@ -31,6 +35,13 @@ class DocumentUploadComponent < ApplicationComponent
 
   def upload_pages(pages: nil)
     @document.pages.attach(pages) if pages.present?
+  end
+
+  # Attach the file AND fold the nested meta into the title, so a spec can assert
+  # the nested-hash param rode alongside the file through the multipart path.
+  def upload_with_meta(file: nil, meta: nil)
+    @document.file.attach(file) if file
+    @document.update!(title: "#{meta[:tag]} #{meta[:year]}") if meta
   end
 
   def view_template

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -51,6 +51,10 @@ class DemosController < ActionController::Base
     render_component PartialGridComponent.new(line_item: LineItem.find(params[:id]))
   end
 
+  def document_upload
+    render_component DocumentUploadComponent.new(document: Document.find(params[:id]))
+  end
+
   # The page a non-intercepted form submit would navigate to (issue #11).
   def nav_probe
     render html: "<div data-testid='nav-probe'>NAVIGATED</div>".html_safe, layout: true

--- a/spec/dummy/app/models/document.rb
+++ b/spec/dummy/app/models/document.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Issue #34: a record an upload component attaches a file to from a reactive
+# action. has_one_attached for the single-file path, has_many_attached for the
+# multiple-file (`[:file]`) path.
+class Document < ActiveRecord::Base
+  has_one_attached :file
+  has_many_attached :pages
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -5,6 +5,7 @@ require_relative "boot"
 require "rails"
 require "active_record/railtie"
 require "active_job/railtie"
+require "active_storage/engine"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "action_cable/engine"
@@ -23,6 +24,13 @@ module Dummy
     config.eager_load = false
     config.hosts.clear
     config.active_job.queue_adapter = :test
+
+    # ActiveStorage: a local disk service rooted in tmp/ so the upload-action
+    # fixture (issue #34 — file/multipart params) can persist an attachment.
+    config.active_storage.service = :test_disk
+    config.active_storage.service_configurations = {
+      "test_disk" => {"service" => "Disk", "root" => root.join("tmp/storage").to_s}
+    }
 
     # The dummy app's components/views live under app/.
     config.autoload_paths << root.join("app/components").to_s

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get "debounce" => "demos#debounce"
   get "morph_grid/:id" => "demos#morph_grid"
   get "partial_grid/:id" => "demos#partial_grid"
+  get "document_upload/:id" => "demos#document_upload"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
   match "nav_probe" => "demos#nav_probe", :via => [:get, :post]

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -46,4 +46,42 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer :price, null: false, default: 0
     t.timestamps
   end
+
+  # Issue #34: a record that accepts a file/multipart param in a reactive action
+  # (has_one_attached :file / has_many_attached :pages via ActiveStorage). The
+  # upload component attaches to it from a reactive action.
+  create_table :documents, force: true do |t|
+    t.string :title, null: false, default: "untitled"
+    t.timestamps
+  end
+
+  # ActiveStorage tables — needed for the has_one_attached/has_many_attached
+  # upload fixture (issue #34). Mirrors Rails' active_storage install migration.
+  create_table :active_storage_blobs, force: true do |t|
+    t.string :key, null: false
+    t.string :filename, null: false
+    t.string :content_type
+    t.text :metadata
+    t.string :service_name, null: false
+    t.bigint :byte_size, null: false
+    t.string :checksum
+    t.datetime :created_at, null: false
+    t.index [:key], unique: true
+  end
+
+  create_table :active_storage_attachments, force: true do |t|
+    t.string :name, null: false
+    t.string :record_type, null: false
+    t.bigint :record_id, null: false
+    t.bigint :blob_id, null: false
+    t.datetime :created_at, null: false
+    t.index [:blob_id]
+    t.index [:record_type, :record_id, :name, :blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table :active_storage_variant_records, force: true do |t|
+    t.bigint :blob_id, null: false
+    t.string :variation_digest, null: false
+    t.index [:blob_id, :variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 end

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -8,9 +8,12 @@ import { Controller } from "@hotwired/stimulus"
 // (replace by default; method="morph" — Response.morph — preserves focus).
 //
 // Wire format (client -> server), POST <action path>, turbo-stream Accept:
-//   { token: "<signed identity>", act: "<action>", params: {...} }
+//   { token: "<signed identity>", act: "<action>", params: {...} }   (JSON)
 // (`act`, not `action`: `action` is a reserved Rails routing param.)
 // The token is a MessageVerifier-signed { component, gid } — NO state is sent.
+// When the root holds a chosen <input type="file">, the SAME payload is sent as
+// multipart FormData instead (token/act flat, params bracketed, files appended)
+// so an upload reaches the action (issue #34) — only the encoding differs.
 // The response is a <turbo-stream> that replaces the component by its id.
 //
 // Server -> client live updates use the SAME element id, pushed over the
@@ -206,21 +209,31 @@ export default class extends Controller {
     // triggered action still receives sibling inputs (Livewire-style).
     // Explicit params (data-reactive-params-param) win over collected fields.
     const fieldParams = this.#collectFields()
+    const allParams = { ...fieldParams, ...this.#parseParams(params) }
+    const token = this.#currentToken
 
-    const body = JSON.stringify({
-      token: this.#currentToken,
-      act: action,
-      params: { ...fieldParams, ...this.#parseParams(params) },
-    })
+    // File/multipart path (issue #34): if THIS root has a populated
+    // <input type="file">, the action can't be JSON (JSON.stringify drops the
+    // File). Send FormData instead — token + act + scalar params as fields, each
+    // chosen file appended. The morph/token machinery downstream is identical;
+    // only the request ENCODING differs when files are present.
+    const files = this.#collectFiles()
+    const multipart = files.length > 0
+    const body = multipart
+      ? this.#buildFormData(token, action, allParams, files)
+      : JSON.stringify({ token, act: action, params: allParams })
 
     this.element.setAttribute("aria-busy", "true")
 
     try {
       const headers = {
-        "Content-Type": "application/json",
         Accept: "text/vnd.turbo-stream.html",
         "X-CSRF-Token": this.#csrfToken(),
       }
+      // For JSON we declare the content type; for multipart we must NOT — the
+      // browser sets `multipart/form-data; boundary=…` itself, and overriding it
+      // would strip the boundary and corrupt the body server-side.
+      if (!multipart) headers["Content-Type"] = "application/json"
       // Send the pgbus SSE connection id (if subscribed) so the server can
       // exclude this connection from its own broadcast echo — the actor
       // already gets the action's HTTP response. Harmless without pgbus.
@@ -293,7 +306,12 @@ export default class extends Controller {
     // Standard form controls owned by THIS root (not a nested reactive root).
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
-      if (field.type === "checkbox") {
+      if (field.type === "file") {
+        // A file input's `.value` is the useless "C:\fakepath\…" string — never
+        // a scalar param. Its chosen files travel via #collectFiles (multipart);
+        // skip it here so an empty picker doesn't post a phantom blank value
+        // (issue #34).
+      } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
         if (field.checked) fields[field.name] = field.value
@@ -322,6 +340,62 @@ export default class extends Controller {
         }
       })
     return fields
+  }
+
+  // Chosen files inside THIS reactive root (issue #34). Returns a flat list of
+  // { name, file } for every populated <input type="file"> the root owns —
+  // honoring `multiple` (every file in the picker) and the nested-root scoping
+  // (#ownsField) so an outer action never sweeps an inner root's file input. An
+  // empty list means "no files" → the JSON path stays in effect.
+  #collectFiles() {
+    const chosen = []
+    this.element.querySelectorAll('input[type="file"][name]').forEach((input) => {
+      if (!this.#ownsField(input)) return
+      const files = input.files
+      if (!files || files.length === 0) return
+      for (const file of files) chosen.push({ name: input.name, file })
+    })
+    return chosen
+  }
+
+  // Build the multipart body (issue #34). `token`/`act` are flat fields the
+  // endpoint reads from params[:token]/params[:act]; scalar params nest under
+  // params[<key>] (Rails parses the bracket into params[:params]); each file is
+  // appended under params[<name>] (single) — a second file with the same name
+  // (a `multiple` picker, several inputs sharing a name) is sent as
+  // params[<name>][] so Rails coerces it to an array for a [:file] schema.
+  #buildFormData(token, action, params, files) {
+    const fd = new FormData()
+    fd.append("token", token)
+    fd.append("act", action)
+    for (const [key, value] of Object.entries(params)) {
+      fd.append(`params[${key}]`, this.#scalarField(value))
+    }
+    const multiNames = this.#multiFileNames(files)
+    for (const { name, file } of files) {
+      const key = multiNames.has(name) ? `params[${name}][]` : `params[${name}]`
+      fd.append(key, file, file.name)
+    }
+    return fd
+  }
+
+  // FormData fields are strings; mirror the JSON wire shape — a boolean
+  // checkbox becomes "true"/"false" (the server's :boolean cast reads it), an
+  // array/object is JSON-encoded (the bracket-expansion path on the server
+  // handles the scalar leaves the same way it does for a JSON body).
+  #scalarField(value) {
+    if (value == null) return ""
+    if (typeof value === "object") return JSON.stringify(value)
+    return String(value)
+  }
+
+  // Names that appear more than once across the chosen files (a `multiple`
+  // picker, or several file inputs sharing a name) — those go to params[name][]
+  // so the server sees an array; a lone file stays params[name].
+  #multiFileNames(files) {
+    const counts = new Map()
+    for (const { name } of files) counts.set(name, (counts.get(name) ?? 0) + 1)
+    return new Set([...counts].filter(([, n]) => n > 1).map(([name]) => name))
   }
 
   #parseParams(raw) {

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -312,7 +312,10 @@ export default class extends Controller {
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
       if (field.type === "file") {
-        for (const file of field.files ?? []) files.push({ name: field.name, file })
+        // Carry the input's `multiple` flag so #buildFormData keeps the array
+        // shape (params[name][]) even when the user picked exactly one file —
+        // otherwise a [:file] schema would see a lone scalar upload and drop it.
+        for (const file of field.files ?? []) files.push({ name: field.name, file, multiple: field.multiple })
       } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -358,8 +361,11 @@ export default class extends Controller {
       this.#appendField(fd, `params[${key}]`, value)
     }
     const multiNames = this.#multiFileNames(files)
-    for (const { name, file } of files) {
-      const key = multiNames.has(name) ? `params[${name}][]` : `params[${name}]`
+    for (const { name, file, multiple } of files) {
+      // params[name][] when the input is `multiple` (array shape even for one
+      // file) OR the name repeats across inputs; otherwise a lone scalar file.
+      const asArray = multiple || multiNames.has(name)
+      const key = asArray ? `params[${name}][]` : `params[${name}]`
       fd.append(key, file, file.name)
     }
     return fd

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -206,10 +206,11 @@ export default class extends Controller {
 
   async #perform(action, params) {
     // Auto-collect named field values inside this component so a button-
-    // triggered action still receives sibling inputs (Livewire-style).
-    // Explicit params (data-reactive-params-param) win over collected fields.
-    const fieldParams = this.#collectFields()
-    const allParams = { ...fieldParams, ...this.#parseParams(params) }
+    // triggered action still receives sibling inputs (Livewire-style), plus any
+    // chosen file inputs in the SAME walk. Explicit params
+    // (data-reactive-params-param) win over collected fields.
+    const { fields, files } = this.#collectFields()
+    const allParams = { ...fields, ...this.#parseParams(params) }
     const token = this.#currentToken
 
     // File/multipart path (issue #34): if THIS root has a populated
@@ -217,7 +218,6 @@ export default class extends Controller {
     // File). Send FormData instead — token + act + scalar params as fields, each
     // chosen file appended. The morph/token machinery downstream is identical;
     // only the request ENCODING differs when files are present.
-    const files = this.#collectFiles()
     const multipart = files.length > 0
     const body = multipart
       ? this.#buildFormData(token, action, allParams, files)
@@ -301,16 +301,18 @@ export default class extends Controller {
     return el.closest('[data-controller~="reactive"]') === this.element
   }
 
+  // One walk over THIS root's named controls (not a nested reactive root's),
+  // returning both the scalar `fields` and any chosen `files`. A file input's
+  // `.value` is the useless "C:\fakepath\…" string, never a scalar — so its
+  // chosen files are collected separately (honoring `multiple`) and it adds no
+  // phantom blank value (issue #34). An empty `files` keeps the JSON path.
   #collectFields() {
     const fields = {}
-    // Standard form controls owned by THIS root (not a nested reactive root).
+    const files = []
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
       if (!this.#ownsField(field)) return
       if (field.type === "file") {
-        // A file input's `.value` is the useless "C:\fakepath\…" string — never
-        // a scalar param. Its chosen files travel via #collectFiles (multipart);
-        // skip it here so an empty picker doesn't post a phantom blank value
-        // (issue #34).
+        for (const file of field.files ?? []) files.push({ name: field.name, file })
       } else if (field.type === "checkbox") {
         fields[field.name] = field.checked
       } else if (field.type === "radio") {
@@ -339,23 +341,7 @@ export default class extends Controller {
           fields[name] = el.value ?? el.textContent ?? el.innerHTML ?? ""
         }
       })
-    return fields
-  }
-
-  // Chosen files inside THIS reactive root (issue #34). Returns a flat list of
-  // { name, file } for every populated <input type="file"> the root owns —
-  // honoring `multiple` (every file in the picker) and the nested-root scoping
-  // (#ownsField) so an outer action never sweeps an inner root's file input. An
-  // empty list means "no files" → the JSON path stays in effect.
-  #collectFiles() {
-    const chosen = []
-    this.element.querySelectorAll('input[type="file"][name]').forEach((input) => {
-      if (!this.#ownsField(input)) return
-      const files = input.files
-      if (!files || files.length === 0) return
-      for (const file of files) chosen.push({ name: input.name, file })
-    })
-    return chosen
+    return { fields, files }
   }
 
   // Build the multipart body (issue #34). `token`/`act` are flat fields the

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -355,7 +355,7 @@ export default class extends Controller {
     fd.append("token", token)
     fd.append("act", action)
     for (const [key, value] of Object.entries(params)) {
-      fd.append(`params[${key}]`, this.#scalarField(value))
+      this.#appendField(fd, `params[${key}]`, value)
     }
     const multiNames = this.#multiFileNames(files)
     for (const { name, file } of files) {
@@ -365,14 +365,35 @@ export default class extends Controller {
     return fd
   }
 
-  // FormData fields are strings; mirror the JSON wire shape — a boolean
-  // checkbox becomes "true"/"false" (the server's :boolean cast reads it), an
-  // array/object is JSON-encoded (the bracket-expansion path on the server
-  // handles the scalar leaves the same way it does for a JSON body).
-  #scalarField(value) {
-    if (value == null) return ""
-    if (typeof value === "object") return JSON.stringify(value)
-    return String(value)
+  // Append a param leaf to FormData under its bracketed key. FormData carries
+  // only strings, so a NON-scalar param (a nested object or an array) is
+  // bracket-EXPANDED into params[key][sub] / params[key][index][...] fields —
+  // the SAME Rails-form shape the server's expand_bracket_keys / array_values
+  // already parse, so a JSON body and a multipart body coerce identically
+  // (issue #39). Previously a non-scalar was JSON.stringify'd into one
+  // params[key]='<json>' field, which the server received as an un-decodable
+  // String leaf and DROPPED (nested hash -> {}, array -> key removed).
+  //
+  // Arrays use NUMERIC indices (params[key][0], params[key][1]) — required for
+  // an array-of-hash so each element's sub-keys stay grouped and the server's
+  // index-hash sort rebuilds order; params[key][] would collapse them. A scalar
+  // (string/number/boolean) is one string field, mirroring the JSON wire shape
+  // (the server's :boolean/:integer casts read "true"/"42"). null/undefined is
+  // an empty field. An EMPTY array/object emits NOTHING — FormData can't carry
+  // []/{}, so the key is omitted and the action's keyword default applies (this
+  // differs from the JSON path, where an explicit [] coerces to an empty array).
+  #appendField(fd, key, value) {
+    if (value == null) {
+      fd.append(key, "")
+    } else if (Array.isArray(value)) {
+      value.forEach((element, index) => this.#appendField(fd, `${key}[${index}]`, element))
+    } else if (typeof value === "object") {
+      for (const [subKey, subValue] of Object.entries(value)) {
+        this.#appendField(fd, `${key}[${subKey}]`, subValue)
+      }
+    } else {
+      fd.append(key, String(value))
+    }
   }
 
   // Names that appear more than once across the chosen files (a `multiple`

--- a/spec/fixtures/files/page1.txt
+++ b/spec/fixtures/files/page1.txt
@@ -1,0 +1,1 @@
+page one

--- a/spec/fixtures/files/page2.txt
+++ b/spec/fixtures/files/page2.txt
@@ -1,0 +1,1 @@
+page two

--- a/spec/fixtures/files/receipt.txt
+++ b/spec/fixtures/files/receipt.txt
@@ -1,0 +1,1 @@
+hello from a reactive upload

--- a/spec/javascript/reactive_multipart.test.js
+++ b/spec/javascript/reactive_multipart.test.js
@@ -1,0 +1,215 @@
+// Unit test for the multipart/FormData request path (issue #34).
+//
+// When a reactive root contains a POPULATED <input type="file">, the action
+// can't be sent as JSON (JSON.stringify drops the File). The controller instead
+// builds a FormData body: `token` + `act` as flat fields, scalar params
+// bracketed (params[caption]), and each chosen file appended (params[file], or
+// params[pages][] for a multiple input). The Content-Type header is OMITTED so
+// the browser sets the multipart boundary; CSRF + connection-id headers still
+// ride along. With NO file present, the JSON path is unchanged.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A DOM-ish node faithful enough for #collectFields() + the file detection:
+//   - matches/closest for the reactive-root + field-owner predicates
+//   - querySelectorAll for descendant named fields
+//   - a file input exposes type === "file" and a `files` array (FileList-ish)
+class FakeNode {
+  constructor({ tag = "div", name = null, type = null, value = "", checked = false, files = null, controller = null } = {}) {
+    this.tag = tag.toLowerCase()
+    this.name = name
+    this.type = type
+    this.value = value
+    this.checked = checked
+    this.files = files // array of File for a file input
+    this.parentNode = null
+    this.children = []
+    this.dataset = {}
+    if (controller) this.dataset.controller = controller
+  }
+
+  append(...nodes) {
+    for (const n of nodes) {
+      n.parentNode = this
+      this.children.push(n)
+    }
+    return this
+  }
+
+  #descendants() {
+    const out = []
+    for (const child of this.children) out.push(child, ...child.#descendants())
+    return out
+  }
+
+  getAttribute(attr) {
+    if (attr === "name") return this.name
+    return null
+  }
+  setAttribute() {}
+  removeAttribute() {}
+
+  matches(selector) {
+    if (selector === '[data-controller~="reactive"]') {
+      const c = this.dataset.controller
+      return !!c && c.split(/\s+/).includes("reactive")
+    }
+    // #collectFiles uses input[type="file"][name] — match a named file input.
+    if (selector.includes('input[type="file"]')) {
+      return this.tag === "input" && this.type === "file" && this.name != null
+    }
+    if (selector.includes("input[name]")) {
+      return ["input", "select", "textarea"].includes(this.tag) && this.name != null
+    }
+    if (selector.includes("lexxy-editor")) return false
+    return false
+  }
+
+  closest(selector) {
+    let node = this
+    while (node) {
+      if (node.matches(selector)) return node
+      node = node.parentNode
+    }
+    return null
+  }
+
+  querySelectorAll(selector) {
+    return this.#descendants().filter((n) => n.matches(selector))
+  }
+}
+
+function fakeFile(name, body = "x") {
+  // bun has File/Blob globally; a real File is what FormData.append stores.
+  return new File([body], name, { type: "text/plain" })
+}
+
+function buildController(rootEl) {
+  const controller = new ReactiveController()
+  controller.element = rootEl
+  controller.tokenValue = "tok"
+  return controller
+}
+
+function stubEnv() {
+  globalThis.document = {
+    querySelector: (sel) => {
+      if (sel.includes("action-path")) return { content: "/reactive/actions" }
+      if (sel.includes("csrf-token")) return { content: "csrf-abc" }
+      return null
+    },
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+}
+
+test("a populated file input sends FormData (multipart), not JSON (issue #34)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const caption = new FakeNode({ tag: "input", name: "caption", value: "My receipt" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("receipt.txt")] })
+  root.append(caption, file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({ params: { action: "upload", params: "{}" }, preventDefault: () => {} })
+
+  // The body is FormData, not a JSON string.
+  expect(captured.body instanceof FormData).toBe(true)
+  // Content-Type is NOT set by us (browser adds the multipart boundary).
+  expect(captured.headers["Content-Type"]).toBeUndefined()
+  // CSRF still rides along.
+  expect(captured.headers["X-CSRF-Token"]).toBe("csrf-abc")
+
+  const fd = captured.body
+  expect(fd.get("token")).toBe("tok")
+  expect(fd.get("act")).toBe("upload")
+  // Scalar field is bracketed under params[...].
+  expect(fd.get("params[caption]")).toBe("My receipt")
+  // The file is appended as a real File under params[file].
+  const sent = fd.get("params[file]")
+  expect(sent instanceof File).toBe(true)
+  expect(sent.name).toBe("receipt.txt")
+})
+
+test("a multiple file input appends every chosen file under params[name][] (issue #34)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const pages = new FakeNode({
+    tag: "input",
+    type: "file",
+    name: "pages",
+    files: [fakeFile("page1.txt"), fakeFile("page2.txt")],
+  })
+  root.append(pages)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({ params: { action: "upload_pages", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured.body instanceof FormData).toBe(true)
+  const all = captured.body.getAll("params[pages][]")
+  expect(all.length).toBe(2)
+  expect(all.map((f) => f.name)).toEqual(["page1.txt", "page2.txt"])
+})
+
+test("an EMPTY file input (no file chosen) keeps the JSON path (issue #34)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const caption = new FakeNode({ tag: "input", name: "caption", value: "no file" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [] })
+  root.append(caption, file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({ params: { action: "upload", params: "{}" }, preventDefault: () => {} })
+
+  // No file chosen → unchanged JSON body, Content-Type application/json.
+  expect(typeof captured.body).toBe("string")
+  expect(captured.headers["Content-Type"]).toBe("application/json")
+  const parsed = JSON.parse(captured.body)
+  expect(parsed.params.caption).toBe("no file")
+  // The empty file input's fake-path value must NOT leak in as a scalar.
+  expect(parsed.params.file).toBeUndefined()
+})

--- a/spec/javascript/reactive_multipart.test.js
+++ b/spec/javascript/reactive_multipart.test.js
@@ -27,13 +27,14 @@ beforeAll(async () => {
 //   - querySelectorAll for descendant named fields
 //   - a file input exposes type === "file" and a `files` array (FileList-ish)
 class FakeNode {
-  constructor({ tag = "div", name = null, type = null, value = "", checked = false, files = null, controller = null } = {}) {
+  constructor({ tag = "div", name = null, type = null, value = "", checked = false, files = null, multiple = false, controller = null } = {}) {
     this.tag = tag.toLowerCase()
     this.name = name
     this.type = type
     this.value = value
     this.checked = checked
     this.files = files // array of File for a file input
+    this.multiple = multiple // the <input multiple> attribute (file inputs)
     this.parentNode = null
     this.children = []
     this.dataset = {}
@@ -180,6 +181,69 @@ test("a multiple file input appends every chosen file under params[name][] (issu
   const all = captured.body.getAll("params[pages][]")
   expect(all.length).toBe(2)
   expect(all.map((f) => f.name)).toEqual(["page1.txt", "page2.txt"])
+})
+
+test("a `multiple` file input with ONE file still sends params[name][] (array shape preserved)", async () => {
+  // A `<input type="file" multiple>` where the user picks exactly one file must
+  // keep its array shape so a [:file] schema coerces it (a scalar params[pages]
+  // would be array_values(file) -> nil -> DROP). The `multiple` attribute, not
+  // the count, decides the encoding.
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const pages = new FakeNode({
+    tag: "input",
+    type: "file",
+    name: "pages",
+    multiple: true,
+    files: [fakeFile("only.txt")],
+  })
+  root.append(pages)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({ params: { action: "upload_pages", params: "{}" }, preventDefault: () => {} })
+
+  const fd = captured.body
+  const all = fd.getAll("params[pages][]")
+  expect(all.length).toBe(1)
+  expect(all[0].name).toBe("only.txt")
+  // NOT sent as a scalar params[pages].
+  expect(fd.get("params[pages]")).toBeNull()
+})
+
+test("a non-multiple single file input stays scalar params[name] (unchanged)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("one.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({ params: { action: "upload", params: "{}" }, preventDefault: () => {} })
+
+  const fd = captured.body
+  expect(fd.get("params[file]").name).toBe("one.txt") // scalar, not array
+  expect(fd.getAll("params[file][]").length).toBe(0)
 })
 
 // Issue #39: an explicit NESTED-hash / ARRAY param sent on the multipart path

--- a/spec/javascript/reactive_multipart.test.js
+++ b/spec/javascript/reactive_multipart.test.js
@@ -182,6 +182,227 @@ test("a multiple file input appends every chosen file under params[name][] (issu
   expect(all.map((f) => f.name)).toEqual(["page1.txt", "page2.txt"])
 })
 
+// Issue #39: an explicit NESTED-hash / ARRAY param sent on the multipart path
+// must reach the server as bracketed/index-hash FormData fields
+// (params[invoice][date], params[items][0][qty]) — the same shape a Rails form
+// posts and the server's expand_bracket_keys/array_values already handle — NOT
+// a single JSON.stringify'd params[key]='<json>' string (which the server
+// decoded to {} / dropped). A scalar param is unchanged.
+test("a nested-object param is bracket-expanded into params[key][sub] fields (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  // A file forces the multipart path; the nested param rides as an explicit param.
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ invoice: { date: "2026-01-02", status: "open" } }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  expect(fd instanceof FormData).toBe(true)
+  // Bracketed leaves, NOT a JSON string under params[invoice].
+  expect(fd.get("params[invoice][date]")).toBe("2026-01-02")
+  expect(fd.get("params[invoice][status]")).toBe("open")
+  expect(fd.get("params[invoice]")).toBeNull() // no JSON-string leaf
+})
+
+test("an array-of-hash param uses numeric indices params[key][i][sub] (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ items: [{ qty: 2 }, { qty: 5 }] }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  // Numeric indices so the server's array_values index-hash sort rebuilds order.
+  expect(fd.get("params[items][0][qty]")).toBe("2")
+  expect(fd.get("params[items][1][qty]")).toBe("5")
+  expect(fd.get("params[items]")).toBeNull()
+})
+
+test("an array-of-scalar param uses indexed fields params[key][i] (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ tags: ["a", "b"] }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  expect(fd.get("params[tags][0]")).toBe("a")
+  expect(fd.get("params[tags][1]")).toBe("b")
+})
+
+test("a scalar param is still a single string field, and booleans/numbers mirror the JSON shape (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ caption: "hello", active: true, count: 42 }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  expect(fd.get("params[caption]")).toBe("hello")
+  expect(fd.get("params[active]")).toBe("true")
+  expect(fd.get("params[count]")).toBe("42")
+})
+
+// Issue #39 regression guards for the falsy/empty leaves. The code is correct
+// (value == null is loose-equal, so 0/false/"" fall through to String(value)),
+// but nothing pinned it — a future switch to `if (!value)` would silently turn
+// 0 into "" and false into "". These lock the behavior.
+test("falsy scalar leaves (0, false, empty string) survive the multipart path (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ count: 0, active: false, note: "" }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  expect(fd.get("params[count]")).toBe("0") // NOT "" — the falsy trap
+  expect(fd.get("params[active]")).toBe("false") // NOT ""
+  expect(fd.get("params[note]")).toBe("")
+})
+
+test("null/undefined leaves (top-level and nested) become empty fields (issue #39)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ a: null, meta: { b: null }, list: [null] }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  expect(fd.get("params[a]")).toBe("")
+  expect(fd.get("params[meta][b]")).toBe("")
+  expect(fd.get("params[list][0]")).toBe("")
+})
+
+test("an empty array/object emits NO field — the key is omitted (issue #39 divergence)", async () => {
+  const root = new FakeNode({ tag: "div", controller: "reactive" })
+  const file = new FakeNode({ tag: "input", type: "file", name: "file", files: [fakeFile("r.txt")] })
+  root.append(file)
+
+  let captured = null
+  globalThis.fetch = (path, opts) => {
+    captured = opts
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  stubEnv()
+
+  const controller = buildController(root)
+  await controller.dispatch({
+    params: { action: "upload", params: JSON.stringify({ tags: [], meta: {}, keep: "yes", nested: { gone: [], stay: "x" } }) },
+    preventDefault: () => {},
+  })
+
+  const fd = captured.body
+  // FormData can't carry []/{} — those keys are absent (action keyword default
+  // applies). This intentionally differs from the JSON path's explicit-clear [].
+  expect(fd.get("params[tags]")).toBeNull()
+  expect(fd.get("params[meta]")).toBeNull()
+  expect(fd.get("params[nested][gone]")).toBeNull()
+  // A non-empty sibling/parent still survives the omission.
+  expect(fd.get("params[keep]")).toBe("yes")
+  expect(fd.get("params[nested][stay]")).toBe("x")
+})
+
 test("an EMPTY file input (no file chosen) keeps the JSON path (issue #34)", async () => {
   const root = new FakeNode({ tag: "div", controller: "reactive" })
   const caption = new FakeNode({ tag: "input", name: "caption", value: "no file" })

--- a/spec/javascript/reactive_multipart.test.js
+++ b/spec/javascript/reactive_multipart.test.js
@@ -66,10 +66,8 @@ class FakeNode {
       const c = this.dataset.controller
       return !!c && c.split(/\s+/).includes("reactive")
     }
-    // #collectFiles uses input[type="file"][name] — match a named file input.
-    if (selector.includes('input[type="file"]')) {
-      return this.tag === "input" && this.type === "file" && this.name != null
-    }
+    // #collectFields walks input[name]/select[name]/textarea[name] — a file
+    // input matches here too (it has a name), and its files are read off it.
     if (selector.includes("input[name]")) {
       return ["input", "select", "textarea"].includes(this.tag) && this.name != null
     }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,10 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
+  # fixture_file_upload (multipart upload specs, issue #34) resolves files here.
+  config.file_fixture_path = File.expand_path("fixtures/files", __dir__)
+  config.include ActionDispatch::TestProcess::FixtureFile
+
   # In the dummy app the verifier comes from secret_key_base; align the test
   # verifier so tokens minted in specs verify against the running app.
   config.before(:suite) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,10 @@ require "rspec/rails"
 ActiveRecord::Schema.verbose = false
 load Rails.root.join("db/schema.rb")
 
+# Auto-load request-spec support modules (mirrors system_helper.rb's
+# system/support autoload). Holds the shared token_for / post_action helpers.
+Dir[File.join(__dir__, "requests/support/**/*.rb")].each { |f| require f }
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
@@ -18,6 +22,9 @@ RSpec.configure do |config|
   # fixture_file_upload (multipart upload specs, issue #34) resolves files here.
   config.file_fixture_path = File.expand_path("fixtures/files", __dir__)
   config.include ActionDispatch::TestProcess::FixtureFile
+
+  # Shared request helpers (token_for / post_action) — issue #40.
+  config.include ActionRequestHelpers, type: :request
 
   # In the dummy app the verifier comes from secret_key_base; align the test
   # verifier so tokens minted in specs verify against the running app.

--- a/spec/requests/bracket_params_spec.rb
+++ b/spec/requests/bracket_params_spec.rb
@@ -10,16 +10,6 @@ require "rails_helper"
 # ("invoice[date]" => { "invoice" => { "date" => … } }) before coercion, so a
 # nested schema matches a normal Rails form with zero field renaming.
 RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, payload:, act:, params: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   def received(response)
     json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
     JSON.parse(CGI.unescapeHTML(json))

--- a/spec/requests/file_params_spec.rb
+++ b/spec/requests/file_params_spec.rb
@@ -9,10 +9,8 @@ require "rails_helper"
 # sent to a `:file` param is DROPPED (consistent with #16 coercion rules), so the
 # method's keyword default applies — never a fabricated/coerced file.
 RSpec.describe "Reactive file/multipart params", type: :request do
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
+  # post_multipart stays LOCAL (it sends multipart FormData, not the shared JSON
+  # post_action), and reuses the shared token_for from ActionRequestHelpers.
   # A multipart POST, exactly as the client's FormData path produces it: token
   # and act are flat fields, params are bracketed (params[caption], params[file]).
   def post_multipart(klass, payload:, act:, params: {})
@@ -67,6 +65,21 @@ RSpec.describe "Reactive file/multipart params", type: :request do
       expect(response).to have_http_status(:ok)
       expect(document.reload.pages.count).to eq(2)
       expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt", "page2.txt")
+    end
+  end
+
+  describe "a :file alongside an explicit nested-hash param (issue #39)" do
+    it "carries the nested param through the multipart path next to the file" do
+      # The exact combination issue #39 flagged: a :file param AND an explicit
+      # nested-hash param in one multipart action. The nested `meta` used to be
+      # dropped; it must now survive alongside the upload.
+      post_multipart(DocumentUploadComponent, payload:, act: "upload_with_meta",
+        params: {file: upload, meta: {tag: "receipts", year: "2026"}})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.file).to be_attached         # the file still attached
+      expect(document.file.filename.to_s).to eq("receipt.txt")
+      expect(document.title).to eq("receipts 2026")       # the nested param survived
     end
   end
 

--- a/spec/requests/file_params_spec.rb
+++ b/spec/requests/file_params_spec.rb
@@ -66,6 +66,40 @@ RSpec.describe "Reactive file/multipart params", type: :request do
       expect(document.reload.pages.count).to eq(2)
       expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt", "page2.txt")
     end
+
+    it "drops non-file elements from a forged [:file] array (no DROP sentinel leaks)" do
+      # A forged/mixed pages[] payload mixes a real upload with a stray scalar.
+      # The non-file element must be dropped — never reach the action as the
+      # internal DROP sentinel (which would explode on .attach).
+      post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
+        params: {pages: [fixture_file_upload("page1.txt", "text/plain"), "not-a-file"]})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.pages.count).to eq(1) # only the real file attached
+      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt")
+    end
+
+    it "applies the keyword default when EVERY [:file] element is a non-file (all dropped)" do
+      # All-forged array: nothing coercible → the param is dropped entirely, so
+      # the action's keyword default (nil) applies — never [] or [DROP].
+      post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
+        params: {pages: ["nope", "still-not-a-file"]})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.pages.count).to eq(0) # nothing attached
+    end
+
+    it "coerces a single-element array shape from a `multiple` picker (one file)" do
+      # The server side of the client's `multiple`-with-one-file fix: the array
+      # shape (a one-element array, not a scalar upload) coerces to a [:file]
+      # array and attaches the lone file.
+      post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
+        params: {pages: [fixture_file_upload("page1.txt", "text/plain")]})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.pages.count).to eq(1)
+      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt")
+    end
   end
 
   describe "a :file alongside an explicit nested-hash param (issue #39)" do

--- a/spec/requests/file_params_spec.rb
+++ b/spec/requests/file_params_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #34: a reactive action can receive a FILE. The client sends the action
+# as multipart FormData (token + act + scalar params as fields, files appended)
+# instead of JSON; the endpoint coerces the declared `:file` param to the
+# ActionDispatch::Http::UploadedFile, passed through untouched. A non-file value
+# sent to a `:file` param is DROPPED (consistent with #16 coercion rules), so the
+# method's keyword default applies — never a fabricated/coerced file.
+RSpec.describe "Reactive file/multipart params", type: :request do
+  def token_for(klass, payload)
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  # A multipart POST, exactly as the client's FormData path produces it: token
+  # and act are flat fields, params are bracketed (params[caption], params[file]).
+  def post_multipart(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:},
+      headers: {"Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  let!(:document) { Document.create!(title: "untitled") }
+  let(:payload) { {"gid" => document.to_gid.to_s} }
+  let(:upload) { fixture_file_upload("receipt.txt", "text/plain") }
+
+  describe "single file (:file)" do
+    it "coerces the upload to an UploadedFile and the action attaches it" do
+      post_multipart(DocumentUploadComponent, payload:, act: "upload",
+        params: {file: upload, caption: "My receipt"})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.file).to be_attached
+      expect(document.file.filename.to_s).to eq("receipt.txt")
+      expect(document.title).to eq("My receipt") # scalar param rode alongside
+    end
+
+    it "drops a non-file value sent to a :file param (no fake file reaches the action)" do
+      # A forged/malformed payload puts a plain string where a file is declared.
+      post_multipart(DocumentUploadComponent, payload:, act: "upload",
+        params: {file: "not-a-file", caption: "still here"})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.file).not_to be_attached # the :file param was dropped
+      expect(document.title).to eq("still here")      # the scalar still coerced
+    end
+
+    it "passes through with no file when the input is empty (keyword default applies)" do
+      post_multipart(DocumentUploadComponent, payload:, act: "upload",
+        params: {caption: "no file this time"})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.file).not_to be_attached
+      expect(document.title).to eq("no file this time")
+    end
+  end
+
+  describe "multiple files ([:file])" do
+    it "coerces an array of uploads and attaches them all" do
+      pages = [fixture_file_upload("page1.txt", "text/plain"),
+        fixture_file_upload("page2.txt", "text/plain")]
+
+      post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
+        params: {pages:})
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.pages.count).to eq(2)
+      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt", "page2.txt")
+    end
+  end
+
+  describe "JSON path is unaffected (back-compat)" do
+    it "still serves a JSON-bodied action with no file param" do
+      post "/reactive/actions",
+        params: {token: token_for(DocumentUploadComponent, payload), act: "upload", params: {caption: "json only"}}.to_json,
+        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+
+      expect(response).to have_http_status(:ok)
+      expect(document.reload.title).to eq("json only")
+      expect(document.file).not_to be_attached
+    end
+  end
+end

--- a/spec/requests/multipart_nested_params_spec.rb
+++ b/spec/requests/multipart_nested_params_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #39: an explicit NESTED-hash / ARRAY param sent on the MULTIPART path
+# was silently dropped. The JSON (no-file) path handled the same nested param
+# correctly, so the two encodings were asymmetric.
+#
+# The fix is client-side (PR #38, issue #39): #buildFormData bracket-expands a
+# non-scalar param into params[key][sub] / params[key][index][...] FormData
+# fields instead of JSON.stringify'ing it into one params[key]='<json>' string.
+# That is the SAME bracketed/index-hash shape a Rails form posts and the SAME
+# shape the server's expand_bracket_keys / array_values already handle — so the
+# server is UNCHANGED and the JSON and multipart paths now coerce identically.
+#
+# These specs post that bracketed multipart shape end-to-end and assert it
+# coerces correctly (the contract the client fix relies on). nested_params_spec
+# and bracket_params_spec cover the same shapes over application/json; this is
+# the missing multipart coverage.
+RSpec.describe "Multipart nested/array param coercion (issue #39)", type: :request do
+  # A real multipart POST. Rack::Test flattens a nested hash into the bracketed
+  # field names the fixed client emits (params[invoice][date], params[items][0]
+  # [qty]) — the multipart encoding, not a JSON body.
+  def post_multipart(klass, payload:, act:, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:},
+      headers: {"Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  # Pull the reflected coerced params back out of the rendered <pre> (Phlex
+  # auto-escapes the JSON text, so unescape before parsing).
+  def received(response)
+    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    JSON.parse(CGI.unescapeHTML(json))
+  end
+
+  let(:payload) { {"s" => {"received" => nil}} }
+
+  it "coerces a nested-object param sent as multipart (the #39 bug case)" do
+    post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {invoice: {date: "2026-01-02", status: "open"}})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
+  end
+
+  it "coerces nested types after multipart bracket expansion (float stays typed)" do
+    post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {invoice: {date: "2026-01-02", total: "9.99"}})
+
+    expect(received(response)["invoice"]["total"]).to eq(9.99)
+  end
+
+  it "coerces an array-of-scalar param sent as multipart ([:integer])" do
+    post_multipart(NestedParamsComponent, payload:, act: "save",
+      params: {bank_account_ids: ["1", "2", "3"]})
+
+    expect(response).to have_http_status(:ok)
+    expect(received(response)["bank_account_ids"]).to eq([1, 2, 3])
+  end
+
+  it "coerces an array-of-hash param sent as multipart (Rails nested attributes)" do
+    post_multipart(NestedParamsComponent, payload:, act: "save",
+      params: {
+        invoice_items_attributes: [
+          {id: "10", quantity: "2", price: "5", _destroy: "false"},
+          {id: "11", quantity: "3", price: "6", _destroy: "true"}
+        ]
+      })
+
+    items = received(response)["invoice_items_attributes"]
+    expect(items.map { |i| i["id"] }).to eq([10, 11])
+    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
+    expect(items.map { |i| i["_destroy"] }).to eq([false, true])
+  end
+
+  it "drops undeclared nested keys on the multipart path too (no mass assignment)" do
+    post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {invoice: {date: "2026-01-02", admin: "true"}})
+
+    expect(received(response)["invoice"].keys).to contain_exactly("date")
+  end
+
+  it "still coerces a flat scalar alongside a nested param over multipart" do
+    post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
+      params: {date: "2026-06-27", invoice: {date: "2026-01-02"}})
+
+    parsed = received(response)
+    expect(parsed["date"]).to eq("2026-06-27")
+    expect(parsed["invoice"]["date"]).to eq("2026-01-02")
+  end
+end

--- a/spec/requests/multipart_nested_params_spec.rb
+++ b/spec/requests/multipart_nested_params_spec.rb
@@ -18,12 +18,18 @@ require "rails_helper"
 # and bracket_params_spec cover the same shapes over application/json; this is
 # the missing multipart coverage.
 RSpec.describe "Multipart nested/array param coercion (issue #39)", type: :request do
-  # A real multipart POST. Rack::Test flattens a nested hash into the bracketed
-  # field names the fixed client emits (params[invoice][date], params[items][0]
-  # [qty]) — the multipart encoding, not a JSON body.
+  # A real multipart POST. Rack::Test only switches to multipart/form-data when
+  # an UploadedFile is present — a nested-hash-only body posts as
+  # application/x-www-form-urlencoded, which would NOT exercise the multipart
+  # parser this spec is about. So we attach a throwaway upload under an
+  # UNDECLARED key (dropped by the schema — no mass assignment) purely to force
+  # the multipart encoding. Rack::Test then flattens the nested hash into the
+  # bracketed field names the fixed client emits (params[invoice][date],
+  # params[items][0][qty]) and the genuine multipart parser reconstructs them.
   def post_multipart(klass, payload:, act:, params: {})
+    probe = fixture_file_upload("receipt.txt", "text/plain")
     post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:},
+      params: {token: token_for(klass, payload), act:, params:, _multipart_probe: probe},
       headers: {"Accept" => "text/vnd.turbo-stream.html"}
   end
 

--- a/spec/requests/nested_attributes_helper_spec.rb
+++ b/spec/requests/nested_attributes_helper_spec.rb
@@ -7,16 +7,6 @@ require "rails_helper"
 # accepts_nested_attributes_for editor doesn't re-derive the *_attributes + id
 # preservation boilerplate by hand (and risk a duplicate has_one build).
 RSpec.describe "accepts_nested_attributes_for helper (issue #24)", type: :request do
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, payload:, act:, params: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   let(:account) { Account.create!(name: "Acme") }
   let(:component) { AddressEditorComponent.new(account:) }
 

--- a/spec/requests/nested_params_spec.rb
+++ b/spec/requests/nested_params_spec.rb
@@ -6,16 +6,6 @@ require "rails_helper"
 # just scalars, so a reactive action can receive Rails-style nested attributes
 # (invoice[invoice_items_attributes][i][...]) or array params (ids[]) in one call.
 RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, payload:, act:, params: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   # Pull the reflected coerced params back out of the rendered <pre>. Phlex
   # auto-escapes the JSON text, so unescape before parsing.
   def received(response)

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -6,17 +6,6 @@ require "turbo/broadcastable/test_helper"
 RSpec.describe "Reactive actions", type: :request do
   include Turbo::Broadcastable::TestHelper
 
-  # Mint a token exactly as a component would, using the app's verifier.
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, payload:, act:, params: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   describe "state-backed component (CounterComponent)" do
     it "runs an action and returns an auto-targeted turbo-stream" do
       post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "increment")

--- a/spec/requests/reactive_collection_spec.rb
+++ b/spec/requests/reactive_collection_spec.rb
@@ -6,16 +6,6 @@ require "rails_helper"
 # helper (issue #35): an action calls reply.append/reply.remove on a declared
 # collection, and the endpoint renders the row + count + empty-state streams.
 RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
-  def token_for(klass, payload = {})
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, act:, params: {}, payload: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   let(:klass) { NotificationsListComponent }
 
   describe "add (reply.append)" do

--- a/spec/requests/reactive_input_spec.rb
+++ b/spec/requests/reactive_input_spec.rb
@@ -7,16 +7,6 @@ require "rails_helper"
 # `name: "value"` magic string. We assert BOTH the rendered markup carries the
 # right name AND the action actually receives the bound param end-to-end.
 RSpec.describe "reactive_input / reactive_select binding (issue #23)", type: :request do
-  def token_for(klass, payload)
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
-  end
-
-  def post_action(klass, payload:, act:, params: {})
-    post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
-  end
-
   let!(:todo) { Todo.create!(title: "before", done: false) }
   let(:payload) { {"gid" => todo.to_gid.to_s, "s" => {"attribute" => "title"}} }
 

--- a/spec/requests/support/action_request_helpers.rb
+++ b/spec/requests/support/action_request_helpers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Shared helpers for the request suite (issue #40). Every request spec mints a
+# signed identity token and POSTs it to the action endpoint exactly as a
+# component would. These two helpers were copy-pasted across the suite; they now
+# live here and are mixed into `type: :request` examples via rails_helper.rb.
+#
+# `post_multipart` (the #34 file path) stays LOCAL to file_params_spec.rb — it
+# sends multipart FormData, not a JSON body, so it doesn't belong in this shared
+# JSON helper.
+module ActionRequestHelpers
+  # Mint a token exactly as a component would, using the app's verifier.
+  def token_for(klass, payload = {})
+    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+  end
+
+  # POST a reactive action as a JSON body (token + act + params), the encoding
+  # the client uses when no file input is present.
+  def post_action(klass, act:, payload: {}, params: {})
+    post "/reactive/actions",
+      params: {token: token_for(klass, payload), act:, params:}.to_json,
+      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+  end
+end

--- a/spec/system/file_upload_spec.rb
+++ b/spec/system/file_upload_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #34: attaching a file is a first-class reactive action. The component's
+# form carries a <input type="file">; when the user submits, the reactive
+# controller detects the chosen file and sends the action as multipart FormData
+# (not JSON), so the file reaches the action and ActiveStorage attaches it. The
+# re-render lands in place — no full-page reload, no bespoke upload controller.
+#
+# This is the end-to-end proof of the whole multipart path under a REAL browser
+# and a REAL server (Puma default; Falcon via CAPYBARA_SERVER=falcon). The wire
+# encoding (FormData vs JSON) is unit-tested in spec/javascript; the server
+# coercion in spec/requests — this proves they meet in the browser.
+RSpec.describe "Reactive file upload (issue #34)", type: :system do
+  it "attaches an uploaded file via a reactive action without a full-page reload" do
+    document = Document.create!(title: "untitled")
+    visit "/document_upload/#{document.id}"
+    page.execute_script("window.__noReload = 'alive'")
+
+    # No attachment yet.
+    expect(page).to have_css("[data-testid='filename']", text: "")
+
+    attach_file("file", Rails.root.join("..", "fixtures", "files", "receipt.txt").to_s, make_visible: true)
+    fill_in("caption", with: "My receipt")
+    find("[data-testid='save']").click
+
+    # The reactive re-render lands in place: the filename + caption appear
+    # (waiting matchers = the async morph barrier), proving the multipart action
+    # ran and the attachment + scalar param both landed.
+    expect(page).to have_css("[data-testid='filename']", text: "receipt.txt")
+    expect(page).to have_css("[data-testid='title']", text: "My receipt")
+
+    # The attachment actually persisted server-side.
+    expect(document.reload.file).to be_attached
+    expect(document.file.filename.to_s).to eq("receipt.txt")
+
+    # No full-page reload happened — the action was a reactive round trip, not a
+    # native multipart form POST that navigates.
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

A reactive action can now accept an **uploaded file**. Declare `params: { file: :file }` (or `[:file]` for multiple), and attaching a document/receipt/image to the bound record stays a reactive action — no dropping out to a bespoke controller + upload Stimulus controller.

When the reactive root holds a populated `<input type="file">`, the client sends the action as **multipart `FormData`** instead of JSON — `token` + `act` as fields, scalar params as fields, **any nested/array params bracket-expanded** (so they coerce identically to the JSON path — see #39 below), and the file(s) appended — and the endpoint coerces `:file` to the `ActionDispatch::Http::UploadedFile`, passed through untouched. A non-file value sent to a `:file` param is **dropped** (the keyword default applies), consistent with the #16 coercion rules.

Token threading and the re-render/morph are **identical**; only the request encoding changes when a file is present.

```ruby
reactive_record :document
action :upload, params: { file: :file, caption: :string } # single (has_one_attached)
action :upload_pages, params: { pages: [:file] }           # multiple (has_many_attached)

def upload(file: nil, caption: nil)
  @document.file.attach(file) if file
  @document.update!(title: caption) if caption.present?
end

def view_template
  form(**on(:upload, event: "submit")) do
    input(type: "file", name: "file")
    input(name: "caption")
    button(type: "submit") { "Upload" }
  end
end
```

This PR also folds in two follow-ups found during the `/simplify` pass on #34, so they ship together rather than as separate review cycles.

## #34 — File / multipart params

| Layer | Change |
|---|---|
| Endpoint | `:file` / `[:file]` coercion in `ActionsController#coerce`. Duck-types on the UploadedFile interface (`original_filename` + `read`) so Rack::Test, ActionDispatch, and Falcon multipart bodies all qualify; drops anything else. No allocation added on the existing-action path. |
| Client | `#perform` sends `FormData` when a populated file input is owned by the root. `Content-Type` is omitted (browser sets the multipart boundary); CSRF + connection-id headers still ride along. File inputs are skipped in `#collectFields` (their `.value` is the useless fakepath) and gathered in the same walk; a `multiple` picker / shared name → `params[name][]`. |
| Dummy app | ActiveStorage wired in (disk service under `tmp/`), a `Document` model (`has_one_attached`/`has_many_attached`), an upload component fixture + demo route. |
| Docs | README param-schema section gains `:file`; `docs/security.md` notes multipart runs the same signature + default-deny + schema gates; CHANGELOG `Added`. |

## #39 — Multipart path silently dropped an explicit nested-hash / array param

When an action declared a `:file` param **alongside** an explicit nested (hash/array) param, the nested param was dropped on the multipart path while the JSON path handled it correctly — the two encodings were asymmetric.

**Root cause:** the client `JSON.stringify`'d a non-scalar param into one `params[key]='<json>'` field; the server received that as an un-decodable `String` leaf in a Hash/Array schema slot and dropped it (nested hash → `{}`, array → key removed).

**Fix (client-side):** `#buildFormData` now recurses via a new `#appendField` that bracket-expands a nested object/array into `params[key][sub]` / `params[key][index][...]` fields (arrays use numeric indices so an array-of-hash round-trips through the server's index-hash sort). That is the **same Rails-form shape** the server's `expand_bracket_keys` / `array_values` already parse, so a JSON body and a multipart body now coerce identically. `#scalarField` is folded in and removed. **The server is unchanged** — the correctness-critical #16/#21/#24 coercion algorithm is not touched (chosen over a server-side JSON-decode after an adversarial design review: same result, smaller blast radius, symmetric wire shape).

One intentional divergence: `FormData` can't carry an empty `[]`/`{}`, so on the multipart path an empty array/object param is **omitted** (the keyword default applies) rather than arriving as an explicit empty collection the way it does over JSON. Documented in the README upload section + CHANGELOG.

## #40 — Extract duplicated request-spec helpers

`token_for` (7 files) and the JSON `post_action` (6 files, byte-identical) are extracted into `spec/requests/support/action_request_helpers.rb`, auto-loaded + included for `type: :request` via `rails_helper.rb` (mirroring the existing `system/support` autoload). `post_multipart` stays local to the multipart specs (it sends `FormData`, not the shared JSON body) and reuses the included `token_for`. Test-infra only, no runtime impact.

## Security

Multipart runs through the **same gates** as JSON: signed identity verified, action default-deny, params schema-coerced. A `:file` param accepts only an actual upload and drops any non-file value — a forged string can't fabricate a file. The #39 fix is client-only and changes no security gate; the bracketed shape is still schema-coerced (undeclared keys dropped). Apply your own attachment rules (content-type/size allow-lists, `authorize!`) in the action exactly as in a plain controller.

## Test plan

- **Request** (`spec/requests/file_params_spec.rb`): single + multiple coercion attach correctly; a non-file value to a `:file` param is dropped; an empty input applies the keyword default; **a `:file` alongside an explicit nested-hash param — both survive (#39)**; the JSON path is unaffected.
- **Request** (`spec/requests/multipart_nested_params_spec.rb`, new for #39): nested object, array-of-scalar, array-of-hash, deep-nested, undeclared-key drop, and a scalar+nested mix all coerce correctly over a real multipart body.
- **Client unit** (`spec/javascript/reactive_multipart.test.js`): a populated file input sends `FormData` (not JSON); `#appendField` emits bracketed/indexed fields (not `JSON.stringify`); scalar/boolean/number mirror the JSON shape; **falsy leaves (`0`/`false`/`""`) survive, `null`/nested-null become empty fields, an empty `[]`/`{}` omits the key (#39)**; a `multiple` input appends every file under `params[name][]`; an empty file input keeps the JSON path.
- **System** (`spec/system/file_upload_spec.rb`): real-browser upload — attach a file, submit, the component morphs in place, the attachment persists, no full-page reload. Passes under **Puma AND Falcon**.

## Verification

- [x] `bundle exec standardrb` — clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 203 examples, 0 failures
- [x] `bun test spec/javascript` — 29 pass
- [x] `bundle exec rake spec:system_servers` — 22 examples each under puma + falcon
- [x] Vendored client re-synced (byte-identical)
- [x] Backwards compatible — existing components unchanged; JSON path untouched
- [x] pgbus optionality preserved (no transport/broadcast code touched)
- [x] Server unchanged for #39 — signed identity / default-deny / schema coercion intact

Closes #34
Closes #39
Closes #40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reactive actions now support `:file` and `[:file]` params for single and multiple uploads.
  * Added a document upload demo page to showcase caption, multi-page uploads, and metadata.
* **Bug Fixes**
  * Multipart encoding now preserves nested hashes/arrays alongside file uploads, matching JSON behavior.
  * Non-file `:file` values are ignored (so keyword defaults apply), and empty file inputs keep the JSON path.
* **Documentation**
  * Updated API and security guidance for file-param multipart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->