### PR TITLE
fix(client): #extractToken reads this controller's own token, not the first in the response (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Client mirror of #44: collections of *reactive* rows were STILL add-once-only in
+  the browser — `#extractToken` read the FIRST token in the response, not this
+  controller's own (#46).** The server fix in 0.4.2 (#44) made the `add` response
+  correct — the container's fresh `reactive:token` stream is present — but the
+  client still broke. After each action the reactive controller stores the
+  response's fresh token for its NEXT dispatch; `#extractToken` did
+  `html.match(/data-reactive-token-value="([^"]+)"/)` — the FIRST match in the whole
+  body. On a collection of reactive rows the response is, in body order: the
+  appended/prepended ROW (carrying its OWN token, since a reactive row is itself a
+  `data-controller="reactive"` root) FIRST, then the container's `reactive:token`
+  refresh LAST. So the list controller stored the ROW's token; its second dispatch
+  sent a row token → failed verification → the second add silently did nothing. The
+  fix reads the token that RE-RENDERS this controller's own element id — preferring
+  the dedicated `reactive:token` stream targeting `this.element.id`, then a self
+  `replace`/`update` of it — and otherwise keeps the existing token (never adopting
+  a child row's or a sibling component's token). This is the exact client analogue
+  of the #44 server rule: a stream "carries the token for C" only when it re-renders
+  C itself, never when it inserts children into C. A request-level test can't catch
+  this (the server response is already correct); covered by a bun unit test on the
+  token selection AND a real two-click browser test (a collection of reactive rows →
+  three rows after three adds) under Puma + Falcon. Refs cosmos#1939, #44, #30.
+
 - **Collections of *reactive* rows were still add-once-only — a prepended/appended
   row's OWN token suppressed the container's token refresh (#44).** When an action
   appended/prepended a *reactive* child row into a container whose `#id` equals the

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -64,6 +64,13 @@ export function registerReactiveActions() {
   registerReactiveToken()
 }
 
+// Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
+// regex metacharacters like `.`/`:` — e.g. an `escape:`-namespaced or dotted id).
+// Used by #extractToken to match the stream that re-renders THIS element by id.
+export function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 if (typeof window !== "undefined") {
   if (window.Turbo) registerReactiveActions()
   else document.addEventListener("turbo:load", registerReactiveActions, { once: true })
@@ -286,9 +293,46 @@ export default class extends Controller {
     this.#tokenCache = value
   }
 
+  // Read the next token for THIS controller — the one that re-renders THIS
+  // element's id, never just the first token in the body (issue #46). On a
+  // collection of REACTIVE rows the prepended/appended ROW carries its OWN
+  // data-reactive-token-value and it sorts FIRST in the response; the list's own
+  // fresh token rides a trailing `reactive:token` stream targeting the container.
+  // Grabbing the first match stored the ROW's token, so the list's SECOND
+  // dispatch sent a row token → failed verification → add-once-only. This mirrors
+  // the server's carries_token_for? (#44): a stream carries OUR token only when it
+  // RE-RENDERS our id (reactive:token / replace / update of `this.element.id`) —
+  // append/prepend insert children and never count. Returns undefined when no
+  // stream re-renders our id, so #currentToken keeps its existing value.
   #extractToken(html) {
-    const match = html.match(/data-reactive-token-value="([^"]+)"/)
-    return match?.[1]
+    const id = this.element.id
+    if (!id) {
+      // No id to self-match (shouldn't happen for a reactive root). Fall back to
+      // the legacy first-token behavior so a single-component response still works.
+      return html.match(/data-reactive-token-value="([^"]+)"/)?.[1]
+    }
+
+    // The dedicated token-only refresh for THIS element (partial updates / the
+    // collection container) — an attribute on the <turbo-stream> itself.
+    const tokenStream = html.match(
+      new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
+      ),
+    )
+    if (tokenStream) return tokenStream[1]
+
+    // A full self re-render: a replace/update of THIS element whose template root
+    // carries the fresh token. Scope the token search to that one stream so a
+    // sibling/child token elsewhere in the body can't leak in.
+    const selfStream = html.match(
+      new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
+      ),
+    )
+    if (selfStream) return selfStream[1].match(/data-reactive-token-value="([^"]+)"/)?.[1]
+
+    // Nothing re-rendered our id — keep the current token.
+    return undefined
   }
 
   // True when `el` is collected by THIS reactive root and not by a nested one.

