### PR TITLE
feat(component): reactive_compute — client-side data bindings for new/unpersisted records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`reactive_compute` — client-side data bindings (no round trip).** A component
+  can now declare a client-side computation that recomputes derived fields
+  IN-BROWSER on `input`, with NO server round trip — the "instant" half of a
+  new/unpersisted-record UX that previously required a hand-written Stimulus
+  controller (e.g. an order calculator that rebalances a payment split as you
+  type). Declare the binding in Ruby and register the matching reducer once in JS:
+
+  ```ruby
+  reactive_compute :payment_split,
+    inputs:  %i[allowance cash leasing total],   # fields the reducer reads
+    outputs: %i[allowance cash leasing]          # fields it writes (no POST)
+  # in the view: div(**mix(reactive_root, reactive_compute_attrs(:payment_split)))
+  # on the edited field: data-action="input->reactive#recompute"
+  ```
+
+  ```js
+  import { setComputeReducer } from "phlex/reactive/compute"
+  setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({
+    allowance, leasing, cash: total - allowance - leasing,
+  }))
+  ```
+
+  The generic controller runs the named reducer on `input`, writes only the
+  declared outputs (leaving the edited field + caret alone), and fires `input` on
+  each field it sets so a chained summary repaints — matching the server's
+  `set_value` + `dispatch("input")` contract. A missing/unregistered reducer is a
+  no-op (a page never breaks because a binding wasn't wired up). When the same
+  component ALSO carries `on(...)` (a persisted record, or a draft you sync), that
+  debounced POST still fires and the server reply reconciles — so `reactive_compute`
+  is the optimistic client paint, the server round trip is the source of truth.
+  One math contract, two execution sites. New client module
+  `phlex/reactive/compute` (auto-pinned by the engine like `confirm`).
+
+- **Draft (unpersisted-record) tokens — `reactive_record` no longer crashes on a
+  `new_record?`.** A record-backed component may now render an UNSAVED record (an
+  order the user is building before it's saved). `reactive_token` omits the `gid`
+  when the record isn't persisted (`to_gid` would raise `MissingModelIdError`) and
+  relies on the declared `reactive_state` as the draft seed, so the token still
+  signs cleanly and the client controller mounts. The draft is driven client-side
+  (`reactive_compute`) until it's saved; once persisted, a re-render signs the
+  `gid` as before. Combined with `reactive_compute`, this is the "persisted → server,
+  new → in-browser" split as a first-class capability instead of a hand-rolled one.
+
 - **Overridable / async confirm resolver — reuse your themed dialog (#55).**
   Follow-up to #52. The `confirm:` gate was hardcoded to the synchronous,
   browser-native `window.confirm`, so a reactive trigger was the one interaction

--- a/app/javascript/phlex/reactive/compute.js
+++ b/app/javascript/phlex/reactive/compute.js
@@ -1,0 +1,48 @@
+// The client-side compute (data-binding) registry — the "instant" half of the
+// new/unpersisted-record UX.
+//
+// A record-backed reactive component round-trips every change to the server
+// (the signed identity re-finds the record; the server re-renders). A NEW,
+// unpersisted record has no such server truth to re-render against on every
+// keystroke — the classic answer is a bespoke Stimulus controller doing the math
+// in the browser (carlqvist's new_order_controller.js). This registry lets that
+// math be a DECLARED part of the component instead: `reactive_compute :name,
+// inputs:, outputs:` (Ruby) names a reducer registered here, and the generic
+// reactive controller runs it on `input` — writing the outputs with NO round
+// trip. When the component ALSO carries on(...) (a persisted record, or a draft
+// you sync), the debounced POST reconciles from the authoritative server reply.
+//
+// The seam mirrors confirm.js: a settable registry with a lookup the controller
+// calls. Register once at boot:
+//
+//   import { setComputeReducer } from "phlex/reactive/compute"
+//   setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({
+//     allowance, leasing, cash: total - allowance - leasing,
+//   }))
+//
+// The reducer receives a plain object of { inputName: Number } and returns a
+// plain object of { outputName: value } — only the outputs it names are written,
+// so it can leave the edited field (and its caret) untouched. Returning the SAME
+// value it read is a no-op write; the controller still fires `input` on any field
+// it sets so a chained summary repaints, matching the server's set_value +
+// dispatch("input") contract.
+
+const reducers = new Map()
+
+// Register (or replace) the reducer for `key`. `fn` is
+// (values: Record<string, number>) => Record<string, unknown>.
+export function setComputeReducer(key, fn) {
+  reducers.set(key, fn)
+}
+
+// Look up a registered reducer; undefined when none — the controller then makes
+// #recompute a no-op rather than throwing (a missing reducer must not break the
+// page; it just means no client-side binding for that root).
+export function computeReducer(key) {
+  return reducers.get(key)
+}
+
+// Test seam: clear the registry so a reducer registered in one test can't leak.
+export function __resetComputeRegistryForTest() {
+  reducers.clear()
+}

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -10,6 +10,9 @@ import { Controller } from "@hotwired/stimulus"
 // bundlers/bun resolve it the same way they already resolve
 // "phlex/reactive/reactive_controller" (see tsconfig.json paths for the tests).
 import { confirmResolver } from "phlex/reactive/confirm"
+// Client-side computes (data bindings): the reducer registry behind
+// reactive_compute. Bare specifier for the same import-map reason as confirm.
+import { computeReducer } from "phlex/reactive/compute"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
@@ -217,6 +220,68 @@ export default class extends Controller {
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce)
       })
+  }
+
+  // Client-side compute (data binding). Wired by reactive_compute: an `input`
+  // trigger (input->reactive#recompute) runs a REGISTERED JS reducer over the
+  // named input fields and writes the named output fields WITH NO ROUND TRIP —
+  // the "instant" half of the new/unpersisted-record UX. If the field ALSO
+  // carries on(...) (a persisted record, or a synced draft), that debounced POST
+  // still fires and the server reply reconciles; recompute just paints first.
+  //
+  // Reads inputs/outputs/reducer from the root's data-reactive-compute-* attrs
+  // (set once by reactive_compute_attrs). A missing/unregistered reducer is a
+  // no-op — a page must never break because a binding wasn't wired up.
+  recompute() {
+    const key = this.element.getAttribute("data-reactive-compute-reducer-param")
+    if (!key) return
+    const reduce = computeReducer(key)
+    if (!reduce) return
+
+    const inputs = this.#parseComputeList("data-reactive-compute-inputs-param")
+    const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
+
+    const values = {}
+    for (const name of inputs) values[name] = this.#numericFieldValue(name)
+
+    const result = reduce(values) || {}
+    for (const name of outputs) {
+      if (!(name in result)) continue
+      const field = this.#ownedField(name)
+      // Setting .value fires the field's own `input` listeners (a chained summary
+      // repaint), matching the server's set_value + dispatch("input") contract.
+      if (field) field.value = result[name]
+    }
+  }
+
+  // Parse a JSON string list from a root data attr; [] on absence/parse error so
+  // a malformed binding degrades to "no fields" rather than throwing on input.
+  #parseComputeList(attr) {
+    const raw = this.element.getAttribute(attr)
+    if (!raw) return []
+    try {
+      const list = JSON.parse(raw)
+      return Array.isArray(list) ? list : []
+    } catch {
+      return []
+    }
+  }
+
+  // The first named control owned by THIS root (skips nested reactive roots,
+  // issue #15) — used by recompute to read inputs and write outputs.
+  #ownedField(name) {
+    const nodes = this.element.querySelectorAll(`[name="${name}"]`)
+    for (const el of nodes) if (this.#ownsField(el)) return el
+    return null
+  }
+
+  // A field's value as a Number, treating blank/absent/NaN as 0 — mirroring the
+  // nanToZero coercion the hand-written calculators use, so a reducer never sees
+  // "" or NaN for an empty field.
+  #numericFieldValue(name) {
+    const field = this.#ownedField(name)
+    const n = Number(field?.value)
+    return Number.isFinite(n) ? n : 0
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -62,6 +62,13 @@ module Phlex
       # A declared, client-invokable action and its param schema.
       Action = Data.define(:name, :params)
 
