### PR TITLE
fix(controller): a prepended/appended reactive row's own token no longer suppresses the container's token refresh (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Collections of *reactive* rows were still add-once-only — a prepended/appended
+  row's OWN token suppressed the container's token refresh (#44).** When an action
+  appended/prepended a *reactive* child row into a container whose `#id` equals the
+  append target (the most common collection shape — rows go directly into the
+  container element), that single `append`/`prepend` stream carried BOTH
+  `target="<container>"` and the row's own `data-reactive-token-value` (embedded in
+  the `<template>`). `carries_token_for?` matched
+  `include?("data-reactive-token-value") && include?(target)` in that one string →
+  both true → it concluded the container's token was already fresh and **skipped**
+  the container's `reactive:token` refresh. So the container (which owns the
+  add/remove trigger) never rolled its token forward, and the second dispatch was
+  rejected with the stale token — the list silently stopped after the first add.
+  This hit both the hand-rolled `reply.streams(Row.prepend(...), …)` form **and**
+  the `reactive_collection` / `reply.append`/`reply.prepend` helper, since they
+  share the gate. Fixed by tightening `carries_token_for?`: a stream "carries the
+  token for C" only when its action RE-RENDERS C itself (`replace`/`update`/
+  `reactive:token` at C's target) — `append`/`prepend` (which insert *children*
+  into C) never count, because a reactive child's token is not the container's. The
+  idempotency the gate provided is preserved (a caller's own self-replace still
+  suppresses the duplicate token) and the #30 sibling case still refreshes
+  correctly. Covered at the request level: a reactive row appended twice in a row
+  (the second using the token the first rolled forward) now succeeds, and each
+  response carries a `reactive:token` stream targeting the container with a
+  non-empty token. Refs cosmos#1939, #35, #30.
+
 - **0.4.0 regression: re-renders lost the `request`, crashing `form_authenticity_token`
   and other request-dependent helpers (#42).** The 0.4.0 render-path perf rework
   built the cached off-request view context from a bare

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -107,15 +107,49 @@ module Phlex
         streams
       end
 
-      # True when one of `streams` already carries a fresh token TARGETING this
-      # component — i.e. the caller hand-built the actor's own token-bearing
-      # stream, so appending to_stream_token would double it. Scoped to the
-      # component's target id (not a global substring) so a sibling component's
-      # stream, which carries its OWN token for a DIFFERENT target, doesn't fool
-      # us into skipping this component's refresh.
+      # Actions that RE-RENDER the component's own root (so the root's fresh
+      # data-reactive-token-value rolls the signed token forward). `append`/
+      # `prepend` are deliberately excluded: they insert CHILDREN into the
+      # component, and a reactive child carries its OWN token — that child token is
+      # not the component's (issue #44). reactive:token is our inert token-only
+      # refresh; replace/update re-render the root.
+      SELF_RENDER_ACTIONS = %w[replace update reactive:token].freeze
+      private_constant :SELF_RENDER_ACTIONS
+
+      # True when one of `streams` already carries a fresh token by RE-RENDERING
+      # this component itself — i.e. the caller hand-built the actor's own
+      # token-bearing stream, so appending to_stream_token would double it.
+      #
+      # The match requires BOTH (a) the stream's action re-renders the component's
+      # ROOT (replace/update/reactive:token — never append/prepend, which insert
+      # children) AND (b) it targets the component's id AND (c) it actually carries
+      # a token. This is stricter than a same-string substring check on purpose:
+      #   * A sibling component's replace targets a DIFFERENT id → (b) fails, so we
+      #     still refresh ours (issue #30).
+      #   * A reactive child row appended/prepended INTO the component carries its
+      #     own token at the component's target, but the action is append/prepend →
+      #     (a) fails, so we still refresh the CONTAINER's token (issue #44). Before
+      #     this, the child's token at the container target suppressed the
+      #     container's refresh and the list was add-once-only.
       def carries_token_for?(streams, component)
         target = %(target="#{ERB::Util.html_escape(component.id)}")
-        streams.any? {  it.include?("data-reactive-token-value") && it.include?(target) }
+        streams.any? do
+          it.include?("data-reactive-token-value") &&
+            it.include?(target) &&
+            self_render_stream_for?(it, target)
+        end
+      end
+
+      # Does this turbo-stream's OPENING tag re-render `target` itself? Matches a
+      # `<turbo-stream action="<self-render>" ... target="<id>">` opening tag — the
+      # action and target on the SAME tag — so a child row's token embedded in an
+      # append/prepend `<template>` can never count as the container's own refresh.
+      def self_render_stream_for?(stream, target)
+        open_tag = stream[/<turbo-stream\b[^>]*>/]
+        return false unless open_tag&.include?(target)
+
+        action = open_tag[/\baction="([^"]+)"/, 1]
+        SELF_RENDER_ACTIONS.include?(action)
       end
 
       # A 200 turbo-stream carrying a namespaced custom action the client turns