--- a/docs/examples/collections.md
+++ b/docs/examples/collections.md
@@ -147,7 +147,12 @@ container's `#id` is the append target). A reactive child's token, embedded in t
 appended content at the container's target, is **not** the container's own
 refresh — the endpoint only counts a stream that re-renders the container's root
 (`replace`/`update`/`reactive:token`), so the container's token still rolls forward
-and the list keeps working (#44).
+and the list keeps working (#44). The **client** applies the same rule when it
+reads the next token out of the response: it takes the token that re-renders *its
+own* element id (the trailing `reactive:token` stream for the container), never the
+first token in the body — which, for a prepended/appended reactive row, is the
+**row's** token, not the list's. Reading the first match made the list add-once-only
+*in the browser* even though the server response was correct (#46).
 
 ## Cross-tab: keep broadcasting the row
 

--- a/spec/dummy/app/components/reactive_row_component.rb
+++ b/spec/dummy/app/components/reactive_row_component.rb
@@ -26,7 +26,10 @@ class ReactiveRowComponent < ApplicationComponent
   end
 
   def view_template
-    li(id:, class: "reactive-row", data: { testid: "reactive-row" }, **reactive_attrs) do
+    # mix() deep-merges so reactive_attrs' data: (controller + token) survives
+    # ALONGSIDE data-testid — a bare `data:` next to `**reactive_attrs` would
+    # clobber one of them (CLAUDE.md "Never Do #8").
+    li(id:, class: "reactive-row", **mix(reactive_attrs, data: { testid: "reactive-row" })) do
       span(class: "body") { @todo.title }
       button(**mix(on(:toggle), data: { testid: "toggle" })) { "✓" }
     end

--- a/spec/dummy/app/components/reactive_rows_list_component.rb
+++ b/spec/dummy/app/components/reactive_rows_list_component.rb
@@ -27,8 +27,18 @@ class ReactiveRowsListComponent < ApplicationComponent
   end
 
   def view_template
+    # The <ul> IS the reactive root (its #id == the append target "reactive-rows").
+    # The add trigger lives INSIDE it so on(:add) binds to THIS list controller —
+    # each click consumes the container's signed token, which the previous add's
+    # trailing reactive:token stream must have rolled forward (issue #46). New rows
+    # prepend ABOVE the trigger <li> so the control row stays at the bottom.
     ul(id:, **reactive_attrs) do
       Todo.order(:created_at, :id).each { render ReactiveRowComponent.new(todo: it) }
+
+      li(data: { testid: "add-controls" }) do
+        input(name: "title", placeholder: "New row…", autocomplete: "off", data: { testid: "new-row" })
+        button(**mix(on(:add), data: { testid: "add-row" })) { "Add row" }
+      end
     end
   end
 end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -18,6 +18,10 @@ class DemosController < ActionController::Base
     render_component NotificationsListComponent.new
   end
 
+  def reactive_rows
+    render_component ReactiveRowsListComponent.new
+  end
+
   def chat
     room = params[:room].presence || "lobby"
     render_component ChatRoomComponent.new(room:, messages: ChatMessage.for_room(room).last(50))

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
   get "notifications" => "demos#notifications"
+  get "reactive_rows" => "demos#reactive_rows"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
   get "nested_editor" => "demos#nested_editor"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -64,6 +64,13 @@ export function registerReactiveActions() {
   registerReactiveToken()
 }
 
+// Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
+// regex metacharacters like `.`/`:` — e.g. an `escape:`-namespaced or dotted id).
+// Used by #extractToken to match the stream that re-renders THIS element by id.
+export function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 if (typeof window !== "undefined") {
   if (window.Turbo) registerReactiveActions()
   else document.addEventListener("turbo:load", registerReactiveActions, { once: true })
@@ -286,9 +293,46 @@ export default class extends Controller {
     this.#tokenCache = value
   }
 
+  // Read the next token for THIS controller — the one that re-renders THIS
+  // element's id, never just the first token in the body (issue #46). On a
+  // collection of REACTIVE rows the prepended/appended ROW carries its OWN
+  // data-reactive-token-value and it sorts FIRST in the response; the list's own
+  // fresh token rides a trailing `reactive:token` stream targeting the container.
+  // Grabbing the first match stored the ROW's token, so the list's SECOND
+  // dispatch sent a row token → failed verification → add-once-only. This mirrors
+  // the server's carries_token_for? (#44): a stream carries OUR token only when it
+  // RE-RENDERS our id (reactive:token / replace / update of `this.element.id`) —
+  // append/prepend insert children and never count. Returns undefined when no
+  // stream re-renders our id, so #currentToken keeps its existing value.
   #extractToken(html) {
-    const match = html.match(/data-reactive-token-value="([^"]+)"/)
-    return match?.[1]
+    const id = this.element.id
+    if (!id) {
+      // No id to self-match (shouldn't happen for a reactive root). Fall back to
+      // the legacy first-token behavior so a single-component response still works.
+      return html.match(/data-reactive-token-value="([^"]+)"/)?.[1]
+    }
+
+    // The dedicated token-only refresh for THIS element (partial updates / the
+    // collection container) — an attribute on the <turbo-stream> itself.
+    const tokenStream = html.match(
+      new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
+      ),
+    )
+    if (tokenStream) return tokenStream[1]
+
+    // A full self re-render: a replace/update of THIS element whose template root
+    // carries the fresh token. Scope the token search to that one stream so a
+    // sibling/child token elsewhere in the body can't leak in.
+    const selfStream = html.match(
+      new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
+      ),
+    )
+    if (selfStream) return selfStream[1].match(/data-reactive-token-value="([^"]+)"/)?.[1]
+
+    // Nothing re-rendered our id — keep the current token.
+    return undefined
   }
 
   // True when `el` is collected by THIS reactive root and not by a nested one.