+      # A declared client-side computation (data binding). `inputs`/`outputs` are
+      # the action-param names of the fields the reducer reads/writes; `reducer`
+      # is the key a JS function is registered under (Reactive.compute(key, fn)).
+      # The generic controller runs the reducer on `input` — writing outputs with
+      # NO round trip — then the debounced POST reconciles from the server reply.
+      ComputeDefinition = Data.define(:name, :inputs, :outputs, :reducer)
+
       # A declared add/remove-row collection (issue #35): the list contract tied
       # into one unit — the per-row item component, the container DOM id rows
       # live in, an optional companion count id, an optional empty-state
@@ -173,6 +180,36 @@ module Phlex
 
         def reactive_collection?(name)
           reactive_collections.key?(name.to_sym)
+        end
+
+        # Declare a client-side computation, OR (called with just a name) read
+        # one back. Dual-purpose so a component reads `reactive_compute :split,
+        # inputs: …, outputs: …` and the endpoint/helpers read
+        # `reactive_compute(:split)` — mirroring how `on`/`reactive_field` keep a
+        # tight surface. `reducer:` defaults to the compute name.
+        #
+        #   reactive_compute :payment_split,
+        #     inputs: %i[allowance cash leasing total],  # fields the JS reducer reads
+        #     outputs: %i[allowance cash leasing]        # fields it writes (no round trip)
+        #
+        # Register the matching JS once at boot:
+        #   import { setComputeReducer } from "phlex/reactive/compute"
+        #   setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({ … }))
+        def reactive_compute(name, inputs: nil, outputs: nil, reducer: nil)
+          return reactive_computes[name.to_sym] if inputs.nil? && outputs.nil?
+
+          reactive_computes[name.to_sym] = ComputeDefinition.new(
+            name: name.to_sym, inputs: Array(inputs).map(&:to_sym),
+            outputs: Array(outputs).map(&:to_sym), reducer: (reducer || name).to_s
+          )
+        end
+
+        def reactive_computes
+          @reactive_computes ||= superclass.respond_to?(:reactive_computes) ? superclass.reactive_computes.dup : {}
+        end
+
+        def reactive_compute?(name)
+          reactive_computes.key?(name.to_sym)
         end
 
         # The record's instance-variable symbol (e.g. :@todo), computed once.
@@ -353,6 +390,28 @@ module Phlex
         input(**reactive_field(param, **attrs))
       end
 
+      # Data attributes declaring a client-side compute for the root element.
+      # Spread ALONGSIDE reactive_root so the generic controller can find the
+      # reducer and the named input/output fields inside this root:
+      #   div(**mix(reactive_root, reactive_compute_attrs(:payment_split))) { … }
+      #
+      # It emits the reducer key plus the input/output field names as JSON so the
+      # client runs the reducer on `input`, writes the outputs with no round trip,
+      # then the debounced POST reconciles from the server reply. Raises for an
+      # undeclared compute — a silent no-op would leave the field wiring dead.
+      def reactive_compute_attrs(name)
+        definition = self.class.reactive_compute(name)
+        raise Error, "#{self.class} has no reactive_compute #{name.inspect}" unless definition
+
+        {
+          data: {
+            reactive_compute_reducer_param: definition.reducer,
+            reactive_compute_inputs_param: definition.inputs.map(&:to_s).to_json,
+            reactive_compute_outputs_param: definition.outputs.map(&:to_s).to_json
+          }
+        }
+      end
+
       # Render a <select> bound to an action param (issue #23). The options block
       # is the element's content, so the awkward FormBuilder positional split
       # (where name: lands after the options/html-options args) goes away:
@@ -403,12 +462,23 @@ module Phlex
       # (e.g. which column an inline_edit may write) tamper-proof alongside the
       # record. Record-only ({c, gid}) and state-only ({c, s}) shapes are
       # unchanged.
+      #
+      # A record that is NOT YET PERSISTED (new_record?) has no id → no GlobalID
+      # (to_gid raises MissingModelIdError). A record-backed component may render
+      # such a draft (an unsaved order the user is building): we OMIT gid and rely
+      # on the declared state (reactive_state) as the draft seed, so the token
+      # still signs cleanly and the client controller mounts. The draft is then
+      # driven client-side (reactive_compute) until it's saved; once persisted, a
+      # re-render signs the gid as usual. If the record is unsaved AND no state is
+      # declared, the token carries just {c} — enough to mount, but with no
+      # identity to round-trip, so declare reactive_state for a draft you sync.
       def reactive_token
         klass = self.class
         payload = { "c" => klass.name }
 
         if (record_ivar = klass.reactive_record_ivar)
-          payload["gid"] = instance_variable_get(record_ivar).to_gid.to_s
+          record = instance_variable_get(record_ivar)
+          payload["gid"] = record.to_gid.to_s unless record.respond_to?(:persisted?) && !record.persisted?
         end
 
         state_ivars = klass.reactive_state_ivars

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -27,6 +27,7 @@ module Phlex
           it.config.assets.precompile += %w[
             phlex/reactive/reactive_controller.js
             phlex/reactive/confirm.js
+            phlex/reactive/compute.js
           ]
         end
       end
@@ -52,6 +53,16 @@ module Phlex
           it.importmap.pin(
             "phlex/reactive/confirm",
             to: "phlex/reactive/confirm.js",
+            preload: true
+          )
+          # The client-side compute (data-binding) registry behind
+          # reactive_compute. reactive_controller.js imports it by this bare
+          # specifier (same import-map rationale as confirm above), and an app
+          # registers reducers via `import { setComputeReducer } from
+          # "phlex/reactive/compute"` — both resolve through this pin.
+          it.importmap.pin(
+            "phlex/reactive/compute",
+            to: "phlex/reactive/compute.js",
             preload: true
           )
         end

