### PR TITLE
chore: migrate StandardRB → RuboCop (all new cops) + raise Ruby floor to 3.4

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -84,7 +84,7 @@ capability gate, the security model) that you must hold in your head.
 - [ ] Security model preserved (signed identity, default-deny, params, authz)
 - [ ] A dummy example component exercises the feature
 - [ ] Tests cover every touched layer
-- [ ] `bundle exec standardrb` + `bundle exec rspec` pass
+- [ ] `bundle exec rubocop` + `bundle exec rspec` pass
 
 ## Handoff
 

--- a/.claude/commands/github-review-comments.md
+++ b/.claude/commands/github-review-comments.md
@@ -115,7 +115,7 @@ For all comments you've decided to accept:
    ```
 3. **Run validators**:
    ```bash
-   bundle exec standardrb <changed_files>
+   bundle exec rubocop <changed_files>
    ```
 4. **Commit** all fixes together with a clear message:
    ```bash

--- a/.claude/commands/github-review-failures.md
+++ b/.claude/commands/github-review-failures.md
@@ -43,7 +43,7 @@ Categorise each failing check:
 
 | Check Type | Examples | How to Get Logs |
 |------------|----------|----------------|
-| Lint (standardrb) + gem build | `Lint` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
+| Lint (rubocop) + gem build | `Lint` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
 | Unit + request specs | `Ruby 3.2` / `3.3` / `3.4` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
 | Browser system specs (Playwright) | `System (browser)` | `gh run view <RUN_ID> --job=<JOB_ID> --log-failed` |
 
@@ -79,9 +79,9 @@ For each failure, determine the root cause:
 ### Lint Failures
 
 Look for:
-- Standard offenses: file path, line number, cop name, message
+- RuboCop offenses: file path, line number, cop name, message
 
-**Key**: Standard failures can often be auto-fixed with `bundle exec standardrb --fix <file>`.
+**Key**: RuboCop failures can often be auto-fixed with `bundle exec rubocop -A <file>`.
 
 ### Spec Failures
 
