### PR TITLE
feat(component): confirm: option on on(...) for confirmation-gated actions

### DIFF
--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -168,8 +168,21 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params, debounce } = event.params
+    const { action, params, debounce, confirm } = event.params
     if (!action) return
+
+    // Confirmation gate (issue #52). A destructive reactive trigger can't use
+    // Hotwire's data-turbo-confirm — this controller preempts the event — so a
+    // `confirm:` message threads a data-reactive-confirm-param and we prompt
+    // HERE, BEFORE any preventDefault/enqueue/debounce. On decline we still
+    // preventDefault (so a `submit`/click can't natively navigate on cancel)
+    // and bail — nothing is enqueued, no timer is scheduled. window.confirm is
+    // synchronous + screen-reader friendly and keeps the no-dependency default;
+    // a richer/async dialog can be layered on additively later.
+    if (confirm && !window.confirm(confirm)) {
+      event.preventDefault()
+      return
+    }
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch. preventDefault() only works while the event is

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -304,13 +304,22 @@ module Phlex
       # live-update-as-you-type doesn't POST per keystroke. A blur flushes a
       # pending dispatch so the last edit is never dropped. Omit it for the
       # immediate-dispatch default.
+      #
+      # `confirm:` (a message string) gates the action behind a confirmation
+      # prompt (issue #52). Destructive reactive triggers can't use Hotwire's
+      # `data-turbo-confirm` — the reactive controller calls preventDefault and
+      # enqueues the POST itself, so Turbo's confirm handling never runs. The
+      # client shows window.confirm(message) FIRST and bails before any
+      # enqueue/debounce if the user declines (and prevents the native default so
+      # a `submit` trigger can't navigate on cancel). Omit it for no prompt.
+      #   button(**on(:destroy, confirm: "Really delete this item?")) { "Delete" }
       # The verbatim JSON for an empty explicit-params payload. The common
       # trigger (on(:increment), no params) hits this on EVERY render — skipping
       # params.to_json (which re-serializes {} to the same "{}" each time) avoids
       # a per-render allocation while keeping the wire format byte-identical.
       EMPTY_PARAMS_JSON = "{}"
 
-      def on(action_name, event: "click", debounce: nil, **params)
+      def on(action_name, event: "click", debounce: nil, confirm: nil, **params)
         attrs = {
           data: {
             action: "#{event}->reactive#dispatch",
@@ -319,6 +328,7 @@ module Phlex
           }
         }
         attrs[:data][:reactive_debounce_param] = debounce if debounce
+        attrs[:data][:reactive_confirm_param] = confirm if confirm
         attrs[:type] = "button" if event == "click"
         attrs
       end

--- a/spec/dummy/app/components/confirm_component.rb
+++ b/spec/dummy/app/components/confirm_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Exercises the confirm option (issue #52). The `delete` action is gated behind
+# on(:delete, confirm: "..."). Each run bumps a `runs` counter — so a system
+# spec can prove that DECLINING the prompt never runs the action (runs stays 0)
+# while ACCEPTING it does (runs -> 1).
+class ConfirmComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :runs
+
+  action :delete
+
+  def initialize(runs: 0)
+    @runs = runs
+  end
+
+  def id = "confirm"
+
+  def delete
+    @runs += 1
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      button(**mix(on(:delete, confirm: "Really delete this item?"),
+        data: { testid: "delete" })) { "Delete" }
+      span(data: { testid: "runs" }) { @runs.to_s }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -47,6 +47,10 @@ class DemosController < ActionController::Base
     render_component DebounceComponent.new
   end
 
+  def confirm
+    render_component ConfirmComponent.new
+  end
+
   def morph_grid
     render_component MorphGridComponent.new(account: Account.find(params[:id]))
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get "nested_editor" => "demos#nested_editor"
   get "nested_params" => "demos#nested_params"
   get "debounce" => "demos#debounce"
+  get "confirm" => "demos#confirm"
   get "morph_grid/:id" => "demos#morph_grid"
   get "partial_grid/:id" => "demos#partial_grid"
   get "document_upload/:id" => "demos#document_upload"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -168,8 +168,21 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params, debounce } = event.params
+    const { action, params, debounce, confirm } = event.params
     if (!action) return
+
+    // Confirmation gate (issue #52). A destructive reactive trigger can't use
+    // Hotwire's data-turbo-confirm — this controller preempts the event — so a
+    // `confirm:` message threads a data-reactive-confirm-param and we prompt
+    // HERE, BEFORE any preventDefault/enqueue/debounce. On decline we still
+    // preventDefault (so a `submit`/click can't natively navigate on cancel)
+    // and bail — nothing is enqueued, no timer is scheduled. window.confirm is
+    // synchronous + screen-reader friendly and keeps the no-dependency default;
+    // a richer/async dialog can be layered on additively later.
+    if (confirm && !window.confirm(confirm)) {
+      event.preventDefault()
+      return
+    }
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch. preventDefault() only works while the event is

