### PR TITLE
fix(streamable): restore the request on the re-render view context (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **0.4.0 regression: re-renders lost the `request`, crashing `form_authenticity_token`
+  and other request-dependent helpers (#42).** The 0.4.0 render-path perf rework
+  built the cached off-request view context from a bare
+  `ActionController::Base.new.view_context`, whose controller has `request == nil`.
+  Any reactive component whose `view_template` calls `form_authenticity_token`,
+  `protect_against_forgery?`, or a host-aware URL helper (all of which read
+  `request.env`) then raised `NoMethodError: undefined method 'env' for nil` on
+  **every** re-render — through the action endpoint AND on broadcasts — so any app
+  with a reactive component rendering a Rails CSRF form could not adopt 0.4.0. Fixed
+  by building the cached view context through a request-bound controller
+  (`Phlex::Reactive.request_bound_view_context`), replicating exactly what
+  `ActionController::Renderer#render` does to set up its mock request: an
+  `ActionDispatch::Request` whose host is derived from the routes'
+  `default_url_options`. The 0.4.0 `render_in` speedup is kept — the request is set
+  up once when the per-thread context is built (not per render), and steady-state
+  render throughput/allocations are unchanged (retained-per-render stays 0). Covered
+  at the request level (a reactive `save` re-rendering a CSRF form returns 200, not
+  500), the broadcast level (the form component broadcasts without crashing), and the
+  unit level (a request is present on the cached context; host-aware `*_url` helpers
+  resolve when the renderer carries routes).
+
 - **Multipart path silently dropped an explicit nested-hash / array param (#39).**
   When an action declared a `:file` param alongside an explicit nested (hash/array)
   param, the nested param was dropped on the multipart path while the JSON path

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -23,7 +23,7 @@ harness below exists so you never have to guess.
 | Path | When it runs | What we did |
 |------|--------------|-------------|
 | `render_component` | every action re-render **and every broadcast render** | Renders through phlex-rails' lightweight `#render_in` against a **memoized** off-request view context, instead of `ActionController.renderer.render`. ~1.9× faster, ~half the allocations, byte-identical HTML. |
-| view context / `TagBuilder` | every render + broadcast | Built **once per component class** and reused (the comment used to say "memoized" — now it actually is). Reset on Rails code reload so a reloaded controller is never served stale. |
+| view context / `TagBuilder` | every render + broadcast | Built **once per thread per component class** and reused. The context is **request-bound** (`Phlex::Reactive.request_bound_view_context`, the same mock-request `ActionController::Renderer#render` sets up) so request-dependent helpers — `form_authenticity_token`, `protect_against_forgery?`, host-aware `*_url` — keep working during a re-render/broadcast (#42). The request setup happens **only on the build**, not per render, so steady-state throughput/allocations are unchanged. Reset on Rails code reload so a reloaded controller is never served stale. |
 | `reactive_token` | every render (it's in `reactive_attrs`) | Ivar symbols (`:@count`) and state string-keys are precomputed per class, so signing no longer allocates a `Symbol`/`String` per state key. The HMAC itself dominates and is unavoidable. |
 | `on(:action)` | every trigger rendered | The no-params case (the common one) skips re-serializing `{}` to JSON. |
 | `coerce_params` | every action with a param schema | The bracket-key regex is hoisted to a frozen constant (no per-key recompile). |

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -78,6 +78,30 @@ module Phlex
         @renderer ||= defined?(::ActionController::Base) ? ::ActionController::Base : nil
       end
 
+      # Build an off-request view context whose controller has a REAL `request`.
+      #
+      # A bare `controller.new.view_context` (the naive off-request context) has
+      # `request == nil`, so any request-dependent helper raises
+      # `undefined method 'env' for nil` — form_authenticity_token,
+      # protect_against_forgery?, and host-aware URL helpers all read
+      # `request.env` (issue #42). We replicate exactly what
+      # ActionController::Renderer#render does to set up its mock request — build
+      # an ActionDispatch::Request from the renderer's env (which derives the host
+      # from the routes' default_url_options), bind the routes, and attach it —
+      # then return the controller's view context instead of rendering a template.
+      # The result keeps the 0.4.0 render_in speedup (no renderer.render
+      # machinery) while restoring the request those helpers need.
+      def request_bound_view_context(controller_class)
+        ar_renderer = controller_class.renderer
+        request = ::ActionDispatch::Request.new(ar_renderer.send(:env_for_request))
+        request.routes = controller_class._routes
+
+        instance = controller_class.new
+        instance.set_request!(request)
+        instance.set_response!(controller_class.make_response!(request))
+        instance.view_context
+      end
+
       # DOM id of the host-app container a Response#flash appends into.
       # Default "flash"; override to match your layout's flash region.
       def flash_target
@@ -136,7 +160,7 @@ module Phlex
         generation = off_request_view_context_generation
 
         unless cache && cache[:renderer].equal?(current) && cache[:generation] == generation
-          view_context = current.new.view_context
+          view_context = request_bound_view_context(current)
           cache = {
             view_context: view_context,
             builder: ::Turbo::Streams::TagBuilder.new(view_context),

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -83,7 +83,10 @@ module Phlex
 
         # Turbo::Streams::TagBuilder needs a real VIEW CONTEXT (it calls
         # `.formats` on it), not a controller class. Build one off-request from
-        # the configured renderer controller. Memoized PER THREAD — building a
+        # the configured renderer controller, bound to a real request so
+        # request-dependent helpers (form_authenticity_token, host-aware URL
+        # helpers) work during a re-render/broadcast (issue #42). Memoized PER
+        # THREAD — building a
         # view context instantiates the renderer controller and assembles its
         # whole helper module set, so doing it per render/broadcast was the
         # hottest server-side allocation in the action round trip. The builder
@@ -260,7 +263,7 @@ module Phlex
           cached = store[self]
 
           unless cached && cached.renderer.equal?(current) && cached.generation == generation
-            view_context = current.new.view_context
+            view_context = Phlex::Reactive.request_bound_view_context(current)
             cached = ThreadViewContext.new(
               view_context,
               ::Turbo::Streams::TagBuilder.new(view_context),

--- a/spec/dummy/app/components/csrf_form_component.rb
+++ b/spec/dummy/app/components/csrf_form_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Issue #42: a reactive component whose view_template renders a real Rails form
+# with a CSRF token via `form_authenticity_token`. That helper reads
+# `request.env`, so it crashes ("undefined method 'env' for nil") whenever the
+# re-render goes through a REQUEST-LESS view context. This component is the
+# regression fixture: render_component / a reactive action that re-renders it
+# must NOT raise, and the rendered HTML must carry the authenticity token field.
+class CsrfFormComponent < ApplicationComponent
+  include Phlex::Rails::Helpers::FormAuthenticityToken
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :save, params: { title: :string }
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, "csrfform")
+
+  def save(title:)
+    @todo.update!(title:) if title.present?
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      form(action: "/todos", method: "post") do
+        # The exact helper from the bug report: reads request.env, so it raises
+        # through a request-less view context.
+        input(type: "hidden", name: "authenticity_token", value: form_authenticity_token)
+        input(name: "title", value: @todo.title, data: { testid: "title" })
+        button(type: "submit", data: { testid: "save" }) { "Save" }
+      end
+      span(data: { testid: "current" }) { @todo.title }
+    end
+  end
+end

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -126,4 +126,71 @@ RSpec.describe "Streamable view-context memoization (performance)" do
       expect(html).to include('data-controller="reactive"')
     end
   end
+
+  # Issue #42: the off-request view context lost the `request` when 0.4.0 swapped
+  # to `controller.new.view_context`, so any request-dependent helper
+  # (form_authenticity_token, protect_against_forgery?, host-aware URL helpers)
+  # raised "undefined method 'env' for nil" on every re-render and broadcast.
+  # The cached context must be bound to a request so those helpers keep working.
+  describe "request-dependent helpers (issue #42)" do
+    let(:todo) { Todo.create!(title: "t", done: false) }
+
+    it "exposes a request on the cached view context's controller" do
+      expect(CounterComponent.turbo_view_context.controller.request).not_to be_nil
+    end
+
+    it "renders a component that calls form_authenticity_token without raising" do
+      expect { CsrfFormComponent.render_component(CsrfFormComponent.new(todo:)) }
+        .not_to raise_error
+    end
+
+    it "renders the authenticity token field into the HTML" do
+      html = CsrfFormComponent.render_component(CsrfFormComponent.new(todo:))
+      expect(html).to include('name="authenticity_token"')
+    end
+
+    it "answers protect_against_forgery? without raising (request present)" do
+      expect { CounterComponent.turbo_view_context.protect_against_forgery? }
+        .not_to raise_error
+    end
+
+    # The issue's second failure mode: a component rendering a host-aware path
+    # (an Action with a full URL). When the renderer is a real app controller
+    # (one with routes + default_url_options, as in a real app), the request
+    # picks up the host so `*_url` helpers resolve instead of raising. We mutate
+    # the host on the route set's default_url_options and restore it EXACTLY —
+    # deleting the key if it was absent rather than setting it to nil, because a
+    # `{ host: nil }` differs from `{}` and makes default_env recompute with a nil
+    # host ("Missing host to link to!"), leaking into every other example. The
+    # route set recomputes default_env automatically once the options match again.
+    it "resolves host-aware URL helpers when the renderer has routes" do
+      routed = DemosController # a real app controller — carries the app routes
+      opts = Rails.application.routes.default_url_options
+      had_host = opts.key?(:host)
+      previous_host = opts[:host]
+      opts[:host] = "example.test"
+
+      vc = Phlex::Reactive.request_bound_view_context(routed)
+      expect(vc.controller.request.host).to eq("example.test")
+      name = Rails.application.routes.named_routes.names.first
+      expect(vc.public_send("#{name}_url")).to start_with("http://example.test/")
+    ensure
+      had_host ? (opts[:host] = previous_host) : opts.delete(:host)
+    end
+  end
+
+  # The standalone off-request render path (Phlex::Reactive.render — used for a
+  # Response#with embedded component) shares the same regression: it must also
+  # carry a request so an embedded CSRF form renders.
+  describe "Phlex::Reactive.render request-dependent helpers (issue #42)" do
+    let(:todo) { Todo.create!(title: "t", done: false) }
+
+    it "exposes a request on the standalone off-request view context" do
+      expect(Phlex::Reactive.off_request_view_context.controller.request).not_to be_nil
+    end
+
+    it "renders an embedded CSRF form without raising" do
+      expect { Phlex::Reactive.render(CsrfFormComponent.new(todo:)) }.not_to raise_error
+    end
+  end
 end

--- a/spec/requests/csrf_form_reactive_spec.rb
+++ b/spec/requests/csrf_form_reactive_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "turbo/broadcastable/test_helper"
+
+# Issue #42 regression: a reactive component whose view_template renders a Rails
+# form with a CSRF token (`form_authenticity_token`) crashed with
+# `NoMethodError: undefined method 'env' for nil` on 0.4.0, because the re-render
+# went through a REQUEST-LESS view context. This drives the real action endpoint
+# (the path the reporter hit) — re-rendering CsrfFormComponent must succeed.
+RSpec.describe "Reactive action re-rendering a CSRF form (issue #42)", type: :request do
+  include Turbo::Broadcastable::TestHelper
+
+  let(:todo) { Todo.create!(title: "before", done: false) }
+
+  it "re-renders the form component without crashing on form_authenticity_token" do
+    post_action(CsrfFormComponent, payload: { "gid" => todo.to_gid.to_s },
+      act: "save", params: { title: "after" })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    expect(response.body).to include('name="authenticity_token"')
+    expect(response.body).to include("after")
+  end
+
+  it "rolls the signed identity token forward in the replace stream" do
+    post_action(CsrfFormComponent, payload: { "gid" => todo.to_gid.to_s },
+      act: "save", params: { title: "after" })
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("data-reactive-token-value=")
+  end
+
+  # The broadcast path is where the off-request render matters most (N
+  # subscribers = N renders, no HTTP request on the stack). A broadcast of a
+  # CSRF-form component must render through the request-bound context too.
+  it "broadcasts the CSRF form component without crashing" do
+    broadcasts = capture_turbo_stream_broadcasts(todo) do
+      CsrfFormComponent.broadcast_replace_to(todo, model: todo)
+    end
+
+    html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+    expect(html).to include('name="authenticity_token"')
+    expect(html).to include('action="replace"')
+  end
+end


### PR DESCRIPTION
## The regression (#42)

The 0.4.0 render-path perf rework (#33) built the cached off-request view
context from a bare `ActionController::Base.new.view_context`. That controller
has `request == nil`, so any reactive component whose `view_template` calls a
**request-dependent helper** — `form_authenticity_token`,
`protect_against_forgery?`, or a host-aware URL helper (all read `request.env`)
— raised `NoMethodError: undefined method 'env' for nil` on **every** re-render.

It surfaced through the action endpoint (request specs hitting `enter_edit` /
`save` / `cancel` on a component rendering a `Form(model:)`) **and** on
broadcasts. System tests masked it: the first render in a live request warms the
cache while a request happens to be on the controller, so the cache made it
nondeterministic rather than safe. This blocked 0.4.0 adoption for any app whose
reactive components render a Rails CSRF form.

## The fix

Build the cached view context through a **request-bound** controller —
`Phlex::Reactive.request_bound_view_context` — replicating exactly what
`ActionController::Renderer#render` does to set up its mock request: an
`ActionDispatch::Request` whose host is derived from the routes'
`default_url_options`, with the routes bound and the request/response attached.
Then return that controller's `view_context` instead of rendering a template.

This is the issue's suggested fix #1: bind the cached view context to the
renderer's request-bearing controller, keeping the speedup while restoring
`request`. Applied at **both** build sites:

- `Streamable.thread_view_context_cache` (the per-thread re-render/broadcast cache)
- `Phlex::Reactive.off_request_view_context_cache` (the standalone `Phlex::Reactive.render` path, used by `Response#with`)

### Why the speedup is preserved

The request is set up **once, when the per-thread context is built** — never per
render. The 0.4.0 `render_in` path (no `ActionController.renderer.render`
machinery) is unchanged. Same-machine micro-bench:

| Path | Before (main) | After |
|------|--------------|-------|
| Cached `render_component` (steady-state, the hot path) | ~15.0k i/s, 99 obj, **0 retained** | ~13.8k i/s, 100 obj, **0 retained** — within the ±9–11% noise band |
| NO_CACHE build (rebuild every call — once-per-thread in prod) | ~7.6k i/s, 219 obj | ~7.1k i/s, 235 obj — ~6% slower, +16 obj |

The steady-state render (what runs on every interaction) is unchanged. The
~6% / +16-obj cost lands only on the context **build**, which is amortized once
per thread across thousands of renders — it does not move request or broadcast
throughput. This is a method-level build cost, not a request-level cost.

## Test coverage

- **Request** (`spec/requests/csrf_form_reactive_spec.rb`) — the path the
  reporter hit: a reactive `save` re-rendering a CSRF form returns **200, not
  500**, carries `name="authenticity_token"`, and rolls the signed identity
  token forward. Plus the **broadcast** path renders the form without crashing.
- **Unit** (`spec/phlex/reactive/streamable_view_context_spec.rb`) — the cached
  context now exposes a `request`; a CSRF-using component renders without
  raising; `protect_against_forgery?` answers; **host-aware `*_url` helpers
  resolve** when the renderer carries routes (the issue's status-dropdown case);
  the standalone `Phlex::Reactive.render` path too.
- **Fixture** (`spec/dummy/app/components/csrf_form_component.rb`) — a reactive
  component whose `view_template` calls `form_authenticity_token` (the minimal
  repro from the issue).

## Verification

- `bundle exec rubocop` — 101 files, no offenses
- `bundle exec rspec spec/phlex spec/requests` — 216 examples, 0 failures (incl. random order — no cache leakage)
- `bundle exec rspec spec/system` — 22 examples, 0 failures (Puma)
- Backwards compatible: the existing byte-identical render spec still passes; no client/JS change.

Closes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where re-renders and broadcasts could lose request context, causing CSRF- and host-aware helpers to fail.
  * Reactive forms now render authenticity tokens reliably outside a live request.
  * URL helpers now resolve correctly when host information is needed.
* **Documentation**
  * Clarified how view context caching works for re-renders and broadcasts, including request-bound behavior and reload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->