### PR TITLE
feat: combobox keyboard navigation via on(:search, …, listnav:) (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Combobox keyboard navigation — `on(:search, …, listnav: "[role=option]")` (#72).**
+  A search/combobox trigger can now declare client-side list navigation: Arrow
+  Up/Down move a highlight among the option elements IN-BROWSER (no round trip),
+  Enter picks the highlighted option by clicking its own `on(:select)` trigger
+  (so the selection stays a normal signed reactive action), and Escape clears —
+  all without a bespoke Stimulus controller. `listnav:` appends Stimulus's native
+  keyboard filters (`keydown.down/up/enter/esc->reactive#listnav*`) to the input's
+  `data-action` and marks the option selector; the generic controller's `listnav*`
+  handlers own the ephemeral highlight (a `data-reactive-highlighted` attribute,
+  never shipped as trusted state), mirroring `#recompute`. Only the highlight is
+  client-side — selection is still a default-deny, signed action. No new client
+  module (the handlers live in the existing controller); covered by unit (JS),
+  request, and real-browser system specs green under Puma AND Falcon.
+
 - **`reactive_compute` — client-side data bindings (no round trip).** A component
   can now declare a client-side computation that recomputes derived fields
   IN-BROWSER on `input`, with NO server round trip — the "instant" half of a

--- a/README.md
+++ b/README.md
@@ -482,12 +482,13 @@ free as an ordinary action-param name (`on(:switch, key: "pgbus")` still passes
 > trigger to its own element (the field saves on Enter; a Cancel button — or the
 > field's own blur — handles Escape), as above.
 
-**Combobox keyboard navigation (`listnav:`).** A searchable list needs Arrow
-keys to move a highlight, Enter to pick, Escape to close — interactions that are
-*ephemeral client UI state* (a highlight per keystroke would be absurd as a
-server round trip). Pass `listnav:` (a CSS selector for the option elements) to a
-search trigger and the generic controller handles all of it client-side, with no
-bespoke Stimulus controller:
+### Combobox keyboard navigation (`listnav:`)
+
+A searchable list needs Arrow keys to move a highlight, Enter to pick, Escape to
+close — interactions that are *ephemeral client UI state* (a highlight per
+keystroke would be absurd as a server round trip). Pass `listnav:` (a CSS
+selector for the option elements) to a search trigger and the generic controller
+handles all of it client-side, with no bespoke Stimulus controller:
 
 ```ruby
 # The search input: debounced live search + keyboard list navigation.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:action, event: "click", **params)` | Spread onto a trigger element. Adds `type=button` for clicks. |
 | `on(:action, event: "input", debounce: 300)` | Coalesce rapid events into one round trip after a quiet period (live-as-you-type). |
 | `on(:action, confirm: "Sure?")` | Gate a destructive trigger behind a confirmation. Defaults to `window.confirm`; override the dialog with [`setConfirmResolver`](#custom-confirmation-dialogs-setconfirmresolver). |
+| `on(:search, listnav: "[role=option]")` | Add combobox keyboard navigation — Arrow keys move a client-side highlight, Enter picks (clicks the option's own trigger), Escape clears. See [Combobox keyboard navigation](#combobox-keyboard-navigation-listnav). |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
@@ -412,6 +413,33 @@ Omit `debounce:` for the immediate-dispatch default.
 # Recompute a total live as the user types, without hammering the endpoint.
 input(**mix(on(:update, event: "input", debounce: 300), name: "quantity", value: @item.quantity))
 ```
+
+**Combobox keyboard navigation (`listnav:`).** A searchable list needs Arrow
+keys to move a highlight, Enter to pick, Escape to close — interactions that are
+*ephemeral client UI state* (a highlight per keystroke would be absurd as a
+server round trip). Pass `listnav:` (a CSS selector for the option elements) to a
+search trigger and the generic controller handles all of it client-side, with no
+bespoke Stimulus controller:
+
+```ruby
+# The search input: debounced live search + keyboard list navigation.
+input(**mix(
+  on(:search, event: "input", debounce: 200, listnav: "[role=option]"),
+  name: "query", value: @query
+))
+
+# Each option is BOTH a listnav target (role=option) and its own reactive
+# select trigger — Enter just clicks the highlighted one.
+button(**mix(on(:select, name: opt), role: "option")) { opt }
+```
+
+`listnav:` appends Stimulus's native keyboard filters
+(`keydown.down/up/enter/esc`) to the input's `data-action`. Arrow Up/Down move a
+`data-reactive-highlighted` marker among the options **with no round trip**;
+Enter **clicks the highlighted option** — so selection runs through its normal
+`on(:select)` reactive action (signed, default-deny, authorized like any other);
+Escape clears the highlight. Only the highlight is client-side — the selection
+stays a real signed action, and the highlight is never shipped as trusted state.
 
 **Combining `on(...)` / `reactive_attrs` with your own attributes.** Both return
 a hash that includes a `data:` key. Spreading them *and* passing another `data:`

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -254,6 +254,69 @@ export default class extends Controller {
     }
   }
 
+  // Client-side list navigation (combobox keyboard nav, issue #72). Wired by
+  // on(:search, …, listnav: "[role=option]"), which appends keyboard filters to
+  // the input's data-action (keydown.down/up/enter/esc->reactive#listnav*) and
+  // sets data-reactive-listnav-option-param. Arrow keys move a highlight among
+  // the options WITH NO ROUND TRIP; Enter picks the highlighted option by
+  // CLICKING IT (so its own on(:select) reactive trigger fires — selection stays
+  // a signed action); Escape clears. Ephemeral highlight state lives on the DOM
+  // (data-reactive-highlighted), never shipped to the client as trusted state.
+  listnavNext(event) {
+    this.#moveHighlight(event, +1)
+  }
+
+  listnavPrev(event) {
+    this.#moveHighlight(event, -1)
+  }
+
+  // Enter: activate the highlighted option (fires its reactive select). No-op if
+  // nothing is highlighted, and in that case DON'T preventDefault — Enter falls
+  // through (there's no selection to make).
+  listnavPick(event) {
+    const options = this.#listnavOptions(event)
+    const current = options.findIndex((el) => el.hasAttribute("data-reactive-highlighted"))
+    if (current < 0) return
+    event.preventDefault()
+    options[current].click()
+  }
+
+  listnavClose(event) {
+    for (const el of this.#listnavOptions(event)) el.removeAttribute("data-reactive-highlighted")
+  }
+
+  // Move the highlight by `step` (with wrap-around) among THIS root's options.
+  // preventDefault stops Arrow keys from moving the caret in the search input.
+  #moveHighlight(event, step) {
+    const options = this.#listnavOptions(event)
+    if (!options.length) return
+    event.preventDefault()
+
+    const current = options.findIndex((el) => el.hasAttribute("data-reactive-highlighted"))
+    // From nothing: Down highlights the first option, Up the last.
+    const next = current < 0 ? (step > 0 ? 0 : options.length - 1) : (current + step + options.length) % options.length
+
+    for (const el of options) el.removeAttribute("data-reactive-highlighted")
+    const chosen = options[next]
+    chosen.setAttribute("data-reactive-highlighted", "true")
+    chosen.scrollIntoView?.({ block: "nearest" })
+  }
+
+  // The option elements this root owns (skips nested reactive roots, issue #15),
+  // per the selector on data-reactive-listnav-option-param. The attr rides on the
+  // TRIGGER element (the search input on(...) is spread onto), read from the
+  // event; the options are still scoped to this controller's root. Empty when
+  // unset. Falls back to the root for a directly-invoked call (unit tests).
+  #listnavOptions(event) {
+    const trigger = event?.currentTarget ?? event?.target ?? this.element
+    const selector =
+      trigger.getAttribute?.("data-reactive-listnav-option-param") ??
+      this.element.getAttribute("data-reactive-listnav-option-param")
+    if (!selector) return []
+    const nodes = this.element.querySelectorAll(selector)
+    return Array.from(nodes).filter((el) => this.#ownsField(el))
+  }
+
   // Parse a JSON string list from a root data attr; [] on absence/parse error so
   // a malformed binding degrades to "no fields" rather than throwing on input.
   #parseComputeList(attr) {

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -350,22 +350,44 @@ module Phlex
       # enqueue/debounce if the user declines (and prevents the native default so
       # a `submit` trigger can't navigate on cancel). Omit it for no prompt.
       #   button(**on(:destroy, confirm: "Really delete this item?")) { "Delete" }
+      #
+      # `listnav:` (a CSS selector for the option elements) adds keyboard list
+      # navigation to a search/combobox trigger (issue #72). It appends Stimulus
+      # keyboard filters to the SAME element's data-action so Arrow Up/Down move a
+      # client-side highlight among the options, Enter picks the highlighted one
+      # (clicking its own reactive trigger — so selection stays a signed action),
+      # and Escape clears — all with NO server round trip for the highlight (the
+      # controller's listnav* handlers, like #recompute). Omit it for no nav.
+      #   input(**on(:search, event: "input", debounce: 300, listnav: "[role=option]"))
       # The verbatim JSON for an empty explicit-params payload. The common
       # trigger (on(:increment), no params) hits this on EVERY render — skipping
       # params.to_json (which re-serializes {} to the same "{}" each time) avoids
       # a per-render allocation while keeping the wire format byte-identical.
       EMPTY_PARAMS_JSON = "{}"
 
-      def on(action_name, event: "click", debounce: nil, confirm: nil, **params)
+      # The keyboard filters appended to a listnav trigger's data-action. Each is
+      # a client-only handler (no POST) except Enter, which clicks the highlighted
+      # option's own reactive trigger. Stimulus binds these natively.
+      LISTNAV_ACTIONS = [
+        "keydown.down->reactive#listnavNext",
+        "keydown.up->reactive#listnavPrev",
+        "keydown.enter->reactive#listnavPick",
+        "keydown.esc->reactive#listnavClose"
+      ].freeze
+
+      def on(action_name, event: "click", debounce: nil, confirm: nil, listnav: nil, **params)
+        action = "#{event}->reactive#dispatch"
+        action = "#{action} #{LISTNAV_ACTIONS.join(" ")}" if listnav
         attrs = {
           data: {
-            action: "#{event}->reactive#dispatch",
+            action:,
             reactive_action_param: action_name.to_s,
             reactive_params_param: params.empty? ? EMPTY_PARAMS_JSON : params.to_json
           }
         }
         attrs[:data][:reactive_debounce_param] = debounce if debounce
         attrs[:data][:reactive_confirm_param] = confirm if confirm
+        attrs[:data][:reactive_listnav_option_param] = listnav if listnav
         attrs[:type] = "button" if event == "click"
         attrs
       end

--- a/spec/dummy/app/components/combobox_component.rb
+++ b/spec/dummy/app/components/combobox_component.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# A searchable combobox exercising client-side list navigation (issue #72).
+#
+# State-backed: `query` and `selected` ride in the signed token. `search` filters
+# a frozen in-memory list server-side (debounced); `select` records the choice.
+# The search input declares `listnav: "[role=option]"`, so the generic controller
+# wires Arrow Up/Down (move a client-side highlight — NO round trip), Enter (pick
+# the highlighted option by clicking its own on(:select) trigger), and Escape
+# (clear) onto the input. Selection stays a signed reactive action; only the
+# highlight is ephemeral client state.
+class ComboboxComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  FRUITS = %w[Apple Apricot Banana Blueberry Cherry Cranberry Grape Mango Orange Peach].freeze
+
+  reactive_state :query, :selected
+  action :search, params: { query: :string }
+  action :select, params: { name: :string }
+
+  def initialize(query: "", selected: nil)
+    @query = query.to_s
+    @selected = selected
+  end
+
+  def id = "combobox"
+
+  def search(query:)
+    @query = query.to_s
+    reply.morph
+  end
+
+  def select(name:)
+    return reply.morph unless FRUITS.include?(name)
+
+    @selected = name
+    @query = name
+    reply.morph
+  end
+
+  def view_template
+    div(**reactive_root(data: { testid: "combobox" })) do
+      input(**mix(
+        on(:search, event: "input", debounce: 100, listnav: "[role=option]"),
+        type: "text", name: "query", value: @query, autocomplete: "off",
+        data: { testid: "combobox-query" }
+      ))
+      results
+      selection if @selected.present?
+    end
+  end
+
+  private
+
+  def filtered
+    needle = @query.to_s.strip.downcase
+    return [] if needle.empty? || needle == @selected.to_s.downcase
+
+    FRUITS.select { it.downcase.include?(needle) }
+  end
+
+  def results
+    ul(data: { testid: "combobox-results" }) do
+      each_option { option_button(it) }
+    end
+  end
+
+  def each_option(&) = filtered.each(&)
+
+  # `fruit` is an explicit param (NOT `it`): the body nests Phlex blocks, where a
+  # bare `it` would resolve to the wrong receiver and serialize a whole component
+  # into the action params — an infinite render recursion.
+  def option_button(fruit)
+    li do
+      # Each option is a reactive select trigger AND a listnav target
+      # ([role=option]). Enter on the input clicks the highlighted one.
+      button(**mix(
+        on(:select, name: fruit),
+        role: "option",
+        data: { testid: "option-#{fruit.downcase}" }
+      )) { fruit }
+    end
+  end
+
+  def selection
+    div(data: { testid: "combobox-selection" }) { "Selected: #{@selected}" }
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -14,6 +14,12 @@ class DemosController < ActionController::Base
     render_component TodoListComponent.new
   end
 
+  def combobox
+    # Seed the query so options render on load — the system spec drives keyboard
+    # nav without hammering the debounced search (which stresses Falcon's fibers).
+    render_component ComboboxComponent.new(query: params[:q].to_s)
+  end
+
   # A NEW (unsaved) order: the split recomputes in-browser via reactive_compute,
   # no round trip. total=500 seeds the three-way split.
   def new_order

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "counter" => "demos#counter"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
+  get "combobox" => "demos#combobox"
   get "new_order" => "demos#new_order"
   get "order/:id" => "demos#order"
   get "notifications" => "demos#notifications"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -254,6 +254,69 @@ export default class extends Controller {
     }
   }
 
+  // Client-side list navigation (combobox keyboard nav, issue #72). Wired by
+  // on(:search, …, listnav: "[role=option]"), which appends keyboard filters to
+  // the input's data-action (keydown.down/up/enter/esc->reactive#listnav*) and
+  // sets data-reactive-listnav-option-param. Arrow keys move a highlight among
+  // the options WITH NO ROUND TRIP; Enter picks the highlighted option by
+  // CLICKING IT (so its own on(:select) reactive trigger fires — selection stays
+  // a signed action); Escape clears. Ephemeral highlight state lives on the DOM
+  // (data-reactive-highlighted), never shipped to the client as trusted state.
+  listnavNext(event) {
+    this.#moveHighlight(event, +1)
+  }
+
+  listnavPrev(event) {
+    this.#moveHighlight(event, -1)
+  }
+
+  // Enter: activate the highlighted option (fires its reactive select). No-op if
+  // nothing is highlighted, and in that case DON'T preventDefault — Enter falls
+  // through (there's no selection to make).
+  listnavPick(event) {
+    const options = this.#listnavOptions(event)
+    const current = options.findIndex((el) => el.hasAttribute("data-reactive-highlighted"))
+    if (current < 0) return
+    event.preventDefault()
+    options[current].click()
+  }
+
+  listnavClose(event) {
+    for (const el of this.#listnavOptions(event)) el.removeAttribute("data-reactive-highlighted")
+  }
+
+  // Move the highlight by `step` (with wrap-around) among THIS root's options.
+  // preventDefault stops Arrow keys from moving the caret in the search input.
+  #moveHighlight(event, step) {
+    const options = this.#listnavOptions(event)
+    if (!options.length) return
+    event.preventDefault()
+
+    const current = options.findIndex((el) => el.hasAttribute("data-reactive-highlighted"))
+    // From nothing: Down highlights the first option, Up the last.
+    const next = current < 0 ? (step > 0 ? 0 : options.length - 1) : (current + step + options.length) % options.length
+
+    for (const el of options) el.removeAttribute("data-reactive-highlighted")
+    const chosen = options[next]
+    chosen.setAttribute("data-reactive-highlighted", "true")
+    chosen.scrollIntoView?.({ block: "nearest" })
+  }
+
+  // The option elements this root owns (skips nested reactive roots, issue #15),
+  // per the selector on data-reactive-listnav-option-param. The attr rides on the
+  // TRIGGER element (the search input on(...) is spread onto), read from the
+  // event; the options are still scoped to this controller's root. Empty when
+  // unset. Falls back to the root for a directly-invoked call (unit tests).
+  #listnavOptions(event) {
+    const trigger = event?.currentTarget ?? event?.target ?? this.element
+    const selector =
+      trigger.getAttribute?.("data-reactive-listnav-option-param") ??
+      this.element.getAttribute("data-reactive-listnav-option-param")
+    if (!selector) return []
+    const nodes = this.element.querySelectorAll(selector)
+    return Array.from(nodes).filter((el) => this.#ownsField(el))
+  }
+
   // Parse a JSON string list from a root data attr; [] on absence/parse error so
   // a malformed binding degrades to "no fields" rather than throwing on input.
   #parseComputeList(attr) {

--- a/spec/javascript/reactive_listnav.test.js
+++ b/spec/javascript/reactive_listnav.test.js
@@ -1,0 +1,178 @@
+// Unit test for client-side list navigation (combobox keyboard nav, issue #72).
+//
+// A search/combobox trigger declares `on(:search, …, listnav: "[role=option]")`
+// (Ruby), which appends Stimulus keyboard filters to the input's data-action and
+// emits data-reactive-listnav-option-param. The controller's listnav* handlers
+// move a client-side highlight among the option elements (Arrow Up/Down), pick
+// the highlighted one on Enter (by clicking its OWN reactive trigger, so the
+// selection stays a signed action), and clear on Escape — all with NO server
+// round trip for the highlight itself.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A fake option element: tracks its highlighted attribute + click count, and
+// answers closest() to the owning root so #ownsField treats it as owned.
+function makeOption(label) {
+  const attrs = {}
+  return {
+    label,
+    tagName: "BUTTON",
+    _root: null,
+    clicks: 0,
+    getAttribute: (k) => attrs[k] ?? null,
+    setAttribute: (k, v) => (attrs[k] = String(v)),
+    removeAttribute: (k) => delete attrs[k],
+    hasAttribute: (k) => k in attrs,
+    click() {
+      this.clicks++
+    },
+    scrollIntoView() {},
+    closest() {
+      return this._root
+    },
+  }
+}
+
+// A root carrying the listnav option selector + a list of option elements. The
+// controller reads the selector from getAttribute and finds options via
+// querySelectorAll(selector).
+function makeRoot({ selector, options }) {
+  const attrs = { "data-reactive-listnav-option-param": selector }
+  const root = {
+    id: "combobox",
+    getAttribute: (k) => attrs[k] ?? null,
+    querySelectorAll: (sel) => (sel === selector ? options.slice() : []),
+    closest: () => null,
+  }
+  for (const o of options) o._root = root
+  return root
+}
+
+function buildController(root) {
+  const controller = new ReactiveController()
+  controller.element = root
+  globalThis.window ??= {}
+  return controller
+}
+
+function event() {
+  let prevented = false
+  return {
+    get defaultPrevented() {
+      return prevented
+    },
+    preventDefault() {
+      prevented = true
+    },
+  }
+}
+
+const HIGHLIGHT = "data-reactive-highlighted"
+const highlightedIndex = (options) => options.findIndex((o) => o.hasAttribute(HIGHLIGHT))
+
+test("listnavNext highlights the first option, then advances and wraps", () => {
+  const options = [makeOption("a"), makeOption("b"), makeOption("c")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  controller.listnavNext(event())
+  expect(highlightedIndex(options)).toBe(0)
+
+  controller.listnavNext(event())
+  expect(highlightedIndex(options)).toBe(1)
+
+  controller.listnavNext(event()) // -> c
+  controller.listnavNext(event()) // wraps -> a
+  expect(highlightedIndex(options)).toBe(0)
+})
+
+test("listnavPrev moves backward and wraps from the top to the bottom", () => {
+  const options = [makeOption("a"), makeOption("b"), makeOption("c")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  controller.listnavPrev(event()) // from nothing -> last
+  expect(highlightedIndex(options)).toBe(2)
+
+  controller.listnavPrev(event()) // -> b
+  expect(highlightedIndex(options)).toBe(1)
+})
+
+test("only ONE option is highlighted at a time", () => {
+  const options = [makeOption("a"), makeOption("b")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  controller.listnavNext(event()) // a
+  controller.listnavNext(event()) // b
+  expect(options.filter((o) => o.hasAttribute(HIGHLIGHT)).length).toBe(1)
+  expect(highlightedIndex(options)).toBe(1)
+})
+
+test("listnavPick clicks the highlighted option and prevents default", () => {
+  const options = [makeOption("a"), makeOption("b")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  controller.listnavNext(event()) // highlight a
+  const e = event()
+  controller.listnavPick(e)
+
+  expect(options[0].clicks).toBe(1)
+  expect(options[1].clicks).toBe(0)
+  expect(e.defaultPrevented).toBe(true)
+})
+
+test("listnavPick with nothing highlighted is a no-op (does not prevent default)", () => {
+  const options = [makeOption("a"), makeOption("b")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  const e = event()
+  controller.listnavPick(e)
+
+  expect(options[0].clicks).toBe(0)
+  expect(options[1].clicks).toBe(0)
+  expect(e.defaultPrevented).toBe(false) // Enter falls through (no selection to make)
+})
+
+test("listnavClose clears the highlight", () => {
+  const options = [makeOption("a"), makeOption("b")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  controller.listnavNext(event())
+  expect(highlightedIndex(options)).toBe(0)
+
+  controller.listnavClose(event())
+  expect(highlightedIndex(options)).toBe(-1)
+})
+
+test("arrow keys prevent default so the caret doesn't jump in the input", () => {
+  const options = [makeOption("a")]
+  const controller = buildController(makeRoot({ selector: "[role=option]", options }))
+
+  const down = event()
+  controller.listnavNext(down)
+  expect(down.defaultPrevented).toBe(true)
+
+  const up = event()
+  controller.listnavPrev(up)
+  expect(up.defaultPrevented).toBe(true)
+})
+
+test("listnav handlers are a no-op when there are no options (empty dropdown)", () => {
+  const controller = buildController(makeRoot({ selector: "[role=option]", options: [] }))
+  // Must not throw on any handler.
+  controller.listnavNext(event())
+  controller.listnavPrev(event())
+  controller.listnavPick(event())
+  controller.listnavClose(event())
+  expect(true).toBe(true)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -376,6 +376,37 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on listnav (combobox keyboard navigation, issue #72)" do
+    subject(:instance) { state_klass.new }
+
+    it "appends the arrow/enter/escape listnav actions to the trigger's data-action" do
+      attrs = instance.send(:on, :search, event: "input", debounce: 300, listnav: "[role=option]")
+      expect(attrs[:data][:action]).to eq(
+        "input->reactive#dispatch " \
+        "keydown.down->reactive#listnavNext " \
+        "keydown.up->reactive#listnavPrev " \
+        "keydown.enter->reactive#listnavPick " \
+        "keydown.esc->reactive#listnavClose"
+      )
+    end
+
+    it "emits the option selector as a Stimulus param" do
+      attrs = instance.send(:on, :search, event: "input", listnav: "[role=option]")
+      expect(attrs[:data][:reactive_listnav_option_param]).to eq("[role=option]")
+    end
+
+    it "keeps listnav out of the explicit params payload" do
+      attrs = instance.send(:on, :search, event: "input", listnav: "[role=option]", query: "x")
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "query" => "x" })
+    end
+
+    it "omits the listnav wiring entirely when not requested" do
+      attrs = instance.send(:on, :search, event: "input")
+      expect(attrs[:data][:action]).to eq("input->reactive#dispatch")
+      expect(attrs[:data]).not_to have_key(:reactive_listnav_option_param)
+    end
+  end
+
   describe "#on confirm gate (issue #52)" do
     subject(:instance) { state_klass.new }
 

--- a/spec/requests/combobox_component_spec.rb
+++ b/spec/requests/combobox_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The combobox exercises client-side list navigation (issue #72): the search
+# input carries the listnav keyboard wiring, and `select` is a normal signed
+# reactive action (the keyboard just clicks an option's trigger).
+RSpec.describe "ComboboxComponent", type: :request do
+  describe "render at /combobox" do
+    before { get "/combobox" }
+
+    it "wires the search input to dispatch + the listnav keyboard filters" do
+      expect(response).to have_http_status(:ok)
+      body = CGI.unescapeHTML(response.body)
+      expect(body).to include("input->reactive#dispatch")
+      expect(body).to include("keydown.down->reactive#listnavNext")
+      expect(body).to include("keydown.up->reactive#listnavPrev")
+      expect(body).to include("keydown.enter->reactive#listnavPick")
+      expect(body).to include("keydown.esc->reactive#listnavClose")
+    end
+
+    it "emits the option selector so the controller can find the options" do
+      expect(response.body).to include('data-reactive-listnav-option-param="[role=option]"')
+    end
+  end
+
+  describe "the select action (signed, server-side — the keyboard just clicks it)" do
+    it "records a valid selection and morphs" do
+      post_action(ComboboxComponent, payload: { "s" => { "query" => "ap", "selected" => nil } },
+        act: "select", params: { name: "Apple" })
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('method="morph"')
+      expect(CGI.unescapeHTML(response.body)).to include("Selected: Apple")
+    end
+
+    it "ignores a forged option not in the list (no trusting client input)" do
+      post_action(ComboboxComponent, payload: { "s" => { "query" => "x", "selected" => nil } },
+        act: "select", params: { name: "DROP TABLE" })
+      expect(response.body).not_to include("Selected: DROP TABLE")
+    end
+
+    it "forbids an undeclared action (default-deny)" do
+      post_action(ComboboxComponent, payload: { "s" => { "query" => "", "selected" => nil } }, act: "obliterate")
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/system/combobox_listnav_spec.rb
+++ b/spec/system/combobox_listnav_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# The end-to-end proof of client-side list navigation (issue #72):
+#
+#   * Arrow Up/Down move a highlight among the options IN-BROWSER — NO round trip.
+#   * Enter picks the highlighted option by clicking its own on(:select) trigger,
+#     so the SELECTION is a normal signed reactive action (server morphs it in).
+#   * Escape clears the highlight (also client-side).
+#
+# One generic controller, no per-combobox JavaScript — the keyboard wiring rides
+# on the search input via on(:search, …, listnav: "[role=option]").
+RSpec.describe "Combobox keyboard navigation (client-side listnav)", type: :system do
+  it "highlights options with the arrow keys, no server round trip" do
+    # Seed the query so options render on load; the nav itself is what we test.
+    visit "/combobox?q=a"
+    query = find("[data-testid='combobox-query']")
+    expect(page).to have_css("[data-testid='combobox-results'] [role=option]", minimum: 2)
+
+    # Count reactive action POSTs from here on: arrow navigation must fire ZERO.
+    page.execute_script(<<~JS)
+      window.__actionPosts = 0
+      const orig = window.fetch
+      window.fetch = (url, opts) => {
+        if (String(url).includes("/reactive/actions")) window.__actionPosts++
+        return orig(url, opts)
+      }
+      window.__noReload = "alive"
+    JS
+
+    # Arrow Down highlights the first option (data-reactive-highlighted).
+    query.send_keys(:down)
+    expect(page).to have_css("[role=option][data-reactive-highlighted]", count: 1)
+    first_highlighted = find("[role=option][data-reactive-highlighted]").text
+
+    # Arrow Down again moves the highlight to the next option.
+    query.send_keys(:down)
+    expect(page).to have_css("[role=option][data-reactive-highlighted]", count: 1)
+    expect(find("[role=option][data-reactive-highlighted]").text).not_to eq(first_highlighted)
+
+    # Still exactly one highlighted, and NOT a single POST fired for the nav.
+    expect(page.evaluate_script("window.__actionPosts")).to eq(0)
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+
+    # Escape clears the highlight — still client-side.
+    query.send_keys(:escape)
+    expect(page).to have_no_css("[role=option][data-reactive-highlighted]")
+    expect(page.evaluate_script("window.__actionPosts")).to eq(0)
+  end
+
+  it "picks the highlighted option on Enter (a signed reactive select)" do
+    visit "/combobox?q=berr" # Blueberry, Cranberry
+    query = find("[data-testid='combobox-query']")
+    expect(page).to have_css("[data-testid='combobox-results'] [role=option]", minimum: 2)
+
+    query.send_keys(:down)  # highlight the first match
+    highlighted = find("[role=option][data-reactive-highlighted]").text
+
+    query.send_keys(:enter) # pick it → fires on(:select) → server morphs
+
+    # The selection landed (a real reactive round trip performed the select).
+    expect(page).to have_css("[data-testid='combobox-selection']", text: "Selected: #{highlighted}")
+    expect(page).to have_field("query", with: highlighted)
+  end
+
+  it "Enter with nothing highlighted does not select" do
+    visit "/combobox?q=apple"
+    query = find("[data-testid='combobox-query']")
+    expect(page).to have_css("[role=option]", minimum: 1)
+
+    # No arrow press → no highlight → Enter is a no-op for selection.
+    query.send_keys(:enter)
+    expect(page).to have_no_css("[data-testid='combobox-selection']")
+  end
+end


### PR DESCRIPTION
## Summary

Adds client-side list navigation to a search/combobox trigger — Arrow keys move a highlight, Enter picks, Escape clears — **with no bespoke Stimulus controller**. Closes #72.

```ruby
# The search input: debounced live search + keyboard list navigation.
input(**mix(on(:search, event: "input", debounce: 200, listnav: "[role=option]"),
            name: "query", value: @query))

# Each option is both a listnav target AND its own reactive select trigger.
button(**mix(on(:select, name: opt), role: "option")) { opt }
```

`listnav:` appends Stimulus's **native keyboard filters** (`keydown.down/up/enter/esc->reactive#listnav*`) to the input's `data-action` and marks the option selector. This is the multi-filtered-event idiom Stimulus already supports — folded into `on(...)` so there's one call site.

## How it works

- **Arrow Up/Down** move a `data-reactive-highlighted` marker among the options **in-browser, no round trip** — the ephemeral highlight is client UI state (a highlight per keystroke as a server POST would be absurd). The `listnav*` handlers mirror `#recompute` from #73.
- **Enter** clicks the highlighted option, so the **selection runs through its own `on(:select)` reactive action** — signed, default-deny, authorized like any other. Only the highlight is client-side.
- **Escape** clears the highlight.

No new client module — the handlers live in the existing controller (vendored copy re-synced, drift guard green). Builds on the merged #73 client-seam pattern.

## Test plan (TDD, RED→GREEN across four layers)

| Layer | Coverage |
|-------|----------|
| JS unit (`spec/javascript/reactive_listnav.test.js`) | highlight move/wrap, single highlight, pick clicks the highlighted, no-op when none highlighted, Escape clears, arrow `preventDefault`, empty-options no-op |
| Ruby unit (`component_spec`) | `on(…, listnav:)` action wiring + option-param + payload isolation |
| Request (`combobox_component_spec`) | listnav `data-action` wiring + the signed `select` action (valid, forged-rejected, default-deny) |
| System (`combobox_listnav_spec`, Playwright) | arrow highlight with **ZERO action POSTs**, Enter picks a signed select, Enter-with-none no-op — green under **Puma AND Falcon** |

The dummy app gains a `ComboboxComponent` (+ `/combobox` route) as the fixture.

## Verification

- [x] `bun test spec/javascript` — 68 pass
- [x] `bundle exec rspec spec/phlex spec/requests` — 261 pass
- [x] `spec/system/combobox_listnav_spec.rb` — 3 pass under **Puma** and **Falcon**
- [x] `bundle exec rubocop` — 116 files clean
- [x] Vendored client re-synced (drift guard green); no new client module

## Note for reviewers

The option list uses an **explicit block param** (not `it`). A bare `it` in the nested Phlex option block resolves to the wrong receiver and serializes a whole component into the action params — an infinite render recursion that first surfaced as a fiber-stack `SystemStackError` under Falcon. Called out in the component with a comment so a future RuboCop `Style/ItBlockParameter` autocorrect doesn't silently reintroduce it.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added combobox-style keyboard navigation for searchable option lists (client-side highlight with Arrow Up/Down, Enter to select, Escape to clear).
  * Introduced `listnav:` trigger support to enable highlight navigation and option picking, plus a combobox demo page.
* **Bug Fixes**
  * Improved safety around selection by ensuring only server-validated options can be chosen and unauthorized actions are rejected.
* **Documentation**
  * Updated changelog and API reference with `listnav:` usage and examples.
* **Tests**
  * Added unit, request, and end-to-end system coverage for list navigation behavior and selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->