### PR TITLE
fix(client): dispatch real change-guarded input events on reactive_compute output writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ```
 
   The generic controller runs the named reducer on `input`, writes only the
-  declared outputs (leaving the edited field + caret alone), and fires `input` on
-  each field it sets so a chained summary repaints — matching the server's
-  `set_value` + `dispatch("input")` contract. A missing/unregistered reducer is a
+  declared outputs (leaving the edited field + caret alone), and — for each
+  output whose value actually changed — dispatches a bubbling `input` event on
+  the field so a chained summary repaints, matching the server's `set_value` +
+  `dispatch("input")` contract (see #76). A missing/unregistered reducer is a
   no-op (a page never breaks because a binding wasn't wired up). When the same
   component ALSO carries `on(...)` (a persisted record, or a draft you sync), that
   debounced POST still fires and the server reply reconciles — so `reactive_compute`
@@ -205,6 +206,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   drops 3.2 and 3.3. Stay on phlex-reactive 0.3.x if you need Ruby 3.2/3.3.
 
 ### Fixed
+
+- **`reactive_compute` output writes never fired real `input` events — chained
+  repaints were dead in production (#76).** The controller's `recompute()` wrote
+  each output with a bare `field.value = …` under a comment claiming the write
+  fires the field's `input` listeners. Only the bun-test fake's custom `value`
+  setter did that — real browsers never fire `input` on a programmatic `.value`
+  write — so anything listening on a computed field (a chained summary repaint,
+  a second compute) silently never ran outside the test suite. The controller now
+  dispatches a real bubbling `new Event("input")` after each output write, and
+  the write is **change-guarded**: a field is written (and the event dispatched)
+  ONLY when the reducer's value differs from the field's current value
+  (String-compared). The guard is load-bearing, not an optimization — the shipped
+  `payment_split` example declares overlapping inputs/outputs, so an
+  unconditional dispatch would re-enter `input->reactive#recompute` forever;
+  with the guard, chains settle deterministically (the re-entrant pass writes
+  nothing and stops). The bun-test fake now matches real DOM (no auto-fire on
+  `.value` assignment; listeners run only through the controller's explicit
+  `dispatchEvent`), with unit coverage for the unchanged-write no-op, the
+  single bubbling dispatch, loop termination on the payment_split shape, and a
+  chained listener firing via the dispatched event — plus a real-browser system
+  assertion that a derived field repaints after typing. The misleading comments
+  in `reactive_controller.js` and `compute.js` now describe the real contract.
 
 - **`reactive_controller.js` used a relative `./confirm.js` import that 404'd under
   importmap-rails + Propshaft — taking down every Stimulus controller on the page (#57).**

--- a/app/javascript/phlex/reactive/compute.js
+++ b/app/javascript/phlex/reactive/compute.js
@@ -22,10 +22,15 @@
 //
 // The reducer receives a plain object of { inputName: Number } and returns a
 // plain object of { outputName: value } — only the outputs it names are written,
-// so it can leave the edited field (and its caret) untouched. Returning the SAME
-// value it read is a no-op write; the controller still fires `input` on any field
-// it sets so a chained summary repaints, matching the server's set_value +
-// dispatch("input") contract.
+// so it can leave the edited field (and its caret) untouched. Output writes are
+// CHANGE-GUARDED: the controller writes a field and dispatches a bubbling
+// `input` event on it ONLY when the new value differs from the field's current
+// value (real browsers never fire `input` on a programmatic .value write, so
+// the controller dispatches explicitly — that's what drives a chained summary
+// repaint, matching the server's set_value + dispatch("input") contract).
+// Returning the SAME value a field already holds is skipped entirely — no
+// write, no event — which is why a reducer with overlapping inputs/outputs
+// (like payment_split above) settles instead of re-entering itself forever.
 
 const reducers = new Map()
 

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -248,9 +248,18 @@ export default class extends Controller {
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
-      // Setting .value fires the field's own `input` listeners (a chained summary
-      // repaint), matching the server's set_value + dispatch("input") contract.
-      if (field) field.value = result[name]
+      if (!field) continue
+      // Real browsers do NOT fire `input` on a programmatic .value write (issue
+      // #76), so after writing we dispatch a bubbling `input` ourselves — that's
+      // what drives a chained repaint (a summary listener, a second compute),
+      // matching the server's set_value + dispatch("input") contract. The write
+      // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
+      // event). The guard is what lets a reducer with overlapping inputs/outputs
+      // (the shipped payment_split shape) settle — an unconditional dispatch
+      // would re-enter input->reactive#recompute forever.
+      if (String(result[name]) === field.value) continue
+      field.value = result[name]
+      field.dispatchEvent(new Event("input", { bubbles: true }))
     }
   }
 

--- a/spec/dummy/public/vendor/compute.js
+++ b/spec/dummy/public/vendor/compute.js
@@ -22,10 +22,15 @@
 //
 // The reducer receives a plain object of { inputName: Number } and returns a
 // plain object of { outputName: value } — only the outputs it names are written,
