### PR TITLE
fix(client): import bare phlex/reactive/confirm, not relative ./confirm.js (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`reactive_controller.js` used a relative `./confirm.js` import that 404'd under
+  importmap-rails + Propshaft — taking down every Stimulus controller on the page (#57).**
+  The #55 confirm resolver added `import { confirmResolver } from "./confirm.js"` to the
+  client controller. Under importmap + Propshaft the controller is served at its
+  **digested** URL, and a relative sibling import is left untouched (Propshaft's JS
+  compiler rewrites only `RAILS_ASSET_URL(...)`, and the import map resolves **only**
+  bare specifiers, never relative-resolved URLs). So the browser resolved `./confirm.js`
+  against the digested controller URL and requested an **undigested**
+  `/assets/phlex/reactive/confirm.js` → **404**. The throwing import meant
+  `reactive_controller.js` never evaluated, and in an app that eagerly registers it the
+  whole controllers entrypoint died — **every** Stimulus controller on the page stopped,
+  with no obvious link to phlex-reactive. The fix imports the **bare** specifier the
+  engine already pins (`phlex/reactive/confirm`), which resolves to the digested asset
+  through the import map and mirrors how the gem already expects apps to import the
+  module (`import { setConfirmResolver } from "phlex/reactive/confirm"`). Bundlers
+  (esbuild/webpack/bun) resolve the bare specifier the same way they already resolve
+  `phlex/reactive/reactive_controller`; the gem's bun JS suite resolves it via a new
+  `tsconfig.json` `paths` alias. Covered by a bun unit test (the bare import resolves,
+  and the source no longer carries the relative form). 0.4.5 was unaffected (inline
+  `window.confirm`, no relative import).
+
 - **Client mirror of #44: collections of *reactive* rows were STILL add-once-only in
   the browser — `#extractToken` read the FIRST token in the response, not this
   controller's own (#46).** The server fix in 0.4.2 (#44) made the `add` response

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -1,5 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
-import { confirmResolver } from "./confirm.js"
+// Import the BARE specifier the engine already pins (phlex/reactive/confirm),
+// NOT a relative "./confirm.js" (issue #57). Under importmap-rails + Propshaft
+// the controller is served at its DIGESTED url; a relative sibling import is
+// left untouched (Propshaft rewrites only RAILS_ASSET_URL(...), and the import
+// map resolves ONLY bare specifiers), so "./confirm.js" resolves against the
+// digested controller url → an undigested /assets/.../confirm.js that 404s, and
+// the throwing import takes down every Stimulus controller on the page. The
+// bare specifier resolves to the digested asset through the import map, and
+// bundlers/bun resolve it the same way they already resolve
+// "phlex/reactive/reactive_controller" (see tsconfig.json paths for the tests).
+import { confirmResolver } from "phlex/reactive/confirm"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -42,8 +42,13 @@ module Phlex
             preload: true
           )
           # The overridable confirm resolver (issue #55). reactive_controller.js
-          # imports it relatively (./confirm.js), and an app reuses its themed
-          # dialog via `import { setConfirmResolver } from "phlex/reactive/confirm"`.
+          # imports it by this BARE specifier — `import { confirmResolver } from
+          # "phlex/reactive/confirm"` — NOT a relative "./confirm.js" (issue #57:
+          # a relative sibling import inside the digested controller resolves to
+          # an undigested /assets/.../confirm.js that 404s under Propshaft). This
+          # pin maps the bare specifier to the digested asset, so the controller's
+          # own import AND an app's `import { setConfirmResolver } from
+          # "phlex/reactive/confirm"` both resolve through the import map.
           it.importmap.pin(
             "phlex/reactive/confirm",
             to: "phlex/reactive/confirm.js",

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -10,7 +10,8 @@
         "imports": {
           "@hotwired/turbo-rails": "/vendor/turbo.js",
           "@hotwired/stimulus": "/vendor/stimulus.js",
-          "reactive_controller": "/vendor/reactive_controller.js"
+          "reactive_controller": "/vendor/reactive_controller.js",
+          "phlex/reactive/confirm": "/vendor/confirm.js"
         }
       }
     </script>

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -1,5 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
-import { confirmResolver } from "./confirm.js"
+// Import the BARE specifier the engine already pins (phlex/reactive/confirm),
+// NOT a relative "./confirm.js" (issue #57). Under importmap-rails + Propshaft
+// the controller is served at its DIGESTED url; a relative sibling import is
+// left untouched (Propshaft rewrites only RAILS_ASSET_URL(...), and the import
+// map resolves ONLY bare specifiers), so "./confirm.js" resolves against the
+// digested controller url → an undigested /assets/.../confirm.js that 404s, and
+// the throwing import takes down every Stimulus controller on the page. The
+// bare specifier resolves to the digested asset through the import map, and
+// bundlers/bun resolve it the same way they already resolve
+// "phlex/reactive/reactive_controller" (see tsconfig.json paths for the tests).
+import { confirmResolver } from "phlex/reactive/confirm"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write

--- a/spec/javascript/reactive_confirm_import.test.js
+++ b/spec/javascript/reactive_confirm_import.test.js
@@ -1,0 +1,57 @@
+// Regression test for issue #57: the reactive controller's confirm import must
+// be the BARE, importmap-pinned specifier `phlex/reactive/confirm`, NOT a
+// relative `./confirm.js`.
+//
+// Under importmap-rails + Propshaft, a relative specifier inside a pinned (and
+// therefore DIGESTED) module is left untouched — Propshaft's JS compiler only
+// rewrites `RAILS_ASSET_URL(...)`, never `import`/`from`, and the import map
+// maps ONLY bare specifiers, never relative-resolved URLs. So the browser
+// resolves `./confirm.js` against the digested controller URL and requests an
+// undigested `/assets/phlex/reactive/confirm.js`, which 404s. The throwing
+// import then cascades: in an app that eagerly registers the controller, the
+// whole controllers entrypoint dies and EVERY Stimulus controller stops.
+//
+// The bare specifier `phlex/reactive/confirm` is the one the engine already
+// pins (and apps already import via README), so it resolves to the digested URL
+// through the import map. For bundlers/bun the same bare specifier resolves via
+// the project's module-resolution config (tsconfig `paths`), exactly like the
+// app-side `phlex/reactive/reactive_controller` import.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const SOURCE = fileURLToPath(
+  new URL("../../app/javascript/phlex/reactive/reactive_controller.js", import.meta.url),
+)
+
+let ReactiveController
+let confirmModule
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  // If the bare specifier `phlex/reactive/confirm` does not resolve (no tsconfig
+  // `paths` mapping), this import throws and the suite goes red — the same
+  // failure shape an importmap app hits when the pin is missing.
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+  confirmModule = await import("../../app/javascript/phlex/reactive/confirm.js")
+})
+
+test("the controller module imports (bare confirm specifier resolves)", () => {
+  expect(typeof ReactiveController).toBe("function")
+  expect(typeof confirmModule.confirmResolver).toBe("function")
+})
+
+test("source imports the bare `phlex/reactive/confirm`, never a relative path (issue #57)", () => {
+  const source = readFileSync(SOURCE, "utf8")
+  // The bare, importmap-pinnable specifier must be present...
+  expect(source).toContain('from "phlex/reactive/confirm"')
+  // ...and the relative form that 404s under importmap + Propshaft must be gone.
+  expect(source).not.toContain('from "./confirm.js"')
+  expect(source).not.toContain("from './confirm.js'")
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "//": "Bun (test + build) module resolution for the gem's client runtime. The controller imports the BARE specifier `phlex/reactive/confirm` (issue #57: a relative `./confirm.js` 404s under importmap-rails + Propshaft). Real apps resolve that bare specifier through the import map (importmap, engine-pinned) or their bundler's gem path mapping; the bun JS suite imports the controller from disk, so it needs this `paths` alias to resolve the same bare specifier.",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "phlex/reactive/confirm": ["./app/javascript/phlex/reactive/confirm.js"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #57. The 0.4.6 confirm resolver (#55) added a **relative** import to the client controller:

```js
import { confirmResolver } from "./confirm.js"
```

Under **importmap-rails + Propshaft** the controller is served at its **digested** URL, and a relative sibling import is left untouched — Propshaft's JS compiler rewrites only `RAILS_ASSET_URL(...)`, and the import map resolves **only bare specifiers**, never relative-resolved URLs. So the browser resolves `./confirm.js` against the digested controller URL and requests an **undigested** `/assets/phlex/reactive/confirm.js` → **404**. The throwing import means `reactive_controller.js` never evaluates; in an app that eagerly registers it, the whole controllers entrypoint dies and **every** Stimulus controller on the page stops — with no obvious link to phlex-reactive.

**Fix:** import the **bare** specifier the engine already pins:

```diff
- import { confirmResolver } from "./confirm.js"
+ import { confirmResolver } from "phlex/reactive/confirm"
```

The bare specifier resolves to the digested asset through the import map, and mirrors how the gem already expects apps to import the module (`import { setConfirmResolver } from "phlex/reactive/confirm"`).

## Why this needed more than the one-line change

A bare **internal** import doesn't resolve everywhere on its own:

| Consumer | relative `./confirm.js` | bare `phlex/reactive/confirm` |
|---|---|---|
| importmap + Propshaft | ❌ 404 (the bug) | ✅ pinned → digested |
| bundlers (esbuild/webpack/bun) | ✅ sibling | ✅ via the same `phlex/reactive/*` mapping apps already use for `reactive_controller` |
| gem's bun JS suite | ✅ | ❌ no package map → needs `tsconfig.json` `paths` |
| dummy system specs (vendored) | ✅ | ❌ needs the bare specifier in the dummy importmap |

So this PR also:

- adds `tsconfig.json` with a `paths` alias so the gem's own `bun test` / `bun build` resolve the bare specifier (real apps already resolve `phlex/reactive/*` to the gem path — that's how they import `phlex/reactive/reactive_controller`);
- adds `phlex/reactive/confirm` → `/vendor/confirm.js` to the **dummy** importmap so the vendored controller resolves it in the browser suite;
- re-syncs the vendored controller copy (byte-identical; the sync spec enforces it);
- updates the engine's now-stale comment (it claimed the controller "imports it relatively").

## Root cause verified against gem source (not assumed)

importmap-rails 2.2.3 + propshaft 1.3.2:

- Propshaft has **no** JS-import compiler — only `CssAssetUrls`, `JsAssetUrls` (matches `RAILS_ASSET_URL(...)` only), and `SourceMappingUrls`. A relative `import`/`from` is left byte-for-byte untouched.
- `Importmap::Map` maps **only bare specifiers** to digested URLs (`resolve_asset_path` → `path_to_asset`); it never sees a relative-resolved URL.

So a relative sibling import **cannot** be remapped to its digested neighbor — the only robust fix is a pinned bare specifier, which the engine already provides.

## Test plan

- **`spec/javascript/reactive_confirm_import.test.js` (new):** asserts the controller module imports (the bare confirm specifier resolves under bun via `tsconfig` `paths`) and that the source uses the bare specifier, never a relative `./confirm.js`. RED before the fix.
- **Browser suite (#52/#55 confirm-gate tests):** exercises the resolved import end-to-end via the vendored controller + dummy importmap.

Verification:

- [x] `bundle exec rubocop` — clean (106 files)
- [x] `bundle exec rspec spec/phlex spec/requests` — 228 passed
- [x] `bun test spec/javascript` — 54 passed
- [x] `bundle exec rspec spec/system` (Puma) — 27, 0 failures
- [x] `CAPYBARA_SERVER=falcon bundle exec rspec spec/system` (Falcon) — 27, 0 failures
- [x] `bun build` (bundler-app simulation) — resolves the bare specifier

## Backwards compatibility

No public API change. The documented app-facing import (`phlex/reactive/confirm`) is unchanged and now matches the internal one. Existing components work verbatim; 0.4.5 confirm behavior is preserved. The pgbus-optional invariant is untouched (this is a client asset-resolution fix).

Closes #57
