### PR TITLE
chore(docs): bump docs-kit to d75a50b

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mhenrixon/daisyui.git
-  revision: 1252a68aff97fc9cf9dd3349fbf66af9407021f6
+  revision: 1eed05df50d386ecdd58a6e1b76252541b8e6ee2
   specs:
     daisyui (1.2.0)
       phlex (~> 2.0, >= 2.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/mhenrixon/docs-kit.git
-  revision: f331b1541b85008f74d2df0cdafaafc9f9deb126
+  revision: d75a50b8575b2a978c28ac9b1f7c1a3a4232247e
   specs:
     docs-kit (0.1.0)
       daisyui (>= 1.2)


### PR DESCRIPTION
## Summary

Bumps the pinned **docs-kit** revision `f331b15` → `d75a50b`. Picks up:

- The eager-load Stimulus fix (`eagerLoadControllersFrom` for the docs_kit
  controllers) + the gem's importmap doc — this site already imported both loaders,
  so it was unaffected, but the bump keeps all sites on one revision.
- The `SECRET_KEY_BASE` new-site-template default.
- The expanded docs-kit docs site (docs-kit's own pages; no effect here).

Lockfile-only change.

## Test plan

- `CI=true bundle exec rspec spec/requests` — **37 green** (eager_load on)
- `bundle exec rspec spec/system` (Puma) — **23 green**
- `bun run build:css` rebuilds the daisyUI CSS