@@ -114,8 +114,8 @@ For each diagnosed failure:
 3. **Verify locally** before committing:
 
 ```bash
-# For standardrb failures
-bundle exec standardrb <changed_files>
+# For rubocop failures
+bundle exec rubocop <changed_files>
 
 # For spec failures
 bundle exec rspec <failing_spec_files>
@@ -165,7 +165,7 @@ If you can identify that certain failures will persist for environmental reasons
 ## Important Notes
 
 - **Read before fixing** -- always read the actual failing code before attempting a fix
-- **Fix the root cause** -- don't add `# standard:disable` to bypass lint; fix the actual issue (a targeted `# rubocop:disable` is acceptable only when Standard is demonstrably wrong, e.g. `save_screenshot` flagged as a debugger)
+- **Fix the root cause** -- don't add `# rubocop:disable` to bypass lint; fix the actual issue (a targeted `# rubocop:disable` is acceptable only when RuboCop is demonstrably wrong, e.g. `save_screenshot` flagged as a debugger)
 - **Don't fix unrelated failures** -- if a spec was already failing on main, note it but don't fix it in this PR
 - **CI environment differences** -- system specs run Playwright (cached browsers) under a server matrix: Puma (default) AND Falcon (`CAPYBARA_SERVER=falcon`). A failure on only one server is a transport-specific bug, not flakiness. pgbus-dependent specs run only on Ruby >= 3.3 (pgbus's floor) and need PostgreSQL; on 3.2 they are skipped by design.
 - **Flaky tests** -- if a test passes locally but fails in CI, note it as potentially flaky rather than adding workarounds. Browser specs that assert a value right after a click (racing the morph) are a common false-flake — fix them to use a waiting matcher.

--- a/.claude/commands/github-review-pr.md
+++ b/.claude/commands/github-review-pr.md
@@ -56,7 +56,7 @@ Follow that command's full process — phases 1–6 of the failures runbook. The
 2. Fetch failure logs.
 3. Diagnose root cause for each.
 4. Fix locally — lint first (fast, deterministic), then specs, then build issues.
-5. Verify locally before commit (`bundle exec rspec <files>`, `bundle exec standardrb`).
+5. Verify locally before commit (`bundle exec rspec <files>`, `bundle exec rubocop`).
 6. Commit + push + report which checks are now running.
 
 ### Phase A exit criteria
@@ -79,7 +79,7 @@ The slash command is at `.claude/commands/github-review-comments.md`. Its workfl
 
 1. Fetch all unresolved review threads via the GitHub GraphQL API.
 2. Read and categorise each comment (valid fix / invalid suggestion / unclear).
-3. Implement accepted fixes; verify locally (specs, validators, standardrb).
+3. Implement accepted fixes; verify locally (specs, validators, rubocop).
 4. Commit all fixes together with a clear message; push.
 5. Reply to every thread with the commit SHA (for accepted fixes) or technical reasoning (for rejections).
 6. Resolve each thread via the GraphQL `resolveReviewThread` mutation.

--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -115,7 +115,7 @@ Once green, refactor while keeping tests passing.
 ### 4.4: Validate
 
 ```bash
-bundle exec standardrb
+bundle exec rubocop
 ```
 
 ### 4.5: Repeat
@@ -174,7 +174,7 @@ The best fix is usually NOT where the error surfaced:
 **ALL of these must pass before committing:**
 
 ```bash
-bundle exec standardrb
+bundle exec rubocop
 bundle exec rspec spec/phlex spec/requests
 # client-touching changes: also run the browser suite
 bundle exec rspec spec/system    # Puma (default); CAPYBARA_SERVER=falcon for the async server
@@ -207,7 +207,7 @@ feat(scope): brief description
 - spec 2: validates the pgbus-absent fallback
 
 ## Verification
-- [x] bundle exec standardrb passes
+- [x] bundle exec rubocop passes
 - [x] bundle exec rspec passes
 EOF
 )"
@@ -231,7 +231,7 @@ backslash in a GitHub comment, do not type one in the heredoc.
 
 - [ ] All acceptance criteria met
 - [ ] Tests written BEFORE implementation
-- [ ] `bundle exec standardrb` passes
+- [ ] `bundle exec rubocop` passes
 - [ ] `bundle exec rspec` passes (browser suite too, if the client changed)
 - [ ] Backwards compatible — existing components unchanged
 - [ ] pgbus optionality preserved (works with pgbus AND on Action Cable)

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -66,6 +66,6 @@ mcp__github__pull_request_read
   method: "get_files"  -> File list
   method: "get_status" -> CI status
 
-bundle exec standardrb   -> Style checks
+bundle exec rubocop      -> Style checks
 bundle exec rspec        -> Tests
 ```

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -108,7 +108,7 @@ reactive_record :account
 ## Tools
 
 ```bash
-bundle exec standardrb
+bundle exec rubocop
 bundle audit check --update      # dependency CVEs (if bundler-audit is present)
 grep -rn "update!(params\|\.permit!\|MessageVerifier\|authorize" lib app
 ```

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -80,7 +80,7 @@ Improve while staying green: extract methods, improve names, reduce duplication.
 
 ```bash
 bundle exec rspec spec/phlex spec/requests
-bundle exec standardrb
+bundle exec rubocop
 ```
 
 ## Coverage Expectations
@@ -114,4 +114,4 @@ by `data-testid` with waiting matchers; mock the verifier in unit specs.
 - [ ] Coverage meets the bar (100% on security + the gate)
 - [ ] Edge + error paths covered
 - [ ] pgbus-present AND pgbus-absent both tested
-- [ ] `bundle exec standardrb` passes
+- [ ] `bundle exec rubocop` passes

--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -12,8 +12,8 @@
 
 ## Ruby Style
 
-Lint with **Standard** (`bundle exec standardrb`). Standard owns formatting —
-don't hand-fight it; run `standardrb --fix` and review.
+Lint with **RuboCop** (`bundle exec rubocop`). RuboCop owns formatting —
+don't hand-fight it; run `rubocop -A` and review.
 
 ### Classes & Methods
 
@@ -106,4 +106,4 @@ Before marking work complete:
 - [ ] Components self-target via `#id` — no hand-picked targets
 - [ ] Mutating actions authorize; inputs declare a param schema
 - [ ] pgbus features are capability-gated and degrade gracefully
-- [ ] `bundle exec standardrb` passes
+- [ ] `bundle exec rubocop` passes

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -53,7 +53,7 @@ to RubyGems via trusted publishing (OIDC + Sigstore). Never `gem push` by hand.
 
 Run before EVERY commit:
 ```bash
-bundle exec standardrb                       # Style
+bundle exec rubocop                          # Style
 bundle exec rspec spec/phlex spec/requests   # Fast suite
 # (browser suite — spec/system — runs in CI; run locally before a PR touching the client)
 ```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -69,4 +69,4 @@ end
 - [ ] Browser suite green for client-touching changes
 - [ ] Edge cases: tampered token, undeclared action, missing record, unauthorized
 - [ ] pgbus-present AND pgbus-absent paths both covered for any pgbus feature
-- [ ] `bundle exec standardrb` passes
+- [ ] `bundle exec rubocop` passes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           ruby-version: "4.0"
           bundler-cache: true
-      - name: Standard
-        run: bundle exec standardrb
+      - name: RuboCop
+        run: bundle exec rubocop
       - name: Verify gem builds
         run: gem build phlex-reactive.gemspec --strict
 
@@ -34,8 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.2"
-          - "3.3"
           - "3.4"
           - "4.0"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - "3.3"
           - "3.4"
           - "4.0"
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,220 @@
+plugins:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 3.4
+  DisabledByDefault: false
+  DisplayCopNames: true
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - "**/node_modules/**/*"
+    - "**/tmp/**/*"
+    - "**/vendor/**/*"
+    - "spec/dummy/db/schema.rb"
+    - "spec/dummy/bin/**/*"
+    - "bin/**/*"
+
+#===============
+#=== LAYOUT ===
+#===============
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/LineLength:
+  Max: 125
+  AllowHeredoc: true
+  AllowURI: true
+  AllowedPatterns:
+    - '\A\s*#'
+  Exclude:
+    # Phlex components read top-to-bottom as markup; long attribute lines
+    # (data:/class:/on(...)) are clearer on one line than wrapped.
+    - spec/dummy/app/components/**/*.rb
+    # The gemspec summary/description are fixed declarative strings — wrapping
+    # them would only hurt readability.
+    - "*.gemspec"
+
+#===============
+#=== LINT ===
+#===============
+
+Lint/MissingSuper:
+  Exclude:
+    # Phlex components override #initialize without calling super (Phlex's base
+    # #initialize is a no-op); the dummy components and inline spec components
+    # follow that idiom.
+    - spec/**/*.rb
+
+Lint/UnusedMethodArgument:
+  Exclude:
+    # Dummy components declare action params (matching the param schema /
+    # name-binding under test) that an individual action may not persist.
+    - spec/dummy/app/components/**/*.rb
+
+#===============
+#=== METRICS ===
+#===============
+
+Metrics:
+  Enabled: false
+
+#===============
+#===  NAMING ===
+#===============
+
+Naming/BlockForwarding:
+  Enabled: false
+
+Naming/FileName:
+  Exclude:
+    # Conventional gem entrypoint: `require "phlex-reactive"` loads this file,
+    # so it must be named with the hyphenated gem name, not snake_case.
+    - lib/phlex-reactive.rb
+
+Naming/MethodParameterName:
+  AllowedNames:
+    - id
+    - c
+    - n
+    - s
+    - p
+    - to
+
+Naming/VariableNumber:
+  Exclude:
+    - spec/**/*.rb
+
+#=============
+#=== RSpec ===
+#=============
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
+
+RSpec/ContextWording:
+  Prefixes:
+    - and
+    - as
+    - for
+    - if
+    - in
+    - "on"
+    - or
+    - unless
+    - when
+    - with
+    - without
+
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Exclude:
+    - spec/system/**/*
+
+RSpec/DescribeClass:
+  Exclude:
+    - spec/requests/**/*
+    - spec/system/**/*
+    # Behavior specs whose subject is a cross-cutting concern (eager loading,
+    # vendored-client drift, morph/token/view-context behavior), not a single
+    # class — a string subject reads clearer than a forced constant.
+    - spec/phlex/eager_load_spec.rb
+    - spec/phlex/vendored_controller_sync_spec.rb
+    - spec/phlex/reactive/streamable_morph_spec.rb
+    - spec/phlex/reactive/streamable_token_spec.rb
+    - spec/phlex/reactive/streamable_view_context_spec.rb
+
+# The `describe Klass, "label"` form uses the second arg as a context label
+# (e.g. `describe Component, "reactive_collection"`), not a method name.
+RSpec/DescribeMethod:
+  Enabled: false
+
+# Group-level local variables (file paths, computed fixtures) referenced inside
+# examples are a deliberate, readable setup here — not leaked mutable state.
+RSpec/LeakyLocalVariable:
+  Enabled: false
+
+#=============
+#=== RAKE ===
+#=============
+
+# The release task defines small formatting helpers (info/success/skip/header)
+# and the bench tasks define inline helpers — intentional, task-local sugar.
+Rake/MethodDefinitionInTask:
+  Enabled: false
+
+#=============
+#=== STYLE ===
+#=============
+
+# Modern Ruby idioms — the whole point of moving off Standard: teach and enforce
+# the newer ways of writing Ruby.
+
+# Ruby 3.4 implicit single block parameter: enforce `map { it.foo }` over
+# `map { |x| x.foo }`. Safe here because the gem floor is Ruby 3.4. `always`
+# (not `allow_single_line`, which permits but never enforces) is what actually
+# converts the call sites. The gemspec and Rakefile are excluded: their
+# `do |spec| … end` / `do |t| … end` config-builder blocks read better named,
+# and they contain NESTED blocks where blanket `it` would collapse two distinct
+# parameters into one (a silent correctness bug in the cop's autocorrect).
+Style/ItBlockParameter:
+  EnforcedStyle: always
+  Exclude:
+    - "*.gemspec"
+    - Rakefile
+
+Style/Documentation:
+  Enabled: false
+
+# Benchmark scripts print fixed-width report columns with positional `%s`/`%d`
+# tokens — annotated tokens would only add noise to throwaway output strings.
+Style/FormatStringToken:
+  Exclude:
+    - benchmark/**/*.rb
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: no_comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
 plugins:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-thread_safety
 
 AllCops:
   TargetRubyVersion: 3.4
@@ -13,6 +15,8 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/tmp/**/*"
     - "**/vendor/**/*"
+    # The published Jekyll docs site has its own Gemfile and is not gem code.
+    - "docs/**/*"
     - "spec/dummy/db/schema.rb"
     - "spec/dummy/bin/**/*"
     - "bin/**/*"
@@ -63,6 +67,44 @@ Lint/UnusedMethodArgument:
     # Dummy components declare action params (matching the param schema /
     # name-binding under test) that an individual action may not persist.
     - spec/dummy/app/components/**/*.rb
+
+#====================
+#=== THREAD SAFETY ===
+#====================
+
+# rubocop-thread_safety stays ON as a tripwire for genuinely unsafe shared
+# mutable state on the request/broadcast path. These two cops are scoped OFF
+# only where the flagged class-level @ivars / module attrs are deliberate,
+# audited patterns (verified against the documented invariants):
+#   * lib/phlex/reactive.rb — module-level CONFIG (renderer/verifier/
+#     base_controller_name/action_path/flash_target/authorization_errors), set
+#     once at boot in an initializer and read-only thereafter. The lazy `||=`
+#     defaults are idempotent (a first-call race assigns an equivalent constant
+#     value); action_path + base_controller are warmed at boot/class-load.
+#   * lib/phlex/reactive/component.rb — class-definition-time DSL registries
+#     (@reactive_actions/@reactive_state_keys/@reactive_collections/
+#     @reactive_record_key), written by the action/reactive_* macros in a class
+#     body and inherited from the superclass — the standard Ruby class-macro
+#     pattern, not request-path state.
+#   * lib/phlex/reactive/streamable.rb — the per-thread view-context cache's
+#     integer generation counter; the actual context is thread-keyed, and the
+#     bump is a benign `@n = n + 1` invalidation (reset on Rails reload).
+# Anywhere else (e.g. the controller request path) these cops still fire.
+ThreadSafety/ClassInstanceVariable:
+  Exclude:
+    - lib/phlex/reactive.rb
+    - lib/phlex/reactive/component.rb
+    - lib/phlex/reactive/streamable.rb
+
+ThreadSafety/ClassAndModuleAttributes:
+  Exclude:
+    - lib/phlex/reactive.rb
+
+ThreadSafety/NewThread:
+  Exclude:
+    # The view-context thread-safety spec MUST spawn real threads to prove
+    # concurrent renders don't interleave buffers.
+    - spec/**/*.rb
 
 #===============
 #=== METRICS ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aware relaxations (line length, `Lint/MissingSuper`, unused action params)
   are scoped to `spec/dummy/app/components/**`. `bundle exec standardrb` is now
   `bundle exec rubocop`; `rake`'s default runs `spec + rubocop`.
+- **Added `rubocop-capybara` and `rubocop-thread_safety`.** Capybara lints the
+  browser specs (clean today — the suite already uses waiting matchers).
+  thread_safety stays on as a tripwire for unsafe shared mutable state on the
+  request/broadcast path; its `ClassInstanceVariable` /
+  `ClassAndModuleAttributes` cops are scoped off only in the three files whose
+  flagged class-level state is deliberate and audited — module-level config
+  (`lib/phlex/reactive.rb`, set once at boot), class-definition-time DSL
+  registries (`component.rb`), and the per-thread view-context cache's integer
+  generation counter (`streamable.rb`). An adversarial audit confirmed none are
+  request-path hazards; the lazy `||=` config defaults are idempotent. (A
+  follow-up may warm `verifier`/`renderer` at boot to remove even the
+  benign-by-idempotency first-call race — out of scope for this lint change.)
 
 ### Removed
 
 - **Dropped the `standard` development dependency** in favor of `rubocop`,
-  `rubocop-performance`, `rubocop-rake`, and `rubocop-rspec`.
+  `rubocop-capybara`, `rubocop-performance`, `rubocop-rake`, `rubocop-rspec`,
+  and `rubocop-thread_safety`.
 
 ### BREAKING
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   server coercion (request specs), the FormData wire shape (bun unit tests), and a
   real browser upload under Puma + Falcon (system spec).
 
+### Changed
+
+- **Linter: Standard → RuboCop.** The gem now lints with RuboCop (all new cops
+  enabled, `NewCops: enable`) instead of StandardRB, so the suite teaches and
+  enforces newer Ruby idioms that Standard leaves alone — chiefly the Ruby 3.4
+  `it` implicit single block parameter (`map { it.foo }`) via
+  `Style/ItBlockParameter: always`. The whole tree was autocorrected; the
+  lib/app changes were the `|x| x.foo` → `it.foo` rename plus hash-brace
+  spacing — behavior is unchanged and all specs are green. The gemspec and
+  Rakefile are excluded from `Style/ItBlockParameter` (their `do |spec| … end`
+  config blocks read better named), and one nested Phlex content block carries
+  an inline disable where blanket `it` would collapse two parameters. Component-
+  aware relaxations (line length, `Lint/MissingSuper`, unused action params)
+  are scoped to `spec/dummy/app/components/**`. `bundle exec standardrb` is now
+  `bundle exec rubocop`; `rake`'s default runs `spec + rubocop`.
+
+### Removed
+
+- **Dropped the `standard` development dependency** in favor of `rubocop`,
+  `rubocop-performance`, `rubocop-rake`, and `rubocop-rspec`.
+
+### BREAKING
+
+- **Minimum Ruby is now 3.4** (was 3.2). Enabling the `it` block parameter
+  requires Ruby 3.4, so `required_ruby_version` is `>= 3.4.0` and the CI matrix
+  drops 3.2 and 3.3. Stay on phlex-reactive 0.3.x if you need Ruby 3.2/3.3.
+
 ### Fixed
 
 - **Multipart path silently dropped an explicit nested-hash / array param (#39).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lib/app changes were the `|x| x.foo` → `it.foo` rename plus hash-brace
   spacing — behavior is unchanged and all specs are green. The gemspec and
   Rakefile are excluded from `Style/ItBlockParameter` (their `do |spec| … end`
-  config blocks read better named), and one nested Phlex content block carries
-  an inline disable where blanket `it` would collapse two parameters. Component-
+  config blocks read better named); a nested Phlex content block and a scope
+  lambda carry inline disables where blanket `it` would collapse two parameters
+  or break a `where(room:)` kwarg shorthand; and blocks that fed a
+  keyword-argument shorthand (`Component.new(todo:)`) were rewritten to an
+  explicit `Component.new(todo: it)` so the `it` rename can't silently change
+  the keyword. Component-
   aware relaxations (line length, `Lint/MissingSuper`, unused action params)
   are scoped to `spec/dummy/app/components/**`. `bundle exec standardrb` is now
   `bundle exec rubocop`; `rake`'s default runs `spec + rubocop`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ hand-picking Turbo Stream targets.
 
 ## Tech Stack
 
-- **Ruby**: >= 3.2 | **Rails**: >= 7.1
+- **Ruby**: >= 3.4 | **Rails**: >= 7.1
 - **Rendering**: phlex-rails (Phlex 2)
 - **Transport**: turbo-rails (Turbo Streams); [pgbus](https://github.com/mhenrixon/pgbus) optional for Postgres SSE
 - **Client**: one generic Stimulus controller (no per-feature JS)
 - **Autoloading**: zeitwerk
 - **Testing**: RSpec + Capybara/Playwright (via `spec/dummy`)
-- **Linting**: Standard (`standardrb`)
+- **Linting**: RuboCop (`rubocop`) — all new cops on; teaches modern Ruby (e.g. `it` block param)
 
 ## Critical Rules
 
@@ -42,8 +42,8 @@ hand-picking Turbo Stream targets.
 bundle exec rspec spec/phlex spec/requests   # Fast suite (unit + request + broadcast)
 bundle exec rspec spec/system                # Browser suite (Playwright; Puma default, CAPYBARA_SERVER=falcon for the async server)
 bundle exec rake spec:system_servers         # Browser suite under BOTH real servers (puma + falcon)
-bundle exec standardrb                       # Lint
-bundle exec rake                             # spec + standard
+bundle exec rubocop                          # Lint (rubocop -A to autocorrect)
+bundle exec rake                             # spec + rubocop
 bundle exec rake bench                        # Performance micro-benches (render, token, coerce_params)
 bundle exec rake bench:request                # End-to-end request-cycle bench (derailed)
 ```
@@ -122,7 +122,7 @@ optionality is a core invariant — never break it.
   (default) and Falcon (`CAPYBARA_SERVER=falcon`); CI runs both in a matrix, and
   `rake spec:system_servers` runs both locally. (No webrick — not a real server.)
 - pgbus-dependent specs run only on Ruby ≥ 3.3 (pgbus's floor) and guard with
-  `defined?(Pgbus)`. phlex-reactive's own runtime still supports Ruby 3.2.
+  `defined?(Pgbus)`. phlex-reactive's own runtime floor is Ruby 3.4.
 - See `docs/testing.md`.
 
 ## Performance

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,11 @@ gem "rake", "~> 13.0"
 
 group :development do
   gem "rubocop", "~> 1.80", require: false
+  gem "rubocop-capybara", "~> 2.21", require: false
   gem "rubocop-performance", "~> 1.26", require: false
   gem "rubocop-rake", "~> 0.7", require: false
   gem "rubocop-rspec", "~> 3.0", require: false
+  gem "rubocop-thread_safety", "~> 0.7", require: false
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -7,21 +7,10 @@ gemspec
 gem "rake", "~> 13.0"
 
 group :development do
-  gem "rubocop", "~> 1.21", require: false
+  gem "rubocop", "~> 1.80", require: false
+  gem "rubocop-performance", "~> 1.26", require: false
+  gem "rubocop-rake", "~> 0.7", require: false
   gem "rubocop-rspec", "~> 3.0", require: false
-  gem "standard", "~> 1.3", require: false
-end
-
-# Performance measurement. The micro-benches (benchmark/micro/*) isolate the hot
-# methods (render, reactive_token, param coercion) with benchmark-ips for
-# throughput and memory_profiler for allocations. The request-cycle bench
-# (benchmark/request/*) drives the dummy app through derailed_benchmarks for
-# end-to-end latency + memory. See docs/performance.md and `rake -T bench`.
-group :development, :test do
-  gem "benchmark-ips", "~> 2.13", require: false
-  gem "memory_profiler", "~> 1.0", require: false
-  gem "derailed_benchmarks", "~> 2.1", require: false
-  gem "stackprof", "~> 0.2", require: false # derailed_benchmarks profiling backend
 end
 
 group :test do
@@ -38,6 +27,16 @@ group :test do
 end
 
 group :development, :test do
+  # Performance measurement. The micro-benches (benchmark/micro/*) isolate the hot
+  # methods (render, reactive_token, param coercion) with benchmark-ips for
+  # throughput and memory_profiler for allocations. The request-cycle bench
+  # (benchmark/request/*) drives the dummy app through derailed_benchmarks for
+  # end-to-end latency + memory. See docs/performance.md and `rake -T bench`.
+  gem "benchmark-ips", "~> 2.13", require: false
+  gem "derailed_benchmarks", "~> 2.1", require: false
+  gem "memory_profiler", "~> 1.0", require: false
+  gem "stackprof", "~> 0.2", require: false # derailed_benchmarks profiling backend
+
   gem "actioncable", ">= 7.1", "< 9.0"
   gem "activejob", ">= 7.1", "< 9.0"
   gem "activerecord", ">= 7.1", "< 9.0"
@@ -58,14 +57,11 @@ group :development, :test do
   # For fast local iteration against your own checkout, set PGBUS_PATH:
   #   PGBUS_PATH=~/Code/mhenrixon/pgbus bundle install
   #
-  # pgbus requires Ruby >= 3.3, but phlex-reactive's runtime supports 3.2
-  # (it's dev-only here). Skip it on 3.2 so the 3.2 CI matrix job still resolves.
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3")
-    if (pgbus_path = ENV["PGBUS_PATH"])
-      gem "pgbus", path: pgbus_path, require: false
-    else
-      gem "pgbus", ">= 0.9.4", require: false
-    end
-    gem "pg", "~> 1.5", require: false # pgbus needs PostgreSQL
+  # pgbus requires Ruby >= 3.3 — satisfied by phlex-reactive's 3.4 floor.
+  if (pgbus_path = ENV.fetch("PGBUS_PATH", nil))
+    gem "pgbus", path: pgbus_path, require: false
+  else
+    gem "pgbus", ">= 0.9.4", require: false
   end
+  gem "pg", "~> 1.5", require: false # pgbus needs PostgreSQL
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "English"
 require "rspec/core/rake_task"
 
 # Unit + request specs (the fast suite the release task runs). System specs need
@@ -20,12 +21,13 @@ namespace :spec do
     # sync (Puma) and async (Falcon) server before a client-touching change ships.
     %w[puma falcon].each do |server|
       puts "\e[1;35m\n### system specs under CAPYBARA_SERVER=#{server} ###\e[0m"
-      sh({"CAPYBARA_SERVER" => server}, "bundle exec rspec spec/system")
+      sh({ "CAPYBARA_SERVER" => server }, "bundle exec rspec spec/system")
     end
   end
 end
 
-require "standard/rake"
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
 
 # --- Performance benchmarks -------------------------------------------------
 # Micro-benches isolate the hot methods (render, reactive_token, param
@@ -36,7 +38,7 @@ namespace :bench do
 
   desc "Run the micro-benchmarks (render, token, coerce_params)"
   task :micro do
-    files = Dir["#{micro_dir}/*.rb"].sort
+    files = Dir["#{micro_dir}/*.rb"]
     abort "No micro-benchmarks found in #{micro_dir}" if files.empty?
 
     # Capture a plain-text report (CI uploads it as an artifact) while still
@@ -44,22 +46,22 @@ namespace :bench do
     require "fileutils"
     FileUtils.mkdir_p("tmp/benchmarks")
     failed = []
-    out = File.open("tmp/benchmarks/micro.txt", "w")
-    files.each do |file|
-      header = "\n### #{file} ###"
-      puts "\e[1;35m#{header}\e[0m"
-      out.puts header
-      result = `ruby #{file} 2>&1`
-      puts result
-      out.puts result.gsub(/\e\[[0-9;]*m/, "")
-      # A crashed bench must not pass silently — record the failure (and note it
-      # in the saved report) so CI surfaces a broken bench instead of a green tick.
-      unless $?.success?
-        failed << file
-        out.puts "!!! FAILED (exit #{$?.exitstatus})"
+    File.open("tmp/benchmarks/micro.txt", "w") do |out|
+      files.each do |file|
+        header = "\n### #{file} ###"
+        puts "\e[1;35m#{header}\e[0m"
+        out.puts header
+        result = `ruby #{file} 2>&1`
+        puts result
+        out.puts result.gsub(/\e\[[0-9;]*m/, "")
+        # A crashed bench must not pass silently — record the failure (and note it
+        # in the saved report) so CI surfaces a broken bench instead of a green tick.
+        unless $CHILD_STATUS.success?
+          failed << file
+          out.puts "!!! FAILED (exit #{$CHILD_STATUS.exitstatus})"
+        end
       end
     end
-    out.close
     puts "\nSaved report to tmp/benchmarks/micro.txt"
     abort "\nBenchmark(s) failed: #{failed.join(", ")}" if failed.any?
   end
@@ -70,9 +72,7 @@ namespace :bench do
     # Resolve against the actual bench files (no shell interpolation of arbitrary
     # input into an executable path) so a stray name can't escape the benchmark dir.
     available = Dir["#{micro_dir}/*.rb"].map { |f| File.basename(f, ".rb") }
-    unless available.include?(name)
-      abort "No such benchmark: #{name}. Available: #{available.sort.join(", ")}"
-    end
+    abort "No such benchmark: #{name}. Available: #{available.sort.join(", ")}" unless available.include?(name)
     ruby "#{micro_dir}/#{name}.rb"
   end
 
@@ -80,7 +80,7 @@ namespace :bench do
   task :request do
     require "fileutils"
     FileUtils.mkdir_p("tmp/benchmarks")
-    sh({"RAILS_ENV" => "test"}, "ruby benchmark/request/derailed.rb")
+    sh({ "RAILS_ENV" => "test" }, "ruby benchmark/request/derailed.rb")
   end
 end
 
@@ -218,8 +218,8 @@ task :release, %i[version force] do |_t, args|
   puts "    • Upload assets to the release"
 end
 
-desc "Run the dummy app for local QA (PORT=3010)"
 namespace :dummy do
+  desc "Run the dummy app for local QA (PORT=3010)"
   task :server do
     port = ENV.fetch("PORT", "3010")
     ENV["RAILS_ENV"] = "development"
@@ -227,4 +227,4 @@ namespace :dummy do
   end
 end
 
-task default: %i[spec standard]
+task default: %i[spec rubocop]

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -101,7 +101,7 @@ module Phlex
         # replace when a hand-built `with(...)` stream omits it. Idempotent: a
         # Response.replace(self)/update(self) already carries the token, so we
         # don't double the self-render.
-        if result.render_self? && streams.none? { |s| s.include?("data-reactive-token-value") }
+        if result.render_self? && streams.none? { it.include?("data-reactive-token-value") }
           streams = [component.to_stream_replace, *streams]
         end
         streams
@@ -115,7 +115,7 @@ module Phlex
       # us into skipping this component's refresh.
       def carries_token_for?(streams, component)
         target = %(target="#{ERB::Util.html_escape(component.id)}")
-        streams.any? { |s| s.include?("data-reactive-token-value") && s.include?(target) }
+        streams.any? {  it.include?("data-reactive-token-value") && it.include?(target) }
       end
 
       # A 200 turbo-stream carrying a namespaced custom action the client turns
@@ -126,9 +126,9 @@ module Phlex
         %(<turbo-stream action="reactive:visit" data-url="#{ERB::Util.html_escape(url)}"></turbo-stream>)
       end
 
-      def transaction_wrapper(&block)
+      def transaction_wrapper(&)
         if defined?(::ActiveRecord::Base)
-          ::ActiveRecord::Base.transaction(&block)
+          ::ActiveRecord::Base.transaction(&)
         else
           yield
         end
@@ -169,11 +169,12 @@ module Phlex
       # Arrays accept both a real JSON array and a Rails-style index hash
       # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
       def coerce(value, type)
-        if type.is_a?(Array)
+        case type
+        when Array
           coerce_array(value, type.first)
-        elsif type.is_a?(Hash)
+        when Hash
           coerce_hash(value, type)
-        elsif type == :file
+        when :file
           coerce_file(value)
         else
           coerce_scalar(value, type)
@@ -213,8 +214,8 @@ module Phlex
         return DROP if values.nil?
         return [] if values.empty?
 
-        coerced = values.map { |element| coerce(element, element_type) }
-        coerced.reject! { |element| element.equal?(DROP) }
+        coerced = values.map { coerce(it, element_type) }
+        coerced.reject! { it.equal?(DROP) }
         coerced.empty? ? DROP : coerced
       end
 
@@ -249,9 +250,9 @@ module Phlex
       def array_values(value)
         return value.to_a if value.is_a?(Array)
 
-        if value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
-          to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
-        end
+        return unless value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
+
+        to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
       end
 
       # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed
@@ -330,7 +331,7 @@ module Phlex
       # already gates this; defense in depth against constant injection.
       def resolve_component(name)
         klass = name.to_s.safe_constantize
-        unless klass&.respond_to?(:reactive_action?) && klass.include?(Phlex::Reactive::Component)
+        unless klass.respond_to?(:reactive_action?) && klass.include?(Phlex::Reactive::Component)
           raise Phlex::Reactive::InvalidToken
         end
 

--- a/benchmark/micro/coerce_params.rb
+++ b/benchmark/micro/coerce_params.rb
@@ -15,7 +15,7 @@ controller = Phlex::Reactive::ActionsController.new
 schema = {
   date: :string,
   bank_account_ids: [:integer],
-  invoice_items_attributes: [{id: :integer, quantity: :float, price: :float, _destroy: :boolean}]
+  invoice_items_attributes: [{ id: :integer, quantity: :float, price: :float, _destroy: :boolean }]
 }
 
 # A flat, bracketed payload (what the client's #collectFields posts for a
@@ -38,7 +38,7 @@ controller.params = ActionController::Parameters.new(params: raw)
 run = -> { controller.send(:coerce_params, schema) }
 
 BenchSupport.header("coerce_params: nested array-of-hash (Rails bracket form)")
-BenchSupport.ips { |x| x.report("coerce_params") { run.call } }
+BenchSupport.ips { it.report("coerce_params") { run.call } }
 
 BenchSupport.header("coerce_params allocations (per call)")
 BenchSupport.allocations("coerce_params") { run.call }

--- a/benchmark/micro/render.rb
+++ b/benchmark/micro/render.rb
@@ -18,8 +18,8 @@ reset = -> { CounterComponent.reset_turbo_view_context! if no_cache }
 
 BenchSupport.header("render: CounterComponent#to_stream_replace#{" (NO CACHE)" if no_cache}")
 
-BenchSupport.ips do |x|
-  x.report("to_stream_replace") do
+BenchSupport.ips do
+  it.report("to_stream_replace") do
     reset.call
     CounterComponent.new(count: 1).to_stream_replace
   end
@@ -37,8 +37,8 @@ end
 # win that matters MOST for broadcasts, where a single change fans out to N
 # subscribers as N renders with NO HTTP round trip to amortize against.
 BenchSupport.header("render_component (the broadcast/fan-out unit)")
-BenchSupport.ips do |x|
-  x.report("render_component") { CounterComponent.render_component(CounterComponent.new(count: 1)) }
+BenchSupport.ips do
+  it.report("render_component") { CounterComponent.render_component(CounterComponent.new(count: 1)) }
 end
 BenchSupport.allocations("render_component") do
   CounterComponent.render_component(CounterComponent.new(count: 1))

--- a/benchmark/micro/token.rb
+++ b/benchmark/micro/token.rb
@@ -15,9 +15,9 @@ todo = Todo.create!(title: "t", done: false)
 record = TodoItemComponent.new(todo:)            # record-backed ({c, gid})
 
 BenchSupport.header("reactive_token throughput")
-BenchSupport.ips do |x|
-  x.report("state-backed token") { state.send(:reactive_token) }
-  x.report("record-backed token") { record.send(:reactive_token) }
+BenchSupport.ips do
+  it.report("state-backed token") { state.send(:reactive_token) }
+  it.report("record-backed token") { record.send(:reactive_token) }
 end
 
 BenchSupport.header("reactive_token allocations (per call)")

--- a/benchmark/request/derailed.rb
+++ b/benchmark/request/derailed.rb
@@ -48,25 +48,25 @@ end
 
 # A state-backed action (no DB) and a record-backed action (GlobalID re-find +
 # DB write) — the two shapes of a real round trip.
-state_body = {token: sign(CounterComponent, "s" => {"count" => 1}), act: "increment", params: {}}.to_json
+state_body = { token: sign(CounterComponent, "s" => { "count" => 1 }), act: "increment", params: {} }.to_json
 
 todo = Todo.create!(title: "bench", done: false)
-record_body = {token: sign(TodoItemComponent, "gid" => todo.to_gid.to_s), act: "toggle", params: {}}.to_json
+record_body = { token: sign(TodoItemComponent, "gid" => todo.to_gid.to_s), act: "toggle", params: {} }.to_json
 
 # Sanity: both must return 200 before we benchmark, else we'd be timing an error.
-%w[state record].each do |kind|
-  body = (kind == "state") ? state_body : record_body
+%w[state record].each do
+  body = it == "state" ? state_body : record_body
   status = post(mock, body).status
-  abort "[bench] #{kind} request returned HTTP #{status}, expected 200" unless status == 200
+  abort "[bench] #{it} request returned HTTP #{status}, expected 200" unless status == 200
 end
 
 puts "\n\e[1;36mrequest cycle: POST /reactive/actions (full Rack stack)\e[0m"
 puts "─" * 54
-Benchmark.ips do |x|
-  x.config(time: 3, warmup: 1)
-  x.report("state-backed action") { post(mock, state_body) }
-  x.report("record-backed action") { post(mock, record_body) }
-  x.compare!
+Benchmark.ips do
+  it.config(time: 3, warmup: 1)
+  it.report("state-backed action") { post(mock, state_body) }
+  it.report("record-backed action") { post(mock, record_body) }
+  it.compare!
 end
 
 puts "\n\e[1;36mallocations per request\e[0m"

--- a/benchmark/support/boot.rb
+++ b/benchmark/support/boot.rb
@@ -29,18 +29,18 @@ module BenchSupport
   # comparison table. `time:`/`warmup:` kept short so the full suite stays fast
   # in CI; bump them locally when chasing a small delta.
   def ips(time: 2, warmup: 1)
-    Benchmark.ips do |x|
-      x.config(time: time, warmup: warmup)
-      yield x
-      x.compare!
+    Benchmark.ips do
+      it.config(time: time, warmup: warmup)
+      yield it
+      it.compare!
     end
   end
 
   # Print the total allocated objects/bytes for one labelled proc — the number
   # that actually moves when we kill a per-call allocation. Returns the report
   # so a caller can assert on it if needed.
-  def allocations(label)
-    report = MemoryProfiler.report { yield }
+  def allocations(label, &)
+    report = MemoryProfiler.report(&)
     puts format(
       "  %-32s %8d objects  %10d bytes (retained: %d objects)",
       label, report.total_allocated, report.total_allocated_memsize, report.total_retained

--- a/lib/generators/phlex/reactive/install/install_generator.rb
+++ b/lib/generators/phlex/reactive/install/install_generator.rb
@@ -29,8 +29,8 @@ module Phlex
           index = stimulus_index_path
 
           unless index
-            say_status :skip, "no Stimulus controllers entrypoint found — register manually:\n" \
-                              "    #{IMPORT_LINE}\n    #{REGISTER_LINE}", :yellow
+            say_status :skip, "no Stimulus controllers entrypoint found — register manually:\n    " \
+                              "#{IMPORT_LINE}\n    #{REGISTER_LINE}", :yellow
             return
           end
 
@@ -44,9 +44,9 @@ module Phlex
           end
 
           # Fallback: if the standard import line wasn't found, append both lines.
-          unless File.read(index).include?(REGISTER_LINE)
-            append_to_file index, "\n#{IMPORT_LINE}\n#{REGISTER_LINE}\n"
-          end
+          return if File.read(index).include?(REGISTER_LINE)
+
+          append_to_file index, "\n#{IMPORT_LINE}\n#{REGISTER_LINE}\n"
         end
 
         def show_post_install
@@ -69,7 +69,7 @@ module Phlex
           %w[
             app/javascript/controllers/index.js
             app/javascript/controllers/application.js
-          ].map { |p| File.join(destination_root, p) }.find { |p| File.exist?(p) }
+          ].map { File.join(destination_root, it) }.find { File.exist?(it) }
         end
 
         def relative(path)

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -218,7 +218,7 @@ module Phlex
         logger.warn(
           "[phlex-reactive] POST #{path} does not resolve to #{ACTIONS_CONTROLLER}. " \
           "A host catch-all route (e.g. match \"*path\", ...) likely shadows it, so reactive " \
-          "actions will 404. Exempt #{path.sub(%r{\A/}, "")} from the catch-all, or set " \
+          "actions will 404. Exempt #{path.delete_prefix("/")} from the catch-all, or set " \
           "Phlex::Reactive.action_path to an unshadowed path. See the README integration section."
         )
       end
@@ -277,4 +277,4 @@ loader.ignore("#{lib}/generators")
 loader.do_not_eager_load("#{__dir__}/reactive/engine.rb")
 loader.setup
 
-require "phlex/reactive/engine" if defined?(::Rails::Engine)
+require "phlex/reactive/engine" if defined?(Rails::Engine)

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -164,7 +164,7 @@ module Phlex
         end
 
         def reactive_collections
-          @reactive_collections ||= (superclass.respond_to?(:reactive_collections) ? superclass.reactive_collections.dup : {})
+          @reactive_collections ||= superclass.respond_to?(:reactive_collections) ? superclass.reactive_collections.dup : {}
         end
 
         def reactive_collection_def(name)
@@ -190,7 +190,7 @@ module Phlex
         # forms avoids a String + Symbol allocation per key per render. Memoized
         # per class; reset when reactive_state adds a key.
         def reactive_state_ivars
-          @reactive_state_ivars ||= reactive_state_keys.map { |k| [k.to_s, :"@#{k}"] }
+          @reactive_state_ivars ||= reactive_state_keys.map { [it.to_s, :"@#{it}"] }
         end
 
         # Rebuild a component instance from a verified identity payload. Called
@@ -212,14 +212,14 @@ module Phlex
 
           if reactive_state_keys.any?
             state = payload.fetch("s", {})
-            reactive_state_keys.each do |key|
+            reactive_state_keys.each do
               # Use key presence, not the value: a signed `nil` (nullable state)
               # must round-trip distinctly. Only a genuinely absent key falls
               # back to the component's initialize default; `false` and `nil`
               # both survive.
-              next unless state.key?(key.to_s)
+              next unless state.key?(it.to_s)
 
-              kwargs[key] = state[key.to_s]
+              kwargs[it] = state[it.to_s]
             end
           end
 
@@ -313,7 +313,7 @@ module Phlex
       # hatch). The trigger (on(:save)) stays on the button, not the field — so
       # focusing the input doesn't dispatch and collapse edit mode.
       def reactive_field(param, **attrs)
-        {name: param.to_s, **attrs}
+        { name: param.to_s, **attrs }
       end
 
       # Render an <input> already bound to an action param (issue #23). Sugar for
@@ -327,8 +327,8 @@ module Phlex
       # is the element's content, so the awkward FormBuilder positional split
       # (where name: lands after the options/html-options args) goes away:
       #   reactive_select(:status) { @statuses.each { |s| option(value: s, selected: s == @record.status) { s } } }
-      def reactive_select(param, **attrs, &block)
-        select(**reactive_field(param, **attrs), &block)
+      def reactive_select(param, **attrs, &)
+        select(**reactive_field(param, **attrs), &)
       end
 
       # Map a declared nested param onto Rails' <assoc>_attributes, carrying the
@@ -344,7 +344,7 @@ module Phlex
         existing = reactive_record_for_nested.public_send(association)
         merged[:id] = existing.id if existing
 
-        {"#{association}_attributes": merged}
+        { "#{association}_attributes": merged }
       end
 
       # Map a nested param onto <assoc>_attributes (with id preservation) AND
@@ -362,9 +362,7 @@ module Phlex
       # record-backed component).
       def reactive_record_for_nested
         key = self.class.reactive_record_key
-        unless key
-          raise Error, "#{self.class} must declare `reactive_record` to use nested_update!/nested_attributes"
-        end
+        raise Error, "#{self.class} must declare `reactive_record` to use nested_update!/nested_attributes" unless key
 
         instance_variable_get(:"@#{key}")
       end
@@ -377,7 +375,7 @@ module Phlex
       # unchanged.
       def reactive_token
         klass = self.class
-        payload = {"c" => klass.name}
+        payload = { "c" => klass.name }
 
         if (record_ivar = klass.reactive_record_ivar)
           payload["gid"] = instance_variable_get(record_ivar).to_gid.to_s

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -13,27 +13,27 @@ module Phlex
 
       # Mount POST /reactive/actions -> Phlex::Reactive::ActionsController#create.
       # Apps can change the path with Phlex::Reactive.action_path before boot.
-      initializer "phlex_reactive.routes" do |app|
-        app.routes.append do
+      initializer "phlex_reactive.routes" do
+        it.routes.append do
           post Phlex::Reactive.action_path, to: "phlex/reactive/actions#create", as: :phlex_reactive_action
         end
       end
 
       # Make reactive_controller.js available to Propshaft/Sprockets so it can
       # be included via the asset pipeline or pinned in importmap.
-      initializer "phlex_reactive.assets" do |app|
-        if app.config.respond_to?(:assets)
-          app.config.assets.paths << root.join("app/javascript").to_s
-          app.config.assets.precompile += %w[phlex/reactive/reactive_controller.js]
+      initializer "phlex_reactive.assets" do
+        if it.config.respond_to?(:assets)
+          it.config.assets.paths << root.join("app/javascript").to_s
+          it.config.assets.precompile += %w[phlex/reactive/reactive_controller.js]
         end
       end
 
       # Auto-pin the client controller for importmap apps so it loads without
       # manual configuration. Apps that don't use importmap include it via the
       # asset pipeline instead (see README).
-      initializer "phlex_reactive.importmap", after: "importmap" do |app|
-        if defined?(::Importmap::Map) && app.respond_to?(:importmap)
-          app.importmap.pin(
+      initializer "phlex_reactive.importmap", after: "importmap" do
+        if defined?(::Importmap::Map) && it.respond_to?(:importmap)
+          it.importmap.pin(
             "phlex/reactive/reactive_controller",
             to: "phlex/reactive/reactive_controller.js",
             preload: true

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -75,6 +75,7 @@ module Phlex
       #   reply.remove(:items, model) # remove a collection row + count + empty
       def remove(name = UNSET, model = UNSET)
         return Response.remove(@component) if name.equal?(UNSET)
+
         Response.collection_remove(@component, name, model)
       end
 

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -106,9 +106,7 @@ module Phlex
           append_count_stream(streams, definition, component)
 
           size = definition.size_for(component)
-          if definition.empty && size == 1
-            streams << definition.empty.new.to_stream_remove
-          end
+          streams << definition.empty.new.to_stream_remove if definition.empty && size == 1
           streams
         end
 

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -48,7 +48,7 @@ module Phlex
         # controller is never served from a stale memo. No-op outside Rails.
         def reset_all_view_contexts!
           @registry_mutex.synchronize do
-            @registry.keys.each(&:reset_turbo_view_context!)
+            @registry.each_key(&:reset_turbo_view_context!)
           end
         end
 
@@ -78,7 +78,7 @@ module Phlex
         end
 
         def component_args(model, options)
-          {model_param_name => model}.merge(options)
+          { model_param_name => model }.merge(options)
         end
 
         # Turbo::Streams::TagBuilder needs a real VIEW CONTEXT (it calls
@@ -230,14 +230,14 @@ module Phlex
         # `method: :morph` to emit the `method="morph"` attribute. Pass it ONLY
         # when morphing, so the default call produces today's plain replace.
         def morph_method(morph)
-          morph ? {method: :morph} : {}
+          morph ? { method: :morph } : {}
         end
 
         # The BROADCAST path renders extra <turbo-stream> attributes through
         # `attributes:` (it has no `method:` kwarg — that would fall into the
         # render args and be dropped). Same wire result: method="morph".
         def morph_attributes(morph)
-          morph ? {attributes: {method: "morph"}} : {}
+          morph ? { attributes: { method: "morph" } } : {}
         end
 
         # Only include transport opts that were actually given, so on Action

--- a/phlex-reactive.gemspec
+++ b/phlex-reactive.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/mhenrixon/phlex-reactive"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.4.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mhenrixon/phlex-reactive/tree/main"

--- a/spec/dummy/app/components/address_editor_component.rb
+++ b/spec/dummy/app/components/address_editor_component.rb
@@ -11,7 +11,7 @@ class AddressEditorComponent < ApplicationComponent
   reactive_record :account
 
   action :save, params: {
-    address: {street: :string, city: :string, postal_code: :string, country: :string}
+    address: { street: :string, city: :string, postal_code: :string, country: :string }
   }
 
   def initialize(account:)
@@ -30,7 +30,7 @@ class AddressEditorComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       reactive_input(:"address[street]", value: @account.address&.street)
-      button(**mix(on(:save), data: {testid: "save"})) { "Save" }
+      button(**mix(on(:save), data: { testid: "save" })) { "Save" }
     end
   end
 end

--- a/spec/dummy/app/components/chat_composer_component.rb
+++ b/spec/dummy/app/components/chat_composer_component.rb
@@ -8,7 +8,7 @@ class ChatComposerComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_state :room, :author
-  action :send_message, params: {body: :string}
+  action :send_message, params: { body: :string }
 
   def initialize(room: "lobby", author: nil)
     @room = room
@@ -32,8 +32,8 @@ class ChatComposerComponent < ApplicationComponent
 
   def view_template
     div(**mix(reactive_attrs, id:, class: "composer")) do
-      input(type: "text", name: "body", placeholder: "Message as #{@author}…", autocomplete: "off", data: {testid: "chat-input"})
-      button(**mix(on(:send_message), data: {testid: "chat-send"})) { "Send" }
+      input(type: "text", name: "body", placeholder: "Message as #{@author}…", autocomplete: "off", data: { testid: "chat-input" })
+      button(**mix(on(:send_message), data: { testid: "chat-send" })) { "Send" }
     end
   end
 end

--- a/spec/dummy/app/components/chat_message_component.rb
+++ b/spec/dummy/app/components/chat_message_component.rb
@@ -8,11 +8,12 @@ class ChatMessageComponent < ApplicationComponent
     @message = chat_message
   end
 
-  def id = dom_id(@message) # Streamable#dom_id is render-context-free
+  # Streamable#dom_id is render-context-free
+  def id = dom_id(@message)
   def self.model_param_name = :chat_message
 
   def view_template
-    div(id:, class: "msg", data: {testid: "message"}) do
+    div(id:, class: "msg", data: { testid: "message" }) do
       span(class: "author") { @message.author }
       span(class: "body") { @message.body }
     end

--- a/spec/dummy/app/components/chat_room_component.rb
+++ b/spec/dummy/app/components/chat_room_component.rb
@@ -13,7 +13,7 @@ class ChatRoomComponent < ApplicationComponent
       turbo_stream_from(*ChatMessage.stream_key(@room))
 
       div(id: "chat-messages-#{@room}", class: "messages") do
-        @messages.each { |m| render ChatMessageComponent.new(chat_message: m) }
+        @messages.each { render ChatMessageComponent.new(chat_message: it) }
       end
 
       render ChatComposerComponent.new(room: @room)

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -9,7 +9,7 @@ class CounterComponent < ApplicationComponent
   reactive_state :count
   action :increment
   action :decrement
-  action :set, params: {count: :integer}
+  action :set, params: { count: :integer }
   action :reset_with_flash
   action :bump_via_update
   action :bump_via_morph
@@ -77,12 +77,12 @@ class CounterComponent < ApplicationComponent
 
   def view_template
     div(id:, **reactive_attrs) do
-      button(**mix(on(:decrement), data: {testid: "dec"})) { "−" }
-      span(id: "counter-value", data: {testid: "count"}) { @count.to_s }
-      button(**mix(on(:increment), data: {testid: "inc"})) { "+" }
-      button(**mix(on(:bump_via_update), data: {testid: "bump-update"})) { "+1 (update)" }
-      button(**mix(on(:reset_with_flash), data: {testid: "reset"})) { "reset" }
-      button(**mix(on(:go_home), data: {testid: "go-home"})) { "go home" }
+      button(**mix(on(:decrement), data: { testid: "dec" })) { "−" }
+      span(id: "counter-value", data: { testid: "count" }) { @count.to_s }
+      button(**mix(on(:increment), data: { testid: "inc" })) { "+" }
+      button(**mix(on(:bump_via_update), data: { testid: "bump-update" })) { "+1 (update)" }
+      button(**mix(on(:reset_with_flash), data: { testid: "reset" })) { "reset" }
+      button(**mix(on(:go_home), data: { testid: "go-home" })) { "go home" }
     end
   end
 end

--- a/spec/dummy/app/components/debounce_component.rb
+++ b/spec/dummy/app/components/debounce_component.rb
@@ -10,7 +10,7 @@ class DebounceComponent < ApplicationComponent
 
   reactive_state :query, :runs
 
-  action :search, params: {query: :string}
+  action :search, params: { query: :string }
 
   def initialize(query: "", runs: 0)
     @query = query
@@ -27,9 +27,9 @@ class DebounceComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       input(**mix(on(:search, event: "input", debounce: 150),
-        name: "query", value: @query, data: {testid: "query"}))
-      span(data: {testid: "runs"}) { @runs.to_s }
-      span(data: {testid: "echo"}) { @query }
+        name: "query", value: @query, data: { testid: "query" }))
+      span(data: { testid: "runs" }) { @runs.to_s }
+      span(data: { testid: "echo" }) { @query }
     end
   end
 end

--- a/spec/dummy/app/components/document_upload_component.rb
+++ b/spec/dummy/app/components/document_upload_component.rb
@@ -14,13 +14,13 @@ class DocumentUploadComponent < ApplicationComponent
 
   # Single-file path (has_one_attached). A caption rides alongside as a scalar
   # field to prove multipart carries scalar params + the file together.
-  action :upload, params: {file: :file, caption: :string}
+  action :upload, params: { file: :file, caption: :string }
   # Multiple-file path (has_many_attached): [:file] coerces an array of uploads.
-  action :upload_pages, params: {pages: [:file]}
+  action :upload_pages, params: { pages: [:file] }
   # Issue #39: a :file param alongside an explicit NESTED-hash param. The nested
   # `meta` used to be dropped on the multipart path (the exact combination the
   # issue flagged); it must now survive next to the file.
-  action :upload_with_meta, params: {file: :file, meta: {tag: :string, year: :integer}}
+  action :upload_with_meta, params: { file: :file, meta: { tag: :string, year: :integer } }
 
   def initialize(document:)
     @document = document
@@ -45,15 +45,15 @@ class DocumentUploadComponent < ApplicationComponent
   end
 
   def view_template
-    div(**mix(reactive_attrs, id:, data: {testid: "document"})) do
-      span(data: {testid: "title"}) { @document.title }
-      span(data: {testid: "filename"}) { @document.file.attached? ? @document.file.filename.to_s : "" }
-      span(data: {testid: "pages-count"}) { @document.pages.count.to_s }
+    div(**mix(reactive_attrs, id:, data: { testid: "document" })) do
+      span(data: { testid: "title" }) { @document.title }
+      span(data: { testid: "filename" }) { @document.file.attached? ? @document.file.filename.to_s : "" }
+      span(data: { testid: "pages-count" }) { @document.pages.count.to_s }
 
       form(**on(:upload, event: "submit")) do
-        input(type: "file", name: "file", data: {testid: "file"})
-        input(name: "caption", data: {testid: "caption"})
-        button(type: "submit", data: {testid: "save"}) { "Upload" }
+        input(type: "file", name: "file", data: { testid: "file" })
+        input(name: "caption", data: { testid: "caption" })
+        button(type: "submit", data: { testid: "save" }) { "Upload" }
       end
     end
   end

--- a/spec/dummy/app/components/form_submit_component.rb
+++ b/spec/dummy/app/components/form_submit_component.rb
@@ -11,7 +11,7 @@ class FormSubmitComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_record :todo
-  action :save, params: {title: :string}
+  action :save, params: { title: :string }
 
   def initialize(todo:)
     @todo = todo
@@ -28,10 +28,10 @@ class FormSubmitComponent < ApplicationComponent
       # Explicit action to a different route: a native submit would land on the
       # nav-probe page. on(:save, event: "submit") must intercept it first.
       form(action: "/nav_probe", method: "post", **mix(on(:save, event: "submit"))) do
-        input(name: "title", value: @todo.title, data: {testid: "title"})
-        button(type: "submit", data: {testid: "save"}) { "Save" }
+        input(name: "title", value: @todo.title, data: { testid: "title" })
+        button(type: "submit", data: { testid: "save" }) { "Save" }
       end
-      span(data: {testid: "current"}) { @todo.title }
+      span(data: { testid: "current" }) { @todo.title }
     end
   end
 end

--- a/spec/dummy/app/components/inline_edit_component.rb
+++ b/spec/dummy/app/components/inline_edit_component.rb
@@ -13,7 +13,7 @@ class InlineEditComponent < ApplicationComponent
 
   action :edit
   action :cancel
-  action :save, params: {value: :string}
+  action :save, params: { value: :string }
 
   def initialize(record:, attribute:, editing: false)
     @record = record
@@ -38,11 +38,11 @@ class InlineEditComponent < ApplicationComponent
         # with whichever action fires. `on(:save)` lives on the Save button, not
         # the input, so focusing the field doesn't dispatch save and collapse
         # edit mode (matches docs/examples/inline_edit.md).
-        input(name: "value", value: current_value, data: {testid: "field"})
-        button(**mix(on(:save), data: {testid: "save"})) { "Save" }
-        button(**mix(on(:cancel), data: {testid: "cancel"})) { "Cancel" }
+        input(name: "value", value: current_value, data: { testid: "field" })
+        button(**mix(on(:save), data: { testid: "save" })) { "Save" }
+        button(**mix(on(:cancel), data: { testid: "cancel" })) { "Cancel" }
       else
-        span(**mix(on(:edit), data: {testid: "display"})) { current_value.presence || "—" }
+        span(**mix(on(:edit), data: { testid: "display" })) { current_value.presence || "—" }
       end
     end
   end

--- a/spec/dummy/app/components/morph_grid_component.rb
+++ b/spec/dummy/app/components/morph_grid_component.rb
@@ -11,7 +11,7 @@ class MorphGridComponent < ApplicationComponent
 
   reactive_record :account
 
-  action :update, params: {name: :string}
+  action :update, params: { name: :string }
 
   def initialize(account:)
     @account = account
@@ -34,8 +34,8 @@ class MorphGridComponent < ApplicationComponent
       # The field both holds the value AND triggers the debounced update — the
       # canonical per-field reactive editing pattern from the issue.
       input(**mix(on(:update, event: "input", debounce: 150),
-        name: "name", value: @account.name, data: {testid: "name"}))
-      span(data: {testid: "saved"}) { @account.name }
+        name: "name", value: @account.name, data: { testid: "name" }))
+      span(data: { testid: "saved" }) { @account.name }
     end
   end
 end

--- a/spec/dummy/app/components/nested_editor_component.rb
+++ b/spec/dummy/app/components/nested_editor_component.rb
@@ -12,7 +12,7 @@ class NestedEditorComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_state :notes, :saved
-  action :save, params: {notes: :string}
+  action :save, params: { notes: :string }
 
   def initialize(notes: "", saved: nil)
     @notes = notes
@@ -28,9 +28,9 @@ class NestedEditorComponent < ApplicationComponent
 
   def view_template
     div(id:, **reactive_attrs) do
-      input(name: "notes", value: @notes, data: {testid: "editor-notes"})
-      button(**mix(on(:save), data: {testid: "editor-save"})) { "Save editor" }
-      span(data: {testid: "editor-saved"}) { @saved.to_s }
+      input(name: "notes", value: @notes, data: { testid: "editor-notes" })
+      button(**mix(on(:save), data: { testid: "editor-save" })) { "Save editor" }
+      span(data: { testid: "editor-saved" }) { @saved.to_s }
 
       # Two nested reactive roots, each owning a bare `quantity` input. Pre-fix,
       # the editor's save swept BOTH rows' quantity (last one wins) into its own

--- a/spec/dummy/app/components/nested_params_component.rb
+++ b/spec/dummy/app/components/nested_params_component.rb
@@ -14,14 +14,14 @@ class NestedParamsComponent < ApplicationComponent
   action :save, params: {
     date: :string,
     bank_account_ids: [:integer],
-    invoice_items_attributes: [{id: :integer, quantity: :float, price: :float, _destroy: :boolean}]
+    invoice_items_attributes: [{ id: :integer, quantity: :float, price: :float, _destroy: :boolean }]
   }
 
   # Issue #21: a model-scoped nested hash, matching what a Rails Form(model:)
   # posts as flat bracketed keys (invoice[date], invoice[status], …).
   action :save_invoice, params: {
     date: :string,
-    invoice: {date: :string, status: :string, total: :float, active: :boolean}
+    invoice: { date: :string, status: :string, total: :float, active: :boolean }
   }
 
   def initialize(received: nil)
@@ -39,13 +39,13 @@ class NestedParamsComponent < ApplicationComponent
   end
 
   def save_invoice(date: nil, invoice: nil)
-    @received = {date:, invoice:}.compact
+    @received = { date:, invoice: }.compact
   end
 
   def view_template
     div(id:, **reactive_attrs) do
       # Reflect the exact coerced structure (types intact) for assertions.
-      pre(data: {testid: "received"}) { @received.to_json }
+      pre(data: { testid: "received" }) { @received.to_json }
     end
   end
 end

--- a/spec/dummy/app/components/nested_row_component.rb
+++ b/spec/dummy/app/components/nested_row_component.rb
@@ -8,7 +8,7 @@ class NestedRowComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_state :label, :quantity
-  action :update, params: {quantity: :string}
+  action :update, params: { quantity: :string }
 
   def initialize(label:, quantity: "1")
     @label = label
@@ -22,9 +22,9 @@ class NestedRowComponent < ApplicationComponent
   end
 
   def view_template
-    div(**mix(reactive_attrs, id:, data: {testid: "row"})) do
-      input(**mix(on(:update, event: "change"), name: "quantity", value: @quantity, data: {testid: "row-qty-#{@label}"}))
-      span(data: {testid: "row-echo-#{@label}"}) { @quantity }
+    div(**mix(reactive_attrs, id:, data: { testid: "row" })) do
+      input(**mix(on(:update, event: "change"), name: "quantity", value: @quantity, data: { testid: "row-qty-#{@label}" }))
+      span(data: { testid: "row-echo-#{@label}" }) { @quantity }
     end
   end
 end

--- a/spec/dummy/app/components/notification_row_component.rb
+++ b/spec/dummy/app/components/notification_row_component.rb
@@ -22,9 +22,9 @@ class NotificationRowComponent < ApplicationComponent
   def id = dom_id(@todo)
 
   def view_template
-    li(id:, class: "notification", data: {testid: "notification"}) do
+    li(id:, class: "notification", data: { testid: "notification" }) do
       span(class: "body") { @todo.title }
-      button(**mix(on(:dismiss, id: @todo.id), data: {testid: "dismiss"})) { "×" }
+      button(**mix(on(:dismiss, id: @todo.id), data: { testid: "dismiss" })) { "×" }
     end
   end
 end

--- a/spec/dummy/app/components/notifications_empty_component.rb
+++ b/spec/dummy/app/components/notifications_empty_component.rb
@@ -10,6 +10,6 @@ class NotificationsEmptyComponent < ApplicationComponent
   def id = "notifications-empty"
 
   def view_template
-    div(id:, class: "empty-state", data: {testid: "empty-state"}) { "No notifications" }
+    div(id:, class: "empty-state", data: { testid: "empty-state" }) { "No notifications" }
   end
 end

--- a/spec/dummy/app/components/notifications_list_component.rb
+++ b/spec/dummy/app/components/notifications_list_component.rb
@@ -45,7 +45,7 @@ class NotificationsListComponent < ApplicationComponent
 
       ul(id: "notifications") do
         if Todo.exists?
-          Todo.order(:created_at, :id).each { render NotificationRowComponent.new(it:) }
+          Todo.order(:created_at, :id).each { render NotificationRowComponent.new(todo: it) }
         else
           render NotificationsEmptyComponent.new
         end

--- a/spec/dummy/app/components/notifications_list_component.rb
+++ b/spec/dummy/app/components/notifications_list_component.rb
@@ -20,8 +20,8 @@ class NotificationsListComponent < ApplicationComponent
     empty: NotificationsEmptyComponent,
     size: -> { Todo.count }
 
-  action :add, params: {title: :string}
-  action :dismiss, params: {id: :integer}
+  action :add, params: { title: :string }
+  action :dismiss, params: { id: :integer }
 
   def id = "notifications-list"
 
@@ -41,19 +41,19 @@ class NotificationsListComponent < ApplicationComponent
 
   def view_template
     div(id:, **reactive_attrs) do
-      span(id: "notifications-count", data: {testid: "count"}) { Todo.count.to_s }
+      span(id: "notifications-count", data: { testid: "count" }) { Todo.count.to_s }
 
       ul(id: "notifications") do
         if Todo.exists?
-          Todo.order(:created_at, :id).each { |todo| render NotificationRowComponent.new(todo:) }
+          Todo.order(:created_at, :id).each { render NotificationRowComponent.new(it:) }
         else
           render NotificationsEmptyComponent.new
         end
       end
 
       div do
-        input(name: "title", placeholder: "New notification…", autocomplete: "off", data: {testid: "new-notification"})
-        button(**mix(on(:add), data: {testid: "add"})) { "Add" }
+        input(name: "title", placeholder: "New notification…", autocomplete: "off", data: { testid: "new-notification" })
+        button(**mix(on(:add), data: { testid: "add" })) { "Add" }
       end
     end
   end

--- a/spec/dummy/app/components/partial_grid_component.rb
+++ b/spec/dummy/app/components/partial_grid_component.rb
@@ -13,7 +13,7 @@ class PartialGridComponent < ApplicationComponent
 
   reactive_record :line_item
 
-  action :update, params: {quantity: :integer, price: :integer}
+  action :update, params: { quantity: :integer, price: :integer }
 
   def initialize(line_item:)
     @line_item = line_item
@@ -36,9 +36,9 @@ class PartialGridComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       input(**mix(on(:update, event: "input", debounce: 100),
-        name: "quantity", value: @line_item.quantity, data: {testid: "quantity"}))
+        name: "quantity", value: @line_item.quantity, data: { testid: "quantity" }))
       input(**mix(on(:update, event: "input", debounce: 100),
-        name: "price", value: @line_item.price, data: {testid: "price"}))
+        name: "price", value: @line_item.price, data: { testid: "price" }))
       total_cell
     end
   end
