### PR TITLE
fix(docs): self-resolving Kamal registry token (env or gh CLI)

### DIFF
--- a/docs/.kamal/secrets
+++ b/docs/.kamal/secrets
@@ -3,11 +3,14 @@
 # reads no Rails encrypted credentials, so there is no master key and no
 # 1Password fetch. The only credential Kamal needs is the registry token.
 #
-# Kamal parses this file with dotenv, which does NOT support bash's ${VAR:-default}
-# syntax — `${KAMAL_REGISTRY_PASSWORD:-$(gh auth token)}` resolves to a malformed
-# `:-<token>}` and the registry login fails with `denied: denied`. So just pass
-# the env var through:
-#   - CI: the deploy workflow sets KAMAL_REGISTRY_PASSWORD from the built-in GITHUB_TOKEN.
-#   - Local: export it first, e.g. `export KAMAL_REGISTRY_PASSWORD=$(gh auth token)`
-#     (or run `bin/deploy`, which does this for you).
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+# Prefer the env var, else fall back to the gh CLI token:
+#   - CI: the deploy workflow sets KAMAL_REGISTRY_PASSWORD from the built-in
+#     GITHUB_TOKEN, so the env branch is taken and `gh` is never called.
+#   - Local: the env var is unset, so it falls back to `gh auth token` — meaning
+#     a bare `kamal deploy` / `kamal setup` works with no manual export.
+#
+# NOTE: Kamal parses this with dotenv, which does NOT support bash's
+# `${VAR:-default}` (that resolves to a malformed `:-<token>}` → `denied: denied`).
+# dotenv DOES run `$(...)` command substitution, so do the env-or-gh choice inside
+# a shell command rather than with dotenv's unsupported `:-` operator.
+KAMAL_REGISTRY_PASSWORD=$(test -n "$KAMAL_REGISTRY_PASSWORD" && printf %s "$KAMAL_REGISTRY_PASSWORD" || gh auth token)

--- a/docs/bin/deploy
+++ b/docs/bin/deploy
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Local Kamal deploy for the phlex-reactive docs site.
+# Convenience wrapper for local Kamal commands against the phlex-reactive docs site.
 #
-# Kamal reads KAMAL_REGISTRY_PASSWORD from the environment (see .kamal/secrets);
-# locally we source it from the gh CLI token. CI sets it from GITHUB_TOKEN instead
-# and runs `kamal deploy` directly, so this helper is for local deploys only.
+# This is OPTIONAL: .kamal/secrets already resolves the registry token on its own
+# (env var if set, else `gh auth token`), so a bare `kamal deploy` / `kamal setup`
+# works too. This helper just also sets the deploy target env (host/domain/ssh
+# user) so you don't have to, and passes any subcommand through:
+#   bin/deploy          # -> kamal deploy
+#   bin/deploy setup    # -> kamal setup
+#   bin/deploy app logs # -> kamal app logs
 #
 # DEPLOY_HOST / DEPLOY_DOMAIN / DEPLOY_SSH_USER can be overridden via the env;
 # they default to the oss-infrastructure target.


### PR DESCRIPTION
## Problem

A bare `kamal setup` / `kamal deploy` against the docs site failed with:

```
docker stderr: flag needs an argument: 'p' in -p
```

The env-passthrough form merged in #60 (`KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD`) resolves to **empty** unless the var is exported first. Kamal then runs `docker login ghcr.io -u … -p` with no argument → the flag error. It only worked via `bin/deploy` (which exports the token) or a manual `export`.

## Fix

dotenv (Kamal's secrets parser) doesn't support bash `${VAR:-default}`, but it **does** run `$(...)` command substitution. So do the env-or-gh choice inside a shell command:

```sh
KAMAL_REGISTRY_PASSWORD=$(test -n "$KAMAL_REGISTRY_PASSWORD" && printf %s "$KAMAL_REGISTRY_PASSWORD" || gh auth token)
```

- **CI**: the deploy workflow sets `KAMAL_REGISTRY_PASSWORD` from `GITHUB_TOKEN` → env branch taken, `gh` never called.
- **Local**: var unset → falls back to `gh auth token`, so a **bare `kamal deploy` / `kamal setup` works with no manual export**.

`bin/deploy` is now an optional convenience (it also sets the deploy-target env), not required for the token.

## Verification

- `kamal secrets print` with env **unset** → resolves to the gh token; with env **set** → uses the env value (gh not called).
- `kamal registry login` with **no export** → logs into ghcr.io both locally and on the server.
- Live site healthy after `kamal setup`: `/up` → HTTP 200.

## Test plan

- [ ] CI green
- [x] Bare `kamal registry login` succeeds locally + on server with no token export
- [x] Live `/up` returns 200