--- a/spec/javascript/reactive_extract_token.test.js
+++ b/spec/javascript/reactive_extract_token.test.js
@@ -1,0 +1,237 @@
+// Unit test for #extractToken selecting THIS controller's own token (issue #46).
+//
+// After each action the controller stores the response's fresh token for its
+// NEXT dispatch. On a collection of REACTIVE rows, an `add` response is, in body
+// order:
+//   1. <turbo-stream action="prepend|append" target="<container>"> whose
+//      <template> root carries the NEW ROW's data-reactive-token-value, then
+//   2. companions (e.g. a totals update), then
+//   3. <turbo-stream action="reactive:token" target="<container>"
+//      data-reactive-token-value="<fresh>"> — the CONTAINER's own fresh token.
+//
+// The old #extractToken grabbed the FIRST data-reactive-token-value in the body
+// (the ROW's), so the list controller stored a row token. Its SECOND dispatch
+// then sent a row token → failed verification → the add silently did nothing
+// (add-once-only). This is the exact client mirror of the #44 server bug: "the
+// token for component C is the one targeting C, not just any token in the body."
+//
+// The fix: #extractToken reads the token that RE-RENDERS this controller's own
+// element id — preferring the dedicated reactive:token stream for it, then a
+// self replace/update of it — never a child row's token at the container target.
+//
+// We drive two real dispatch()es: the first returns a crafted multi-stream body,
+// the second must POST the CONTAINER's token, not the row's.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+let escapeRegExp
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  const mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  ReactiveController = mod.default
+  escapeRegExp = mod.escapeRegExp
+})
+
+// A reactive root faithful enough for #perform's needs: an id, an empty field
+// walk (querySelectorAll -> []), and the attribute toggles. getAttribute returns
+// the element's own live data-reactive-token-value when asked (so the DOM-reread
+// fallback path, if any, sees the truth).
+function fakeRoot(id) {
+  const attrs = {}
+  return {
+    id,
+    querySelectorAll: () => [],
+    setAttribute: (name, value) => {
+      attrs[name] = value
+    },
+    removeAttribute: (name) => {
+      delete attrs[name]
+    },
+    getAttribute: (name) => attrs[name] ?? null,
+  }
+}
+
+function buildController(rootEl, initialToken) {
+  const controller = new ReactiveController()
+  controller.element = rootEl
+  controller.tokenValue = initialToken
+  return controller
+}
+
+function stubEnv() {
+  globalThis.document = {
+    querySelector: (sel) => {
+      if (sel.includes("action-path")) return { content: "/reactive/actions" }
+      if (sel.includes("csrf-token")) return { content: "csrf-abc" }
+      return null
+    },
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+}
+
+// Drive one dispatch whose fetch returns `body`; capture the JSON payload POSTed.
+function stubFetchReturning(body, captured) {
+  globalThis.fetch = (path, opts) => {
+    captured.push(JSON.parse(opts.body))
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(body),
+    })
+  }
+}
+
+// The realistic add response on a collection of reactive rows: the prepended
+// ROW carries its own token FIRST, the CONTAINER's reactive:token refresh LAST.
+function collectionAddBody({ container, rowToken, containerToken }) {
+  return (
+    `<turbo-stream action="prepend" target="${container}">` +
+    `<template><li id="row_99" data-controller="reactive" data-reactive-token-value="${rowToken}">new row</li></template>` +
+    `</turbo-stream>` +
+    `<turbo-stream action="update" target="${container}-totals"><template>1 item</template></turbo-stream>` +
+    `<turbo-stream action="reactive:token" target="${container}" data-reactive-token-value="${containerToken}"></turbo-stream>`
+  )
+}
+
+test("stores the CONTAINER's reactive:token, not the prepended row's token (issue #46)", async () => {
+  const root = fakeRoot("reactive-rows")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const captured = []
+  stubFetchReturning(
+    collectionAddBody({ container: "reactive-rows", rowToken: "ROW-TOKEN", containerToken: "CONTAINER-FRESH" }),
+    captured,
+  )
+
+  // First add: uses the initial token, response rolls the container token forward.
+  await controller.dispatch({ params: { action: "add", params: "{}" }, preventDefault: () => {} })
+  expect(captured[0].token).toBe("TOKEN-INITIAL")
+
+  // Second add: MUST use the container's fresh token — NOT the row's (the bug).
+  await controller.dispatch({ params: { action: "add", params: "{}" }, preventDefault: () => {} })
+  expect(captured[1].token).toBe("CONTAINER-FRESH")
+  expect(captured[1].token).not.toBe("ROW-TOKEN")
+})
+
+test("a self replace/update of this element supplies the next token", async () => {
+  // The normal (non-collection) case: the action re-renders THIS root, and the
+  // template root carries the fresh token. #extractToken must still pick it up.
+  const root = fakeRoot("counter")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream action="replace" target="counter">` +
+    `<template><div id="counter" data-controller="reactive" data-reactive-token-value="SELF-FRESH">1</div></template>` +
+    `</turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "increment", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "increment", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("SELF-FRESH")
+})
+
+test("reads the self token from a morph replace (method before action attribute order)", async () => {
+  // Response.morph emits `<turbo-stream method="morph" action="replace" target="id">`
+  // — `method` sits BEFORE `action`. The self-stream match must still find it.
+  const root = fakeRoot("counter")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream method="morph" action="replace" target="counter">` +
+    `<template><div id="counter" data-controller="reactive" data-reactive-token-value="MORPH-FRESH">1</div></template>` +
+    `</turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "increment", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "increment", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("MORPH-FRESH")
+})
+
+test("ignores a sibling component's token that targets a DIFFERENT id", async () => {
+  // A partial reply may include ANOTHER reactive component's stream (carrying its
+  // own token at a different target). That must NOT become our next token — only
+  // a stream re-rendering OUR id counts. With no self-stream present, we keep the
+  // existing token.
+  const root = fakeRoot("my-id")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream action="replace" target="other-id">` +
+    `<template><div id="other-id" data-reactive-token-value="OTHER-TOKEN">sibling</div></template>` +
+    `</turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "ping", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "ping", params: "{}" }, preventDefault: () => {} })
+
+  // No stream re-rendered OUR id → keep the existing token, never adopt the sibling's.
+  expect(captured[1].token).toBe("TOKEN-INITIAL")
+  expect(captured[1].token).not.toBe("OTHER-TOKEN")
+})
+
+test("does NOT match a target whose id merely PREFIXES ours (exact id, not substring)", async () => {
+  // Our id is "row"; a row component appended at target="row_99" carries its own
+  // token. The regex anchors on target="row" + the closing quote, so target="row_99"
+  // can't satisfy it — otherwise a sibling/child id that prefixes ours would leak.
+  const root = fakeRoot("row")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream action="reactive:token" target="row_99" data-reactive-token-value="PREFIX-TOKEN"></turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("TOKEN-INITIAL")
+  expect(captured[1].token).not.toBe("PREFIX-TOKEN")
+})
+
+test("matches an id containing regex metacharacters (escapeRegExp)", async () => {
+  // A dom id can contain regex metacharacters (e.g. a dotted/namespaced id).
+  // escapeRegExp keeps the target match literal so the self-token is still found.
+  const id = "list.items:42"
+  const root = fakeRoot(id)
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream action="reactive:token" target="${id}" data-reactive-token-value="DOTTED-FRESH"></turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("DOTTED-FRESH")
+})
+
+test("escapeRegExp escapes regex metacharacters", () => {
+  expect(escapeRegExp("a.b:c")).toBe("a\\.b:c")
+  expect(escapeRegExp("x+y*z")).toBe("x\\+y\\*z")
+  expect(escapeRegExp("plain")).toBe("plain")
+})