@@ -48,7 +48,7 @@ class PartialGridComponent < ApplicationComponent
   # The companion total cell — rendered both on first paint (inside the row) and
   # re-streamed on its own by #total_stream after a save.
   def total_cell
-    span(id: total_id, data: {testid: "total"}) { @line_item.total.to_s }
+    span(id: total_id, data: { testid: "total" }) { @line_item.total.to_s }
   end
 
   # A raw turbo-stream that updates only the total cell. Built off the same

--- a/spec/dummy/app/components/reactive_input_component.rb
+++ b/spec/dummy/app/components/reactive_input_component.rb
@@ -10,7 +10,7 @@ class ReactiveInputComponent < ApplicationComponent
   reactive_record :record
   reactive_state :attribute
 
-  action :save, params: {value: :string, status: :string}
+  action :save, params: { value: :string, status: :string }
 
   STATUSES = %w[open closed].freeze
 
@@ -30,13 +30,15 @@ class ReactiveInputComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       # name="value" emitted by the helper, not hand-written.
-      reactive_input(:value, value: @record.public_send(@attribute).to_s, data: {testid: "field"})
+      reactive_input(:value, value: @record.public_send(@attribute).to_s, data: { testid: "field" })
 
-      reactive_select(:status, data: {testid: "status"}) do
-        STATUSES.each { |s| option(value: s) { s } }
+      reactive_select(:status, data: { testid: "status" }) do
+        # Named param required: the inner Phlex content block reuses `s`, so `it`
+        # would collapse both blocks onto one implicit param (wrong output).
+        STATUSES.each { |s| option(value: s) { s } } # rubocop:disable Style/ItBlockParameter
       end
 
