### PR TITLE
fix(docs): land the deploy fixes that missed the #61 merge

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -87,14 +87,29 @@ jobs:
       - name: Install Kamal
         run: gem install kamal
 
-      - name: Add SSH key
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure SSH for the deploy host
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          chmod 700 ~/.ssh
+          # Disable host-key verification for the deploy host. Kamal uses net-ssh,
+          # which raises HostKeyMismatch on any known_hosts conflict (e.g. after the
+          # server is reprovisioned and its host key changes). net-ssh honors
+          # ~/.ssh/config, so this turns verification off for this single known IP.
+          # Acceptable here: a throwaway demo site reached over an authenticated
+          # deploy key behind SSH + a Cloudflare Tunnel.
+          cat >> ~/.ssh/config <<EOF
+          Host $DEPLOY_HOST
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+          EOF
+          chmod 600 ~/.ssh/config
 
       - name: Deploy with Kamal (image already pushed by the build job)
         env:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,15 +20,24 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only the build job pushes to GHCR (docker/login-action + build-push-action).
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_tag: ${{ steps.tag.outputs.image_tag }}
     steps:
+      # persist-credentials: false — checkout is only for the short SHA + build
+      # context; no git push/pull follows. The build COPYs the repo root (incl .git,
+      # kept for the gemspec's `git ls-files`) into the image, which is pushed to a
+      # public ghcr package, so a persisted GITHUB_TOKEN in .git/config must not ride along.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Determine image tag
         id: tag
@@ -72,11 +81,17 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: docs
+    # Pull-only (kamal deploy --skip-push); no image push, so no packages: write.
+    permissions:
+      contents: read
+      packages: read
     defaults:
       run:
         working-directory: docs
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   deploy:
@@ -20,7 +19,13 @@ jobs:
       DEPLOY_DOMAIN: ${{ secrets.DEPLOY_DOMAIN }}
       # No 1Password / OP_SERVICE_ACCOUNT_TOKEN: this demo has no managed secrets
       # (SECRET_KEY_BASE + DB password are inline in config/deploy.yml).
-      KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      #
+      # The ghcr package `phlex-reactive` is user-owned and not connected to this
+      # repo, so the default GITHUB_TOKEN can't push to it (403 Forbidden even with
+      # packages:write). Use a PAT with write:packages instead, stored as the repo
+      # secret GHCR_TOKEN. (If the package is ever connected to the repo via the
+      # ghcr UI, this can revert to GITHUB_TOKEN + `permissions: packages: write`.)
+      KAMAL_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,37 +2,81 @@ name: Deploy docs
 
 # Deploys the docs site (docs/) to the oss-infrastructure server via Kamal when a
 # release is published, or on demand. See oss-infrastructure/docs/adding-a-new-gem.md.
+#
+# Two jobs, mirroring the daisyui docs deploy:
+#   build  — builds + pushes the image to ghcr with docker/build-push-action,
+#            logged in as the Actions actor with GITHUB_TOKEN. Pushing the image
+#            FROM the repo's Actions context is what links the ghcr package to the
+#            repo, so GITHUB_TOKEN keeps push access (no PAT needed).
+#   deploy — pulls that pre-pushed image and boots it: `kamal deploy --skip-push`.
 on:
   release:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
 permissions:
   contents: read
+  packages: write
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine image tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            TAG="sha-$(git rev-parse --short HEAD)"
+          fi
+          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Building image tag: $TAG"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the repo root so the path gem dependency
+          # (`gem "phlex-reactive", path: ".."`) resolves; the Dockerfile lives in docs/.
+          context: .
+          file: docs/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/mhenrixon/phlex-reactive:${{ steps.tag.outputs.image_tag }}
+            ghcr.io/mhenrixon/phlex-reactive:latest
+          cache-from: type=registry,ref=ghcr.io/mhenrixon/phlex-reactive:buildcache
+          cache-to: type=registry,ref=ghcr.io/mhenrixon/phlex-reactive:buildcache,mode=max
+
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     environment: docs
-    env:
-      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-      DEPLOY_DOMAIN: ${{ secrets.DEPLOY_DOMAIN }}
-      # No 1Password / OP_SERVICE_ACCOUNT_TOKEN: this demo has no managed secrets
-      # (SECRET_KEY_BASE + DB password are inline in config/deploy.yml).
-      #
-      # The ghcr package `phlex-reactive` is user-owned and not connected to this
-      # repo, so the default GITHUB_TOKEN can't push to it (403 Forbidden even with
-      # packages:write). Use a PAT with write:packages instead, stored as the repo
-      # secret GHCR_TOKEN. (If the package is ever connected to the repo via the
-      # ghcr UI, this can revert to GITHUB_TOKEN + `permissions: packages: write`.)
-      KAMAL_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
     defaults:
       run:
         working-directory: docs
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -43,15 +87,21 @@ jobs:
       - name: Install Kamal
         run: gem install kamal
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Add SSH key
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-      - name: Deploy with Kamal
-        run: kamal deploy
+      - name: Deploy with Kamal (image already pushed by the build job)
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_DOMAIN: ${{ secrets.DEPLOY_DOMAIN }}
+          # kamal still logs into the registry to pull; GITHUB_TOKEN can pull the
+          # now repo-linked package. No image push happens here (--skip-push).
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+        run: kamal deploy --skip-push --version="$IMAGE_TAG"

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -51,6 +51,12 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails tailwindcss:build && \
 # --- Final stage --------------------------------------------------------------
 FROM base
 