--- a/spec/javascript/reactive_confirm.test.js
+++ b/spec/javascript/reactive_confirm.test.js
@@ -1,0 +1,144 @@
+// Unit test for the confirm option on reactive triggers (issue #52).
+//
+// on(:destroy, confirm: "Sure?") gates the action behind window.confirm(message).
+// Declining must bail BEFORE any fetch/enqueue (the action never runs) while
+// still preventing the native default (so a submit/click can't navigate on
+// cancel). Accepting proceeds exactly as today. A confirm + debounce decline
+// must schedule NOTHING (the prompt runs before the debounce timer).
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A trigger element stub that records blur listeners so the test can fire blur.
+function makeTarget() {
+  const listeners = {}
+  return {
+    addEventListener: (type, fn) => {
+      (listeners[type] ||= []).push(fn)
+    },
+    removeEventListener: (type, fn) => {
+      listeners[type] = (listeners[type] || []).filter((f) => f !== fn)
+    },
+    fire: (type) => (listeners[type] || []).slice().forEach((fn) => fn()),
+  }
+}
+
+function makeRoot() {
+  return {
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+function buildController() {
+  const controller = new ReactiveController()
+  controller.element = makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    calls++
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+// Install a window.confirm stub returning `answer`; record the message it saw.
+function stubConfirm(answer) {
+  const seen = []
+  globalThis.window.confirm = (message) => {
+    seen.push(message)
+    return answer
+  }
+  return seen
+}
+
+test("declining the confirm bails before any fetch (the action never runs)", async () => {
+  const { controller, calls } = buildController()
+  const seen = stubConfirm(false)
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Really delete?" },
+    preventDefault: () => {},
+  })
+
+  expect(seen).toEqual(["Really delete?"]) // the prompt was shown with our message
+  expect(calls()).toBe(0) // declined → no round trip
+})
+
+test("declining still preventDefaults (a submit/click can't navigate on cancel)", async () => {
+  const { controller } = buildController()
+  stubConfirm(false)
+  const order = []
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?" },
+    preventDefault: () => order.push("preventDefault"),
+  })
+
+  expect(order).toEqual(["preventDefault"]) // native default stopped even on cancel
+})
+
+test("accepting the confirm proceeds to the round trip", async () => {
+  const { controller, calls } = buildController()
+  stubConfirm(true)
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?" },
+    preventDefault: () => {},
+  })
+
+  expect(calls()).toBe(1) // confirmed → the action fires
+})
+
+test("declining a confirm+debounce trigger schedules NOTHING", async () => {
+  const { controller, calls } = buildController()
+  stubConfirm(false)
+
+  controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?", debounce: 50 },
+    preventDefault: () => {},
+  })
+
+  await wait(80) // past the debounce window
+  expect(calls()).toBe(0) // the prompt ran before the timer; cancel scheduled no dispatch
+})
+
+test("no confirm → dispatch fires immediately (unchanged behavior)", async () => {
+  const { controller, calls } = buildController()
+  // Even if a confirm impl exists on window, no confirm param means no prompt.
+  stubConfirm(false)
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "save", params: "{}" }, // no confirm
+    preventDefault: () => {},
+  })
+
+  expect(calls()).toBe(1)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -376,6 +376,31 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on confirm gate (issue #52)" do
+    subject(:instance) { state_klass.new }
+
+    it "omits the confirm param by default" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:data]).not_to have_key(:reactive_confirm_param)
+    end
+
+    it "emits the confirm message as a Stimulus param when given" do
+      attrs = instance.send(:on, :destroy, confirm: "Really delete this item?")
+      expect(attrs[:data][:reactive_confirm_param]).to eq("Really delete this item?")
+    end
+
+    it "keeps confirm out of the explicit params payload" do
+      attrs = instance.send(:on, :set, confirm: "Sure?", count: 5)
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "count" => 5 })
+    end
+
+    it "threads confirm alongside debounce without collision" do
+      attrs = instance.send(:on, :set, event: "input", debounce: 300, confirm: "Sure?")
+      expect(attrs[:data][:reactive_debounce_param]).to eq(300)
+      expect(attrs[:data][:reactive_confirm_param]).to eq("Sure?")
+    end
+  end
+
   # Performance: reactive_token runs on EVERY render. It must produce a byte-
   # identical payload before/after caching the ivar symbols + class name. These
   # pin the payload SHAPE (decoded) so an allocation optimization can't silently