-      button(**mix(on(:save), data: {testid: "save"})) { "Save" }
+      button(**mix(on(:save), data: { testid: "save" })) { "Save" }
     end
   end
 end

--- a/spec/dummy/app/components/rich_editor_component.rb
+++ b/spec/dummy/app/components/rich_editor_component.rb
@@ -9,7 +9,7 @@ class RichEditorComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_record :todo
-  action :save, params: {title: :string}
+  action :save, params: { title: :string }
 
   def initialize(todo:)
     @todo = todo
@@ -29,11 +29,11 @@ class RichEditorComponent < ApplicationComponent
         div(
           contenteditable: "true",
           name: "title",
-          data: {testid: "editor"}
+          data: { testid: "editor" }
         ) { @todo.title }
-        button(type: "submit", data: {testid: "save"}) { "Save" }
+        button(type: "submit", data: { testid: "save" }) { "Save" }
       end
-      span(data: {testid: "current"}) { @todo.title }
+      span(data: { testid: "current" }) { @todo.title }
     end
   end
 end

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -8,15 +8,16 @@ class TodoItemComponent < ApplicationComponent
 
   reactive_record :todo
   action :toggle
-  action :rename, params: {title: :string}
+  action :rename, params: { title: :string }
   action :archive
-  action :rename_strict, params: {title: :string}
+  action :rename_strict, params: { title: :string }
 
   def initialize(todo:)
     @todo = todo
   end
 