--- a/docs/examples/collections.md
+++ b/docs/examples/collections.md
@@ -141,6 +141,14 @@ on the list root, so without the refresh the list would be *add-once-only*
 container's token went stale, with no error). The helper bakes this in, so
 repeated adds and removes just work.
 
+This holds even when the **rows are themselves reactive** (each row carries its
+own signed token) and they're appended directly *into* the container element (the
+container's `#id` is the append target). A reactive child's token, embedded in the
+appended content at the container's target, is **not** the container's own
+refresh — the endpoint only counts a stream that re-renders the container's root
+(`replace`/`update`/`reactive:token`), so the container's token still rolls forward
+and the list keeps working (#44).
+
 ## Cross-tab: keep broadcasting the row
 
 `reactive_collection` governs the **actor's** HTTP reply. For a *live* list where

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -16,6 +16,7 @@ class CounterComponent < ApplicationComponent
   action :go_home
   action :bump_via_partial
   action :bump_with_sibling
+  action :bump_with_self_stream
 
   def initialize(count: 0)
     @count = count
@@ -73,6 +74,16 @@ class CounterComponent < ApplicationComponent
   def bump_with_sibling
     @count += 1
     reply.streams(TodoItemComponent.replace(Todo.create!(title: "sibling", done: false)))
+  end
+
+  # Reply: a partial update whose streams ALREADY include the actor's OWN
+  # self-replace (which re-renders the root and carries the fresh token). The
+  # endpoint must NOT also append a token-only stream — that would double the
+  # token. Locks the idempotency carries_token_for? guarantees: a self-rendering
+  # stream at the actor's own target counts as the refresh. REQUEST-spec fixture.
+  def bump_with_self_stream
+    @count += 1
+    reply.streams(self.class.replace(count: @count))
   end
 
   def view_template

--- a/spec/dummy/app/components/reactive_row_component.rb
+++ b/spec/dummy/app/components/reactive_row_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A single row that is ITSELF reactive (issue #44). Unlike NotificationRowComponent
+# (which carries no token of its own), this row declares reactive_record and renders
+# `reactive_attrs` on its root — so its `<li>` carries its OWN
+# data-reactive-token-value. When it is appended/prepended INTO a container whose
+# #id equals the append target, the row's embedded token sat in the SAME stream
+# string as `target="<container>"`, fooling carries_token_for? into skipping the
+# container's token refresh — the add-once-only bug this fixture reproduces.
+class ReactiveRowComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :toggle
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo)
+
+  def toggle
+    @todo.update!(done: !@todo.done)
+    reply.replace
+  end
+
+  def view_template
+    li(id:, class: "reactive-row", data: { testid: "reactive-row" }, **reactive_attrs) do
+      span(class: "body") { @todo.title }
+      button(**mix(on(:toggle), data: { testid: "toggle" })) { "✓" }
+    end
+  end
+end

--- a/spec/dummy/app/components/reactive_rows_list_component.rb
+++ b/spec/dummy/app/components/reactive_rows_list_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A reactive_collection whose container #id EQUALS the append target and whose
+# rows are themselves reactive (ReactiveRowComponent carries its own token). This
+# is the exact shape from issue #44: rows append directly INTO the container
+# element, so the row's embedded data-reactive-token-value lives in the same
+# stream string as `target="reactive-rows"` — which fooled carries_token_for? into
+# concluding the container's token was already fresh and skipping its refresh,
+# making the list add-once-only.
+class ReactiveRowsListComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_collection :rows,
+    item: ReactiveRowComponent,
+    container: "reactive-rows", # rows append INTO this element (== #id)
+    size: -> { Todo.count }
+
+  action :add, params: { title: :string }
+
+  # The container's #id IS the append target — the issue #44 trigger.
+  def id = "reactive-rows"
+
+  def add(title:)
+    todo = Todo.create!(title: title.to_s.strip, done: false)
+    reply.append(:rows, todo)
+  end
+
+  def view_template
+    ul(id:, **reactive_attrs) do
+      Todo.order(:created_at, :id).each { render ReactiveRowComponent.new(todo: it) }
+    end
+  end
+end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -307,6 +307,26 @@ RSpec.describe "Reactive actions", type: :request do
         # Sanity: the sibling stream targets the sibling, not the counter.
         expect(sibling_dom).not_to eq("counter")
       end
+
+      # Idempotency (the flip side of the issue #44 fix): when the caller's own
+      # streams ALREADY include a self-replace/update (which re-renders the root
+      # and carries the fresh token), the endpoint must NOT also append a token-only
+      # stream — that would double the token. carries_token_for? counts a
+      # self-RENDERING stream (replace/update at the actor's target), so exactly one
+      # token-bearing stream targets self.
+      it "does NOT double the token when the caller's streams already re-render self" do
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_self_stream")
+
+        expect(response).to have_http_status(:ok)
+        # The caller's self-replace is present (re-renders the root, carries the token)...
+        expect(response.body).to include('action="replace"')
+        expect(response.body).to include('target="counter"')
+        # ...and it is NOT doubled with an extra reactive:token stream.
+        expect(response.body).not_to include('action="reactive:token"')
+        # Exactly one stream targets self — the caller's self-replace, no extra.
+        expect(response.body.scan('target="counter"').size).to eq(1)
+        expect(response.body.scan("data-reactive-token-value=").size).to eq(1)
+      end
     end
   end
 

--- a/spec/requests/reactive_collection_spec.rb
+++ b/spec/requests/reactive_collection_spec.rb
@@ -160,6 +160,52 @@ RSpec.describe "Reactive collection endpoint (issue #35)", type: :request do
     end
   end
 
+  # Regression for issue #44: when the container's #id EQUALS the append target
+  # AND the rows are themselves reactive (each carries its OWN
+  # data-reactive-token-value), the row's embedded token landed in the SAME stream
+  # string as `target="<container>"`. carries_token_for? matched
+  # `include?("data-reactive-token-value") && include?(target)` in that one string
+  # → both true → it concluded the container's token was already fresh and SKIPPED
+  # the container's reactive:token refresh. So the container's token never rolled
+  # forward and the second add was rejected — collections of reactive rows were
+  # add-once-only. The fix: a stream "carries the token for C" only when its action
+  # RE-RENDERS C itself (replace/update/reactive:token at C's target); append/prepend
+  # (which insert children INTO C) must never count.
+  describe "container id == append target with reactive rows (issue #44)" do
+    let(:klass) { ReactiveRowsListComponent }
+    let(:container_id) { "reactive-rows" }
+
+    it "still emits the container's reactive:token even though the prepended row carries its own token" do
+      post_action(klass, act: "add", params: { title: "ping" })
+
+      expect(response).to have_http_status(:ok)
+      # The appended row IS reactive — it carries its own token, at the container target.
+      expect(response.body).to include('action="append"')
+      expect(response.body).to include(%(target="#{container_id}"))
+      # ...and the container's OWN token-only refresh is STILL present (this is what
+      # carries_token_for? wrongly suppressed before the fix).
+      expect(response.body).to include('action="reactive:token"')
+      expect(token_from(response.body, container_id)).to be_present
+    end
+
+    # The load-bearing assertion: a SECOND add using the token the first response
+    # rolled forward must succeed. Before the fix this 400s (stale container token).
+    it "supports repeated adds — the second uses the token the first refreshed" do
+      post_action(klass, act: "add", params: { title: "first" })
+      expect(response).to have_http_status(:ok)
+      next_token = token_from(response.body, container_id)
+      expect(next_token).to be_present
+
+      post "/reactive/actions",
+        params: { token: next_token, act: "add", params: { title: "second" } }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(Todo.count).to eq(2)
+      expect(response.body).to include("second")
+    end
+  end
+
   # Pull the fresh data-reactive-token-value from the reactive:token stream that
   # targets the given container id — exactly what the client's #extractToken does.
   def token_from(body, container_id)


### PR DESCRIPTION
## Summary

A reactive **collection** whose container `#id` equals the append target **and**
whose rows are themselves reactive was still add-once-only on 0.4.1: the first
"Add item" worked, the second silently did nothing.

When the action prepends/appends a *reactive* child row **into** the container,
that single `append`/`prepend` stream carries **both** `target="<container>"` and
the row's **own** `data-reactive-token-value` (embedded in the `<template>`):

```
<turbo-stream action="prepend" target="invoice_items">
  <template>
    <div id="invoice_item_42" data-controller="reactive" data-reactive-token-value="<ROW's token>">…</div>
  </template>
</turbo-stream>
```

`carries_token_for?` matched `include?("data-reactive-token-value") &&
include?(target)` in that one string → both true → it concluded the container's
token was already fresh and **skipped** the container's `reactive:token` refresh.
The container (which owns the add/remove trigger) never rolled its token forward,
so the next dispatch was rejected with the stale token — add-once-only, no error.

This hit both the hand-rolled `reply.streams(Row.prepend(...), …)` form **and**
the `reactive_collection` / `reply.append`/`reply.prepend` helper, since they
share the gate.

## Fix

Tighten `carries_token_for?`: a stream "carries the token for C" only when its
action **re-renders C itself** (`replace`/`update`/`reactive:token` at C's
target). `append`/`prepend` (which insert *children* into C) never count, because
a reactive child's token is not the container's. The match now inspects the
opening `<turbo-stream>` tag (action + target on the **same** tag), so a child's
token embedded in an append/prepend `<template>` can't be mistaken for the
container's refresh.

What stays correct:

- **Idempotency** — a caller's own self-replace still suppresses the duplicate
  token (new `bump_with_self_stream` regression).
- **#30 sibling** — a sibling component's stream targeting a *different* id still
  lets the actor's token refresh.

## Test Coverage

- **request (#44, the load-bearing one):** new dummy `ReactiveRowsListComponent` +
  `ReactiveRowComponent` — container `#id` == append target, rows are reactive
  (carry their own token). A reactive row appended twice in a row (the second
  using the token the first rolled forward) now succeeds, and each response
  carries a `reactive:token` stream targeting the container with a non-empty
  token. RED before the fix, GREEN after.
- **request (idempotency):** when the caller's `.streams` already re-render self,
  the endpoint does NOT double the token.
- Existing #30 sibling + cosmos#1939 container-token specs still green.

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests` — 219 examples, 0 failures
- [x] `bundle exec rubocop` — 103 files, no offenses
- [x] Backwards compatible — server-side gate only, no client/JS change; existing
      components (non-reactive rows, separate container id/target) unaffected
- [x] pgbus optionality untouched (this path is transport-agnostic)

Refs cosmos#1939, #35, #30
Closes #44


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reactive list updates so container token refreshes still happen when adding reactive child rows.
  * Prevented duplicate token-only refreshes when the response already re-renders the updated item.
  * Improved repeated add behavior for containers and rows that share the same target.

* **Documentation**
  * Clarified the expected behavior for repeated add/remove flows with reactive items.

* **Tests**
  * Added regression coverage for self-refreshing actions and repeated collection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->