-// so it can leave the edited field (and its caret) untouched. Returning the SAME
-// value it read is a no-op write; the controller still fires `input` on any field
-// it sets so a chained summary repaints, matching the server's set_value +
-// dispatch("input") contract.
+// so it can leave the edited field (and its caret) untouched. Output writes are
+// CHANGE-GUARDED: the controller writes a field and dispatches a bubbling
+// `input` event on it ONLY when the new value differs from the field's current
+// value (real browsers never fire `input` on a programmatic .value write, so
+// the controller dispatches explicitly — that's what drives a chained summary
+// repaint, matching the server's set_value + dispatch("input") contract).
+// Returning the SAME value a field already holds is skipped entirely — no
+// write, no event — which is why a reducer with overlapping inputs/outputs
+// (like payment_split above) settles instead of re-entering itself forever.
 
 const reducers = new Map()
 

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -248,9 +248,18 @@ export default class extends Controller {
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
-      // Setting .value fires the field's own `input` listeners (a chained summary
-      // repaint), matching the server's set_value + dispatch("input") contract.
-      if (field) field.value = result[name]
+      if (!field) continue
+      // Real browsers do NOT fire `input` on a programmatic .value write (issue
+      // #76), so after writing we dispatch a bubbling `input` ourselves — that's
+      // what drives a chained repaint (a summary listener, a second compute),
+      // matching the server's set_value + dispatch("input") contract. The write
+      // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
+      // event). The guard is what lets a reducer with overlapping inputs/outputs
+      // (the shipped payment_split shape) settle — an unconditional dispatch
+      // would re-enter input->reactive#recompute forever.
+      if (String(result[name]) === field.value) continue
+      field.value = result[name]
+      field.dispatchEvent(new Event("input", { bubbles: true }))
     }
   }
 

--- a/spec/javascript/reactive_compute.test.js
+++ b/spec/javascript/reactive_compute.test.js
@@ -26,9 +26,10 @@ beforeAll(async () => {
   computeModule = await import("../../app/javascript/phlex/reactive/compute.js")
 })
 
-// A fake named form control: value is read/written like a real input, and
-// setting .value fires any registered "input" listeners so a chained summary
-// repaints (matches the browser: set_value + dispatch("input")). `closest`
+// A fake named form control matching REAL DOM semantics: a programmatic .value
+// write coerces to String and fires NOTHING (browsers never fire `input` on a
+// programmatic assignment — issue #76). Listeners only run through an explicit
+// dispatchEvent, which is what the controller must call itself. `closest`
 // returns the owning root so #ownsField (issue #15) treats it as owned.
 function makeField(name, value) {
   const listeners = []
@@ -41,14 +42,16 @@ function makeField(name, value) {
       return this._value
     },
     set value(v) {
-      this._value = String(v)
-      listeners.slice().forEach((fn) => fn({ target: this }))
+      this._value = String(v) // real DOM: coerce only, NO events
     },
     closest() {
       return this._root
     },
     addEventListener: (type, fn) => type === "input" && listeners.push(fn),
-    dispatchEvent: () => {},
+    dispatchEvent(event) {
+      if (event.type === "input") listeners.slice().forEach((fn) => fn(event))
+      return true
+    },
   }
 }
 
@@ -168,14 +171,14 @@ test("#recompute is a no-op when no reducer is registered for the key", () => {
   expect(fields.cash.value).toBe("999")
 })
 
