### PR TITLE
fix(response): reply.flash carries its level to the wire (+ Phlex::Reactive.flash_component)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   assertion that a derived field repaints after typing. The misleading comments
   in `reactive_controller.js` and `compute.js` now describe the real contract.
 
+- **`reply.flash` discarded its level — `:error` and `:notice` emitted
+  byte-identical streams (#77).** `Response.flash_stream` declared the level as
+  `_level` and never used it, so an app could not style errors red without
+  abandoning the flash helper — while the public API and every README example
+  pass a level. String flash content is now wrapped in
+  `<div class="reactive-flash reactive-flash--{level}"
+  data-reactive-flash-level="{level}">…</div>`, so the level reaches the wire as
+  a style hook (class) and a script/test hook (data attribute); the level is
+  HTML-escaped before landing in either attribute. **This intentionally changes
+  the wire output for string flashes** (previously the bare string was appended
+  with no wrapper) — restyle against `.reactive-flash--{level}` if you targeted
+  the raw text node. The string itself keeps the exact pre-existing injection
+  contract, now applied inside the wrapper: a plain String is HTML-escaped, an
+  `html_safe` String passes verbatim. Phlex **component** content still renders
+  VERBATIM — byte-identical to before, no wrapper (the caller owns the markup;
+  a spec pins it). New config `Phlex::Reactive.flash_component = MyFlash`
+  (default nil) renders string flashes through your own component instead of
+  the default wrapper — instantiated `MyFlash.new(level:, content:)` and
+  rendered through the existing render path; component content bypasses it.
+
 - **`reactive_controller.js` used a relative `./confirm.js` import that 404'd under
   importmap-rails + Propshaft — taking down every Stimulus controller on the page (#57).**
   The #55 confirm resolver added `import { confirmResolver } from "./confirm.js"` to the

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 | `reply.morph` / `reply.replace(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (issue #28) |
 | `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
 | `.also_replace(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
-| `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped) or a Phlex component (off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
+| `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped, wrapped in a level-carrying `<div>` — see [Flash levels](#flash-levels)) or a Phlex component (rendered verbatim; off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `reply.remove` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `reply.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
 | `reply.streams(*streams)` | **partial update** — emit exactly these streams (no full-self replace) + a tiny token-only refresh, so live inputs survive; for per-field grid editing (issue #30) |
@@ -663,6 +663,35 @@ the rule: it deliberately skips the full-self replace (so your hand-built stream
 update only the targets you name) and refreshes the token via a tiny inert
 `reactive:token` stream instead — the token rolls forward without re-rendering
 (and clobbering) the component's live inputs.
+
+#### Flash levels
+
+The level reaches the wire (issue #77). **String** content is wrapped in a
+level-carrying `<div>`, so `:error` and `:notice` are styleable:
+
+```html
+<div class="reactive-flash reactive-flash--error" data-reactive-flash-level="error">
+  Save failed
+</div>
+```
+
+Style against `.reactive-flash--{level}` (the class) and hook scripts/tests on
+`data-reactive-flash-level` (the data attribute). The string keeps the same
+injection contract as before, applied inside the wrapper: a plain string is
+HTML-escaped (a model value can't inject markup); an `html_safe` string passes
+verbatim.
+
+Prefer your own markup? Two escape hatches:
+
+```ruby
+# 1. Pass a Phlex component as the content — rendered VERBATIM, no wrapper
+#    (you own the markup entirely, including the level styling):
+reply.replace.flash(:error, Alert.new(level: :error, message: msg))
+
+# 2. Or configure a flash component ONCE — string flashes render through it
+#    (instantiated new(level:, content:)); component content still bypasses it:
+Phlex::Reactive.flash_component = MyFlash   # default nil → the built-in wrapper
+```
 
 #### Record-authorized, transient-state actions (issue #64)
 

--- a/docs/app/views/docs/pages/example_inline_edit.rb
+++ b/docs/app/views/docs/pages/example_inline_edit.rb
@@ -206,7 +206,14 @@ module Views
                 code { 'Phlex::Reactive.flash_target' }
                 plain ' (default '
                 code { '<div id="flash">' }
-                plain '); pass a Phlex component instead of a string for rich markup.'
+                plain '). A string is escaped and wrapped in a level-carrying '
+                code { '<div class="reactive-flash reactive-flash--error" data-reactive-flash-level="error">' }
+                plain ' so errors and notices style differently; pass a Phlex component instead for '
+                plain 'fully custom markup (rendered verbatim, no wrapper), or set '
+                code { 'Phlex::Reactive.flash_component' }
+                plain ' once to render every string flash through your own component ('
+                code { 'new(level:, content:)' }
+                plain ').'
               end
             end
           end

--- a/docs/app/views/docs/pages/installation.rb
+++ b/docs/app/views/docs/pages/installation.rb
@@ -231,6 +231,7 @@ module Views
               # Phlex::Reactive.action_path = "/_r/actions"                   # custom endpoint
               # Phlex::Reactive.verifier    = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
               # Phlex::Reactive.flash_target = "flash"                         # DOM id reply…flash appends into
+              # Phlex::Reactive.flash_component = MyFlash                      # renders string flashes: new(level:, content:)
             RUBY
             DocsUI::Prose() do
               p do

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -110,6 +110,14 @@ module Phlex
 
       attr_writer :flash_target
 
+      # Component class used to render STRING flash content (issue #77).
+      # Instantiated as flash_component.new(level:, content:) and rendered
+      # through the existing render path, replacing the built-in
+      # <div class="reactive-flash reactive-flash--{level}"> wrapper. Default
+      # nil (the built-in wrapper). Phlex component content passed to
+      # reply.flash always renders verbatim and bypasses this.
+      attr_accessor :flash_component
+
       # Render a Phlex component to HTML with a full (off-request) view context.
       # Uses phlex-rails' #render_in against the memoized view context — a direct
       # component.call that skips ActionController's renderer.render machinery

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -167,11 +167,51 @@ module Phlex
 
         # Build a flash turbo-stream that appends `content` into a host-app
         # container. `content` is a Phlex component instance (rendered through
-        # the configured renderer so t()/url_for work) or a ready HTML string —
-        # supplied by the caller because the render context is off-request
-        # (there is no Rails `flash`).
-        def flash_stream(_level, content, target:)
-          Phlex::Reactive.flash_builder.append(target, html: render_html(content))
+        # the configured renderer so t()/url_for work) or a String — supplied
+        # by the caller because the render context is off-request (there is no
+        # Rails `flash`). The LEVEL reaches the wire (issue #77): string
+        # content gets a level-carrying wrapper (or the configured
+        # Phlex::Reactive.flash_component); component content renders VERBATIM
+        # — the caller owns the markup, no wrapper, no double-wrapping.
+        def flash_stream(level, content, target:)
+          Phlex::Reactive.flash_builder.append(target, html: flash_html(level, content))
+        end
+
+        # Resolve flash `content` to HTML, carrying the level (issue #77):
+        #   * a Phlex component instance — rendered verbatim, exactly as before
+        #     (byte-identical; it also bypasses flash_component).
+        #   * a String with Phlex::Reactive.flash_component configured — the
+        #     app's component is instantiated new(level:, content:) and
+        #     rendered through the existing render_html path.
+        #   * a String otherwise — the default level-carrying wrapper below.
+        def flash_html(level, content)
+          return render_html(content) if content.is_a?(::Phlex::SGML)
+
+          component_class = Phlex::Reactive.flash_component
+          return render_html(component_class.new(level:, content:)) if component_class
+
+          default_flash_html(level, content)
+        end
+
+        # The default string-flash wrapper:
+        #   <div class="reactive-flash reactive-flash--{level}"
+        #        data-reactive-flash-level="{level}">{content}</div>
+        # The level is unconditionally HTML-escaped (it lands in a class name
+        # and a data attribute). The content keeps the exact pre-#77 injection
+        # contract, now applied INSIDE the wrapper: ERB::Util.html_escape
+        # escapes a plain String but passes an html_safe String verbatim —
+        # the same behavior Turbo's TagBuilder gave the unwrapped string, so
+        # a model value still can't inject markup while intentional raw HTML
+        # (html_safe) still renders. The wrapper is html_safe by construction
+        # (both interpolations are escaped above), so the TagBuilder emits it
+        # as-is.
+        def default_flash_html(level, content)
+          level_attr = CGI.escapeHTML(level.to_s)
+          body = ERB::Util.html_escape(content.to_s)
+
+          # html_safe is safe by construction: both interpolated pieces are escaped above.
+          %(<div class="reactive-flash reactive-flash--#{level_attr}" \
+data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
         end
 
         # Build a turbo-stream that updates an arbitrary target id with `content`

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -158,6 +158,101 @@ RSpec.describe Phlex::Reactive::Response do
     end
   end
 
+  # Issue #77: the flash level must reach the wire. String content gets a
+  # level-carrying wrapper (class + data attribute); Phlex component content
+  # renders VERBATIM (byte-identical to before — the caller owns the markup);
+  # Phlex::Reactive.flash_component swaps the default wrapper for the app's own
+  # flash component (string content only).
+  describe "flash levels (issue #77)" do
+    it ":error and :notice produce different streams" do
+      error = described_class.with.flash(:error, "boom").streams.first
+      notice = described_class.with.flash(:notice, "saved").streams.first
+
+      expect(error.to_s.gsub("boom", "MSG")).not_to eq(notice.to_s.gsub("saved", "MSG"))
+      expect(error).to include('class="reactive-flash reactive-flash--error"')
+      expect(error).to include('data-reactive-flash-level="error"')
+      expect(notice).to include('class="reactive-flash reactive-flash--notice"')
+      expect(notice).to include('data-reactive-flash-level="notice"')
+    end
+
+    it "keeps HTML-escaping plain string content (injection contract unchanged)" do
+      stream = described_class.with.flash(:notice, "<em>x</em> & y").streams.first
+
+      expect(stream).to include("&lt;em&gt;x&lt;/em&gt; &amp; y")
+      expect(stream).not_to include("<em>x</em>")
+      expect(stream).to include('class="reactive-flash reactive-flash--notice"')
+    end
+
+    it "passes an html_safe string verbatim INSIDE the wrapper (intentional raw HTML)" do
+      stream = described_class.with.flash(:notice, "<em>x</em>".html_safe).streams.first
+
+      expect(stream).to include('data-reactive-flash-level="notice"')
+      expect(stream).to include("<em>x</em>")
+    end
+
+    it "HTML-escapes the level (it lands in a class name and a data attribute)" do
+      stream = described_class.with.flash(%(err"or><script>), "x").streams.first
+
+      expect(stream).not_to include('err"or><script>')
+      expect(stream).to include("err&quot;or&gt;&lt;script&gt;")
+    end
+
+    it "renders Phlex component content VERBATIM — byte-identical to the raw builder append, no wrapper" do
+      klass = Class.new(Phlex::HTML) do
+        def self.name = "FlashPassthroughProbe"
+        def view_template = span { "rendered flash" }
+      end
+
+      via_flash = described_class.with.flash(:error, klass.new).streams.first
+      raw = Phlex::Reactive.flash_builder.append("flash", html: Phlex::Reactive.render(klass.new))
+
+      expect(via_flash.to_s).to eq(raw.to_s)
+      expect(via_flash).not_to include("reactive-flash")
+    end
+
+    describe "Phlex::Reactive.flash_component" do
+      let(:flash_component) do
+        Class.new(Phlex::HTML) do
+          def self.name = "AppFlashProbe"
+
+          def initialize(level:, content:)
+            @level = level
+            @content = content
+          end
+
+          def view_template = div(class: "toast toast--#{@level}") { @content }
+        end
+      end
+
+      around do
+        Phlex::Reactive.flash_component = flash_component
+        it.run
+      ensure
+        Phlex::Reactive.flash_component = nil
+      end
+
+      it "renders string content through the configured component (level + content)" do
+        stream = described_class.with.flash(:error, "Save failed").streams.first
+
+        expect(stream).to include('class="toast toast--error"')
+        expect(stream).to include("Save failed")
+        expect(stream).not_to include("reactive-flash")
+      end
+
+      it "component content still bypasses flash_component (renders verbatim)" do
+        klass = Class.new(Phlex::HTML) do
+          def self.name = "CustomFlashCard"
+          def view_template = span { "custom card" }
+        end
+
+        stream = described_class.with.flash(:error, klass.new).streams.first
+
+        expect(stream).to include("<span>custom card</span>")
+        expect(stream).not_to include("toast")
+      end
+    end
+  end
+
   it "flash accepts a Phlex component, rendered through the configured renderer" do
     klass = Class.new(Phlex::HTML) do
       # ActionView's render logger needs a name


### PR DESCRIPTION
## Summary
- `flash_stream` no longer discards the level: string content is wrapped in `<div class="reactive-flash reactive-flash--{level}" data-reactive-flash-level="{level}">` so `:error` and `:notice` are finally styleable. Level is unconditionally escaped (`CGI.escapeHTML`); content keeps the exact pre-existing injection contract (plain strings escaped, `html_safe` passes verbatim) now applied inside the wrapper.
- Phlex component content renders **verbatim** as before — byte-identity pinned by spec, no double-wrapping.
- New config: `Phlex::Reactive.flash_component = Ui::Flash` — instantiated `new(level:, content:)` for string content, rendered through the existing path; component content bypasses it.

## Test plan
- TDD: RED → GREEN. 7 new unit specs: :error vs :notice differ, component passthrough byte-identical, flash_component path, escaping contract.
- Fast suite + RuboCop green; flash-exercising system spec green.

## Reviewer notes
- Intentional wire-output change for string flashes (was: bare escaped string) — CHANGELOG flags it; worth a minor-version framing.
- An `html_safe` full flash card now renders inside the wrapper; escape hatches (Phlex component / flash_component) documented.

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flash messages now preserve and emit their level in the rendered output for string content, with level-specific styling hooks and safer escaping.
  * Flash content provided as a component continues to render exactly as written, without extra wrapper markup.

* **New Features**
  * Added a configuration option to render string flash messages through a custom component.

* **Documentation**
  * Updated the README and guides to explain flash rendering behavior, styling hooks, and the new customization option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->