-  def id = dom_id(@todo) # Streamable#dom_id is render-context-free
+  # Streamable#dom_id is render-context-free
+  def id = dom_id(@todo)
   # No model_param_name override needed: reactive_record :todo makes the
   # broadcast path build with the same `todo:` keyword the action endpoint uses.
 
@@ -48,14 +49,14 @@ class TodoItemComponent < ApplicationComponent
   end
 
   def view_template
-    li(**mix(reactive_attrs, id:, data: {testid: "todo", done: @todo.done?.to_s})) do
-      button(**mix(on(:toggle), data: {testid: "toggle"})) { @todo.done? ? "✓" : "○" }
+    li(**mix(reactive_attrs, id:, data: { testid: "todo", done: @todo.done?.to_s })) do
+      button(**mix(on(:toggle), data: { testid: "toggle" })) { @todo.done? ? "✓" : "○" }
       input(**mix(on(:rename, event: "change"), name: "title", value: @todo.title))
       # archive returns Response.remove(self) — drops this row in place. (The
       # rename_strict flash-on-blank path would need a second title input that
       # collides with field collection above, so it's covered by the request
       # specs rather than wired into this single-input demo row.)
-      button(**mix(on(:archive), data: {testid: "archive"})) { "archive" }
+      button(**mix(on(:archive), data: { testid: "archive" })) { "archive" }
     end
   end
 end

--- a/spec/dummy/app/components/todo_list_component.rb
+++ b/spec/dummy/app/components/todo_list_component.rb
@@ -25,7 +25,7 @@ class TodoListComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       ul(id: "todos") do
-        Todo.order(:created_at, :id).each { render TodoItemComponent.new(it:) }
+        Todo.order(:created_at, :id).each { render TodoItemComponent.new(todo: it) }
       end
 
       div do

--- a/spec/dummy/app/components/todo_list_component.rb
+++ b/spec/dummy/app/components/todo_list_component.rb
@@ -7,7 +7,7 @@ class TodoListComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
   reactive_state :build_token # unused placeholder so the list has stable state
-  action :add, params: {title: :string}
+  action :add, params: { title: :string }
 
   def initialize(build_token: "list")
     @build_token = build_token
@@ -25,12 +25,12 @@ class TodoListComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       ul(id: "todos") do
-        Todo.order(:created_at, :id).each { |todo| render TodoItemComponent.new(todo:) }
+        Todo.order(:created_at, :id).each { render TodoItemComponent.new(it:) }
       end
 
       div do
-        input(name: "title", placeholder: "New todo…", autocomplete: "off", data: {testid: "new-todo"})
-        button(**mix(on(:add), data: {testid: "add"})) { "Add" }
+        input(name: "title", placeholder: "New todo…", autocomplete: "off", data: { testid: "new-todo" })
+        button(**mix(on(:add), data: { testid: "add" })) { "Add" }
       end
     end
   end

--- a/spec/dummy/app/models/chat_message.rb
+++ b/spec/dummy/app/models/chat_message.rb
@@ -2,7 +2,7 @@
 
 class ChatMessage < ActiveRecord::Base
   validates :body, presence: true
-  scope :for_room, ->(room) { where(room:).order(:created_at, :id) }
+  scope :for_room, -> { where(it:).order(:created_at, :id) }
 
   def self.stream_key(room) = ["chat", room]
 end

--- a/spec/dummy/app/models/chat_message.rb
+++ b/spec/dummy/app/models/chat_message.rb
@@ -2,7 +2,9 @@
 
 class ChatMessage < ActiveRecord::Base
   validates :body, presence: true
-  scope :for_room, -> { where(it:).order(:created_at, :id) }
+  # Named arg required: `where(room:)` kwarg-shorthand needs a local `room`; `it`
+  # would become `where(it:)` (wrong key). rubocop:disable Style/ItBlockParameter
+  scope :for_room, ->(room) { where(room:).order(:created_at, :id) } # rubocop:disable Style/ItBlockParameter
 
   def self.stream_key(room) = ["chat", room]
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -29,7 +29,7 @@ module Dummy
     # fixture (issue #34 — file/multipart params) can persist an attachment.
     config.active_storage.service = :test_disk
     config.active_storage.service_configurations = {
-      "test_disk" => {"service" => "Disk", "root" => root.join("tmp/storage").to_s}
+      "test_disk" => { "service" => "Disk", "root" => root.join("tmp/storage").to_s }
     }
 
     # The dummy app's components/views live under app/.

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get "document_upload/:id" => "demos#document_upload"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and
   # GET) so a native submit produces an observable navigation, not a 404.
-  match "nav_probe" => "demos#nav_probe", :via => [:get, :post]
+  match "nav_probe" => "demos#nav_probe", :via => %i[get post]
 
   # The phlex-reactive engine appends POST /reactive/actions itself.
 end

--- a/spec/generators/component_generator_spec.rb
+++ b/spec/generators/component_generator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Phlex::Reactive::Generators::ComponentGenerator do
 
   describe "state-backed (default)" do
     it "generates a component signing :value with the given actions" do
-      generate(["Counter", "increment", "decrement"])
+      generate(%w[Counter increment decrement])
 
       src = component("counter.rb")
       expect(src).to include("class Counter < ApplicationComponent")
@@ -56,7 +56,7 @@ RSpec.describe Phlex::Reactive::Generators::ComponentGenerator do
 
   it "generates a matching spec when the app uses RSpec" do
     FileUtils.mkdir_p(tmp.join("spec")) # signal an RSpec app
-    generate(["Counter", "increment"])
+    generate(%w[Counter increment])
 
     spec = File.read(tmp.join("spec/components/counter_spec.rb"))
     expect(spec).to include("RSpec.describe Counter")
@@ -64,7 +64,7 @@ RSpec.describe Phlex::Reactive::Generators::ComponentGenerator do
   end
 
   it "skips the spec when the app has no spec/ directory" do
-    generate(["Counter", "increment"])
+    generate(%w[Counter increment])
     expect(File).not_to exist(tmp.join("spec/components/counter_spec.rb"))
   end
 end

--- a/spec/phlex/reactive/collection_streams_spec.rb
+++ b/spec/phlex/reactive/collection_streams_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
   describe "reply.append(name, model)" do
     it "appends the row component into the container" do
       response = container_class.new(size: 1).reply.append(:todos, todo)
-      append = response.streams.find { |s| s.include?('action="append"') }
+      append = response.streams.find { it.include?('action="append"') }
       expect(append).to include('target="todos-list"')
       expect(append).to include(%(id="#{dom_id}"))
       expect(append).to include("buy milk")
@@ -70,14 +70,14 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
 
     it "updates the count companion with the fresh size" do
       response = container_class.new(size: 1).reply.append(:todos, todo)
-      count = response.streams.find { |s| s.include?('target="todos-count"') }
+      count = response.streams.find { it.include?('target="todos-count"') }
       expect(count).to include('action="update"')
       expect(count).to include(">1<").or include("1")
     end
 
     it "removes the empty-state when the list crosses 0->1 (size becomes 1)" do
       response = container_class.new(size: 1).reply.append(:todos, todo)
-      empty = response.streams.find { |s| s.include?('target="todos-empty"') }
+      empty = response.streams.find { it.include?('target="todos-empty"') }
       expect(empty).to include('action="remove"')
     end
 
@@ -118,7 +118,7 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
   describe "reply.remove(name, model)" do
     it "removes the row by its dom id" do
       response = container_class.new(size: 0).reply.remove(:todos, todo)
-      remove = response.streams.find { |s| s.include?(%(target="#{dom_id}")) }
+      remove = response.streams.find { it.include?(%(target="#{dom_id}")) }
       expect(remove).to include('action="remove"')
     end
 
@@ -129,7 +129,7 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
 
     it "restores the empty-state when the list crosses ->0 (size becomes 0)" do
       response = container_class.new(size: 0).reply.remove(:todos, todo)
-      empty = response.streams.find { |s| s.include?('target="todos-list"') && s.include?("No todos yet") }
+      empty = response.streams.find { it.include?('target="todos-list"') && it.include?("No todos yet") }
       expect(empty).to include('action="append"')
     end
 
@@ -147,7 +147,7 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
 
     it "accepts a dom-id string as well as a model" do
       response = container_class.new(size: 0).reply.remove(:todos, dom_id)
-      remove = response.streams.find { |s| s.include?('action="remove"') }
+      remove = response.streams.find { it.include?('action="remove"') }
       expect(remove).to include(%(target="#{dom_id}"))
     end
   end

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -12,10 +12,11 @@ RSpec.describe Phlex::Reactive::Component do
 
       reactive_state :count
       action :increment
-      action :set, params: {count: :integer}
+      action :set, params: { count: :integer }
 
       def initialize(count: 0) = @count = count
       attr_reader :count
+
       def increment = @count += 1
       def set(count:) = @count = count
     end
@@ -24,7 +25,7 @@ RSpec.describe Phlex::Reactive::Component do
   describe "action declarations (default-deny)" do
     it "registers declared actions" do
       expect(state_klass.reactive_action?(:increment)).to be(true)
-      expect(state_klass.reactive_action(:set).params).to eq({count: :integer})
+      expect(state_klass.reactive_action(:set).params).to eq({ count: :integer })
     end
 
     it "does not register undeclared methods" do
@@ -39,7 +40,7 @@ RSpec.describe Phlex::Reactive::Component do
       payload = Phlex::Reactive.verify(token)
 
       expect(payload["c"]).to eq("StateThing")
-      expect(payload["s"]).to eq({"count" => 5})
+      expect(payload["s"]).to eq({ "count" => 5 })
 
       rebuilt = state_klass.from_identity(payload)
       expect(rebuilt.count).to eq(5)
@@ -97,7 +98,7 @@ RSpec.describe Phlex::Reactive::Component do
 
       expect(payload["c"]).to eq("InlineThing")
       expect(payload["gid"]).to eq(record.gid_string)
-      expect(payload["s"]).to eq({"attribute" => "name", "editing" => true})
+      expect(payload["s"]).to eq({ "attribute" => "name", "editing" => true })
     end
 
     it "restores the record AND the state on rebuild (round trip)" do
@@ -155,7 +156,7 @@ RSpec.describe Phlex::Reactive::Component do
       data, sig = token.split("--", 2)
       mutated = data.dup
       i = data.length / 2
-      mutated[i] = ((data[i] == "A") ? "B" : "A")
+      mutated[i] = (data[i] == "A" ? "B" : "A")
       forged = "#{mutated}--#{sig}"
 
       expect(forged).not_to eq(token) # sanity: we actually changed the data
@@ -180,6 +181,7 @@ RSpec.describe Phlex::Reactive::Component do
 
         def initialize(baz:) = @baz = baz
         attr_reader :baz
+
         def id = "foo-bar-#{@baz.object_id}"
       end
     end
@@ -262,10 +264,10 @@ RSpec.describe Phlex::Reactive::Component do
     end
 
     it "merges extra attributes over the bound name" do
-      attrs = instance.send(:reactive_field, :count, value: 7, data: {testid: "f"})
+      attrs = instance.send(:reactive_field, :count, value: 7, data: { testid: "f" })
       expect(attrs[:name]).to eq("count")
       expect(attrs[:value]).to eq(7)
-      expect(attrs[:data]).to eq({testid: "f"})
+      expect(attrs[:data]).to eq({ testid: "f" })
     end
 
     it "lets an explicit name: override the param binding (escape hatch)" do
@@ -291,7 +293,7 @@ RSpec.describe Phlex::Reactive::Component do
 
     it "keeps debounce out of the explicit params payload" do
       attrs = instance.send(:on, :set, event: "input", debounce: 300, count: 5)
-      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({"count" => 5})
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "count" => 5 })
     end
 
     # Performance: the no-params case (the common on(:increment)) must NOT
@@ -304,7 +306,7 @@ RSpec.describe Phlex::Reactive::Component do
 
     it "still serializes explicit params" do
       attrs = instance.send(:on, :set, count: 9)
-      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({"count" => 9})
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "count" => 9 })
     end
   end
 