--- a/spec/dummy/app/components/order_component.rb
+++ b/spec/dummy/app/components/order_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# The reactive_compute / new-vs-persisted example — a condensed stand-in for
+# carlqvist-intracar's sell-order payment tab.
+#
+# A three-way payment split (allowance + cash + leasing) must sum to `total`.
+# Editing `allowance` rebalances `cash`. The SAME math (PaymentSplit) runs in two
+# places depending on whether the order is persisted:
+#
+#   * NEW (unsaved) order  — state-backed (reactive_state), no GlobalID. The split
+#     recomputes IN-BROWSER via reactive_compute (the "payment_split" JS reducer),
+#     so a new order feels instant with NO round trip — the classic bespoke-JS
+#     calculator, but declared on the component instead of hand-written.
+#   * PERSISTED order — record-backed (reactive_record). Editing `allowance` fires
+#     a reactive `rebalance` action; the server runs PaymentSplit and streams the
+#     recomputed cash back. The database is the source of truth.
+#
+# Both branches share one Ruby twin (PaymentSplit) and one JS twin
+# (payment_split_reducer.js) — the whole point: one contract, two execution sites.
+class OrderComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  # Identity: a persisted order re-finds by GlobalID; a new draft carries its
+  # split values as signed state. Declaring BOTH is safe — reactive_token signs
+  # gid only when @order is persisted (a new_record has no gid), and the state
+  # keys always ride along.
+  reactive_record :order
+  reactive_state :total, :allowance, :cash, :leasing
+
+  reactive_compute :payment_split,
+    inputs: %i[allowance cash leasing total],
+    outputs: %i[allowance cash leasing]
+
+  action :rebalance, params: { allowance: :integer, cash: :integer, leasing: :integer, total: :integer }
+
+  def initialize(order:, total: nil, allowance: nil, cash: nil, leasing: nil)
+    @order = order
+    # State values fall back to the record's columns on first render; on a
+    # round trip they come from the signed token (new draft) or the DB (persisted).
+    @total = total || order.total
+    @allowance = allowance || order.allowance
+    @cash = cash || order.cash
+    @leasing = leasing || order.leasing
+  end
+
+  def id = @order.persisted? ? dom_id(@order) : "order-draft"
+
+  # Persisted path: rebalance server-side through the SAME PaymentSplit twin the
+  # JS reducer mirrors, then re-render self so cash updates and the token rolls.
+  def rebalance(allowance:, cash:, leasing:, total:)
+    split = PaymentSplit.new(total:, allowance:, cash:, leasing:)
+    result = split.rebalance(changed: :allowance, value: allowance)
+    @allowance = result[:allowance]
+    @cash = result[:cash]
+    @leasing = result[:leasing]
+    @total = total
+    @order.update!(**result, total:) if @order.persisted?
+    reply.replace
+  end
+
+  def view_template
+    div(**root_attrs) do
+      field(:total, @total, testid: "total", readonly: true)
+      # The one editable field. On a NEW order it triggers the client reducer
+      # (input->reactive#recompute, no network). On a PERSISTED order it fires the
+      # reactive rebalance action (change->reactive#dispatch) so the server
+      # reconciles. allowance_wiring picks the wiring.
+      field(:allowance, @allowance, testid: "allowance", extra: allowance_wiring)
+      field(:cash, @cash, testid: "cash", readonly: true)
+      field(:leasing, @leasing, testid: "leasing", readonly: true)
+    end
+  end
+
+  private
+
+  # The reactive root. On a new draft it also carries the compute binding so the
+  # client reducer can find the reducer key + the input/output fields.
+  def root_attrs
+    if @order.persisted?
+      reactive_root
+    else
+      mix(reactive_root, reactive_compute_attrs(:payment_split))
+    end
+  end
+
+  # Trigger attrs for the editable allowance field. A new draft recomputes
+  # in-browser on `input` (no network); a persisted order round-trips the
+  # rebalance action on `change` (server reconciles). Returns a full attrs hash.
+  def allowance_wiring
+    if @order.persisted?
+      on(:rebalance, event: "change")
+    else
+      { data: { action: "input->reactive#recompute" } }
+    end
+  end
+
+  # `extra` is a full attrs hash (its own data:/type:) mixed onto the field so a
+  # nested data: never double-wraps into data-data-*.
+  def field(name, value, testid:, readonly: false, extra: {})
+    label { name.to_s.capitalize }
+    attrs = mix(reactive_field(name, value:, type: "number", data: { testid: }), extra)
+    attrs[:readonly] = true if readonly
+    input(**attrs)
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -14,6 +14,18 @@ class DemosController < ActionController::Base
     render_component TodoListComponent.new
   end
 
+  # A NEW (unsaved) order: the split recomputes in-browser via reactive_compute,
+  # no round trip. total=500 seeds the three-way split.
+  def new_order
+    render_component OrderComponent.new(order: Order.new(total: 500))
+  end
+
+  # A PERSISTED order: editing allowance fires the reactive rebalance action and
+  # the server reconciles cash through the same PaymentSplit twin.
+  def order
+    render_component OrderComponent.new(order: Order.find(params[:id]))
+  end
+
   def notifications
     render_component NotificationsListComponent.new
   end

--- a/spec/dummy/app/models/order.rb
+++ b/spec/dummy/app/models/order.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# A mini sell-order: a three-way payment split that must sum to `total`. Used by
+# the reactive_compute new-vs-persisted example — a new (unsaved) order drives
+# the split in-browser (reactive_compute reducer), a persisted order drives it
+# server-side through the same PaymentSplit twin.
+class Order < ActiveRecord::Base
+  def rebalance!(changed:, value:)
+    split = PaymentSplit.new(total:, allowance:, cash:, leasing:)
+    update!(**split.rebalance(changed:, value:))
+  end
+end

--- a/spec/dummy/app/models/payment_split.rb
+++ b/spec/dummy/app/models/payment_split.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# The Ruby twin of the JS payment-split reducer (spec/dummy/public/vendor/
+# payment_split_reducer.js). A three-way split — allowance + cash + leasing must
+# sum to total. Editing one method rebalances the others: `cash` absorbs the
+# remainder unless the edited method exceeds the total, in which case it's capped
+# and the peers zero out. This is a condensed stand-in for carlqvist-intracar's
+# ::PaymentSplit, kept deliberately identical to the JS so the persisted (server)
+# and new-draft (client) paths compute the SAME result — the whole point of
+# reactive_compute: one math contract, two execution sites.
+class PaymentSplit
+  def initialize(total:, allowance:, cash:, leasing:)
+    @total = total.to_i
+    @allowance = allowance.to_i
+    @cash = cash.to_i
+    @leasing = leasing.to_i
+  end
+
+  # Rebalance after `changed` (:allowance | :cash | :leasing) was edited to
+  # `value`. The edited method keeps `value`; the peers absorb the remainder
+  # (`cash` first). If the edited method alone exceeds the total, cap it at the
+  # total and zero the peers. Returns { allowance:, cash:, leasing: }.
+  def rebalance(changed:, value:)
+    value = value.to_i
+    return capped(changed) if value >= @total
+
+    remainder = @total - value
+    zeroed.merge(changed => value, first_peer(changed) => remainder)
+  end
+
+  private
+
+  # { allowance: 0, cash: 0, leasing: 0 } with the edited method capped at total.
+  def capped(changed)
+    zeroed.merge(changed => @total)
+  end
+
+  def zeroed
+    { allowance: 0, cash: 0, leasing: 0 }
+  end
+
+  # The peer that absorbs the remainder for a given edited method: cash absorbs
+  # for allowance/leasing edits; allowance absorbs for a cash edit.
+  def first_peer(changed)
+    changed == :cash ? :allowance : :cash
+  end
+end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -11,7 +11,9 @@
           "@hotwired/turbo-rails": "/vendor/turbo.js",
           "@hotwired/stimulus": "/vendor/stimulus.js",
           "reactive_controller": "/vendor/reactive_controller.js",
