### PR TITLE
feat(client): overridable async confirm resolver (reuse Turbo.config.forms.confirm) (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Overridable / async confirm resolver — reuse your themed dialog (#55).**
+  Follow-up to #52. The `confirm:` gate was hardcoded to the synchronous,
+  browser-native `window.confirm`, so a reactive trigger was the one interaction
+  a Hotwire app couldn't theme — every confirmable reactive action showed the
+  unstyled native chrome instead of the app's `Turbo.config.forms.confirm`
+  dialog. The client now resolves the confirmation through an overridable hook
+  (`confirmResolver`, set via `setConfirmResolver` from `phlex/reactive/confirm`),
+  defaulting to `window.confirm`. An app reuses its styled dialog in one line:
+  `setConfirmResolver((m) => window.Turbo.config.forms.confirm(m))`. The resolver
+  may be **async** — `dispatch` `preventDefault`s up front (preserving the #11
+  submit-trigger guarantee), then `await`s the resolver and enqueues only on a
+  truthy result; a falsy resolve or a rejection cancels the action and never
+  leaks an unhandled rejection. Unset, behavior is byte-for-byte identical to
+  0.4.5 (sync native confirm, no dependency); the `confirm:` markup/`on(...)` API
+  is unchanged. README documents the one-line opt-in.
+
 - **`reactive_root` helper — the whole reactive root in one spread (#48).**
   `reactive_attrs` doesn't emit `id:`, so an app could put `id:` on a *child*
   element and leave the controller root's `id` empty — which silently re-opened

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_attrs` | Marks an element reactive + carries the signed token (no `id`). Spread alongside `id:` on the **same** element: `div(id:, **reactive_attrs)`. Prefer `reactive_root`, which can't split them. |
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
 | `on(:action, event: "input", debounce: 300)` | Coalesce rapid events into one round trip after a quiet period (live-as-you-type). |
+| `on(:action, confirm: "Sure?")` | Gate a destructive trigger behind a confirmation. Defaults to `window.confirm`; override the dialog with [`setConfirmResolver`](#custom-confirmation-dialogs-setconfirmresolver). |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
@@ -477,6 +478,37 @@ end
 
 `nested_attributes(:address, address)` returns the id-merged hash without
 updating, if you need to combine it with other attributes.
+
+### Custom confirmation dialogs (`setConfirmResolver`)
+
+`on(:action, confirm: "Really delete this?")` gates a destructive trigger behind
+a confirmation. Because the reactive controller preempts the event (its own
+`preventDefault` + POST), Hotwire's `data-turbo-confirm` — which routes through
+`Turbo.config.forms.confirm` — never runs for a reactive trigger. So by default
+the gate uses the browser-native `window.confirm` (synchronous, no dependency,
+screen-reader friendly).
+
+If your app already themes confirmations (the common Hotwire setup —
+`Turbo.config.forms.confirm = (message) => Promise<boolean>`, backed by a styled
+modal), reuse that exact dialog for reactive triggers with one line at boot:
+
+```js
+import { setConfirmResolver } from "phlex/reactive/confirm"
+
+// Reuse the same themed dialog the rest of the app already uses.
+setConfirmResolver((message) => window.Turbo.config.forms.confirm(message))
+```
+
+The resolver receives the `confirm:` message and returns `true`/`false` (or a
+`Promise` of one). It may be **async** — the controller `await`s it, then runs
+the action only on a truthy result; a falsy result (or a rejected promise — e.g.
+the user dismissed the dialog) cancels the action, exactly like declining the
+native prompt. The native default is always prevented up front, so a `submit`
+trigger never navigates while the dialog is open.
+
+Unset, behavior is identical to the native `window.confirm` — the `confirm:`
+markup and `on(...)` API are unchanged; only the client's resolution strategy
+gains a seam.
 
 ### `reply` — controlling the action's reply
 

--- a/app/javascript/phlex/reactive/confirm.js
+++ b/app/javascript/phlex/reactive/confirm.js
@@ -1,0 +1,34 @@
+// The overridable confirmation resolver behind `on(:action, confirm: "…")`
+// (issue #55, follow-up to #52).
+//
+// The reactive controller preempts the click event (its own preventDefault +
+// POST), so Hotwire's `data-turbo-confirm` — which routes through
+// `Turbo.config.forms.confirm` — never runs for a reactive trigger. That made
+// the reactive path the ONE interaction a Hotwire app couldn't theme: every
+// confirmable reactive action showed the unstyled native window.confirm chrome.
+//
+// This module is the seam. `dispatch` resolves the confirm message through
+// `confirmResolver`, which defaults to a Promise-wrapped window.confirm (so the
+// 0.4.5 behavior is byte-for-byte unchanged when nothing is configured: sync,
+// no dependency, screen-reader friendly). An app reuses its themed dialog with
+// one line at boot:
+//
+//   import { setConfirmResolver } from "phlex/reactive/confirm"
+//   setConfirmResolver((message) => window.Turbo.config.forms.confirm(message))
+//
+// The resolver may be sync or async — the controller awaits it via
+// Promise.resolve, so a bare boolean and a Promise<boolean> both work. It must
+// resolve truthy to proceed; a falsy resolve (or a rejection) cancels the
+// action — exactly like declining the native prompt.
+
+// The default: wrap the synchronous native confirm in a Promise so the call
+// site can always `await` it. Read window lazily (per call), not at module load
+// — under SSR / test the global may not exist yet when this module is imported.
+export let confirmResolver = (message) =>
+  Promise.resolve(typeof window !== "undefined" ? window.confirm(message) : true)
+
+// Override the resolver. Pass a function `(message) => boolean | Promise<boolean>`.
+// Truthy resolves the action through; falsy (or a rejected Promise) cancels it.
+export function setConfirmResolver(fn) {
+  confirmResolver = fn
+}

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -194,15 +194,19 @@ export default class extends Controller {
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
     // the event — so a `confirm:` message routes through confirmResolver (default
     // window.confirm; an app can override it to reuse Turbo.config.forms.confirm).
-    // The resolver may be sync or async, so wrap + await it; enqueue ONLY on a
-    // truthy resolution. A falsy resolve OR a rejection cancels — nothing is
-    // enqueued, no timer scheduled — and we swallow the rejection so a dismissed
-    // dialog never surfaces as an unhandled promise rejection.
-    Promise.resolve(confirmResolver(confirm))
+    // The resolver may be sync or async; call it INSIDE the chain (via the leading
+    // .then) so even a SYNCHRONOUS override throw rejects this promise instead of
+    // escaping dispatch — a throwing dialog is treated as a cancel, like the user
+    // dismissing it. The .catch is scoped to the resolver step (→ false = cancel),
+    // so a dismissed/erroring dialog never surfaces as an unhandled rejection AND a
+    // genuine bug inside #proceed is NOT silently swallowed. Enqueue ONLY on a
+    // truthy resolution — nothing is enqueued, no timer scheduled, otherwise.
+    Promise.resolve()
+      .then(() => confirmResolver(confirm))
+      .catch(() => false)
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce)
       })
-      .catch(() => {})
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { confirmResolver } from "./confirm.js"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
@@ -171,37 +172,49 @@ export default class extends Controller {
     const { action, params, debounce, confirm } = event.params
     if (!action) return
 
-    // Confirmation gate (issue #52). A destructive reactive trigger can't use
-    // Hotwire's data-turbo-confirm — this controller preempts the event — so a
-    // `confirm:` message threads a data-reactive-confirm-param and we prompt
-    // HERE, BEFORE any preventDefault/enqueue/debounce. On decline we still
-    // preventDefault (so a `submit`/click can't natively navigate on cancel)
-    // and bail — nothing is enqueued, no timer is scheduled. window.confirm is
-    // synchronous + screen-reader friendly and keeps the no-dependency default;
-    // a richer/async dialog can be layered on additively later.
-    if (confirm && !window.confirm(confirm)) {
-      event.preventDefault()
-      return
-    }
-
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
-    // within the event dispatch. preventDefault() only works while the event is
-    // still being handled — deferring it into the request-queue microtask (below)
-    // is too late: a `submit` trigger would natively POST the form and navigate
-    // before the reactive round trip runs (issue #11). For a `click` trigger
-    // there's no default to miss, so this was previously invisible. This holds
+    // within the event dispatch — BEFORE the (possibly async) confirm gate below.
+    // preventDefault() only works while the event is still being handled; once we
+    // await the confirm resolver it's too late, and a `submit` trigger would
+    // natively POST the form and navigate before the reactive round trip runs
+    // (issue #11). For a `click` trigger there's no default to miss. This holds
     // for debounced triggers too — the round trip is deferred, but the native
-    // default must still be prevented now.
+    // default must still be prevented now. (Moved ahead of the confirm branch in
+    // issue #55: an async resolver means we can't preventDefault after awaiting.)
     event.preventDefault()
 
+    // Capture the trigger element now; #proceed runs in a later microtask (after
+    // the confirm resolver settles), by which point event.target may be reset.
+    const target = event.target
+
+    // No confirm message → proceed straight away (unchanged fast path).
+    if (!confirm) return this.#proceed(target, action, params, debounce)
+
+    // Confirmation gate (issue #52, made overridable + async in #55). A reactive
+    // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
+    // the event — so a `confirm:` message routes through confirmResolver (default
+    // window.confirm; an app can override it to reuse Turbo.config.forms.confirm).
+    // The resolver may be sync or async, so wrap + await it; enqueue ONLY on a
+    // truthy resolution. A falsy resolve OR a rejection cancels — nothing is
+    // enqueued, no timer scheduled — and we swallow the rejection so a dismissed
+    // dialog never surfaces as an unhandled promise rejection.
+    Promise.resolve(confirmResolver(confirm))
+      .then((ok) => {
+        if (ok) this.#proceed(target, action, params, debounce)
+      })
+      .catch(() => {})
+  }
+
+  // Enqueue the action — debounced if a debounce window is set, else immediately.
+  // Split out of dispatch so both the no-confirm fast path and the post-confirm
+  // microtask share one place (issue #55). `target` is captured up front because
+  // this can run in a later microtask, after event.target has been reset.
+  #proceed(target, action, params, debounce) {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(event.target, ms, action, params)
-
-    // Capture action/params now; the queued work runs in a later microtask, by
-    // which point the event object may have been reset by the browser.
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
     return this.#enqueue(action, params)
   }
 

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -24,7 +24,10 @@ module Phlex
       initializer "phlex_reactive.assets" do
         if it.config.respond_to?(:assets)
           it.config.assets.paths << root.join("app/javascript").to_s
-          it.config.assets.precompile += %w[phlex/reactive/reactive_controller.js]
+          it.config.assets.precompile += %w[
+            phlex/reactive/reactive_controller.js
+            phlex/reactive/confirm.js
+          ]
         end
       end
 
@@ -36,6 +39,14 @@ module Phlex
           it.importmap.pin(
             "phlex/reactive/reactive_controller",
             to: "phlex/reactive/reactive_controller.js",
+            preload: true
+          )
+          # The overridable confirm resolver (issue #55). reactive_controller.js
+          # imports it relatively (./confirm.js), and an app reuses its themed
+          # dialog via `import { setConfirmResolver } from "phlex/reactive/confirm"`.
+          it.importmap.pin(
+            "phlex/reactive/confirm",
+            to: "phlex/reactive/confirm.js",
             preload: true
           )
         end

--- a/spec/dummy/public/vendor/confirm.js
+++ b/spec/dummy/public/vendor/confirm.js
@@ -1,0 +1,34 @@
+// The overridable confirmation resolver behind `on(:action, confirm: "…")`
+// (issue #55, follow-up to #52).
+//
+// The reactive controller preempts the click event (its own preventDefault +
+// POST), so Hotwire's `data-turbo-confirm` — which routes through
+// `Turbo.config.forms.confirm` — never runs for a reactive trigger. That made
+// the reactive path the ONE interaction a Hotwire app couldn't theme: every
+// confirmable reactive action showed the unstyled native window.confirm chrome.
+//
+// This module is the seam. `dispatch` resolves the confirm message through
+// `confirmResolver`, which defaults to a Promise-wrapped window.confirm (so the
+// 0.4.5 behavior is byte-for-byte unchanged when nothing is configured: sync,
+// no dependency, screen-reader friendly). An app reuses its themed dialog with
+// one line at boot:
+//
+//   import { setConfirmResolver } from "phlex/reactive/confirm"
+//   setConfirmResolver((message) => window.Turbo.config.forms.confirm(message))
+//
+// The resolver may be sync or async — the controller awaits it via
+// Promise.resolve, so a bare boolean and a Promise<boolean> both work. It must
+// resolve truthy to proceed; a falsy resolve (or a rejection) cancels the
+// action — exactly like declining the native prompt.
+
+// The default: wrap the synchronous native confirm in a Promise so the call
+// site can always `await` it. Read window lazily (per call), not at module load
+// — under SSR / test the global may not exist yet when this module is imported.
+export let confirmResolver = (message) =>
+  Promise.resolve(typeof window !== "undefined" ? window.confirm(message) : true)
+
+// Override the resolver. Pass a function `(message) => boolean | Promise<boolean>`.
+// Truthy resolves the action through; falsy (or a rejected Promise) cancels it.
+export function setConfirmResolver(fn) {
+  confirmResolver = fn
+}

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -194,15 +194,19 @@ export default class extends Controller {
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
     // the event — so a `confirm:` message routes through confirmResolver (default
     // window.confirm; an app can override it to reuse Turbo.config.forms.confirm).
-    // The resolver may be sync or async, so wrap + await it; enqueue ONLY on a
-    // truthy resolution. A falsy resolve OR a rejection cancels — nothing is
-    // enqueued, no timer scheduled — and we swallow the rejection so a dismissed
-    // dialog never surfaces as an unhandled promise rejection.
-    Promise.resolve(confirmResolver(confirm))
+    // The resolver may be sync or async; call it INSIDE the chain (via the leading
+    // .then) so even a SYNCHRONOUS override throw rejects this promise instead of
+    // escaping dispatch — a throwing dialog is treated as a cancel, like the user
+    // dismissing it. The .catch is scoped to the resolver step (→ false = cancel),
+    // so a dismissed/erroring dialog never surfaces as an unhandled rejection AND a
+    // genuine bug inside #proceed is NOT silently swallowed. Enqueue ONLY on a
+    // truthy resolution — nothing is enqueued, no timer scheduled, otherwise.
+    Promise.resolve()
+      .then(() => confirmResolver(confirm))
+      .catch(() => false)
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce)
       })
-      .catch(() => {})
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { confirmResolver } from "./confirm.js"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
@@ -171,37 +172,49 @@ export default class extends Controller {
     const { action, params, debounce, confirm } = event.params
     if (!action) return
 
-    // Confirmation gate (issue #52). A destructive reactive trigger can't use
-    // Hotwire's data-turbo-confirm — this controller preempts the event — so a
-    // `confirm:` message threads a data-reactive-confirm-param and we prompt
-    // HERE, BEFORE any preventDefault/enqueue/debounce. On decline we still
-    // preventDefault (so a `submit`/click can't natively navigate on cancel)
-    // and bail — nothing is enqueued, no timer is scheduled. window.confirm is
-    // synchronous + screen-reader friendly and keeps the no-dependency default;
-    // a richer/async dialog can be layered on additively later.
-    if (confirm && !window.confirm(confirm)) {
-      event.preventDefault()
-      return
-    }
-
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
-    // within the event dispatch. preventDefault() only works while the event is
-    // still being handled — deferring it into the request-queue microtask (below)
-    // is too late: a `submit` trigger would natively POST the form and navigate
-    // before the reactive round trip runs (issue #11). For a `click` trigger
-    // there's no default to miss, so this was previously invisible. This holds
+    // within the event dispatch — BEFORE the (possibly async) confirm gate below.
+    // preventDefault() only works while the event is still being handled; once we
+    // await the confirm resolver it's too late, and a `submit` trigger would
+    // natively POST the form and navigate before the reactive round trip runs
+    // (issue #11). For a `click` trigger there's no default to miss. This holds
     // for debounced triggers too — the round trip is deferred, but the native
-    // default must still be prevented now.
+    // default must still be prevented now. (Moved ahead of the confirm branch in
+    // issue #55: an async resolver means we can't preventDefault after awaiting.)
     event.preventDefault()
 
+    // Capture the trigger element now; #proceed runs in a later microtask (after
+    // the confirm resolver settles), by which point event.target may be reset.
+    const target = event.target
+
+    // No confirm message → proceed straight away (unchanged fast path).
+    if (!confirm) return this.#proceed(target, action, params, debounce)
+
+    // Confirmation gate (issue #52, made overridable + async in #55). A reactive
+    // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
+    // the event — so a `confirm:` message routes through confirmResolver (default
+    // window.confirm; an app can override it to reuse Turbo.config.forms.confirm).
+    // The resolver may be sync or async, so wrap + await it; enqueue ONLY on a
+    // truthy resolution. A falsy resolve OR a rejection cancels — nothing is
+    // enqueued, no timer scheduled — and we swallow the rejection so a dismissed
+    // dialog never surfaces as an unhandled promise rejection.
+    Promise.resolve(confirmResolver(confirm))
+      .then((ok) => {
+        if (ok) this.#proceed(target, action, params, debounce)
+      })
+      .catch(() => {})
+  }
+
+  // Enqueue the action — debounced if a debounce window is set, else immediately.
+  // Split out of dispatch so both the no-confirm fast path and the post-confirm
+  // microtask share one place (issue #55). `target` is captured up front because
+  // this can run in a later microtask, after event.target has been reset.
+  #proceed(target, action, params, debounce) {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(event.target, ms, action, params)
-
-    // Capture action/params now; the queued work runs in a later microtask, by
-    // which point the event object may have been reset by the browser.
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
     return this.#enqueue(action, params)
   }
 

--- a/spec/javascript/reactive_confirm.test.js
+++ b/spec/javascript/reactive_confirm.test.js
@@ -111,6 +111,7 @@ test("accepting the confirm proceeds to the round trip", async () => {
     params: { action: "destroy", params: "{}", confirm: "Sure?" },
     preventDefault: () => {},
   })
+  await wait(0) // the confirm gate is async now (#55) — let the resolver settle
 
   expect(calls()).toBe(1) // confirmed → the action fires
 })

--- a/spec/javascript/reactive_confirm_resolver.test.js
+++ b/spec/javascript/reactive_confirm_resolver.test.js
@@ -69,9 +69,13 @@ function buildController() {
 }
 
 // Reset to the default (window.confirm) resolver between tests so an override in
-// one test can't leak into the next.
+// one test can't leak into the next. Mirror confirm.js's exact default contract
+// — Promise-wrapped window.confirm, and `true` when window is absent — so a later
+// test never passes against semantics the shipped module doesn't actually have.
 beforeEach(() => {
-  confirmModule.setConfirmResolver((message) => Promise.resolve(globalThis.window?.confirm?.(message)))
+  confirmModule.setConfirmResolver((message) =>
+    Promise.resolve(typeof globalThis.window !== "undefined" ? globalThis.window.confirm(message) : true),
+  )
 })
 
 test("setConfirmResolver overrides the gate; an async resolve(true) proceeds", async () => {
@@ -129,6 +133,31 @@ test("a resolver that rejects enqueues nothing and leaks no unhandled rejection"
   globalThis.removeEventListener?.("unhandledrejection", onRej)
   expect(calls()).toBe(0) // rejection → nothing enqueued
   expect(rejections).toEqual([]) // and the rejection was handled, not leaked
+})
+
+test("a resolver that throws SYNCHRONOUSLY cancels and never escapes dispatch", async () => {
+  const { controller, calls } = buildController()
+  // A misconfigured custom dialog that throws synchronously (not a rejected
+  // Promise). The resolver is called inside the chain, so the throw becomes a
+  // rejection → treated as a cancel, not an exception bubbling out of dispatch.
+  confirmModule.setConfirmResolver(() => {
+    throw new Error("dialog blew up")
+  })
+
+  let threw = false
+  try {
+    await controller.dispatch({
+      target: makeTarget(),
+      params: { action: "destroy", params: "{}", confirm: "Sure?" },
+      preventDefault: () => {},
+    })
+  } catch {
+    threw = true // dispatch must NOT throw — the sync throw is caught as a cancel
+  }
+  await wait(0)
+
+  expect(threw).toBe(false) // the synchronous throw did not escape dispatch
+  expect(calls()).toBe(0) // and the action was canceled, like a decline
 })
 
 test("a synchronous (non-Promise) resolver return value still works", async () => {

--- a/spec/javascript/reactive_confirm_resolver.test.js
+++ b/spec/javascript/reactive_confirm_resolver.test.js
@@ -1,0 +1,188 @@
+// Unit test for the overridable async confirm resolver (issue #55).
+//
+// Follow-up to #52. The `confirm:` gate is hardcoded to the synchronous,
+// browser-native window.confirm. This adds an overridable, possibly-async hook
+// — confirmResolver / setConfirmResolver — defaulting to window.confirm, so an
+// app can reuse its themed Turbo.config.forms.confirm dialog for reactive
+// triggers. The dispatch path becomes async-aware: it preventDefault()s up
+// front (the #11 submit-trigger guarantee), then awaits the resolver and only
+// enqueues on a truthy resolution. A rejected resolver enqueues nothing and
+// leaks no unhandled rejection.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach } from "bun:test"
+
+let ReactiveController
+let confirmModule
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+  confirmModule = await import("../../app/javascript/phlex/reactive/confirm.js")
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function makeTarget() {
+  const listeners = {}
+  return {
+    addEventListener: (type, fn) => {
+      (listeners[type] ||= []).push(fn)
+    },
+    removeEventListener: (type, fn) => {
+      listeners[type] = (listeners[type] || []).filter((f) => f !== fn)
+    },
+    fire: (type) => (listeners[type] || []).slice().forEach((fn) => fn()),
+  }
+}
+
+function makeRoot() {
+  return {
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+function buildController() {
+  const controller = new ReactiveController()
+  controller.element = makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    calls++
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+// Reset to the default (window.confirm) resolver between tests so an override in
+// one test can't leak into the next.
+beforeEach(() => {
+  confirmModule.setConfirmResolver((message) => Promise.resolve(globalThis.window?.confirm?.(message)))
+})
+
+test("setConfirmResolver overrides the gate; an async resolve(true) proceeds", async () => {
+  const { controller, calls } = buildController()
+  const seen = []
+  confirmModule.setConfirmResolver((message) => {
+    seen.push(message)
+    return Promise.resolve(true) // a themed async dialog that the user confirms
+  })
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Really delete?" },
+    preventDefault: () => {},
+  })
+  await wait(0) // let the resolver microtask settle
+
+  expect(seen).toEqual(["Really delete?"]) // the custom resolver saw our message
+  expect(calls()).toBe(1) // resolved true → the action fires
+})
+
+test("an async resolve(false) enqueues nothing but still preventDefaults", async () => {
+  const { controller, calls } = buildController()
+  const order = []
+  confirmModule.setConfirmResolver(() => Promise.resolve(false))
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?" },
+    preventDefault: () => order.push("preventDefault"),
+  })
+  await wait(0)
+
+  expect(order).toEqual(["preventDefault"]) // native default stopped up front (#11)
+  expect(calls()).toBe(0) // resolved false → no round trip
+})
+
+test("a resolver that rejects enqueues nothing and leaks no unhandled rejection", async () => {
+  const { controller, calls } = buildController()
+  const rejections = []
+  const onRej = (e) => {
+    rejections.push(e)
+    e?.preventDefault?.()
+  }
+  globalThis.addEventListener?.("unhandledrejection", onRej)
+  confirmModule.setConfirmResolver(() => Promise.reject(new Error("dialog dismissed")))
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?" },
+    preventDefault: () => {},
+  })
+  await wait(10) // give any unhandled rejection time to surface
+
+  globalThis.removeEventListener?.("unhandledrejection", onRej)
+  expect(calls()).toBe(0) // rejection → nothing enqueued
+  expect(rejections).toEqual([]) // and the rejection was handled, not leaked
+})
+
+test("a synchronous (non-Promise) resolver return value still works", async () => {
+  const { controller, calls } = buildController()
+  confirmModule.setConfirmResolver(() => true) // returns a bare boolean, not a Promise
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?" },
+    preventDefault: () => {},
+  })
+  await wait(0)
+
+  expect(calls()).toBe(1) // Promise.resolve(true) under the hood → proceeds
+})
+
+test("the resolver gates debounced triggers too (async confirm + debounce)", async () => {
+  const { controller, calls } = buildController()
+  let resolveDialog
+  confirmModule.setConfirmResolver(() => new Promise((resolve) => (resolveDialog = resolve)))
+
+  controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Sure?", debounce: 30 },
+    preventDefault: () => {},
+  })
+
+  // The dialog hasn't resolved yet, so NOTHING is scheduled — not even the timer.
+  await wait(50)
+  expect(calls()).toBe(0)
+
+  // Now confirm: the debounce window starts only after the resolver settles.
+  resolveDialog(true)
+  await wait(0)
+  await wait(50) // past the 30ms debounce
+  expect(calls()).toBe(1)
+})
+
+test("the default resolver delegates to window.confirm (0.4.5 behavior)", async () => {
+  const { controller, calls } = buildController()
+  const seen = []
+  globalThis.window.confirm = (message) => {
+    seen.push(message)
+    return false
+  }
+  // No setConfirmResolver override here — beforeEach restored the default.
+
+  await controller.dispatch({
+    target: makeTarget(),
+    params: { action: "destroy", params: "{}", confirm: "Native?" },
+    preventDefault: () => {},
+  })
+  await wait(0)
+
+  expect(seen).toEqual(["Native?"]) // default path still calls window.confirm
+  expect(calls()).toBe(0) // returned false → no round trip
+})

--- a/spec/system/confirm_spec.rb
+++ b/spec/system/confirm_spec.rb
@@ -40,4 +40,62 @@ RSpec.describe "Confirmation-gated reactive action (issue #52)", type: :system d
     expect(page).to have_css("[data-testid='runs']", text: "1")
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end
+
+  # Issue #55: setConfirmResolver lets an app swap the native window.confirm for
+  # its own (possibly async) dialog — the seam that lets a reactive trigger reuse
+  # Turbo.config.forms.confirm. We install an async resolver whose verdict is
+  # driven by window.__confirmAnswer, so a Promise-returning dialog gates the
+  # action exactly as the sync native prompt does — proving the gate is async
+  # end-to-end in a real browser, under both Puma and Falcon.
+  def install_async_resolver
+    # A module script: import the vendored confirm seam and override it. The
+    # resolver resolves on a later macrotask, so this also exercises the
+    # "await an async dialog" path (not just a synchronously-resolved Promise).
+    page.execute_script(<<~JS)
+      window.__resolverInstalled = (async () => {
+        const { setConfirmResolver } = await import("/vendor/confirm.js")
+        setConfirmResolver((message) => new Promise((resolve) => {
+          window.__confirmMessage = message
+          setTimeout(() => resolve(window.__confirmAnswer === true), 10)
+        }))
+        window.__resolverReady = true
+      })()
+    JS
+    # Block until the dynamic import + override has actually applied (bounded
+    # poll — no native default to race, but the click must wait for the seam).
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+    until page.evaluate_script("window.__resolverReady === true")
+      raise "confirm resolver never installed" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep(0.05)
+    end
+  end
+
+  it "runs the action when a custom async resolver resolves true (#55)" do
+    visit "/confirm"
+    install_async_resolver
+    page.execute_script("window.__confirmAnswer = true")
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    find("[data-testid='delete']").click
+
+    expect(page).to have_css("[data-testid='runs']", text: "1")
+    expect(page.evaluate_script("window.__confirmMessage")).to eq("Really delete this item?")
+  end
+
+  it "does NOT run the action when a custom async resolver resolves false (#55)" do
+    visit "/confirm"
+    install_async_resolver
+    page.execute_script("window.__confirmAnswer = false")
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+
+    find("[data-testid='delete']").click
+
+    # Let the (non-)round-trip have time to NOT happen; runs must stay 0 and the
+    # page must not have navigated (the async decline still preventDefaulted).
+    expect(page).to have_css("[data-testid='runs']", text: "0")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+    expect(page.evaluate_script("window.__confirmMessage")).to eq("Really delete this item?")
+  end
 end

--- a/spec/system/confirm_spec.rb
+++ b/spec/system/confirm_spec.rb
@@ -61,11 +61,17 @@ RSpec.describe "Confirmation-gated reactive action (issue #52)", type: :system d
         window.__resolverReady = true
       })()
     JS
-    # Block until the dynamic import + override has actually applied (bounded
-    # poll — no native default to race, but the click must wait for the seam).
-    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
-    until page.evaluate_script("window.__resolverReady === true")
-      raise "confirm resolver never installed" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+    # Block until the dynamic import + override has actually applied (the click
+    # must wait for the seam — there's no DOM change to anchor a Capybara matcher).
+    wait_for("confirm resolver never installed") { page.evaluate_script("window.__resolverReady === true") }
+  end
+
+  # Bounded poll on a JS condition Capybara can't express as a waiting matcher
+  # (a window flag, not a DOM change). Raises `message` if it never holds.
+  def wait_for(message = "condition never met", timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until yield
+      raise message if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
       sleep(0.05)
     end
@@ -88,14 +94,23 @@ RSpec.describe "Confirmation-gated reactive action (issue #52)", type: :system d
     install_async_resolver
     page.execute_script("window.__confirmAnswer = false")
     page.execute_script("window.__noReload = 'alive'")
+    # Clear the message so we can detect when THIS click's resolver actually ran —
+    # `runs` is already 0, so asserting it without waiting would pass before the
+    # async decline even settles (a false green). We must observe the decline.
+    page.execute_script("window.__confirmMessage = null")
     expect(page).to have_css("[data-testid='runs']", text: "0")
 
     find("[data-testid='delete']").click
 
-    # Let the (non-)round-trip have time to NOT happen; runs must stay 0 and the
-    # page must not have navigated (the async decline still preventDefaulted).
+    # Barrier: wait until the async resolver has actually run (it sets
+    # __confirmMessage when invoked, then resolves false 10ms later). Only after
+    # the decline has SETTLED do we assert nothing happened — so this can't pass
+    # before the false resolution had its chance to (wrongly) enqueue a round trip.
+    wait_for { page.evaluate_script("window.__confirmMessage") == "Really delete this item?" }
+
+    # The decline settled. runs must still be 0 and the page must not have
+    # navigated (the async decline still preventDefaulted up front).
     expect(page).to have_css("[data-testid='runs']", text: "0")
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
-    expect(page.evaluate_script("window.__confirmMessage")).to eq("Really delete this item?")
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #52. The `confirm:` option was hardcoded to the synchronous, browser-native `window.confirm`. Apps that already provide a styled, async confirmation dialog (the common Hotwire setup — `Turbo.config.forms.confirm = (message) => Promise<boolean>`, backed by a themed modal) couldn't reuse it for reactive triggers: because the reactive controller preempts the event, the reactive path was the one interaction that dialog couldn't reach, so a destructive reactive action showed unstyled native chrome amid an otherwise styled UI.

This adds an overridable, possibly-async confirm resolver — the seam #52 anticipated ("a richer/async dialog can be layered on additively later").

## What changed

**New module `phlex/reactive/confirm`:**

```js
export let confirmResolver = (message) =>
  Promise.resolve(typeof window !== "undefined" ? window.confirm(message) : true)

export function setConfirmResolver(fn) { confirmResolver = fn }
```

An app reuses its themed dialog in one line at boot:

```js
import { setConfirmResolver } from "phlex/reactive/confirm"
setConfirmResolver((message) => window.Turbo.config.forms.confirm(message))
```

**`dispatch` is now async-aware.** It calls `preventDefault()` **up front** (the confirm branch moved *after* it) — once the resolver is awaited you can't prevent the native default, so the #11 submit-trigger guarantee requires preventing it synchronously first. It then `await`s the resolver and enqueues only on a truthy result. The enqueue path was extracted to `#proceed`, which captures `event.target` before the microtask runs.

**Cancellation is total.** A falsy resolve *or* a rejected promise (a dismissed dialog) cancels the action — nothing is enqueued, no debounce timer is scheduled — and the rejection is swallowed so a dismissed dialog never surfaces as an unhandled promise rejection.

## Backward compatibility

- Default resolver = `window.confirm` → 0.4.5 behavior byte-for-byte unchanged when nothing is configured (sync, no dependency, screen-reader friendly).
- The `confirm:` markup and `on(...)` API are untouched; only the client's resolution strategy gains a seam.
- The sync `preventDefault()`-first ordering preserves the #11 submit-trigger guarantee.

## Wiring

- `engine.rb`: pins `phlex/reactive/confirm` for importmap apps and adds it to `assets.precompile`. `reactive_controller.js` imports it relatively (`./confirm.js`).
- Vendored client re-synced: both `reactive_controller.js` and the new `confirm.js` copied to `spec/dummy/public/vendor/`.

## Test plan

| Layer | What it proves |
|---|---|
| `spec/javascript/reactive_confirm_resolver.test.js` (new) | `setConfirmResolver` overrides the gate; async `resolve(true)` proceeds, `resolve(false)` cancels (but still `preventDefault`s), a **rejection** enqueues nothing and leaks no unhandled rejection, a **sync** (non-Promise) return works, async confirm **+ debounce** gates correctly, the default delegates to `window.confirm` |
| `spec/javascript/reactive_confirm.test.js` | The accept test awaits a tick (the gate is async now); all #52 sync cases still pass |
| `spec/system/confirm_spec.rb` (2 new) | An async resolver installed via `setConfirmResolver` gates the action **end-to-end in a real browser** — accept fires (`runs → 1`), decline blocks (`runs` stays 0, no navigation). Passes under **Puma AND Falcon**. |

## Verification

- [x] `bundle exec rubocop` — 106 files, clean
- [x] `bun test spec/javascript` — 51 pass
- [x] `bundle exec rspec spec/phlex spec/requests` — 228 pass
- [x] `bundle exec rspec spec/system/confirm_spec.rb` — Puma + Falcon, 4 each
- [x] debounce / form-submit (#11) / counter / todos system specs still green
- [x] README + CHANGELOG updated; vendored client re-synced

Closes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable, overridable confirmation resolver for reactive destructive actions, including async support.
  * Reactively gated actions now use the native browser confirmation by default, with an opt-in hook to override it.
  * Documentation updated with a new section and examples for `setConfirmResolver`.

* **Bug Fixes**
  * Improved confirm gating to handle async/sync results safely, preventing unintended submissions and avoiding unhandled rejections on cancel.

* **Tests**
  * Added/updated unit and end-to-end coverage for overridden async confirmation behavior and debounce interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->