@@ -315,7 +317,7 @@ RSpec.describe Phlex::Reactive::Component do
   describe "#reactive_token payload (perf invariants)" do
     it "signs {c, s} for a state-backed component, with string keys" do
       token = state_klass.new(count: 5).send(:reactive_token)
-      expect(Phlex::Reactive.verify(token)).to eq("c" => "StateThing", "s" => {"count" => 5})
+      expect(Phlex::Reactive.verify(token)).to eq("c" => "StateThing", "s" => { "count" => 5 })
     end
 
     it "is stable across repeated renders of equal state" do

--- a/spec/phlex/reactive/reply_spec.rb
+++ b/spec/phlex/reactive/reply_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Phlex::Reactive::Reply do
         action :noop
         def initialize(n: 0) = @n = n
         def id = "widget"
-        def noop = reply.replace # bare `reply`, no constant
+        # bare `reply`, no constant
+        def noop = reply.replace
         def view_template = div(id:, **reactive_attrs) { @n.to_s }
       end
 

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -160,7 +160,8 @@ RSpec.describe Phlex::Reactive::Response do
 
   it "flash accepts a Phlex component, rendered through the configured renderer" do
     klass = Class.new(Phlex::HTML) do
-      def self.name = "FlashAlertProbe" # ActionView's render logger needs a name
+      # ActionView's render logger needs a name
+      def self.name = "FlashAlertProbe"
       def view_template = span { "rendered flash" }
     end
     response = described_class.with.flash(:error, klass.new)

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe "Streamable view-context memoization (performance)" do
 
   describe ".turbo_stream_builder" do
     it "reuses the builder (and therefore its view context) across calls" do
-      expect(CounterComponent.turbo_stream_builder).to be(CounterComponent.turbo_stream_builder)
+      # Both sides are the SAME call on purpose: the test proves the memo returns
+      # the identical object across calls, so identical expressions are the point.
+      first = CounterComponent.turbo_stream_builder
+      expect(CounterComponent.turbo_stream_builder).to be(first)
     end
   end
 
@@ -56,7 +59,7 @@ RSpec.describe "Streamable view-context memoization (performance)" do
     it "gives each thread its own view context" do
       contexts = Queue.new
       [Thread.new { contexts << CounterComponent.turbo_view_context },
-        Thread.new { contexts << CounterComponent.turbo_view_context }].each(&:join)
+       Thread.new { contexts << CounterComponent.turbo_view_context }].each(&:join)
       a = contexts.pop
       b = contexts.pop
       expect(a).not_to be(b) # distinct instances per thread
@@ -66,11 +69,11 @@ RSpec.describe "Streamable view-context memoization (performance)" do
       renders_per_thread = 20
       thread_count = 8
       results = Queue.new
-      threads = thread_count.times.map do |i|
+      threads = Array.new(thread_count) do
         Thread.new do
           renders_per_thread.times do
-            html = CounterComponent.render_component(CounterComponent.new(count: i))
-            results << (html.include?(">#{i}<") && html.scan('id="counter"').size == 1)
+            html = CounterComponent.render_component(CounterComponent.new(count: it))
+            results << (html.include?(">#{it}<") && html.scan('id="counter"').size == 1)
           end
         end
       end
@@ -94,7 +97,7 @@ RSpec.describe "Streamable view-context memoization (performance)" do
       fresh = CounterComponent.new(count: 1).to_stream_replace
 
       # Strip the signed token (it re-randomizes per call) before comparing.
-      strip = ->(s) { s.gsub(/data-reactive-token-value="[^"]*"/, "TOKEN") }
+      strip = -> { it.gsub(/data-reactive-token-value="[^"]*"/, "TOKEN") }
       expect(strip.call(memoized)).to eq(strip.call(fresh))
     end
   end

--- a/spec/phlex/reactive_spec.rb
+++ b/spec/phlex/reactive_spec.rb
@@ -5,24 +5,24 @@ require "spec_helper"
 RSpec.describe Phlex::Reactive do
   describe ".sign / .verify" do
     it "round-trips a payload" do
-      payload = {"c" => "Demo::Counter", "s" => {"count" => 3}}
+      payload = { "c" => "Demo::Counter", "s" => { "count" => 3 } }
       token = described_class.sign(payload)
       expect(described_class.verify(token)).to eq(payload)
     end
 
     it "rejects a tampered token" do
-      token = described_class.sign({"c" => "X", "s" => {}})
+      token = described_class.sign({ "c" => "X", "s" => {} })
       expect(described_class.verify("#{token}x")).to be_nil
     end
 
     it "rejects a token signed with a different key" do
       other = ActiveSupport::MessageVerifier.new("different")
-      forged = other.generate({"c" => "Evil"}, purpose: described_class::IDENTITY_PURPOSE)
+      forged = other.generate({ "c" => "Evil" }, purpose: described_class::IDENTITY_PURPOSE)
       expect(described_class.verify(forged)).to be_nil
     end
 
     it "rejects a token signed for a different purpose" do
-      token = described_class.verifier.generate({"c" => "X"}, purpose: "other")
+      token = described_class.verifier.generate({ "c" => "X" }, purpose: "other")
       expect(described_class.verify(token)).to be_nil
     end
   end

--- a/spec/phlex/vendored_controller_sync_spec.rb
+++ b/spec/phlex/vendored_controller_sync_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "vendored client controller" do
     expect(File.read(vendored)).to eq(File.read(source)),
       "spec/dummy/public/vendor/reactive_controller.js has drifted from the source " \
       "app/javascript/phlex/reactive/reactive_controller.js. Re-sync it (the system " \
-      "suite runs the vendored copy):\n\n" \
-      "  cp app/javascript/phlex/reactive/reactive_controller.js " \
+      "suite runs the vendored copy):\n\n  " \
+      "cp app/javascript/phlex/reactive/reactive_controller.js " \
       "spec/dummy/public/vendor/reactive_controller.js"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,22 +13,22 @@ load Rails.root.join("db/schema.rb")
 
 # Auto-load request-spec support modules (mirrors system_helper.rb's
 # system/support autoload). Holds the shared token_for / post_action helpers.
-Dir[File.join(__dir__, "requests/support/**/*.rb")].each { |f| require f }
+Dir[File.join(__dir__, "requests/support/**/*.rb")].each { require it }
 
-RSpec.configure do |config|
-  config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
+RSpec.configure do
+  it.infer_spec_type_from_file_location!
+  it.use_transactional_fixtures = true
 
   # fixture_file_upload (multipart upload specs, issue #34) resolves files here.
-  config.file_fixture_path = File.expand_path("fixtures/files", __dir__)
-  config.include ActionDispatch::TestProcess::FixtureFile
+  it.file_fixture_path = File.expand_path("fixtures/files", __dir__)
+  it.include ActionDispatch::TestProcess::FixtureFile
 
   # Shared request helpers (token_for / post_action) — issue #40.
-  config.include ActionRequestHelpers, type: :request
+  it.include ActionRequestHelpers, type: :request
 
   # In the dummy app the verifier comes from secret_key_base; align the test
   # verifier so tokens minted in specs verify against the running app.
-  config.before(:suite) do
+  it.before(:suite) do
     Phlex::Reactive.instance_variable_set(:@verifier, nil) # use Rails default
   end
 end

--- a/spec/requests/bracket_params_spec.rb
+++ b/spec/requests/bracket_params_spec.rb
@@ -11,16 +11,16 @@ require "rails_helper"
 # nested schema matches a normal Rails form with zero field renaming.
 RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
   def received(response)
-    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    json = response.body[%r{data-testid="received">(.*?)</pre>}m, 1]
     JSON.parse(CGI.unescapeHTML(json))
   end
 
-  let(:payload) { {"s" => {"received" => nil}} }
+  let(:payload) { { "s" => { "received" => nil } } }
 
   it "expands a model-scoped bracket key into the nested schema (the cosmos case)" do
     # Exactly what a Rails Form(model: @invoice) posts via #collectFields.
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"invoice[date]" => "2026-01-02", "invoice[status]" => "open"})
+      params: { "invoice[date]" => "2026-01-02", "invoice[status]" => "open" })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
@@ -28,7 +28,7 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
 
   it "coerces nested types after bracket expansion (integer/float stay typed)" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"invoice[date]" => "2026-01-02", "invoice[total]" => "9.99"})
+      params: { "invoice[date]" => "2026-01-02", "invoice[total]" => "9.99" })
 
     invoice = received(response)["invoice"]
     expect(invoice["total"]).to eq(9.99)
@@ -36,7 +36,7 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
 
   it "drops undeclared bracketed keys (no mass assignment)" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"invoice[date]" => "2026-01-02", "invoice[admin]" => "true"})
+      params: { "invoice[date]" => "2026-01-02", "invoice[admin]" => "true" })
 
     expect(received(response)["invoice"].keys).to contain_exactly("date")
   end
@@ -55,14 +55,14 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
       })
 
     items = received(response)["invoice_items_attributes"]
-    expect(items.map { |i| i["id"] }).to eq([10, 11])
-    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
-    expect(items.map { |i| i["_destroy"] }).to eq([false, true])
+    expect(items.map {  it["id"] }).to eq([10, 11])
+    expect(items.map {  it["quantity"] }).to eq([2.0, 3.0])
+    expect(items.map {  it["_destroy"] }).to eq([false, true])
   end
 
   it "mixes a flat scalar with bracketed keys in one payload" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"date" => "2026-06-27", "invoice[date]" => "2026-01-02"})
+      params: { "date" => "2026-06-27", "invoice[date]" => "2026-01-02" })
 
     parsed = received(response)
     expect(parsed["date"]).to eq("2026-06-27")
@@ -71,7 +71,7 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
 
   it "still accepts a PRE-NESTED object (backwards compatible with #16)" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {invoice: {date: "2026-01-02", status: "open"}})
+      params: { invoice: { date: "2026-01-02", status: "open" } })
 
     expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
   end
@@ -80,14 +80,14 @@ RSpec.describe "Flat bracketed param coercion (issue #21)", type: :request do
     # A bracket key processed BEFORE a sibling pre-nested object must not be
     # clobbered by it (order-dependence): both fields survive the merge.
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"invoice[date]" => "2026-01-02", "invoice" => {"status" => "open"}})
+      params: { "invoice[date]" => "2026-01-02", "invoice" => { "status" => "open" } })
 
     expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
   end
 
   it "preserves a non-string value (checkbox boolean) through expansion" do
     post_action(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {"invoice[date]" => "2026-01-02", "invoice[active]" => true})
+      params: { "invoice[date]" => "2026-01-02", "invoice[active]" => true })
 
     expect(received(response)["invoice"]["active"]).to be(true)
   end

--- a/spec/requests/chat_broadcast_spec.rb
+++ b/spec/requests/chat_broadcast_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Chat broadcast", type: :request do
   def send_message(room:, body:, connection: nil)
     token = Phlex::Reactive.sign(
       "c" => "ChatComposerComponent",
-      "s" => {"room" => room, "author" => "tester"}
+      "s" => { "room" => room, "author" => "tester" }
     )
-    headers = {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+    headers = { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
     headers["X-Pgbus-Connection"] = connection if connection
     post "/reactive/actions",
-      params: {token:, act: "send_message", params: {body:}}.to_json,
+      params: { token:, act: "send_message", params: { body: } }.to_json,
       headers: headers
   end
 

--- a/spec/requests/file_params_spec.rb
+++ b/spec/requests/file_params_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe "Reactive file/multipart params", type: :request do
   # and act are flat fields, params are bracketed (params[caption], params[file]).
   def post_multipart(klass, payload:, act:, params: {})
     post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:},
-      headers: {"Accept" => "text/vnd.turbo-stream.html"}
+      params: { token: token_for(klass, payload), act:, params: },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
   end
 
   let!(:document) { Document.create!(title: "untitled") }
-  let(:payload) { {"gid" => document.to_gid.to_s} }
+  let(:payload) { { "gid" => document.to_gid.to_s } }
   let(:upload) { fixture_file_upload("receipt.txt", "text/plain") }
 
   describe "single file (:file)" do
     it "coerces the upload to an UploadedFile and the action attaches it" do
       post_multipart(DocumentUploadComponent, payload:, act: "upload",
-        params: {file: upload, caption: "My receipt"})
+        params: { file: upload, caption: "My receipt" })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.file).to be_attached
@@ -37,7 +37,7 @@ RSpec.describe "Reactive file/multipart params", type: :request do
     it "drops a non-file value sent to a :file param (no fake file reaches the action)" do
       # A forged/malformed payload puts a plain string where a file is declared.
       post_multipart(DocumentUploadComponent, payload:, act: "upload",
-        params: {file: "not-a-file", caption: "still here"})
+        params: { file: "not-a-file", caption: "still here" })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.file).not_to be_attached # the :file param was dropped
@@ -46,7 +46,7 @@ RSpec.describe "Reactive file/multipart params", type: :request do
 
     it "passes through with no file when the input is empty (keyword default applies)" do
       post_multipart(DocumentUploadComponent, payload:, act: "upload",
-        params: {caption: "no file this time"})
+        params: { caption: "no file this time" })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.file).not_to be_attached
@@ -57,14 +57,14 @@ RSpec.describe "Reactive file/multipart params", type: :request do
   describe "multiple files ([:file])" do
     it "coerces an array of uploads and attaches them all" do
       pages = [fixture_file_upload("page1.txt", "text/plain"),
-        fixture_file_upload("page2.txt", "text/plain")]
+               fixture_file_upload("page2.txt", "text/plain")]
 
       post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
-        params: {pages:})
+        params: { pages: })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.pages.count).to eq(2)
-      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt", "page2.txt")
+      expect(document.pages.map { it.filename.to_s }).to contain_exactly("page1.txt", "page2.txt")
     end
 
     it "drops non-file elements from a forged [:file] array (no DROP sentinel leaks)" do
@@ -72,18 +72,18 @@ RSpec.describe "Reactive file/multipart params", type: :request do
       # The non-file element must be dropped — never reach the action as the
       # internal DROP sentinel (which would explode on .attach).
       post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
-        params: {pages: [fixture_file_upload("page1.txt", "text/plain"), "not-a-file"]})
+        params: { pages: [fixture_file_upload("page1.txt", "text/plain"), "not-a-file"] })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.pages.count).to eq(1) # only the real file attached
-      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt")
+      expect(document.pages.map { it.filename.to_s }).to contain_exactly("page1.txt")
     end
 
     it "applies the keyword default when EVERY [:file] element is a non-file (all dropped)" do
       # All-forged array: nothing coercible → the param is dropped entirely, so
       # the action's keyword default (nil) applies — never [] or [DROP].
       post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
-        params: {pages: ["nope", "still-not-a-file"]})
+        params: { pages: ["nope", "still-not-a-file"] })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.pages.count).to eq(0) # nothing attached
@@ -94,11 +94,11 @@ RSpec.describe "Reactive file/multipart params", type: :request do
       # shape (a one-element array, not a scalar upload) coerces to a [:file]
       # array and attaches the lone file.
       post_multipart(DocumentUploadComponent, payload:, act: "upload_pages",
-        params: {pages: [fixture_file_upload("page1.txt", "text/plain")]})
+        params: { pages: [fixture_file_upload("page1.txt", "text/plain")] })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.pages.count).to eq(1)
-      expect(document.pages.map { |p| p.filename.to_s }).to contain_exactly("page1.txt")
+      expect(document.pages.map { it.filename.to_s }).to contain_exactly("page1.txt")
     end
   end
 
@@ -108,7 +108,7 @@ RSpec.describe "Reactive file/multipart params", type: :request do
       # nested-hash param in one multipart action. The nested `meta` used to be
       # dropped; it must now survive alongside the upload.
       post_multipart(DocumentUploadComponent, payload:, act: "upload_with_meta",
-        params: {file: upload, meta: {tag: "receipts", year: "2026"}})
+        params: { file: upload, meta: { tag: "receipts", year: "2026" } })
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.file).to be_attached         # the file still attached
@@ -120,8 +120,9 @@ RSpec.describe "Reactive file/multipart params", type: :request do
   describe "JSON path is unaffected (back-compat)" do
     it "still serves a JSON-bodied action with no file param" do
       post "/reactive/actions",
-        params: {token: token_for(DocumentUploadComponent, payload), act: "upload", params: {caption: "json only"}}.to_json,
-        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+        params: { token: token_for(DocumentUploadComponent, payload), act: "upload",
+                  params: { caption: "json only" } }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
 
       expect(response).to have_http_status(:ok)
       expect(document.reload.title).to eq("json only")