-          "phlex/reactive/confirm": "/vendor/confirm.js"
+          "phlex/reactive/confirm": "/vendor/confirm.js",
+          "phlex/reactive/compute": "/vendor/compute.js",
+          "payment_split_reducer": "/vendor/payment_split_reducer.js"
         }
       }
     </script>
@@ -20,11 +22,16 @@
       import "@hotwired/turbo-rails"
       import { Application } from "@hotwired/stimulus"
       import ReactiveController from "reactive_controller"
+      import { registerPaymentSplit } from "payment_split_reducer"
 
       const application = Application.start()
       // Register eagerly so a click right after load is never missed.
       application.register("reactive", ReactiveController)
       window.Stimulus = application
+
+      // Register the demo's client-side compute reducer (the JS twin of the Ruby
+      // PaymentSplit). The OrderComponent's new-draft path runs this on input.
+      registerPaymentSplit()
     </script>
   </head>
   <body>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   get "counter" => "demos#counter"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
+  get "new_order" => "demos#new_order"
+  get "order/:id" => "demos#order"
   get "notifications" => "demos#notifications"
   get "reactive_rows" => "demos#reactive_rows"
   get "rich_editor/:id" => "demos#rich_editor"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -15,6 +15,16 @@ ActiveRecord::Schema.define(version: 1) do
     t.timestamps
   end
 
+  # A mini sell-order for the reactive_compute / new-vs-persisted example: a
+  # three-way payment split (allowance + cash + leasing) that must sum to total.
+  create_table :orders, force: true do |t|
+    t.integer :total, null: false, default: 0
+    t.integer :allowance, null: false, default: 0
+    t.integer :cash, null: false, default: 0
+    t.integer :leasing, null: false, default: 0
+    t.timestamps
+  end
+
   create_table :chat_messages, force: true do |t|
     t.string :room, null: false, default: "lobby"
     t.string :author, null: false, default: "anon"

--- a/spec/dummy/public/vendor/compute.js
+++ b/spec/dummy/public/vendor/compute.js
@@ -1,0 +1,48 @@
+// The client-side compute (data-binding) registry — the "instant" half of the
+// new/unpersisted-record UX.
+//
+// A record-backed reactive component round-trips every change to the server
+// (the signed identity re-finds the record; the server re-renders). A NEW,
+// unpersisted record has no such server truth to re-render against on every
+// keystroke — the classic answer is a bespoke Stimulus controller doing the math
+// in the browser (carlqvist's new_order_controller.js). This registry lets that
+// math be a DECLARED part of the component instead: `reactive_compute :name,
+// inputs:, outputs:` (Ruby) names a reducer registered here, and the generic
+// reactive controller runs it on `input` — writing the outputs with NO round
+// trip. When the component ALSO carries on(...) (a persisted record, or a draft
+// you sync), the debounced POST reconciles from the authoritative server reply.
+//
+// The seam mirrors confirm.js: a settable registry with a lookup the controller
+// calls. Register once at boot:
+//
+//   import { setComputeReducer } from "phlex/reactive/compute"
+//   setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({
+//     allowance, leasing, cash: total - allowance - leasing,
+//   }))
+//
+// The reducer receives a plain object of { inputName: Number } and returns a
+// plain object of { outputName: value } — only the outputs it names are written,
+// so it can leave the edited field (and its caret) untouched. Returning the SAME
+// value it read is a no-op write; the controller still fires `input` on any field
+// it sets so a chained summary repaints, matching the server's set_value +
+// dispatch("input") contract.
+
+const reducers = new Map()
+
+// Register (or replace) the reducer for `key`. `fn` is
+// (values: Record<string, number>) => Record<string, unknown>.
+export function setComputeReducer(key, fn) {
+  reducers.set(key, fn)
+}
+
+// Look up a registered reducer; undefined when none — the controller then makes
+// #recompute a no-op rather than throwing (a missing reducer must not break the
+// page; it just means no client-side binding for that root).
+export function computeReducer(key) {
+  return reducers.get(key)
+}
+
+// Test seam: clear the registry so a reducer registered in one test can't leak.
+export function __resetComputeRegistryForTest() {
+  reducers.clear()
+}

--- a/spec/dummy/public/vendor/payment_split_reducer.js
+++ b/spec/dummy/public/vendor/payment_split_reducer.js
@@ -1,0 +1,26 @@
+// The JS twin of the Ruby PaymentSplit (spec/dummy/app/models/payment_split.rb).
+// Registered under the "payment_split" reducer key so a NEW (unpersisted) order's
+// reactive_compute recomputes the three-way split IN-BROWSER on input, with no
+// round trip. A persisted order runs the identical math server-side. Keep the two
+// in lockstep — that's the contract reactive_compute exists to enforce.
+import { setComputeReducer } from "phlex/reactive/compute"
+
+// values: { allowance, cash, leasing, total } as Numbers (blank → 0, handled by
+// the controller). The controller passes the LIVE field values every time; we
+// figure out which one the user just edited by comparing against the identity the
+// reducer is called with... but since inputs are stateless here, we mirror the
+// server contract: the edited field keeps its value, cash absorbs the remainder,
+// and an over-total edit caps + zeros the peers.
+//
+// The demo edits `allowance` (the wired input), so `allowance` is authoritative
+// and `cash`/`leasing` rebalance. This keeps the reducer tiny and matches
+// PaymentSplit#rebalance(changed: :allowance).
+export function registerPaymentSplit() {
+  setComputeReducer("payment_split", ({ allowance, total }) => {
+    // Mirrors PaymentSplit#rebalance(changed: :allowance): the edited allowance
+    // keeps its value; cash absorbs the whole remainder; leasing zeros out. Cap
+    // allowance at total (peers zero) when it exceeds the total.
+    if (allowance >= total) return { allowance: total, cash: 0, leasing: 0 }
+    return { allowance, cash: total - allowance, leasing: 0 }
+  })
+}

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -10,6 +10,9 @@ import { Controller } from "@hotwired/stimulus"
 // bundlers/bun resolve it the same way they already resolve
 // "phlex/reactive/reactive_controller" (see tsconfig.json paths for the tests).
 import { confirmResolver } from "phlex/reactive/confirm"
+// Client-side computes (data bindings): the reducer registry behind
+// reactive_compute. Bare specifier for the same import-map reason as confirm.
+import { computeReducer } from "phlex/reactive/compute"
 
 // The ONE generic controller behind every reactive Phlex component. It
 // replaces the per-feature Stimulus controllers you'd otherwise hand-write
@@ -217,6 +220,68 @@ export default class extends Controller {
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce)
       })