--- a/spec/system/confirm_spec.rb
+++ b/spec/system/confirm_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #52: on(:action, confirm: "message") gates a reactive trigger behind a
+# confirmation prompt. The reactive controller preempts the event (preventDefault
+# + its own POST), so Hotwire's data-turbo-confirm can't run — `confirm:` threads
+# a data-reactive-confirm-param and the client prompts window.confirm() BEFORE
+# enqueuing. Declining must run NOTHING (the action never fires); accepting runs
+# the action exactly as an unguarded trigger would.
+#
+# We override window.confirm in the page so accept/decline is deterministic
+# across both drivers and both servers (Puma + Falcon) — the click path is what's
+# under test, not the browser's native dialog chrome.
+RSpec.describe "Confirmation-gated reactive action (issue #52)", type: :system do
+  it "does NOT run the action when the confirm is declined" do
+    visit "/confirm"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    # window.confirm returns false → the dispatch must bail before any POST.
+    page.execute_script("window.confirm = () => false")
+    find("[data-testid='delete']").click
+
+    # Give the (non-)round-trip time to NOT happen, then assert runs is still 0.
+    # The marker proves the cancel didn't trigger a navigation either.
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "runs the action when the confirm is accepted" do
+    visit "/confirm"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    # window.confirm returns true → the action fires and runs increments.
+    page.execute_script("window.confirm = () => true")
+    find("[data-testid='delete']").click
+
+    expect(page).to have_css("[data-testid='runs']", text: "1")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

Adds an optional `confirm:` keyword to `on(...)` so destructive reactive triggers can be gated behind a confirmation prompt — the reactive-native answer to Hotwire's `data-turbo-confirm`, which can't run because the reactive controller preempts the event (it `preventDefault`s and enqueues its own POST).

```ruby
button(**on(:destroy, confirm: "Really delete this item?")) { "Delete" }
```

**How it works** (mirrors the existing `debounce:` threading):

- **Ruby (`Component#on`)** — `confirm:` defaults to `nil`; when present it emits `data-reactive-confirm-param`.
- **Client (`dispatch`)** — reads `confirm` from `event.params` and prompts `window.confirm(message)` **first**, before any `preventDefault` / enqueue / debounce. On decline it still `preventDefault`s (so a `submit`/click can't natively navigate on cancel) and bails — nothing is enqueued, no timer scheduled.

`window.confirm` keeps the controller's no-dependency, screen-reader-friendly default; a richer/async dialog can be layered on additively later (e.g. a cancelable custom event) without changing this API.

## Edge cases handled

- **confirm + debounce** — the prompt runs before the debounce timer, so a decline schedules nothing.
- **confirm on a `submit` trigger** — the early `preventDefault()` on cancel stops the native form submission/navigation (same reasoning as #11).
- **confirm + params** — explicit params still serialize normally; `confirm` never leaks into the params payload.

## Backwards compatibility

`confirm:` defaults to `nil`. With it omitted the emitted attributes and the wire format are byte-identical to before — existing components are unchanged. No endpoint, token, or pgbus interaction (the round trip is identical once confirmed), so the Action-Cable-or-pgbus optionality is untouched.

## Test Coverage

| Layer | What it proves |
|-------|----------------|
| Ruby (`component_spec`) | emits / omits `reactive_confirm_param`; keeps confirm out of the params payload; threads alongside `debounce` without collision |
| JS (`reactive_confirm.test.js`) | decline bails before any `fetch` but still `preventDefault`s; accept proceeds; confirm + debounce decline schedules nothing; no-confirm path unchanged |
| System (`confirm_spec`) | declining does **not** run the action (`runs` stays `0`, no reload); accepting runs it (`runs` → `1`) — green under **Puma AND Falcon** |

## Verification

- [x] `bundle exec rubocop` — clean (106 files)
- [x] `bundle exec rspec spec/phlex spec/requests` — 228 passed
- [x] `bundle exec rspec spec/system` — 25 passed (Puma); `confirm_spec` green on Falcon
- [x] `bun test spec/javascript` — 45 passed; vendored client re-synced

## Note on docs

README / CHANGELOG / docs-site updates are **intentionally deferred** — the docs site is owned by a separate in-flight branch. Happy to add the `confirm:` docs once that lands (or in a follow-up).

Closes #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts for reactive actions, letting users approve or cancel before an action runs.
  * New demo page showcases a confirm-protected delete action.

* **Bug Fixes**
  * Canceling a confirmation now correctly stops the action from running and prevents any network request or delayed dispatch.
  * Confirm prompts work alongside debounced actions without triggering unintended behavior.

* **Tests**
  * Added coverage for confirmed, canceled, and debounced confirmation flows in both unit and system tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->