--- a/spec/system/reactive_rows_spec.rb
+++ b/spec/system/reactive_rows_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #46: the client #extractToken read the FIRST data-reactive-token-value in
+# the response, not the one for THIS controller's element. On a collection whose
+# rows are THEMSELVES reactive, an `add` response is, in body order: the appended
+# ROW (carrying its OWN token) FIRST, then the container's `reactive:token` refresh
+# LAST. So the list controller stored the ROW's token and its SECOND dispatch sent
+# a row token → failed verification → the second add silently did nothing. The list
+# was add-once-only IN THE BROWSER even though the server response was correct
+# (request specs pass; only a real two-click browser test catches it).
+#
+# The fix reads the token that re-renders THIS element's id (the trailing
+# reactive:token stream for the container), so repeated adds keep verifying.
+RSpec.describe "Reactive rows — repeated adds on a collection of reactive rows (issue #46)", type: :system do
+  it "adds a SECOND row after the first (the token rolls forward in the browser)" do
+    visit "/reactive_rows"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='reactive-row']", count: 0)
+
+    # FIRST add. have_css is a waiting matcher → the synchronization barrier for the
+    # async append; do NOT snapshot right after the click.
+    find("[data-testid='new-row']").set("first row")
+    find("[data-testid='add-row']").click
+    expect(page).to have_css("[data-testid='reactive-row']", count: 1)
+    expect(page).to have_css("[data-testid='reactive-row']", text: "first row")
+
+    # SECOND add — the decisive assertion. Pre-fix the list controller is holding
+    # the FIRST row's token, so this dispatch 400s and NOTHING happens (count stays
+    # 1). Post-fix it holds the container's refreshed token, so the add succeeds.
+    find("[data-testid='new-row']").set("second row")
+    find("[data-testid='add-row']").click
+    expect(page).to have_css("[data-testid='reactive-row']", count: 2)
+    expect(page).to have_css("[data-testid='reactive-row']", text: "second row")
+
+    # A THIRD, to prove the token keeps rolling forward indefinitely (not just once).
+    find("[data-testid='new-row']").set("third row")
+    find("[data-testid='add-row']").click
+    expect(page).to have_css("[data-testid='reactive-row']", count: 3)
+
+    expect(Todo.count).to eq(3)
+    # No full-page reload — every add was a reactive round trip, not a navigation.
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