-test("writing an output fires its input listeners (so a chained summary repaints)", () => {
+test("a changed output write dispatches exactly one bubbling input event on the field", () => {
   const fields = {
     allowance: makeField("allowance", 100),
     cash: makeField("cash", 0),
     total: makeField("total", 500),
   }
-  let summaryRepaints = 0
-  fields.cash.addEventListener("input", () => summaryRepaints++)
+  const events = []
+  fields.cash.addEventListener("input", (e) => events.push(e))
 
   computeModule.setComputeReducer("split", ({ allowance, total }) => ({ cash: total - allowance }))
   const controller = buildController(
@@ -184,5 +187,90 @@ test("writing an output fires its input listeners (so a chained summary repaints
 
   controller.recompute({ target: fields.allowance })
   expect(fields.cash.value).toBe("400")
-  expect(summaryRepaints).toBe(1) // the output write drove the summary, no round trip
+  // Real browsers do NOT fire input on a programmatic .value write (issue #76) —
+  // the controller must dispatch a real bubbling Event("input") itself.
+  expect(events.length).toBe(1)
+  expect(events[0].type).toBe("input")
+  expect(events[0].bubbles).toBe(true)
+})
+
+test("an UNCHANGED output write dispatches NO input event (the change guard)", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 400),
+    total: makeField("total", 500),
+  }
+  let cashEvents = 0
+  fields.cash.addEventListener("input", () => cashEvents++)
+
+  // The reducer returns the value cash already holds → no write, no dispatch.
+  computeModule.setComputeReducer("split", ({ allowance, total }) => ({ cash: total - allowance }))
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: ["cash"], fields }),
+  )
+
+  controller.recompute({ target: fields.allowance })
+  expect(fields.cash.value).toBe("400")
+  expect(cashEvents).toBe(0)
+})
+
+test("overlapping inputs/outputs (payment_split shape) settle — no infinite recompute loop", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 0),
+    leasing: makeField("leasing", 0),
+    total: makeField("total", 500),
+  }
+  let reducerCalls = 0
+  // The SHIPPED payment_split reducer shape: reads fields it also writes.
+  computeModule.setComputeReducer("payment_split", ({ allowance, total }) => {
+    reducerCalls++
+    if (allowance >= total) return { allowance: total, cash: 0, leasing: 0 }
+    return { allowance, cash: total - allowance, leasing: 0 }
+  })
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "payment_split",
+      inputs: ["allowance", "cash", "leasing", "total"],
+      outputs: ["allowance", "cash", "leasing"],
+      fields,
+    }),
+  )
+  // Wire every output like the DOM would: a dispatched input re-enters recompute
+  // (input->reactive#recompute bubbles to the root). Without the change guard
+  // this recurses forever; with it, the second pass writes nothing and stops.
+  for (const name of ["allowance", "cash", "leasing"]) {
+    fields[name].addEventListener("input", (e) => controller.recompute(e))
+  }
+
+  controller.recompute({ target: fields.allowance })
+
+  expect(fields.cash.value).toBe("400")
+  expect(fields.allowance.value).toBe("100")
+  expect(fields.leasing.value).toBe("0")
+  // Initial run + exactly one re-entry per changed output (cash) — then settled.
+  expect(reducerCalls).toBe(2)
+})
+
+test("a chained listener on an output field fires via the dispatched event (summary repaint)", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 0),
+    total: makeField("total", 500),
+  }
+  // Simulates a summary repaint / a second compute hanging off the output field.
+  let summary = null
+  fields.cash.addEventListener("input", (e) => {
+    summary = `cash is ${fields.cash.value}`
+    expect(e.bubbles).toBe(true)
+  })
+
+  computeModule.setComputeReducer("split", ({ allowance, total }) => ({ cash: total - allowance }))
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: ["cash"], fields }),
+  )
+
+  controller.recompute({ target: fields.allowance })
+  expect(summary).toBe("cash is 400") // the chained repaint saw the new value
 })

--- a/spec/system/order_compute_spec.rb
+++ b/spec/system/order_compute_spec.rb
@@ -26,12 +26,24 @@ RSpec.describe "Order payment split (reactive_compute new vs persisted)", type: 
           return orig(url, opts)
         }
         window.__noReload = "alive"
+
+        // A chained/derived repaint hanging off the computed output (issue #76):
+        // real browsers do NOT fire `input` on a programmatic .value write, so
+        // this listener only runs if the controller dispatches the event itself.
+        const echo = document.createElement("output")
+        echo.id = "cash-echo"
+        document.body.appendChild(echo)
+        document.querySelector('[name="cash"]').addEventListener("input", (e) => {
+          echo.textContent = "cash is " + e.target.value
+        })
       JS
 
       # Type an allowance; the reducer runs on `input` and writes cash = 500 - 100.
       fill_in "allowance", with: "100"
 
       expect(page).to have_field("cash", with: "400") # instant, client-computed
+      # The chained listener repainted via the controller's dispatched input event.
+      expect(page).to have_css("#cash-echo", text: "cash is 400")
       expect(page.evaluate_script("window.__actionPosts")).to eq(0) # NO round trip
       expect(page.evaluate_script("window.__noReload")).to eq("alive") # no reload
 


### PR DESCRIPTION
## Summary
- `recompute()` now dispatches a real bubbling `input` event after writing each output field — real browsers do not fire `input` on programmatic `.value` writes, so chained repaints (summary listeners, second computes) were silently dead in production; the documented `set_value + dispatch("input")` contract existed only in the bun-test fake.
- Writes are **change-guarded** (skip when the value is unchanged): load-bearing, because the shipped `payment_split` reducer has overlapping inputs/outputs — an unconditional dispatch re-enters `input->reactive#recompute` forever; with the guard the re-entrant pass settles (pinned: reducer called exactly twice).
- Test fake updated to match real DOM (no auto-fired listeners on `.value` assignment); misleading comments in `reactive_controller.js`/`compute.js` corrected; vendored copies re-synced.

## Test plan
- bun: RED (3 failures) → GREEN, 71 pass. New tests: unchanged write → no dispatch; changed write → exactly one bubbling event; payment_split overlap terminates; chained listener fires with the new value.
- System spec reproduces the production symptom: RED in a real browser against the OLD vendored client (derived `#cash-echo` never repainted), GREEN after — under Puma **and** Falcon.
- Fast suite 267 examples green; full browser suite (Puma) 32 examples green; RuboCop clean.

## Reviewer notes
- Programmatic (non-`isTrusted`) events: an output field that also carries its own `input->reactive#dispatch` trigger will now start its debounced POST — this matches the intended server contract, previously broken.

Closes #76