+  }
+
+  // Client-side compute (data binding). Wired by reactive_compute: an `input`
+  // trigger (input->reactive#recompute) runs a REGISTERED JS reducer over the
+  // named input fields and writes the named output fields WITH NO ROUND TRIP —
+  // the "instant" half of the new/unpersisted-record UX. If the field ALSO
+  // carries on(...) (a persisted record, or a synced draft), that debounced POST
+  // still fires and the server reply reconciles; recompute just paints first.
+  //
+  // Reads inputs/outputs/reducer from the root's data-reactive-compute-* attrs
+  // (set once by reactive_compute_attrs). A missing/unregistered reducer is a
+  // no-op — a page must never break because a binding wasn't wired up.
+  recompute() {
+    const key = this.element.getAttribute("data-reactive-compute-reducer-param")
+    if (!key) return
+    const reduce = computeReducer(key)
+    if (!reduce) return
+
+    const inputs = this.#parseComputeList("data-reactive-compute-inputs-param")
+    const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
+
+    const values = {}
+    for (const name of inputs) values[name] = this.#numericFieldValue(name)
+
+    const result = reduce(values) || {}
+    for (const name of outputs) {
+      if (!(name in result)) continue
+      const field = this.#ownedField(name)
+      // Setting .value fires the field's own `input` listeners (a chained summary
+      // repaint), matching the server's set_value + dispatch("input") contract.
+      if (field) field.value = result[name]
+    }
+  }
+
+  // Parse a JSON string list from a root data attr; [] on absence/parse error so
+  // a malformed binding degrades to "no fields" rather than throwing on input.
+  #parseComputeList(attr) {
+    const raw = this.element.getAttribute(attr)
+    if (!raw) return []
+    try {
+      const list = JSON.parse(raw)
+      return Array.isArray(list) ? list : []
+    } catch {
+      return []
+    }
+  }
+
+  // The first named control owned by THIS root (skips nested reactive roots,
+  // issue #15) — used by recompute to read inputs and write outputs.
+  #ownedField(name) {
+    const nodes = this.element.querySelectorAll(`[name="${name}"]`)
+    for (const el of nodes) if (this.#ownsField(el)) return el
+    return null
+  }
+
+  // A field's value as a Number, treating blank/absent/NaN as 0 — mirroring the
+  // nanToZero coercion the hand-written calculators use, so a reducer never sees
+  // "" or NaN for an empty field.
+  #numericFieldValue(name) {
+    const field = this.#ownedField(name)
+    const n = Number(field?.value)
+    return Number.isFinite(n) ? n : 0
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/spec/javascript/reactive_compute.test.js
+++ b/spec/javascript/reactive_compute.test.js
@@ -1,0 +1,188 @@
+// Unit test for client-side computes (data bindings) — the "instant" half of
+// the new/unpersisted-record UX.
+//
+// A component declares `reactive_compute :name, inputs:, outputs:` (Ruby) which
+// emits data-reactive-compute-* on the root. A JS reducer registered under the
+// reducer key runs on `input` — reading the named input fields, writing the
+// named output fields — with NO round trip. The debounced POST (if the field
+// also carries on(...)) reconciles from the server reply afterward.
+//
+// This mirrors confirm.js's settable-registry seam: setComputeReducer(key, fn)
+// registers; the controller's #recompute looks it up and applies it.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach } from "bun:test"
+
+let ReactiveController
+let computeModule
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+  computeModule = await import("../../app/javascript/phlex/reactive/compute.js")
+})
+
+// A fake named form control: value is read/written like a real input, and
+// setting .value fires any registered "input" listeners so a chained summary
+// repaints (matches the browser: set_value + dispatch("input")). `closest`
+// returns the owning root so #ownsField (issue #15) treats it as owned.
+function makeField(name, value) {
+  const listeners = []
+  return {
+    name,
+    tagName: "INPUT",
+    _root: null, // set by makeRoot so closest() can resolve ownership
+    _value: String(value),
+    get value() {
+      return this._value
+    },
+    set value(v) {
+      this._value = String(v)
+      listeners.slice().forEach((fn) => fn({ target: this }))
+    },
+    closest() {
+      return this._root
+    },
+    addEventListener: (type, fn) => type === "input" && listeners.push(fn),
+    dispatchEvent: () => {},
+  }
+}
+
+// A root element carrying the compute config + a set of named fields. The
+// controller reads inputs/outputs/reducer from the root's dataset-style getAttribute
+// and finds fields by name via querySelectorAll('[name=...]').
+function makeRoot({ reducer, inputs, outputs, fields }) {
+  const attrs = {
+    "data-reactive-compute-reducer-param": reducer,
+    "data-reactive-compute-inputs-param": JSON.stringify(inputs),
+    "data-reactive-compute-outputs-param": JSON.stringify(outputs),
+  }
+  const root = {
+    id: "order",
+    getAttribute: (k) => attrs[k] ?? null,
+    querySelectorAll: (sel) => {
+      const m = sel.match(/\[name="(.+?)"\]/)
+      if (!m) return []
+      const f = fields[m[1]]
+      return f ? [f] : []
+    },
+    closest: () => null,
+  }
+  // Point each field's closest() at this root so #ownsField sees it as owned.
+  for (const f of Object.values(fields)) f._root = root
+  return root
+}
+
+function buildController(root) {
+  const controller = new ReactiveController()
+  controller.element = root
+  globalThis.window ??= {}
+  return controller
+}
+
+// Reset the registry between tests so a reducer registered in one test can't
+// leak into the next.
+beforeEach(() => {
+  computeModule.__resetComputeRegistryForTest()
+})
+
+test("setComputeReducer registers a reducer looked up by key", () => {
+  const fn = () => ({})
+  computeModule.setComputeReducer("split", fn)
+  expect(computeModule.computeReducer("split")).toBe(fn)
+})
+
+test("an unregistered key resolves to undefined (no throw)", () => {
+  expect(computeModule.computeReducer("missing")).toBeUndefined()
+})
+
+test("#recompute runs the reducer over the input fields and writes the outputs", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 0),
+    leasing: makeField("leasing", 0),
+    total: makeField("total", 500),
+  }
+  computeModule.setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => {
+    // trivial three-way split: cash absorbs the remainder
+    return { allowance, leasing, cash: total - allowance - leasing }
+  })
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "payment_split",
+      inputs: ["allowance", "cash", "leasing", "total"],
+      outputs: ["allowance", "cash", "leasing"],
+      fields,
+    }),
+  )
+
+  controller.recompute({ target: fields.allowance })
+
+  // cash recomputed instantly, no network
+  expect(fields.cash.value).toBe("400")
+  // untouched peers keep their submitted values
+  expect(fields.allowance.value).toBe("100")
+  expect(fields.leasing.value).toBe("0")
+})
+
+test("#recompute coerces field values to numbers for the reducer", () => {
+  const fields = {
+    allowance: makeField("allowance", "100"),
+    cash: makeField("cash", ""),
+    leasing: makeField("leasing", ""),
+    total: makeField("total", "500"),
+  }
+  let seen
+  computeModule.setComputeReducer("payment_split", (values) => {
+    seen = values
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "payment_split",
+      inputs: ["allowance", "cash", "leasing", "total"],
+      outputs: [],
+      fields,
+    }),
+  )
+  controller.recompute({ target: fields.allowance })
+
+  // blank fields → 0, not NaN or "" (matches new_order_controller.js nanToZero)
+  expect(seen).toEqual({ allowance: 100, cash: 0, leasing: 0, total: 500 })
+})
+
+test("#recompute is a no-op when no reducer is registered for the key", () => {
+  const fields = { total: makeField("total", 500), cash: makeField("cash", 999) }
+  const controller = buildController(
+    makeRoot({ reducer: "unregistered", inputs: ["total"], outputs: ["cash"], fields }),
+  )
+
+  // must not throw, must not touch the outputs
+  controller.recompute({ target: fields.total })
+  expect(fields.cash.value).toBe("999")
+})
+
+test("writing an output fires its input listeners (so a chained summary repaints)", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 0),
+    total: makeField("total", 500),
+  }
+  let summaryRepaints = 0
+  fields.cash.addEventListener("input", () => summaryRepaints++)
+
+  computeModule.setComputeReducer("split", ({ allowance, total }) => ({ cash: total - allowance }))
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: ["cash"], fields }),
+  )
+
+  controller.recompute({ target: fields.allowance })
+  expect(fields.cash.value).toBe("400")
+  expect(summaryRepaints).toBe(1) // the output write drove the summary, no round trip
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -401,6 +401,146 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  # A record-backed component whose record is UNSAVED (new_record?) has no
+  # GlobalID to sign. reactive_token must not crash calling to_gid on it — it
+  # signs the declared state instead (the draft seed), so the client controller
+  # still mounts and a client-side compute (reactive_compute) can drive the
+  # unpersisted record in-browser. This is the "tokenless draft" seam.
+  describe "record-backed component holding an UNSAVED record (draft seed)" do
+    # A record double that is not persisted and raises on to_gid (mirroring
+    # ActiveRecord::Base#to_gid on a new_record — MissingModelIdError).
+    let(:unsaved_record) do
+      Class.new do
+        def persisted? = false
+        def to_gid = raise(URI::GID::MissingModelIdError, "no id")
+      end.new
+    end
+
+    let(:draft_klass) do
+      Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "DraftThing"
+
+        reactive_record :order
+        reactive_state :total, :allowance
+
+        def initialize(order:, total: 0, allowance: 0)
+          @order = order
+          @total = total
+          @allowance = allowance
+        end
+
+        attr_reader :order, :total, :allowance
+
+        def id = "draft-thing"
+      end
+    end
+
+    it "signs {c, s} WITHOUT a gid when the record is unsaved (no crash)" do
+      token = draft_klass.new(order: unsaved_record, total: 500, allowance: 100).send(:reactive_token)
+      payload = Phlex::Reactive.verify(token)
+
+      expect(payload["c"]).to eq("DraftThing")
+      expect(payload).not_to have_key("gid")
+      expect(payload["s"]).to eq({ "total" => 500, "allowance" => 100 })
+    end
+
+    it "still signs the gid when the record IS persisted" do
+      saved = Struct.new(:gid_string).new("gid://app/Order/7")
+      allow(saved).to receive_messages(persisted?: true, to_gid: instance_double(GlobalID, to_s: saved.gid_string))
+
+      token = draft_klass.new(order: saved, total: 500).send(:reactive_token)
+      payload = Phlex::Reactive.verify(token)
+
+      expect(payload["gid"]).to eq("gid://app/Order/7")
+    end
+  end
+
+  # reactive_compute declares a CLIENT-SIDE reducer: on `input`, the generic
+  # controller runs a registered JS function over the named input fields and
+  # writes the named output fields WITHOUT a round trip (the "instant" half of
+  # the new-record UX), then the debounced POST reconciles from the server reply.
+  # The Ruby side is pure hash-building — no view context, no DB — so it lives
+  # here alongside on/reactive_field.
+  describe "reactive_compute DSL (client-side data bindings)" do
+    let(:compute_klass) do
+      Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "ComputeThing"
+
+        reactive_state :total
+        reactive_compute :payment_split,
+          inputs: %i[allowance cash leasing total],
+          outputs: %i[allowance cash leasing]
+
+        def initialize(total: 0) = @total = total
+      end
+    end
+
+    describe "declaration registry" do
+      it "registers a declared compute" do
+        expect(compute_klass.reactive_compute?(:payment_split)).to be(true)
+      end
+
+      it "does not register an undeclared name" do
+        expect(compute_klass.reactive_compute?(:wat)).to be(false)
+        expect(compute_klass.reactive_compute(:wat)).to be_nil
+      end
+
+      it "captures the inputs and outputs" do
+        definition = compute_klass.reactive_compute(:payment_split)
+        expect(definition.inputs).to eq(%i[allowance cash leasing total])
+        expect(definition.outputs).to eq(%i[allowance cash leasing])
+      end
+
+      it "defaults the reducer key to the compute name" do
+        expect(compute_klass.reactive_compute(:payment_split).reducer).to eq("payment_split")
+      end
+
+      it "honors an explicit reducer key" do
+        klass = Class.new do
+          include Phlex::Reactive::Component
+
+          def self.name = "CustomReducer"
+          reactive_compute :split, inputs: %i[a], outputs: %i[b], reducer: "shared_split"
+        end
+        expect(klass.reactive_compute(:split).reducer).to eq("shared_split")
+      end
+    end
+
+    describe "inheritance" do
+      it "inherits computes from a parent and adds its own without mutating the parent" do
+        child = Class.new(compute_klass) do
+          def self.name = "ComputeChild"
+          reactive_compute :totals, inputs: %i[price qty], outputs: %i[total]
+        end
+
+        expect(child.reactive_compute?(:payment_split)).to be(true) # inherited
+        expect(child.reactive_compute?(:totals)).to be(true)        # own
+        expect(compute_klass.reactive_compute?(:totals)).to be(false) # parent unaffected
+      end
+    end
+
+    describe "#reactive_compute_attrs (data attributes for the root)" do
+      subject(:instance) { compute_klass.new }
+
+      it "emits the reducer key and the input/output field names as data attrs" do
+        attrs = instance.send(:reactive_compute_attrs, :payment_split)
+        expect(attrs[:data][:reactive_compute_reducer_param]).to eq("payment_split")
+        expect(JSON.parse(attrs[:data][:reactive_compute_inputs_param])).to eq(%w[allowance cash leasing total])
+        expect(JSON.parse(attrs[:data][:reactive_compute_outputs_param])).to eq(%w[allowance cash leasing])
+      end
+
+      it "raises for an undeclared compute (fail fast, not a silent no-op)" do
+        expect { instance.send(:reactive_compute_attrs, :nope) }
+          .to raise_error(Phlex::Reactive::Error, /reactive_compute/)
+      end
+    end
+  end
+
   # Performance: reactive_token runs on EVERY render. It must produce a byte-
   # identical payload before/after caching the ivar symbols + class name. These
   # pin the payload SHAPE (decoded) so an allocation optimization can't silently

