### PR TITLE
fix(deploy): grant packages:write in the docs deploy caller

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+# The caller must GRANT packages: write — a reusable workflow can only narrow the
+# permissions it's given, never escalate. With the repo default of read-only, the
+# build job's packages: write would exceed the grant → startup_failure.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   deploy:
     uses: mhenrixon/docs-kit/.github/workflows/deploy.yml@main


### PR DESCRIPTION
## Summary

The docs deploy (reusable-workflow caller, merged in #63/#68) failed at
**startup** (`startup_failure`, 2s, no jobs). Root cause: the caller had no
`permissions:` block, so with the repo's read-only default `GITHUB_TOKEN` the
reusable **build** job's `packages: write` **exceeded** the granted permissions —
a reusable workflow can only *narrow* permissions, never escalate.

Fix: grant `contents: read` + `packages: write` in the caller (matches the
docs-kit and daisyui callers).

## Verification

Confirmed on the docs-kit deploy after the same fix: the workflow now passes
startup, the **build job builds + pushes the image to GHCR** (2m12s), and only
the deploy step remains (which needs the `SSH_PRIVATE_KEY` / `docs` environment
secrets). No app code changes — workflow-only.