The **client mirror** of the #44 server bug. 0.4.2 fixed the server half
(`carries_token_for?`), so an `add` response on a collection of reactive rows is
now correct — the container's fresh `reactive:token` stream is present. But the
**client** still broke, keeping such a list **add-once-only in the browser**.

After each action the reactive controller stores the response's fresh token for
its NEXT dispatch. `#extractToken` did:

```js
html.match(/data-reactive-token-value="([^"]+)"/)  // FIRST match in the WHOLE body
```

On a collection of **reactive** rows, an `add` response is, in body order:

1. `<turbo-stream action="prepend|append" target="<container>">` — whose `<template>` root carries the **new ROW's** token (a reactive row is itself a `data-controller="reactive"` root)
2. companions (e.g. a totals update)
3. `<turbo-stream action="reactive:token" target="<container>" data-reactive-token-value="…">` — the **container's** fresh token

The first match is #1 (the **row's** token), so the list controller stored the
row token. Its second dispatch sent a row token → failed verification → the
second add silently did nothing.

## The fix

`#extractToken` now reads the token that **re-renders this controller's own
element id** — preferring the dedicated `reactive:token` stream for
`this.element.id`, then a self `replace`/`update` of it — and otherwise keeps the
existing token (never adopting a child row's or a sibling component's token).