--- a/spec/phlex/vendored_controller_sync_spec.rb
+++ b/spec/phlex/vendored_controller_sync_spec.rb
@@ -2,23 +2,36 @@
 
 require "spec_helper"
 
-# The system suite drives the REAL browser via a vendored copy of the client
-# controller at spec/dummy/public/vendor/reactive_controller.js (importmap-pinned
-# in the dummy layout). If that copy drifts from the shipped source, the browser
-# specs validate stale code — exactly how the pgbus connection-id logic and, later,
-# the issue #8 rich-text collection fix could have gone untested. This guard makes
-# drift a hard failure: keep the vendored copy byte-identical to source.
-RSpec.describe "vendored client controller" do
+# The system suite drives the REAL browser via vendored copies of the client
+# modules under spec/dummy/public/vendor (importmap-pinned in the dummy layout).
+# If a copy drifts from the shipped source, the browser specs validate stale code
+# — exactly how the pgbus connection-id logic and, later, the issue #8 rich-text
+# collection fix could have gone untested. This guard makes drift a hard failure:
+# keep every vendored copy byte-identical to its source under app/javascript.
+RSpec.describe "vendored client modules" do
   root = File.expand_path("../..", __dir__)
-  source = File.join(root, "app/javascript/phlex/reactive/reactive_controller.js")
-  vendored = File.join(root, "spec/dummy/public/vendor/reactive_controller.js")
 