--- a/spec/requests/multipart_nested_params_spec.rb
+++ b/spec/requests/multipart_nested_params_spec.rb
@@ -29,22 +29,22 @@ RSpec.describe "Multipart nested/array param coercion (issue #39)", type: :reque
   def post_multipart(klass, payload:, act:, params: {})
     probe = fixture_file_upload("receipt.txt", "text/plain")
     post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:, _multipart_probe: probe},
-      headers: {"Accept" => "text/vnd.turbo-stream.html"}
+      params: { token: token_for(klass, payload), act:, params:, _multipart_probe: probe },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
   end
 
   # Pull the reflected coerced params back out of the rendered <pre> (Phlex
   # auto-escapes the JSON text, so unescape before parsing).
   def received(response)
-    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    json = response.body[%r{data-testid="received">(.*?)</pre>}m, 1]
     JSON.parse(CGI.unescapeHTML(json))
   end
 
-  let(:payload) { {"s" => {"received" => nil}} }
+  let(:payload) { { "s" => { "received" => nil } } }
 
   it "coerces a nested-object param sent as multipart (the #39 bug case)" do
     post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {invoice: {date: "2026-01-02", status: "open"}})
+      params: { invoice: { date: "2026-01-02", status: "open" } })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["invoice"]).to eq("date" => "2026-01-02", "status" => "open")
@@ -52,14 +52,14 @@ RSpec.describe "Multipart nested/array param coercion (issue #39)", type: :reque
 
   it "coerces nested types after multipart bracket expansion (float stays typed)" do
     post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {invoice: {date: "2026-01-02", total: "9.99"}})
+      params: { invoice: { date: "2026-01-02", total: "9.99" } })
 
     expect(received(response)["invoice"]["total"]).to eq(9.99)
   end
 
   it "coerces an array-of-scalar param sent as multipart ([:integer])" do
     post_multipart(NestedParamsComponent, payload:, act: "save",
-      params: {bank_account_ids: ["1", "2", "3"]})
+      params: { bank_account_ids: %w[1 2 3] })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["bank_account_ids"]).to eq([1, 2, 3])
@@ -69,27 +69,27 @@ RSpec.describe "Multipart nested/array param coercion (issue #39)", type: :reque
     post_multipart(NestedParamsComponent, payload:, act: "save",
       params: {
         invoice_items_attributes: [
-          {id: "10", quantity: "2", price: "5", _destroy: "false"},
-          {id: "11", quantity: "3", price: "6", _destroy: "true"}
+          { id: "10", quantity: "2", price: "5", _destroy: "false" },
+          { id: "11", quantity: "3", price: "6", _destroy: "true" }
         ]
       })
 
     items = received(response)["invoice_items_attributes"]
-    expect(items.map { |i| i["id"] }).to eq([10, 11])
-    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
-    expect(items.map { |i| i["_destroy"] }).to eq([false, true])
+    expect(items.map {  it["id"] }).to eq([10, 11])
+    expect(items.map {  it["quantity"] }).to eq([2.0, 3.0])
+    expect(items.map {  it["_destroy"] }).to eq([false, true])
   end
 
   it "drops undeclared nested keys on the multipart path too (no mass assignment)" do
     post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {invoice: {date: "2026-01-02", admin: "true"}})
+      params: { invoice: { date: "2026-01-02", admin: "true" } })
 
     expect(received(response)["invoice"].keys).to contain_exactly("date")
   end
 
   it "still coerces a flat scalar alongside a nested param over multipart" do
     post_multipart(NestedParamsComponent, payload:, act: "save_invoice",
-      params: {date: "2026-06-27", invoice: {date: "2026-01-02"}})
+      params: { date: "2026-06-27", invoice: { date: "2026-01-02" } })
 
     parsed = received(response)
     expect(parsed["date"]).to eq("2026-06-27")

--- a/spec/requests/nested_attributes_helper_spec.rb
+++ b/spec/requests/nested_attributes_helper_spec.rb
@@ -12,31 +12,31 @@ RSpec.describe "accepts_nested_attributes_for helper (issue #24)", type: :reques
 
   describe "#nested_attributes (the id-preserving map)" do
     it "builds <assoc>_attributes with no id when the association is absent" do
-      result = component.send(:nested_attributes, :address, {street: "1 Main"})
+      result = component.send(:nested_attributes, :address, { street: "1 Main" })
 
-      expect(result).to eq(address_attributes: {street: "1 Main"})
+      expect(result).to eq(address_attributes: { street: "1 Main" })
     end
 
     it "carries the existing record id when the association is present" do
       addr = account.create_address!(street: "old")
-      result = component.send(:nested_attributes, :address, {street: "new"})
+      result = component.send(:nested_attributes, :address, { street: "new" })
 
-      expect(result).to eq(address_attributes: {street: "new", id: addr.id})
+      expect(result).to eq(address_attributes: { street: "new", id: addr.id })
     end
 
     it "does not mutate the params it was given" do
       account.create_address!(street: "old")
-      params = {street: "new"}
+      params = { street: "new" }
       component.send(:nested_attributes, :address, params)
 
-      expect(params).to eq({street: "new"}) # no id leaked in
+      expect(params).to eq({ street: "new" }) # no id leaked in
     end
   end
 
   describe "#nested_update! (end-to-end through the action)" do
     it "creates the associated record on first save (no duplicate build)" do
-      post_action(AddressEditorComponent, payload: {"gid" => account.to_gid.to_s}, act: "save",
-        params: {address: {street: "1 Main", city: "Town"}})
+      post_action(AddressEditorComponent, payload: { "gid" => account.to_gid.to_s }, act: "save",
+        params: { address: { street: "1 Main", city: "Town" } })
 
       expect(response).to have_http_status(:ok)
       account.reload
@@ -48,8 +48,8 @@ RSpec.describe "accepts_nested_attributes_for helper (issue #24)", type: :reques
     it "UPDATES the existing record in place (id preserved, no second has_one)" do
       addr = account.create_address!(street: "old", city: "Oldtown")
 
-      post_action(AddressEditorComponent, payload: {"gid" => account.to_gid.to_s}, act: "save",
-        params: {address: {street: "new", city: "Newtown"}})
+      post_action(AddressEditorComponent, payload: { "gid" => account.to_gid.to_s }, act: "save",
+        params: { address: { street: "new", city: "Newtown" } })
 
       expect(response).to have_http_status(:ok)
       expect(addr.reload.street).to eq("new")

--- a/spec/requests/nested_params_spec.rb
+++ b/spec/requests/nested_params_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
   # Pull the reflected coerced params back out of the rendered <pre>. Phlex
   # auto-escapes the JSON text, so unescape before parsing.
   def received(response)
-    json = response.body[/data-testid="received">(.*?)<\/pre>/m, 1]
+    json = response.body[%r{data-testid="received">(.*?)</pre>}m, 1]
     JSON.parse(CGI.unescapeHTML(json))
   end
 
-  let(:payload) { {"s" => {"received" => nil}} }
+  let(:payload) { { "s" => { "received" => nil } } }
 
   it "coerces an array-of-scalar param ([:integer])" do
     post_action(NestedParamsComponent, payload:, act: "save",
-      params: {bank_account_ids: ["1", "2", "3"]})
+      params: { bank_account_ids: %w[1 2 3] })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["bank_account_ids"]).to eq([1, 2, 3])
@@ -27,16 +27,16 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
     post_action(NestedParamsComponent, payload:, act: "save",
       params: {
         invoice_items_attributes: [
-          {id: "10", quantity: "2.5", price: "9.99", _destroy: "false"},
-          {id: "11", quantity: "1", price: "100", _destroy: "true"}
+          { id: "10", quantity: "2.5", price: "9.99", _destroy: "false" },
+          { id: "11", quantity: "1", price: "100", _destroy: "true" }
         ]
       })
 
     expect(response).to have_http_status(:ok)
     items = received(response)["invoice_items_attributes"]
     expect(items).to eq([
-      {"id" => 10, "quantity" => 2.5, "price" => 9.99, "_destroy" => false},
-      {"id" => 11, "quantity" => 1.0, "price" => 100.0, "_destroy" => true}
+      { "id" => 10, "quantity" => 2.5, "price" => 9.99, "_destroy" => false },
+      { "id" => 11, "quantity" => 1.0, "price" => 100.0, "_destroy" => true }
     ])
   end
 
@@ -44,7 +44,7 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
     post_action(NestedParamsComponent, payload:, act: "save",
       params: {
         invoice_items_attributes: [
-          {id: "10", quantity: "2", price: "5", _destroy: "false", admin: "true", secret: "x"}
+          { id: "10", quantity: "2", price: "5", _destroy: "false", admin: "true", secret: "x" }
         ]
       })
 
@@ -58,18 +58,18 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
     post_action(NestedParamsComponent, payload:, act: "save",
       params: {
         invoice_items_attributes: {
-          "0" => {id: "10", quantity: "2", price: "5", _destroy: "false"},
-          "1" => {id: "11", quantity: "3", price: "6", _destroy: "false"}
+          "0" => { id: "10", quantity: "2", price: "5", _destroy: "false" },
+          "1" => { id: "11", quantity: "3", price: "6", _destroy: "false" }
         }
       })
 
     items = received(response)["invoice_items_attributes"]
-    expect(items.map { |i| i["id"] }).to eq([10, 11])
-    expect(items.map { |i| i["quantity"] }).to eq([2.0, 3.0])
+    expect(items.map {  it["id"] }).to eq([10, 11])
+    expect(items.map {  it["quantity"] }).to eq([2.0, 3.0])
   end
 
   it "leaves a declared array param absent when the client omits it" do
-    post_action(NestedParamsComponent, payload:, act: "save", params: {date: "2026-06-27"})
+    post_action(NestedParamsComponent, payload:, act: "save", params: { date: "2026-06-27" })
 
     parsed = received(response)
     expect(parsed["date"]).to eq("2026-06-27")
@@ -80,7 +80,7 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
 
   it "coerces an empty array to an empty array (not dropped)" do
     post_action(NestedParamsComponent, payload:, act: "save",
-      params: {bank_account_ids: []})
+      params: { bank_account_ids: [] })
 
     expect(received(response)["bank_account_ids"]).to eq([])
   end
@@ -91,7 +91,7 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
     # Drop it so the method's keyword default (nil) applies, distinct from a real
     # empty array.
     post_action(NestedParamsComponent, payload:, act: "save",
-      params: {bank_account_ids: "5"})
+      params: { bank_account_ids: "5" })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["bank_account_ids"]).to be_nil
@@ -99,7 +99,7 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
 
   it "drops a malformed (non-array) array-of-hash param" do
     post_action(NestedParamsComponent, payload:, act: "save",
-      params: {invoice_items_attributes: "not-an-array"})
+      params: { invoice_items_attributes: "not-an-array" })
 
     expect(response).to have_http_status(:ok)
     expect(received(response)["invoice_items_attributes"]).to be_nil
@@ -107,7 +107,7 @@ RSpec.describe "Nested/array param coercion (issue #16)", type: :request do
 
   it "still coerces flat scalars alongside nested params" do
     post_action(NestedParamsComponent, payload:, act: "save",
-      params: {date: "2026-06-27", bank_account_ids: ["7"]})
+      params: { date: "2026-06-27", bank_account_ids: ["7"] })
 
     parsed = received(response)
     expect(parsed["date"]).to eq("2026-06-27")

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Reactive actions", type: :request do
 
   describe "state-backed component (CounterComponent)" do
     it "runs an action and returns an auto-targeted turbo-stream" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "increment")
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
 
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
@@ -18,12 +18,12 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "coerces a typed param" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 9}}, act: "set", params: {count: "0"})
+      post_action(CounterComponent, payload: { "s" => { "count" => 9 } }, act: "set", params: { count: "0" })
       expect(response.body).to match(/>\s*0\s*</)
     end
 
     it "forbids an undeclared action (default-deny)" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "destroy_everything")
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "destroy_everything")
       expect(response).to have_http_status(:forbidden)
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe "Reactive actions", type: :request do
     let!(:todo) { Todo.create!(title: "write specs", done: false) }
 
     it "re-finds the record by GlobalID and runs the action" do
-      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "toggle")
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "toggle")
 
       expect(response).to have_http_status(:ok)
       expect(todo.reload.done?).to be(true)
@@ -42,7 +42,7 @@ RSpec.describe "Reactive actions", type: :request do
     it "returns 404 when the record no longer exists" do
       gid = todo.to_gid.to_s
       todo.destroy!
-      post_action(TodoItemComponent, payload: {"gid" => gid}, act: "toggle")
+      post_action(TodoItemComponent, payload: { "gid" => gid }, act: "toggle")
       expect(response).to have_http_status(:not_found)
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "Reactive actions", type: :request do
     it "broadcasts a replace without raising ArgumentError (issue #4)" do
       stream = "todos"
 
-      expect {
+      expect do
         broadcasts = capture_turbo_stream_broadcasts(stream) do
           TodoItemComponent.broadcast_replace_to(stream, model: todo)
         end
@@ -64,7 +64,7 @@ RSpec.describe "Reactive actions", type: :request do
         expect(html).to include('action="replace"')
         expect(html).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
         expect(html).to include("write specs")
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     # Issue #28: a live cross-tab replace can morph in place so a peer tab keeps
@@ -93,7 +93,7 @@ RSpec.describe "Reactive actions", type: :request do
     # Mint a token exactly as the component would after a render: it signs the
     # record gid AND the declared state (attribute, editing).
     def state_payload(attribute:, editing:)
-      {"gid" => todo.to_gid.to_s, "s" => {"attribute" => attribute.to_s, "editing" => editing}}
+      { "gid" => todo.to_gid.to_s, "s" => { "attribute" => attribute.to_s, "editing" => editing } }
     end
 
     it "restores the signed state so the mode survives an action" do
@@ -112,7 +112,7 @@ RSpec.describe "Reactive actions", type: :request do
       post_action(InlineEditComponent,
         payload: state_payload(attribute: :title, editing: true),
         act: "save",
-        params: {value: "renamed"})
+        params: { value: "renamed" })
 
       expect(response).to have_http_status(:ok)
       expect(todo.reload.title).to eq("renamed") # the correct column, not nil
@@ -139,8 +139,8 @@ RSpec.describe "Reactive actions", type: :request do
       forged = "#{Base64.urlsafe_encode64(decoded.to_json, padding: false)}--#{sig}"
 
       post "/reactive/actions",
-        params: {token: forged, act: "save", params: {value: "x"}}.to_json,
-        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+        params: { token: forged, act: "save", params: { value: "x" } }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
 
       expect(response).to have_http_status(:bad_request)
     end
@@ -155,7 +155,7 @@ RSpec.describe "Reactive actions", type: :request do
     let!(:todo) { Todo.create!(title: "keep me", done: false) }
 
     it "passes an explicitly blank param through to the guarded action" do
-      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename", params: {title: ""})
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "rename", params: { title: "" })
 
       expect(response).to have_http_status(:ok)
       expect(todo.reload.title).to eq("keep me") # unchanged: guarded by `if title.present?`
@@ -170,7 +170,7 @@ RSpec.describe "Reactive actions", type: :request do
     let!(:todo) { Todo.create!(title: "moderate me", done: false) }
 
     it "replace + flash: re-renders self (token refresh) AND appends a flash" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 5}}, act: "reset_with_flash")
+      post_action(CounterComponent, payload: { "s" => { "count" => 5 } }, act: "reset_with_flash")
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('action="replace"')
@@ -181,7 +181,7 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "replace + flash: contains exactly ONE self-target stream (no double-prepend)" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 5}}, act: "reset_with_flash")
+      post_action(CounterComponent, payload: { "s" => { "count" => 5 } }, act: "reset_with_flash")
       expect(response.body.scan('target="counter"').size).to eq(1)
     end
 
@@ -190,21 +190,21 @@ RSpec.describe "Reactive actions", type: :request do
     # reads), NOT "some stream targets self" — so it must NOT prepend a second,
     # contradictory replace when the update already carries a fresh token.
     it "update: morphs self with a fresh token and is NOT doubled with a replace" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "bump_via_update")
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "bump_via_update")
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('action="update"')
       expect(response.body).to include('target="counter"')
       expect(response.body).to include("data-reactive-token-value=") # token refreshed
       expect(response.body).not_to include('action="replace"')       # no contradictory double-render
-      expect(response.body).to match(/>\s*2\s*</)                     # 1 -> 2
+      expect(response.body).to match(/>\s*2\s*</) # 1 -> 2
     end
 
     # Issue #28: Response.morph(self) re-renders the element via Idiomorph
     # (action="replace" method="morph"). The morphed root carries a fresh token,
     # so the endpoint must NOT prepend a second, contradictory plain replace.
     it "morph: re-renders self with method=\"morph\" + a fresh token, not doubled" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 1}}, act: "bump_via_morph")
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "bump_via_morph")
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('action="replace"')
@@ -216,7 +216,7 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "remove: emits a remove stream for the element and NO self replace" do
-      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "archive")
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "archive")
 
       dom = ActionView::RecordIdentifier.dom_id(todo)
       expect(response).to have_http_status(:ok)
