### PR TITLE
chore(docs): bump docs-kit (all Rouge languages + later fixes)

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/mhenrixon/docs-kit.git
-  revision: feed27f3c302190ee3e5661b3e534ad900dd50e2
+  revision: f331b1541b85008f74d2df0cdafaafc9f9deb126
   specs:
     docs-kit (0.1.0)
       daisyui (>= 1.2)

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mhenrixon/daisyui.git
-  revision: bdf47be1425b1ac8bd1b58dc6add450cd28e3d8d
+  revision: 1252a68aff97fc9cf9dd3349fbf66af9407021f6
   specs:
     daisyui (1.2.0)
       phlex (~> 2.0, >= 2.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/mhenrixon/docs-kit.git
-  revision: 19a983ad40574874f2682dc573ca5c1d4b65c05d
+  revision: feed27f3c302190ee3e5661b3e534ad900dd50e2
   specs:
     docs-kit (0.1.0)
       daisyui (>= 1.2)


### PR DESCRIPTION
## Summary

Bumps the pinned **docs-kit** revision from `19a983a` → `feed27f`, picking up
everything merged into docs-kit after the initial extraction PR:

- **All Rouge languages** — `DocsUI::Code` resolves any of Rouge's ~200 lexers by
  name (no allowlist); `DocsKit.configure` adds `code_lexer_aliases`,
  `code_lexer_fallback`, `code_language_labels`.
- **Reusable deploy workflow** — least-privilege permissions + documented
  repo-linked image naming.
- **`DocsUI::Section` optional description** and the on-page toggle tree-shake fix.

Lockfile-only change (the shared chrome lives in the gem).

## Test plan

- `bundle exec rspec spec/requests` — **37 green**
- `bundle exec rspec spec/system` (Puma) — **23 green** (theme persistence, TOC
  panel, multi-language code example, all through the shared shell)
- `bundle exec rake lint` — clean (68 files)
- `bun run build:css` rebuilds the daisyUI CSS with the renamed `DocsUI` kit