-  it "is byte-identical to the shipped source (no drift)" do
-    expect(File.read(vendored)).to eq(File.read(source)),
-      "spec/dummy/public/vendor/reactive_controller.js has drifted from the source " \
-      "app/javascript/phlex/reactive/reactive_controller.js. Re-sync it (the system " \
-      "suite runs the vendored copy):\n\n  " \
-      "cp app/javascript/phlex/reactive/reactive_controller.js " \
-      "spec/dummy/public/vendor/reactive_controller.js"
+  # Each client module the system suite serves from spec/dummy/public/vendor.
+  vendored_modules = %w[
+    reactive_controller.js
+    confirm.js
+    compute.js
+  ]
+
+  # Explicit block param (not `it`): the block body defines RSpec `it` examples,
+  # so naming the param `it` would shadow RSpec's example method.
+  # rubocop:disable Style/ItBlockParameter
+  vendored_modules.each do |filename|
+    it "#{filename} is byte-identical to the shipped source (no drift)" do
+      source = File.join(root, "app/javascript/phlex/reactive", filename)
+      vendored = File.join(root, "spec/dummy/public/vendor", filename)
+
+      expect(File.read(vendored)).to eq(File.read(source)),
+        "spec/dummy/public/vendor/#{filename} has drifted from the source " \
+        "app/javascript/phlex/reactive/#{filename}. Re-sync it (the system suite " \
+        "runs the vendored copy):\n\n  " \
+        "cp app/javascript/phlex/reactive/#{filename} spec/dummy/public/vendor/#{filename}"
+    end
   end
+  # rubocop:enable Style/ItBlockParameter
 end

--- a/spec/requests/order_component_render_spec.rb
+++ b/spec/requests/order_component_render_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Renders OrderComponent through a real request (needs the DB for persisted?)
+# and asserts the new-vs-persisted wiring split: a NEW draft carries the
+# reactive_compute binding + the client-only recompute action; a PERSISTED order
+# carries the reactive rebalance dispatch (server reconciles).
+RSpec.describe "OrderComponent render (new vs persisted)", type: :request do
+  # Render via the demo pages so the component goes through a real view context.
+  describe "a NEW (unsaved) order at /new_order" do
+    before { get "/new_order" }
+
+    it "renders the compute binding on the root (client-side split, no round trip)" do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('data-reactive-compute-reducer-param="payment_split"')
+      expect(response.body).to include("data-reactive-compute-inputs-param")
+      expect(response.body).to include("data-reactive-compute-outputs-param")
+    end
+
+    it "wires the allowance field to the client recompute (input), not a POST" do
+      root = response.body[%r{<div [^>]*data-reactive-compute-reducer-param[^>]*>.*?</div>}m] || response.body
+      expect(root).to include("input-&gt;reactive#recompute").or include("input->reactive#recompute")
+    end
+
+    it "uses the stable draft id (no GlobalID for an unsaved record)" do
+      expect(response.body).to include('id="order-draft"')
+    end
+  end
+
+  describe "a PERSISTED order at /order/:id" do
+    let(:order) { Order.create!(total: 500, allowance: 0, cash: 500, leasing: 0) }
+
+    before { get "/order/#{order.id}" }
+
+    it "does NOT render the compute binding (server owns the split)" do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("data-reactive-compute-reducer-param")
+    end
+
+    it "wires the allowance field to the reactive rebalance dispatch on change" do
+      expect(response.body).to include("change-&gt;reactive#dispatch").or include("change->reactive#dispatch")
+      expect(response.body).to include("rebalance")
+    end
+  end
+end

--- a/spec/requests/order_rebalance_spec.rb
+++ b/spec/requests/order_rebalance_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The PERSISTED (server-side) half of the reactive_compute example: a persisted
+# order's `rebalance` action runs the PaymentSplit twin server-side and streams
+# the recomputed component back. (The NEW-draft half runs entirely in-browser and
+# is covered by the JS unit test + the system spec.)
+RSpec.describe "Order rebalance action", type: :request do
+  let(:order) { Order.create!(total: 500, allowance: 0, cash: 500, leasing: 0) }
+
+  it "rebalances cash server-side and persists the split" do
+    post_action(
+      OrderComponent,
+      payload: { "gid" => order.to_gid.to_s },
+      act: "rebalance",
+      params: { allowance: 100, cash: 500, leasing: 0, total: 500 }
+    )
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    # cash absorbed the remainder (500 - 100)
+    expect(order.reload.allowance).to eq(100)
+    expect(order.cash).to eq(400)
+    # the streamed component reflects the new cash and refreshes the token
+    expect(response.body).to include('action="replace"')
+    expect(response.body).to include("data-reactive-token-value")
+  end
+
+  it "caps the edited method and zeros the peers when it exceeds the total" do
+    post_action(
+      OrderComponent,
+      payload: { "gid" => order.to_gid.to_s },
+      act: "rebalance",
+      params: { allowance: 999, cash: 500, leasing: 0, total: 500 }
+    )
+
+    expect(response).to have_http_status(:ok)
+    expect(order.reload.allowance).to eq(500)
+    expect(order.cash).to eq(0)
+    expect(order.leasing).to eq(0)
+  end
+
+  it "is default-deny for an undeclared action" do
+    post_action(OrderComponent, payload: { "gid" => order.to_gid.to_s }, act: "drop_table")
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/spec/requests/payment_split_spec.rb
+++ b/spec/requests/payment_split_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The shared Ruby twin of the JS payment-split reducer. Locking it here keeps the
+# two execution sites (server rebalance action + client reactive_compute) in
+# lockstep — a divergence would mean a new draft and a saved order compute
+# different splits, the exact bug reactive_compute exists to prevent.
+RSpec.describe PaymentSplit do
+  subject(:split) { described_class.new(total: 500, allowance: 0, cash: 500, leasing: 0) }
+
+  it "cash absorbs the remainder when allowance is edited" do
+    expect(split.rebalance(changed: :allowance, value: 100)).to eq(allowance: 100, cash: 400, leasing: 0)
+  end
+
+  it "allowance absorbs the remainder when cash is edited" do
+    expect(split.rebalance(changed: :cash, value: 200)).to eq(allowance: 300, cash: 200, leasing: 0)
+  end
+
+  it "caps the edited method at total and zeros the peers when it exceeds total" do
+    expect(split.rebalance(changed: :allowance, value: 999)).to eq(allowance: 500, cash: 0, leasing: 0)
+  end
+
+  it "caps exactly at total (== total edits to a full cap, peers zero)" do
+    expect(split.rebalance(changed: :leasing, value: 500)).to eq(allowance: 0, cash: 0, leasing: 500)
+  end
+end