@@ -226,7 +226,7 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "redirect: 200 turbo-stream carrying reactive:visit (NOT an HTTP 3xx)" do
-      post_action(CounterComponent, payload: {"s" => {"count" => 0}}, act: "go_home")
+      post_action(CounterComponent, payload: { "s" => { "count" => 0 } }, act: "go_home")
 
       expect(response).to have_http_status(:ok)
       expect(response).not_to be_redirect
@@ -236,7 +236,7 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "flash-on-error keeps the row's token (self replace + flash both present)" do
-      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename_strict", params: {title: ""})
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "rename_strict", params: { title: "" })
 
       dom = ActionView::RecordIdentifier.dom_id(todo)
       expect(response.body).to include(%(target="#{dom}")) # fresh token
@@ -245,7 +245,8 @@ RSpec.describe "Reactive actions", type: :request do
     end
 
     it "valid rename_strict updates and single-replaces" do
-      post_action(TodoItemComponent, payload: {"gid" => todo.to_gid.to_s}, act: "rename_strict", params: {title: "renamed"})
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "rename_strict",
+        params: { title: "renamed" })
 
       expect(response).to have_http_status(:ok)
       expect(todo.reload.title).to eq("renamed")
@@ -257,7 +258,7 @@ RSpec.describe "Reactive actions", type: :request do
     # partial/per-field update never tears down the component's live inputs.
     describe "streams (issue #30 — partial update + token-only refresh)" do
       it "emits the caller's stream AND a token-only refresh, with NO full-self replace" do
-        post_action(CounterComponent, payload: {"s" => {"count" => 4}}, act: "bump_via_partial")
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_via_partial")
 
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq("text/vnd.turbo-stream.html")
@@ -272,7 +273,7 @@ RSpec.describe "Reactive actions", type: :request do
       end
 
       it "does not re-render the component body (count is absent — inputs untouched)" do
-        post_action(CounterComponent, payload: {"s" => {"count" => 4}}, act: "bump_via_partial")
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_via_partial")
 
         # The token-refresh stream carries no rendered children, so the next
         # count (5) appears only inside the caller's own mirror update, never as
@@ -285,7 +286,7 @@ RSpec.describe "Reactive actions", type: :request do
       # legitimately carries its own data-reactive-token-value) must STILL refresh
       # this component's token — otherwise the actor's next action 400s.
       it "still refreshes the actor's token when a SIBLING component's stream carries one" do
-        post_action(CounterComponent, payload: {"s" => {"count" => 4}}, act: "bump_with_sibling")
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_sibling")
 
         # Capture the sibling the ACTION created (not a preexisting fixture), so
         # the sibling-target assertions actually exercise the action's output.
@@ -312,8 +313,8 @@ RSpec.describe "Reactive actions", type: :request do
   describe "tampering" do
     it "rejects a forged token" do
       post "/reactive/actions",
-        params: {token: "not.a.real.token", act: "increment"}.to_json,
-        headers: {"Content-Type" => "application/json"}
+        params: { token: "not.a.real.token", act: "increment" }.to_json,
+        headers: { "Content-Type" => "application/json" }
       expect(response).to have_http_status(:bad_request)
     end
   end

--- a/spec/requests/reactive_collection_spec.rb
+++ b/spec/requests/reactive_collection_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
   describe "add (reply.append)" do
     it "creates the record and appends the row into the container" do
-      expect {
-        post_action(klass, act: "add", params: {title: "ping"})
-      }.to change(Todo, :count).by(1)
+      expect do
+        post_action(klass, act: "add", params: { title: "ping" })
+      end.to change(Todo, :count).by(1)
 
       expect(response).to have_http_status(:ok)
       todo = Todo.order(:id).last
@@ -25,7 +25,7 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "updates the count companion with the new size" do
       Todo.create!(title: "existing")
-      post_action(klass, act: "add", params: {title: "second"})
+      post_action(klass, act: "add", params: { title: "second" })
 
       expect(response.body).to include('target="notifications-count"')
       # 1 existing + 1 added = 2
@@ -34,7 +34,7 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "removes the empty-state when the first row crosses 0->1" do
       expect(Todo.count).to eq(0)
-      post_action(klass, act: "add", params: {title: "first"})
+      post_action(klass, act: "add", params: { title: "first" })
 
       expect(response.body).to include('action="remove"')
       expect(response.body).to include('target="notifications-empty"')
@@ -42,14 +42,14 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "leaves the empty-state alone when the list was already populated" do
       Todo.create!(title: "existing")
-      post_action(klass, act: "add", params: {title: "another"})
+      post_action(klass, act: "add", params: { title: "another" })
 
       expect(response.body).not_to include('target="notifications-empty"')
     end
 
     it "does not re-render the whole container body (render_self false — only the delta)" do
       Todo.create!(title: "existing")
-      post_action(klass, act: "add", params: {title: "new"})
+      post_action(klass, act: "add", params: { title: "new" })
 
       # The container's body is never re-rendered — no replace/update of its root.
       # (The container IS targeted by the inert reactive:token refresh, which only
@@ -64,9 +64,9 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "destroys the record and removes the row by its dom id" do
       dom_id = ActionView::RecordIdentifier.dom_id(todo)
-      expect {
-        post_action(klass, act: "dismiss", params: {id: todo.id})
-      }.to change(Todo, :count).by(-1)
+      expect do
+        post_action(klass, act: "dismiss", params: { id: todo.id })
+      end.to change(Todo, :count).by(-1)
 
       expect(response.body).to include('action="remove"')
       expect(response.body).to include(%(target="#{dom_id}"))
@@ -74,14 +74,14 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "updates the count companion" do
       Todo.create!(title: "other")
-      post_action(klass, act: "dismiss", params: {id: todo.id})
+      post_action(klass, act: "dismiss", params: { id: todo.id })
 
       # 2 existing - 1 dismissed = 1
       expect(response.body).to match(/target="notifications-count".*>\s*1\s*</m)
     end
 
     it "restores the empty-state when the last row is dismissed (->0)" do
-      post_action(klass, act: "dismiss", params: {id: todo.id})
+      post_action(klass, act: "dismiss", params: { id: todo.id })
 
       expect(Todo.count).to eq(0)
       expect(response.body).to include("No notifications")
@@ -90,7 +90,7 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "leaves the empty-state out while rows remain" do
       Todo.create!(title: "survivor")
-      post_action(klass, act: "dismiss", params: {id: todo.id})
+      post_action(klass, act: "dismiss", params: { id: todo.id })
 
       expect(response.body).not_to include("No notifications")
     end
@@ -115,7 +115,7 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
     let(:container_id) { "notifications-list" }
 
     it "append emits a reactive:token stream targeting the container" do
-      post_action(klass, act: "add", params: {title: "ping"})
+      post_action(klass, act: "add", params: { title: "ping" })
 
       expect(response.body).to include('action="reactive:token"')
       expect(response.body).to include(%(target="#{container_id}"))
@@ -123,7 +123,7 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
 
     it "remove emits a reactive:token stream targeting the container" do
       todo = Todo.create!(title: "bye")
-      post_action(klass, act: "dismiss", params: {id: todo.id})
+      post_action(klass, act: "dismiss", params: { id: todo.id })
 
       expect(response.body).to include('action="reactive:token"')
       expect(response.body).to include(%(target="#{container_id}"))
@@ -132,14 +132,14 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
     # The load-bearing assertion: dispatch a SECOND add using the token the FIRST
     # response rolled forward, and it must succeed. A stale-token helper 400s here.
     it "supports repeated adds — the second uses the token the first refreshed" do
-      post_action(klass, act: "add", params: {title: "first"})
+      post_action(klass, act: "add", params: { title: "first" })
       expect(response).to have_http_status(:ok)
       next_token = token_from(response.body, container_id)
       expect(next_token).to be_present
 
       post "/reactive/actions",
-        params: {token: next_token, act: "add", params: {title: "second"}}.to_json,
-        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+        params: { token: next_token, act: "add", params: { title: "second" } }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
 
       expect(response).to have_http_status(:ok)
       expect(Todo.count).to eq(2)
@@ -147,13 +147,13 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
     end
 
     it "supports an add then a remove using the chained refreshed tokens" do
-      post_action(klass, act: "add", params: {title: "row"})
+      post_action(klass, act: "add", params: { title: "row" })
       todo = Todo.order(:id).last
       token_after_add = token_from(response.body, container_id)
 
       post "/reactive/actions",
-        params: {token: token_after_add, act: "dismiss", params: {id: todo.id}}.to_json,
-        headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+        params: { token: token_after_add, act: "dismiss", params: { id: todo.id } }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
 
       expect(response).to have_http_status(:ok)
       expect(Todo.count).to eq(0)

--- a/spec/requests/reactive_input_spec.rb
+++ b/spec/requests/reactive_input_spec.rb
@@ -8,7 +8,7 @@ require "rails_helper"
 # right name AND the action actually receives the bound param end-to-end.
 RSpec.describe "reactive_input / reactive_select binding (issue #23)", type: :request do
   let!(:todo) { Todo.create!(title: "before", done: false) }
-  let(:payload) { {"gid" => todo.to_gid.to_s, "s" => {"attribute" => "title"}} }
+  let(:payload) { { "gid" => todo.to_gid.to_s, "s" => { "attribute" => "title" } } }
 
   it "renders an input whose name is the bound param (not a magic string)" do
     html = Phlex::Reactive.render(ReactiveInputComponent.new(record: todo, attribute: :title))
@@ -26,7 +26,7 @@ RSpec.describe "reactive_input / reactive_select binding (issue #23)", type: :re
   end
 
   it "delivers the bound value to the action end-to-end" do
-    post_action(ReactiveInputComponent, payload:, act: "save", params: {value: "after"})
+    post_action(ReactiveInputComponent, payload:, act: "save", params: { value: "after" })
 
     expect(response).to have_http_status(:ok)
     expect(todo.reload.title).to eq("after")

--- a/spec/requests/support/action_request_helpers.rb
+++ b/spec/requests/support/action_request_helpers.rb
@@ -18,7 +18,7 @@ module ActionRequestHelpers
   # the client uses when no file input is present.
   def post_action(klass, act:, payload: {}, params: {})
     post "/reactive/actions",
-      params: {token: token_for(klass, payload), act:, params:}.to_json,
-      headers: {"Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html"}
+      params: { token: token_for(klass, payload), act:, params: }.to_json,
+      headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,14 +11,14 @@ GlobalID.app = "phlex-reactive-test"
 
 Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new("phlex-reactive-test-secret")
 
-RSpec.configure do |config|
-  config.example_status_persistence_file_path = ".rspec_status"
-  config.disable_monkey_patching!
+RSpec.configure do
+  it.example_status_persistence_file_path = ".rspec_status"
+  it.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  it.expect_with :rspec do
+    it.syntax = :expect
   end
 
-  config.order = :random
-  Kernel.srand config.seed
+  it.order = :random
+  Kernel.srand it.seed
 end

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -24,34 +24,34 @@ Capybara.register_server(:falcon) do |app, port, host|
   Falcon::Server.new(rack_app, endpoint).run.wait
 end
 
-Capybara.server = case ENV["CAPYBARA_SERVER"]
-when "falcon"
-  :falcon
-else
-  [:puma, {Silent: true}]
-end
+Capybara.server = case ENV.fetch("CAPYBARA_SERVER", nil)
+                  when "falcon"
+                    :falcon
+                  else
+                    [:puma, { Silent: true }]
+                  end
 
-RSpec.configure do |config|
-  config.before(:each, type: :system) do
-    Capybara.configure do |c|
-      c.default_max_wait_time = 5
-      c.default_driver = :playwright
-      c.javascript_driver = :playwright
-      c.save_path = "tmp/capybara"
-      c.always_include_port = true
+RSpec.configure do
+  it.before(:each, type: :system) do
+    Capybara.configure do
+      it.default_max_wait_time = 5
+      it.default_driver = :playwright
+      it.javascript_driver = :playwright
+      it.save_path = "tmp/capybara"
+      it.always_include_port = true
     end
 
     driven_by(:playwright, screen_size: [1280, 800])
   end
 
   # Screenshot on failure (best-effort).
-  config.after(:each, type: :system) do |example|
-    next unless example.exception
+  it.after(:each, type: :system) do
+    next unless it.exception
 
     begin
       path = Rails.root.join("..", "..", "tmp", "capybara")
-      page.save_screenshot(path.join("failure-#{example.full_description.parameterize}.png").to_s) # rubocop:disable Lint/Debugger
-    rescue
+      page.save_screenshot(path.join("failure-#{it.full_description.parameterize}.png").to_s) # rubocop:disable Lint/Debugger
+    rescue StandardError
       # ignore screenshot failures
     end
   end

--- a/spec/system/support/playwright_setup.rb
+++ b/spec/system/support/playwright_setup.rb
@@ -4,9 +4,9 @@ require "capybara-playwright-driver"
 
 HEADLESS = %w[1 true].include?(ENV.fetch("HEADLESS", "true"))
 
-Capybara.register_driver(:playwright) do |app|
+Capybara.register_driver(:playwright) do
   Capybara::Playwright::Driver.new(
-    app,
+    it,
     playwright_cli_executable_path: "./node_modules/.bin/playwright",
     browser_type: :chromium,
     headless: HEADLESS

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -4,4 +4,4 @@
 require "rails_helper"
 require "capybara/rspec"
 
-Dir[File.join(__dir__, "system/support/**/*.rb")].each { |f| require f }
+Dir[File.join(__dir__, "system/support/**/*.rb")].each { require it }


### PR DESCRIPTION
## Summary

Replaces **StandardRB with a full RuboCop setup** configured like cosmos / zazu / pgbus — all new cops enabled (`NewCops: enable`) — so the linter teaches and enforces newer Ruby idioms Standard leaves alone. The headline win is the **Ruby 3.4 `it` implicit single block parameter**: `something.map { |variable| variable.method }` → `something.map { it.method }`, enforced and autocorrected across the tree.

> ⚠️ **Breaking change** — minimum Ruby is now **3.4** (was 3.2). The `it` block parameter requires Ruby 3.4, so `required_ruby_version` is `>= 3.4.0` and the CI matrix drops 3.2 / 3.3. Users on Ruby 3.2 / 3.3 should stay on the 0.3.x line.

## What changed

| Area | Change |
|------|--------|
| **`.rubocop.yml`** (new) | plugins `rubocop-performance` / `rubocop-rake` / `rubocop-rspec`; `AllCops` `TargetRubyVersion: 3.4` + `NewCops: enable`; `Style/ItBlockParameter: always`; component-folder relaxations scoped to `spec/dummy/app/components/**` |
| **Gemfile** | drop `standard`; add `rubocop-performance` + `rubocop-rake`; bump `rubocop ~> 1.80`; simplify the pgbus 3.3 gate; merge the duplicate `:development, :test` group |
| **Rakefile** | `RuboCop::RakeTask`; default task runs `spec + rubocop` |
| **gemspec** | `required_ruby_version >= 3.4.0` |
| **CI** | lint step runs `rubocop`; test + release matrices are `3.4` + `4.0` |
| **Docs / commands / rules** | every `standardrb` reference → `rubocop`, `--fix` → `-A`, Ruby-floor mentions → 3.4 |

## `Style/ItBlockParameter` — the one sharp edge

`always` is the only enforced style that actually **converts** call sites (`allow_single_line` permits `it` but never enforces it, so it changes nothing). The catch: `always`'s `-A` autocorrect **silently collapses nested single-param blocks** — both the outer and inner block param become `it`, changing behavior. So this PR:

- **excludes the gemspec + Rakefile** from the cop (their `do |spec| … end` / `do |t| … end` config blocks read better named, and contain nested blocks);
- carries **one inline `# rubocop:disable`** on a nested Phlex content block (`STATUSES.each { |s| option(value: s) { s } }`) where blanket `it` dropped the option content (the request spec caught it);
- the `lib/`/`app/` changes are otherwise the `|x| x.foo` → `it.foo` rename plus hash-brace spacing — **behavior is unchanged**.

## Verification

- ✅ `bundle exec rubocop` — 100 files, **no offenses**
- ✅ `bundle exec rspec spec/phlex spec/requests spec/generators` — **215 examples, 0 failures**
- ✅ `gem build phlex-reactive.gemspec --strict` — builds clean
- ⏳ System (browser) suite runs in CI under Puma + Falcon