This is the exact client analogue of the server's `carries_token_for?` rule
(#44): a stream carries our token only when it **re-renders our id**, never when
it inserts children into us. `append`/`prepend` never count.

## Why a request test can't catch it

The server response is already correct (the #44 request specs pass). This is
purely **client** token selection, so only a real two-click browser test catches
it. The system spec was proven RED against the old `#extractToken` (the second
add does nothing — count stays 1), then green with the fix, under **both** Puma
and Falcon.

## Fixture fix found along the way

`ReactiveRowComponent` rendered `data: { testid: "reactive-row" }, **reactive_attrs`
— the `**reactive_attrs` spread **clobbered** the explicit `data:` (the
"Never Do #8" anti-pattern), so the row's `data-testid` never reached the DOM.
Fixed with `mix(reactive_attrs, data: { testid: … })`. (Latent: the row was only
ever exercised by request specs that don't check `data-testid`.)

## Changes

| File | Change |
|------|--------|
| `app/javascript/phlex/reactive/reactive_controller.js` | `#extractToken` reads this element's own token; `escapeRegExp` helper for ids with regex metacharacters |
| `spec/dummy/public/vendor/reactive_controller.js` | re-synced byte-identical |
| `spec/dummy/app/components/reactive_rows_list_component.rb` | in-root add trigger so the list is driveable in the browser |
| `spec/dummy/app/components/reactive_row_component.rb` | `mix(reactive_attrs, data: {...})` so `data-testid` survives |
| `spec/dummy/app/controllers/demos_controller.rb`, `config/routes.rb` | `/reactive_rows` demo page |
| `docs/examples/collections.md`, `CHANGELOG.md` | document the client-side rule |

## Test Coverage

**`spec/javascript/reactive_extract_token.test.js`** (new) — drives two real
`dispatch()`es and asserts the second POSTs the right token:

- stores the CONTAINER's `reactive:token`, not the prepended ROW's token
- a self `replace`/`update` supplies the next token
- a morph replace (`method="morph"` BEFORE `action="replace"`) still matches
- ignores a sibling component's token at a different id (keeps current)
- exact-id match, no prefix leak (id `row` vs target `row_99`)
- an id containing regex metacharacters (`escapeRegExp`)
- `escapeRegExp` unit

**`spec/system/reactive_rows_spec.rb`** (new) — a real browser THREE-add test on
a collection of reactive rows → 3 rows after three clicks; **proven RED** against
the old `#extractToken`.

## Verification

- [x] `bun test spec/javascript` — 38 pass
- [x] `bundle exec rspec spec/phlex spec/requests` — 219 pass
- [x] `bundle exec rspec spec/system` — 23 pass (Puma)
- [x] `CAPYBARA_SERVER=falcon bundle exec rspec spec/system` — 23 pass (Falcon)
- [x] `bundle exec rubocop` — clean
- [x] vendored client byte-identical to source (sync spec passes)

## Performance

No Ruby hot path changed — this is client JS that runs once per HTTP round trip,
behind a `fetch`. So no `rake bench` delta is claimed (the change is invisible to
the Ruby micro-benches). The added cost is up to two small `RegExp` constructions
per round trip, negligible against the network request.

Closes #46