--- a/spec/system/order_compute_spec.rb
+++ b/spec/system/order_compute_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# The end-to-end proof of the reactive_compute / new-vs-persisted split (Option C):
+#
+#   * A NEW (unsaved) order recomputes the payment split IN-BROWSER via
+#     reactive_compute — cash updates instantly with NO round trip to the server.
+#   * A PERSISTED order routes the same edit through the reactive rebalance action;
+#     the server runs the SAME PaymentSplit twin and streams cash back, persisting.
+#
+# One math contract (PaymentSplit ⇄ payment_split_reducer.js), two execution sites.
+RSpec.describe "Order payment split (reactive_compute new vs persisted)", type: :system do
+  describe "a NEW (unsaved) order" do
+    it "recomputes cash in-browser with NO server round trip" do
+      visit "/new_order"
+      expect(page).to have_field("total", with: "500")
+      expect(page).to have_field("cash", with: "0")
+
+      # Count reactive action POSTs: a client-side compute must fire ZERO.
+      page.execute_script(<<~JS)
+        window.__actionPosts = 0
+        const orig = window.fetch
+        window.fetch = (url, opts) => {
+          if (String(url).includes("/reactive/actions")) window.__actionPosts++
+          return orig(url, opts)
+        }
+        window.__noReload = "alive"
+      JS
+
+      # Type an allowance; the reducer runs on `input` and writes cash = 500 - 100.
+      fill_in "allowance", with: "100"
+
+      expect(page).to have_field("cash", with: "400") # instant, client-computed
+      expect(page.evaluate_script("window.__actionPosts")).to eq(0) # NO round trip
+      expect(page.evaluate_script("window.__noReload")).to eq("alive") # no reload
+
+      # A second edit recomputes again, still client-side.
+      fill_in "allowance", with: "200"
+      expect(page).to have_field("cash", with: "300")
+      expect(page.evaluate_script("window.__actionPosts")).to eq(0)
+    end
+  end
+
+  describe "a PERSISTED order" do
+    let(:order) { Order.create!(total: 500, allowance: 0, cash: 500, leasing: 0) }
+
+    it "rebalances through the server and persists the split" do
+      visit "/order/#{order.id}"
+      expect(page).to have_field("cash", with: "500")
+      page.execute_script("window.__noReload = 'alive'")
+
+      # Editing allowance fires the reactive rebalance action (change trigger);
+      # the server recomputes cash and streams the component back.
+      fill_in "allowance", with: "100"
+      find("body").click # blur → the `change` event fires the reactive dispatch
+
+      expect(page).to have_field("cash", with: "400") # server-reconciled
+      expect(page.evaluate_script("window.__noReload")).to eq("alive") # no reload
+
+      # The server persisted it (the DB is the source of truth for a saved order).
+      expect(order.reload.allowance).to eq(100)
+      expect(order.cash).to eq(400)
+    end
+  end
+end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "phlex/reactive/confirm": ["./app/javascript/phlex/reactive/confirm.js"]
+      "phlex/reactive/confirm": ["./app/javascript/phlex/reactive/confirm.js"],
+      "phlex/reactive/compute": ["./app/javascript/phlex/reactive/compute.js"]
     }
   }
 }


### PR DESCRIPTION
## What & why

Investigation + prototype for a question from **carlqvist-intracar**: can one component update another via pure-JS data bindings, so a **new/unpersisted** `sell_order` recomputes **in the browser** (no Turbo round trip) while a **persisted** one keeps going through the server?

Today phlex-reactive only works through Turbo, so carlqvist hand-writes `new_order_controller.js` (an in-memory sell-order calculator) *and* a Ruby twin (`PaymentSplit`) — the same math in two places. This PR makes the "persisted → server, new → in-browser" split a **first-class capability**, so that duplication can collapse to one declared contract.

## The two additions (both additive; every invariant preserved)

### 1. `reactive_compute` — client-side data bindings

Declare a computation whose derived fields recompute **in-browser on `input`, with no POST**:

```ruby
reactive_compute :payment_split,
  inputs:  %i[allowance cash leasing total],   # fields the reducer reads
  outputs: %i[allowance cash leasing]          # fields it writes (no round trip)

# view: div(**mix(reactive_root, reactive_compute_attrs(:payment_split)))
# edited field: data-action="input->reactive#recompute"
```

```js
import { setComputeReducer } from "phlex/reactive/compute"
setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({
  allowance, leasing, cash: total - allowance - leasing,
}))
```

The generic controller runs the named reducer on `input`, writes only the declared outputs (leaving the edited field + caret alone), and fires `input` on each field it sets so a chained summary repaints — matching the server's `set_value` + `dispatch("input")` contract. A missing/unregistered reducer is a **no-op** (a page never breaks because a binding wasn't wired). When the same component **also** carries `on(...)` (a persisted record, or a draft you sync), the debounced POST still fires and the server reply reconciles — so `reactive_compute` is the optimistic client paint and the server round trip is the source of truth. **One math contract, two execution sites.**

New client module `phlex/reactive/compute` (auto-pinned by the engine like `confirm`, vendored into the dummy app, covered by the drift guard).

### 2. Draft tokens — `reactive_record` no longer crashes on a `new_record?`

`reactive_token` omits `gid` when the record isn't persisted (`to_gid` raises `MissingModelIdError`) and relies on the declared `reactive_state` as the **draft seed**, so a record-backed component can render an unsaved record and the client controller still mounts. Persisted records sign `gid` exactly as before.

## How this maps to Option C (correct + instant)

- **Instant** — `reactive_compute` recomputes the new draft client-side, zero network.
- **Correct / source of truth** — the persisted path (and, when wired, a synced draft) round-trips the same `PaymentSplit` twin server-side.

## Prototype scope

Built in the gem and proven with a self-contained dummy example (`OrderComponent` — a condensed sell-order payment split at `/new_order` and `/order/:id`). **Not yet wired into carlqvist** — that's the follow-up once the API is agreed.

## Test plan (TDD, RED→GREEN across all four layers)

| Layer | Coverage |
|-------|----------|
| Unit (`spec/phlex`) | `reactive_compute` DSL registry + inheritance + `reactive_compute_attrs`; `reactive_token` draft seed (unsaved omits gid, persisted signs it) |
| JS (`spec/javascript`) | compute registry + controller `#recompute` (runs reducer, numeric coercion, no-op when unregistered, chained `input` repaint) |
| Request (`spec/requests`) | persisted `rebalance` runs `PaymentSplit` server-side + persists + default-deny; new-vs-persisted render wiring; `PaymentSplit` twin |
| System (`spec/system`) | new draft recomputes cash in-browser with **ZERO action POSTs**; persisted rebalances through the server + persists — green under **Puma AND Falcon** |

## Verification

- [x] `bundle exec rubocop` (113 files) clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 252 pass
- [x] `bun test spec/javascript` — 60 pass
- [x] `spec/system` — 29 pass under Puma **and** Falcon
- [x] Backwards compatible (the token change only affects previously-crashing unsaved records); pgbus optionality untouched (no transport changes)

## Open questions for review

1. **API shape** — `reactive_compute` name/args; `input->reactive#recompute` as the trigger vs. inferring it from the binding.
2. **Draft round-trip** — the prototype's new draft is pure-client (never POSTs). If a draft should also sync to the server (optimistic + reconcile for a new record), `from_identity` needs a "build a new record from signed state" path — deliberately left out of this prototype.
3. **Reducer duplication** — the reducer is still JS + Ruby twins. A future declarative-formula path (Ruby+JS interpret one spec) could remove even that, but `PaymentSplit`'s capping/spillback branching is hard to express as pure data.