+# Kamal verifies this label on deploy (must match `service:` in deploy.yml). When
+# Kamal builds the image it injects `--label service=...` itself, but CI builds
+# the image with docker/build-push-action (so the package links to the repo), so
+# set the label here rather than relying on Kamal's injection.
+LABEL service="phlex-reactive"
+
 # curl for the healthcheck; libpq5 (Postgres client lib) is already in `base`.
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl && \

--- a/docs/config/deploy.yml
+++ b/docs/config/deploy.yml
@@ -1,8 +1,11 @@
 # Kamal deploy for the phlex-reactive docs site → the oss-infrastructure server.
 # Routing is via kamal-proxy behind a Cloudflare Tunnel (no Traefik; TLS is
 # terminated at the Cloudflare edge), per oss-infrastructure/docs/adding-a-new-gem.md.
-service: phlex-reactive-docs
-image: mhenrixon/phlex-reactive-docs
+service: phlex-reactive
+# Match the repo (ghcr.io/mhenrixon/phlex-reactive) so GitHub auto-links the
+# package to this repo and the Actions GITHUB_TOKEN can push to it. A package
+# named differently from the repo stays user-owned + unlinked → push 403s in CI.
+image: mhenrixon/phlex-reactive
 
 servers:
   web:
@@ -15,7 +18,7 @@ ssh:
 
 # Kamal puts the app AND accessories on the auto-created `kamal` Docker network,
 # so the app reaches the postgres accessory by its container name
-# (phlex-reactive-docs-postgres) with no manual network config — see DATABASE_URL.
+# (phlex-reactive-postgres) with no manual network config — see DATABASE_URL.
 
 # kamal-proxy routes by host; TLS is at the Cloudflare edge, so ssl: false.
 proxy:
@@ -52,7 +55,7 @@ env:
     # and the DB password are inline rather than managed secrets — no master key,
     # no 1Password needed. Rotate here if ever required.
     SECRET_KEY_BASE: "b9155e47dce1f0bb6c653eeef87d02fc8ce3b77210338903c74a82c17f8959e442c13d3072f56ac5c074aa498909e34236f0e22c38ccb6f529c97d90a5dc6049"
-    DATABASE_URL: "postgres://phlex_reactive:49aefea6368f231f568fc7efcdd1aa19c72f19314610983d@phlex-reactive-docs-postgres:5432/phlex_reactive_docs_production"
+    DATABASE_URL: "postgres://phlex_reactive:49aefea6368f231f568fc7efcdd1aa19c72f19314610983d@phlex-reactive-postgres:5432/phlex_reactive_docs_production"
 
 # Postgres 18 + PGMQ — the transport the deployed site dogfoods via pgbus.
 accessories:


### PR DESCRIPTION
## Why

PR #61 was merged **before** these commits were pushed to its branch, so they never reached `main`. `main` still has the old `phlex-reactive-docs` image name + single-job workflow, so re-running the deploy on `main` reproduces the original 403.

These 4 fixes (verified green on run 28475541047, live site serving the CI image) are stranded on the branch and need to land on `main`:

- `17320d7` — name the ghcr image after the repo (`mhenrixon/phlex-reactive`) so the package auto-links
- `4708f1d` — two-job workflow: `build` pushes via docker/build-push-action (auto-links package), `deploy` runs `kamal deploy --skip-push` (mirrors daisyui). Kills the push 403 without a PAT.
- `d6fff05` — fix `Net::SSH::HostKeyMismatch`: webfactory/ssh-agent + `~/.ssh/config` StrictHostKeyChecking no
- `e326359` — `LABEL service="phlex-reactive"` in the Dockerfile (kamal's deploy-time label check)

## Net diff vs main
- `.github/workflows/deploy-docs.yml` — two-job build+push + SSH fix
- `docs/Dockerfile` — service label
- `docs/config/deploy.yml` — rename to `phlex-reactive`

## Test plan
- [x] Deploy run green end-to-end off this branch (28475541047)
- [x] ghcr package `phlex-reactive` repo-linked + public
- [x] Live https://phlex-reactive.zoolutions.llc/ -> 200
- [ ] Re-run Deploy docs on `main` after merge to confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved docs site deployment reliability by separating image build/push from deployment and using the published image during release.
  * Updated deployment settings so the docs site and database connection use consistent naming, reducing environment mismatch issues.
* **Chores**
  * Added image metadata needed for container-based builds and deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->