### PR TITLE
feat(component): reactive_root helper + connect() id guard (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`reactive_root` helper — the whole reactive root in one spread (#48).**
+  `reactive_attrs` doesn't emit `id:`, so an app could put `id:` on a *child*
+  element and leave the controller root's `id` empty — which silently re-opened
+  the #46 add-once-only bug (the client falls back to the first token in the
+  response, the next action POSTs a foreign token, and the endpoint 403s).
+  `div(**reactive_root)` emits the component `id` **and** `reactive_attrs` on one
+  element, so the id can't land on the wrong node; `reactive_root(class:, data:)`
+  deep-merges via `mix`, and an explicit `id:` override still wins. `reactive_attrs`
+  is unchanged — existing `div(id:, **reactive_attrs)` components keep working. The
+  generic Stimulus controller now also `console.warn`s on `connect()` when a
+  reactive root has an empty `id`, so the failure surfaces on page load (a one-line
+  hint) instead of on the second click. README/docs promote `div(**reactive_root)`.
+
 - **File / multipart params in a reactive action (#34).** An action can now accept
   an uploaded file: declare `params: { file: :file }` (or `[:file]` for multiple).
   When the reactive root holds a populated `<input type="file">`, the client sends

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class Counter < ApplicationComponent
   def decrement = @count -= 1
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
       button(**on(:decrement)) { "−" }
       span { @count }
       button(**on(:increment)) { "+" }
@@ -245,7 +245,7 @@ class Todos::Item < ApplicationComponent
   end
 
   def view_template
-    li(id:, **reactive_attrs, class: ("done" if @todo.done?)) do
+    li(**reactive_root(class: ("done" if @todo.done?))) do
       button(**on(:toggle)) { @todo.done? ? "✓" : "○" }
       span { @todo.title }
     end
@@ -307,7 +307,8 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_record :name` | Record-backed identity (GlobalID). State = the DB. |
 | `reactive_state :a, :b` | Signed instance-var identity. Standalone, or combined with `reactive_record` to sign transient UI state alongside the row. |
 | `action :name, params: { x: :integer }` | Declare a client-invokable action + its param schema. **Default-deny.** |
-| `reactive_attrs` | Spread onto the root element: marks it reactive + carries the signed token. |
+| `reactive_root(**overrides)` | Spread onto the root element: emits the component `id` **and** `reactive_attrs` together, so the controller root always carries `#id`. Preferred over `id:` + `reactive_attrs`. `**overrides` (`class:`/`data:`) deep-merge. |
+| `reactive_attrs` | Marks an element reactive + carries the signed token (no `id`). Spread alongside `id:` on the **same** element: `div(id:, **reactive_attrs)`. Prefer `reactive_root`, which can't split them. |
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
 | `on(:action, event: "input", debounce: 300)` | Coalesce rapid events into one round trip after a quiet period (live-as-you-type). |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
@@ -413,16 +414,28 @@ input(**mix(on(:update, event: "input", debounce: 300), name: "quantity", value:
 
 **Combining `on(...)` / `reactive_attrs` with your own attributes.** Both return
 a hash that includes a `data:` key. Spreading them *and* passing another `data:`
-(or `class:`, `id:`) would clobber it — use Phlex's `mix` to deep-merge:
+(or `class:`, `id:`) would clobber it — use Phlex's `mix` to deep-merge. For the
+**root**, prefer `reactive_root`, which already `mix`es id + token for you:
 
 ```ruby
 # ✅ merges cleanly (data-action survives, your data-testid/class are added)
 button(**mix(on(:increment), class: "btn", data: { testid: "inc" })) { "+" }
-div(**mix(reactive_attrs, id:, class: "card")) { ... }
+div(**reactive_root(class: "card", data: { testid: "root" })) { ... }   # id + token + your attrs
 
 # ❌ the extra data: overwrites on()'s data:, so the action never binds
 button(**on(:increment), data: { testid: "inc" }) { "+" }
 ```
+
+> **The reactive root must carry `#id` (issue #48).** The server targets your
+> component's `#id` and the client self-matches its next signed token by the root
+> element's `id`. `reactive_attrs` does **not** emit the id — so if you put `id:`
+> on a **child** instead of the `**reactive_attrs` element, the root's id is empty,
+> token threading falls back to the first token in the response, and the *next*
+> action silently fails with **HTTP 403**. Use `div(**reactive_root)` (it emits id
+> + token on one element) so the id can't land on the wrong node; if you spread
+> `reactive_attrs` directly, keep `id:` on the **same** element
+> (`div(id:, **reactive_attrs)`). The controller `console.warn`s on connect when a
+> reactive root has no id.
 
 **Binding inputs to action params (drop the magic `name:`).** A field's value
 travels with an action only if its `name` equals the param. Hand-writing
@@ -435,7 +448,7 @@ mode):
 action :save, params: { value: :string, status: :string }
 
 def view_template
-  span(id:, **reactive_attrs) do
+  span(**reactive_root) do
     reactive_input(:value, value: @record.name)            # <input name="value" …>
     reactive_select(:status) do                            # <select name="status">…</select>
       %w[open closed].each { |s| option(value: s, selected: s == @record.status) { s } }
@@ -719,7 +732,7 @@ class Counter < ApplicationComponent
   def decrement = @counter.decrement!(:value)
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
       button(**on(:decrement)) { "−" }
       span { @counter.value }
       button(**on(:increment)) { "+" }

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -135,6 +135,22 @@ export default class extends Controller {
   // guard above knows the controller was registered (issue #26 part 2).
   connect() {
     reactiveConnected = true
+
+    // Root-id guard (issue #48). The token round trip assumes the reactive root
+    // element's id == component.id: the server targets component.id and the client
+    // self-matches its NEXT token by this.element.id (#extractToken, issue #46).
+    // If `id:` landed on a CHILD instead of the `**reactive_attrs` root, this id is
+    // "" — #extractToken falls back to the FIRST token in the response (a child's),
+    // so the next action POSTs a foreign token → endpoint default-deny → silent 403.
+    // Warn NOW (on connect) so the failure surfaces on page load, not on click 2.
+    if (this.element.id === "") {
+      console.warn(
+        "[phlex-reactive] a reactive root has no id; its next-action token can't self-match " +
+          "and may fall back to the first token in the response → a silent HTTP 403 on the NEXT action. " +
+          "Put id: on the SAME element as reactive_attrs — use div(**reactive_root) (emits id + token together), " +
+          "or div(id:, **reactive_attrs). The id: must NOT be on a child. See the README."
+      )
+    }
   }
 
   // Tear down any pending debounce timers when the controller leaves the DOM

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,8 +110,8 @@ from `on(:save, extra: ...)` always win over a collected field of the same name.
 
 #### Nested reactive roots collect independently
 
-A reactive component can be rendered **inside** another — each `**reactive_attrs`
-root is its own `data-controller="reactive"` element. Field collection stops at
+A reactive component can be rendered **inside** another — each `**reactive_root`
+is its own `data-controller="reactive"` element. Field collection stops at
 nested roots: an action collects only the named inputs whose nearest
 `[data-controller~="reactive"]` ancestor is *its own* root. A descendant
 reactive component's inputs belong to that component, not the outer one.
@@ -121,7 +121,7 @@ reactive component's inputs belong to that component, not the outer one.
 class InvoiceEditor < ApplicationComponent
   # ... reactive_record :invoice; action :save, params: { notes: :string }
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do                                    # root carries #id + token
       input(name: "notes", value: @invoice.notes)              # collected by `save`
       @invoice.items.each { |item| render LineItem.new(item:) } # each row is its own root
       button(**on(:save)) { "Save" }
@@ -135,10 +135,17 @@ A `save` on the editor receives `{ notes: }` only — never the rows' bare
 row's* controller and updates only that row. So outer flat fields and per-row
 reactive editing compose without name-collision workarounds (issue #15).
 
-> Remember `mix` when a nested root needs its own `id`/`data`:
-> `div(**mix(reactive_attrs, id:, data: { testid: "row" }))`. A bare
-> `div(id:, **reactive_attrs, data: {...})` lets the extra `data:` clobber
-> `reactive_attrs`' `data-controller`, so the element never becomes a root.
+> **The reactive root must carry `#id` (issue #48).** The server targets the
+> component's `#id`, and the client self-matches its next signed token by the root
+> element's `id`. `reactive_attrs` does **not** emit the id, so spreading it onto a
+> wrapper while putting `id:` on a *child* (e.g. the rows container) leaves the
+> root's id empty — token threading then falls back to the first token in the
+> response (a child row's) and the *next* action silently 403s. Prefer
+> `div(**reactive_root)`: it emits id + token on one element, so the id can't land
+> on the wrong node. `reactive_root(class:, data: {...})` deep-merges via `mix`, so
+> a nested root's own `data-testid` no longer clobbers `data-controller`. If you
+> spread `reactive_attrs` directly, keep `id:` on the **same** element. The
+> controller `console.warn`s on connect when a reactive root has no id.
 
 ## Why state isn't in the browser
 

--- a/docs/examples/chat.md
+++ b/docs/examples/chat.md
@@ -97,7 +97,7 @@ class Chat::Composer < ApplicationComponent
   end
 
   def view_template
-    div(id:, class: "composer", **reactive_attrs) do
+    div(**reactive_root(class: "composer")) do
       input(type: "text", name: "body", placeholder: "Message as #{@author}…", autocomplete: "off")
       button(**on(:send_message)) { "Send" }
     end

--- a/docs/examples/collections.md
+++ b/docs/examples/collections.md
@@ -48,7 +48,7 @@ class NotificationsList < ApplicationComponent
   end
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
       span(id: "notifications-count") { Todo.count.to_s }
 
       ul(id: "notifications") do

--- a/docs/examples/counter.md
+++ b/docs/examples/counter.md
@@ -29,7 +29,7 @@ class Counter < ApplicationComponent
   def set(count:) = @count = count
 
   def view_template
-    div(id:, class: "counter", **reactive_attrs) do
+    div(**reactive_root(class: "counter")) do
       button(**on(:decrement)) { "−" }
       span(class: "value") { @count }
       button(**on(:increment)) { "+" }

--- a/docs/examples/inline_edit.md
+++ b/docs/examples/inline_edit.md
@@ -41,7 +41,7 @@ class Fields::InlineEdit < ApplicationComponent
   end
 
   def view_template
-    span(id:, **reactive_attrs) do
+    span(**reactive_root) do
       if @editing
         input(name: "value", value: current_value, autocomplete: "off")
         button(**on(:save)) { "Save" }
@@ -124,7 +124,7 @@ def update(name:)
 end
 
 def view_template
-  div(id:, **reactive_attrs) do
+  div(**reactive_root) do
     # The field both holds the value AND triggers the debounced save.
     input(**mix(on(:update, event: "input", debounce: 300),
       name: "name", value: @record.name))

--- a/docs/examples/todo_list.md
+++ b/docs/examples/todo_list.md
@@ -62,7 +62,7 @@ class Todos::Item < ApplicationComponent
   end
 
   def view_template
-    li(id:, **reactive_attrs, class: ("done" if @todo.done?)) do
+    li(**reactive_root(class: ("done" if @todo.done?))) do
       button(**on(:toggle)) { @todo.done? ? "✓" : "○" }
       input(name: "title", value: @todo.title, **on(:rename, event: "change"))
       button(**on(:destroy)) { "✕" }
@@ -106,7 +106,7 @@ class Todos::List < ApplicationComponent
   end
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
       turbo_stream_from @list, :todos                       # subscribe to live updates
 
       ul(id: dom_id(@list, :todos)) do

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ class Counter < ApplicationComponent
   def decrement = @count -= 1
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
       button(**on(:decrement)) { "−" }
       span { @count }
       button(**on(:increment)) { "+" }

--- a/lib/generators/phlex/reactive/component/templates/component.rb.erb
+++ b/lib/generators/phlex/reactive/component/templates/component.rb.erb
@@ -24,7 +24,7 @@ class <%= class_name %> < ApplicationComponent
 <% end -%>
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
 <% action_names.each do |a| -%>
       button(**on(:<%= a %>)) { "<%= a.to_s.humanize %>" }
 <% end -%>
@@ -51,7 +51,7 @@ class <%= class_name %> < ApplicationComponent
 <% end -%>
 
   def view_template
-    div(id:, **reactive_attrs) do
+    div(**reactive_root) do
 <% state_keys.each do |k| -%>
       span(data: { <%= file_name %>_<%= k %>: true }) { @<%= k %>.to_s }
 <% end -%>

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -270,6 +270,26 @@ module Phlex
         }
       end
 
+      # The WHOLE reactive root in one spread (issue #48). reactive_attrs alone
+      # doesn't emit `id:`, so `id:` and `data-controller="reactive"` can land on
+      # DIFFERENT elements — putting `id:` on a child leaves the controller root's
+      # `id` empty, which silently breaks token threading (the client self-matches
+      # its next token by `this.element.id`) and 403s on the next action.
+      #
+      # reactive_root binds the id to the SAME element as reactive_attrs, so the
+      # footgun is unbuildable:
+      #   div(**reactive_root) { ... }                       # id + controller + token
+      #   div(**reactive_root(class: "card")) { ... }        # add your own attrs
+      #
+      # mix deep-merges, so overrides add `class:`/`data:` without clobbering the
+      # controller/token data: (a bare data: would). The id is resolved separately
+      # (an explicit override wins as a clean replace, not a `mix` string-concat —
+      # mix would join two String ids into "default override").
+      def reactive_root(**overrides)
+        root_id = overrides.delete(:id) || id
+        mix({ **reactive_attrs }, overrides, { id: root_id })
+      end
+
       # Attributes for an element that triggers an action.
       #   button(**on(:toggle)) { "○" }
       #   form(**on(:save, event: "submit")) { ... }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -135,6 +135,22 @@ export default class extends Controller {
   // guard above knows the controller was registered (issue #26 part 2).
   connect() {
     reactiveConnected = true
+
+    // Root-id guard (issue #48). The token round trip assumes the reactive root
+    // element's id == component.id: the server targets component.id and the client
+    // self-matches its NEXT token by this.element.id (#extractToken, issue #46).
+    // If `id:` landed on a CHILD instead of the `**reactive_attrs` root, this id is
+    // "" — #extractToken falls back to the FIRST token in the response (a child's),
+    // so the next action POSTs a foreign token → endpoint default-deny → silent 403.
+    // Warn NOW (on connect) so the failure surfaces on page load, not on click 2.
+    if (this.element.id === "") {
+      console.warn(
+        "[phlex-reactive] a reactive root has no id; its next-action token can't self-match " +
+          "and may fall back to the first token in the response → a silent HTTP 403 on the NEXT action. " +
+          "Put id: on the SAME element as reactive_attrs — use div(**reactive_root) (emits id + token together), " +
+          "or div(id:, **reactive_attrs). The id: must NOT be on a child. See the README."
+      )
+    }
   }
 
   // Tear down any pending debounce timers when the controller leaves the DOM

--- a/spec/javascript/reactive_root_id_guard.test.js
+++ b/spec/javascript/reactive_root_id_guard.test.js
@@ -1,0 +1,53 @@
+// Unit test for the reactive-root id guard (issue #48).
+//
+// The token round trip is load-bearing on the invariant "the reactive controller
+// root element's id == component.id": the server targets component.id, and the
+// client self-matches its NEXT token by this.element.id (#extractToken, issue #46).
+// If an app puts `id:` on a CHILD instead of the `**reactive_attrs` root, the root's
+// id is "" — #extractToken falls back to the first token in the body (a child's),
+// and the next action POSTs a foreign token → endpoint default-deny → 403, SILENTLY.
+//
+// connect() warns the instant a reactive root has an empty id, so the failure
+// surfaces on page load (a one-line console hint) instead of on the second click.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  const mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  ReactiveController = mod.default
+})
+
+let warnings
+beforeEach(() => {
+  warnings = []
+  globalThis.console = { warn: (...a) => warnings.push(a.join(" ")), error: () => {} }
+})
+
+function connectWithId(id) {
+  const controller = new ReactiveController()
+  controller.element = { id }
+  controller.connect()
+  return controller
+}
+
+test("warns when the reactive root has an empty id", () => {
+  connectWithId("")
+  expect(warnings.length).toBe(1)
+  expect(warnings[0]).toContain("phlex-reactive")
+  expect(warnings[0].toLowerCase()).toContain("id")
+  // points at the fix (reactive_root / id: on the same element)
+  expect(warnings[0]).toContain("reactive_root")
+})
+
+test("stays silent when the reactive root has an id", () => {
+  connectWithId("invoice_items")
+  expect(warnings.length).toBe(0)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "phlex" # for the render-context-free `mix` helper used by reactive_root (issue #48)
 
 RSpec.describe Phlex::Reactive::Component do
   # A minimal state-backed component (no Rails/Phlex render needed for these).
@@ -273,6 +274,71 @@ RSpec.describe Phlex::Reactive::Component do
     it "lets an explicit name: override the param binding (escape hatch)" do
       attrs = instance.send(:reactive_field, :count, name: "other")
       expect(attrs[:name]).to eq("other")
+    end
+  end
+
+  describe "#reactive_root (issue #48 — id on the root, not a child)" do
+    subject(:instance) { root_klass.new }
+
+    # A real Phlex component (so the render-context-free `mix` helper is present,
+    # exactly as in production) with a custom #id. reactive_root must emit that id
+    # ON the reactive-controller element, so this.element.id can never be empty and
+    # #extractToken's first-token-wins fallback is unreachable.
+    let(:root_klass) do
+      Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "RootThing"
+
+        reactive_state :count
+        def initialize(count: 0) = @count = count
+
+        def id = "root-thing"
+      end
+    end
+
+    it "spreads the component id ALONGSIDE reactive_attrs on one element" do
+      attrs = instance.send(:reactive_root)
+      expect(attrs[:id]).to eq("root-thing")
+      expect(attrs[:data][:controller]).to eq("reactive")
+      expect(attrs[:data][:reactive_token_value]).to be_a(String)
+    end
+
+    it "carries the SAME token reactive_attrs would (no second signing path)" do
+      attrs = instance.send(:reactive_root)
+      payload = Phlex::Reactive.verify(attrs[:data][:reactive_token_value])
+      expect(payload["c"]).to eq("RootThing")
+    end
+
+    it "deep-merges overrides without clobbering the controller/token data:" do
+      attrs = instance.send(:reactive_root, class: "card", data: { testid: "root" })
+      expect(attrs[:class]).to eq("card")
+      # the override's data: must NOT wipe out controller/reactive_token_value
+      expect(attrs[:data][:controller]).to eq("reactive")
+      expect(attrs[:data][:reactive_token_value]).to be_a(String)
+      expect(attrs[:data][:testid]).to eq("root")
+    end
+
+    it "lets an explicit id: override win (escape hatch)" do
+      attrs = instance.send(:reactive_root, id: "explicit")
+      expect(attrs[:id]).to eq("explicit")
+    end
+
+    it "renders id and data-controller onto the SAME element (the whole point)" do
+      render_klass = Class.new(root_klass) do
+        def self.name = "RenderRootThing"
+        def view_template = div(**reactive_root(class: "card")) { "hi" }
+      end
+      html = render_klass.new.call
+
+      # the SAME opening tag carries BOTH the id and the controller — never split
+      # across elements (the issue #48 footgun is `id:` on a child). Match the one
+      # <div …> tag, then assert both attributes live inside it (order-independent).
+      open_tag = html[/<div [^>]*>/]
+      expect(open_tag).to include('id="root-thing"')
+      expect(open_tag).to include('data-controller="reactive"')
+      expect(open_tag).to include('class="card"')
     end
   end
 


### PR DESCRIPTION
## Summary

`reactive_attrs` doesn't emit `id:`, so an app could spread it onto a wrapper `div` and put `id:` on a **child** (the rows container / stream target) — leaving the reactive controller root's `id` empty. That silently re-opened the #46 add-once-only bug:

- With no root id, the client's `#extractToken` takes its legacy first-token-wins fallback and grabs the **prepended child row's** token.
- The next action POSTs that foreign token; the endpoint resolves it to the child's class, finds no matching action, and `head(:forbidden)`.
- Nothing fails loud — diagnosing it (cosmos#1939) was a Playwright bisect.

The invariant *"the reactive controller-root element's `id` == `component.id`"* is load-bearing across **both** halves of the round trip (the server targets `#id`; the client self-matches `this.element.id`), but it was established only by README convention. This PR makes the footgun **unbuildable** and **fails loud** when it still happens — without breaking any existing component.

Ships the issue's recommended **(a)** + **(c)**. Option **(b)** (making `reactive_attrs` emit `id:`) was rejected as a breaking change — `div(id:, **reactive_attrs)` apps would get a duplicate-keyword `ArgumentError` — per the issue's own analysis.

## What changed

### (a) `reactive_root` helper — the whole root in one spread (back-compat-safe)

```ruby
def reactive_root(**overrides)
  root_id = overrides.delete(:id) || id
  mix({ **reactive_attrs }, overrides, { id: root_id })
end
```

- `div(**reactive_root)` emits the component `id` **and** `reactive_attrs` on **one** element, so the id can't land on a child.
- `reactive_root(class: "card", data: { testid: "root" })` deep-merges via Phlex `mix`, so your `data:` doesn't clobber `data-controller`/`reactive_token_value`.
- An explicit `id:` override wins **cleanly** — the id is resolved outside `mix` so two String ids don't string-concat into `"default override"`.
- `reactive_attrs` is **unchanged**: every `div(id:, **reactive_attrs)` component keeps working verbatim.

### (c) `connect()` id guard — fail loud on page load

The generic Stimulus controller now `console.warn`s on `connect()` when `this.element.id === ""`, pointing at `reactive_root` / `id:`-on-the-same-element. The failure surfaces immediately instead of on the second click. Mirrors the #26 part-2 registration guard.

### Docs

README, the docs site examples, the architecture "nested roots" note, and the component generator all promote `div(**reactive_root)`, and the invariant is stated explicitly (server targets `#id`; client self-matches `this.element.id`; `id:` on a child silently 403s the next action).

## Test plan

| Layer | What it proves |
|---|---|
| `spec/phlex/reactive/component_spec.rb` | `reactive_root` spreads id + reactive_attrs on one element, carries the same signed token, deep-merges overrides without clobbering controller/token `data:`, lets an explicit `id:` win, and (real Phlex render) emits `id` + `data-controller` on the **same** opening tag |
| `spec/javascript/reactive_root_id_guard.test.js` | `connect()` warns on an empty root id; stays silent when the root has an id |

Both were written RED-first.

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests` — 224 green
- [x] `bundle exec rspec spec/system` (Puma) — 23 green
- [x] `bun test spec/javascript` — 40 green
- [x] `bundle exec rubocop` — clean
- [x] vendored client re-synced (byte-identical to source)
- [x] backwards compatible — `reactive_attrs` untouched; existing components pass verbatim
- [x] pgbus optionality unaffected (no transport change)

Closes #48
