### PR TITLE
docs: broadcast renders once per call — correct the 'N subscribers = N renders' claim + stale doc paths

### DIFF
--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -7,7 +7,7 @@ argument-hint: "optional: a specific hot path or bench name (e.g. render)"
 
 Measure, don't guess. This command produces a **same-machine before/after** so
 any performance claim is backed by numbers, and keeps the perf docs/discipline
-in sync. See `docs/performance.md` for the hot paths and how the harness works.
+in sync. See the performance page (`docs/app/views/docs/pages/performance.rb`) for the hot paths and how the harness works.
 
 ## The non-negotiable rule
 
@@ -63,7 +63,7 @@ worktree variance entirely.
 - [ ] A bench exists for the changed hot path (`benchmark/micro/<name>.rb` or
       the request bench). Add one if missing — `rake bench:micro` globs them.
 - [ ] The before/after numbers are in the PR body.
-- [ ] `docs/performance.md` updated if the representative numbers moved.
+- [ ] The performance page (`docs/app/views/docs/pages/performance.rb`) updated if the representative numbers moved.
 - [ ] CHANGELOG notes the perf change (`perf:` scope).
 - [ ] If the client (`reactive_controller.js`) changed, the vendored copy
       (`spec/dummy/public/vendor/reactive_controller.js`) is re-synced and the

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -2,7 +2,8 @@
 
 phlex-reactive must be fast in the places that run on every interaction. These
 rules make performance a standing part of every change, not an afterthought.
-See `docs/performance.md` for the harness and the current numbers.
+See the performance page (`docs/app/views/docs/pages/performance.rb`) for the
+harness and the current numbers.
 
 ## The prime directive
 
@@ -39,7 +40,8 @@ A pure docs/test/refactor change with no hot-path edit does not need a bench.
    does NOT mean 2× faster requests (Rails stack + DB dominate); it means ~2× on
    broadcast fan-out and less GC pressure. Say which the number is.
 5. **Update the docs + CHANGELOG** — if representative numbers moved, update
-   `docs/performance.md`; note the change under a `perf:` CHANGELOG entry.
+   the performance page (`docs/app/views/docs/pages/performance.rb`); note the
+   change under a `perf:` CHANGELOG entry.
 6. **Re-sync the vendored client** — any `reactive_controller.js` edit re-copies
    to `spec/dummy/public/vendor/reactive_controller.js`; run `bun test
    spec/javascript`.
@@ -84,7 +86,7 @@ builder, the flash builder, token ivar symbols):
 - [ ] A bench exists for every hot path touched
 - [ ] Throughput + allocations reported; retained-per-render is 0
 - [ ] Method-level vs request-level framing is honest
-- [ ] `docs/performance.md` + CHANGELOG updated if numbers moved
+- [ ] Performance page (`docs/app/views/docs/pages/performance.rb`) + CHANGELOG updated if numbers moved
 - [ ] Vendored client re-synced + JS tests green (if the client changed)
 - [ ] `bundle exec rspec spec/phlex spec/requests` still green
 - [ ] No security/correctness invariant traded for speed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Documentation
 
+- **Corrected the broadcast render-cost mental model — "N subscribers = N
+  renders" was wrong (#78).** A `broadcast_*_to` call renders the component
+  ONCE and passes the finished `html:` to `Turbo::StreamsChannel`, so every
+  subscriber of that stream shares one payload (the per-subscriber cost is
+  transport-side). The render cost is per CALL — broadcasting one change to K
+  different stream keys is K builds + K renders + K token signings of
+  byte-identical HTML — and per-viewer rendering (`visible_to:`-style content)
+  is the irreducible render-per-viewer case. Fixed in the performance docs
+  page, the render micro-bench comment, and CLAUDE.md; also repointed stale
+  `docs/performance.md` references to the docs app's performance page
+  (`docs/app/views/docs/pages/performance.rb`). No behavior changed.
+
 - **The auto-collected-params contract, spelled out (#64, #65, #66, #67).** Four
   gaps surfaced from building one model-scoped form (numeric fields that rebalance
   live). No behavior changed — the README now documents what the code already

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ hand-picking Turbo Stream targets.
 5. **Capability-detect pgbus features at runtime** — probe the actual keyword (`broadcast.parameters` includes `:exclude`), never `defined?(Pgbus)` alone or a version string
 6. **Degrade gracefully** — every pgbus-only feature must no-op or fall back when pgbus is absent
 7. **Control the reply via the return value** — return a `Phlex::Reactive::Response` (`replace`/`update`/`remove`/`redirect`/`with`, chain `.flash(level, content)` / `.stream(...)`) to govern the actor's HTTP reply; returning anything else keeps the implicit single replace. See the README "Controlling the action's reply" section and `lib/phlex/reactive/response.rb`.
-8. **Measure performance, don't guess** — any hot-path change (render, token signing, param coercion, broadcast, client dispatch) ships with a same-machine before/after from `rake bench` (or `/perf`). No speedup claim without a measured baseline. Report throughput AND allocations; distinguish a method-level win from a request-level one. See `.claude/rules/performance.md` and `docs/performance.md`.
+8. **Measure performance, don't guess** — any hot-path change (render, token signing, param coercion, broadcast, client dispatch) ships with a same-machine before/after from `rake bench` (or `/perf`). No speedup claim without a measured baseline. Report throughput AND allocations; distinguish a method-level win from a request-level one. See `.claude/rules/performance.md` and the performance page (`docs/app/views/docs/pages/performance.rb`).
 
 ## Commands
 
@@ -135,16 +135,20 @@ token signing (`reactive_token`), and param coercion. Key facts:
   the allocations, byte-identical HTML. The off-request view context + Turbo
   `TagBuilder` are memoized per class and reset on Rails code reload
   (`config.to_prepare`).
-- **The render win matters most for broadcasts** (N subscribers = N renders, no
-  HTTP). At the full-request level the Rails stack + DB dominate — don't expect
-  a render optimization to move request throughput.
+- **The render win matters most for broadcasts** (no HTTP to amortize against).
+  A broadcast call renders ONCE and all subscribers of that stream share the
+  payload; the cost is per CALL — N-key fan-out = N renders (per-viewer
+  `visible_to:` content is the irreducible render-per-viewer case). At the
+  full-request level the Rails stack + DB dominate — don't expect a render
+  optimization to move request throughput.
 - **Measure before you change.** `rake bench` (micro) and `rake bench:request`
   (end-to-end); `/perf` captures a same-machine before/after against `main`. The
   CI `bench` job is run-and-report (artifact), never a hard fail.
 - **Cache correctness:** key any hot-path memo on what can change (renderer
   identity), reset on reload, never cache values that rotate (CSRF token, pgbus
   connection id are read live).
-- See `docs/performance.md` and `.claude/rules/performance.md`.
+- See the performance page (`docs/app/views/docs/pages/performance.rb`) and
+  `.claude/rules/performance.md`.
 
 ## More Documentation
 

--- a/benchmark/micro/render.rb
+++ b/benchmark/micro/render.rb
@@ -34,8 +34,10 @@ end
 
 # render_component is the lightweight phlex-rails render_in path (vs the old
 # ActionController renderer.render). This isolates the pure render cost — the
-# win that matters MOST for broadcasts, where a single change fans out to N
-# subscribers as N renders with NO HTTP round trip to amortize against.
+# win that matters MOST for broadcasts, which have NO HTTP round trip to
+# amortize against. Each broadcast_*_to CALL renders once and all subscribers
+# of that stream share the payload; the cost multiplies per call (K stream
+# keys = K renders) and per viewer for visible_to:-style per-viewer content.
 BenchSupport.header("render_component (the broadcast/fan-out unit)")
 BenchSupport.ips do
   it.report("render_component") { CounterComponent.render_component(CounterComponent.new(count: 1)) }

--- a/benchmark/request/derailed.rb
+++ b/benchmark/request/derailed.rb
@@ -10,7 +10,7 @@
 # Rack::MockRequest — the same call-the-app primitive derailed_benchmarks uses
 # internally — wrapped in benchmark-ips for throughput and memory_profiler for
 # per-request allocations. derailed_benchmarks is loaded so its memory/object
-# helpers are available for ad-hoc deep dives (see docs/performance.md).
+# helpers are available for ad-hoc deep dives (see the performance docs page, docs/app/views/docs/pages/performance.rb).
 #
 #   rake bench:request
 #   TEST_COUNT=500 rake bench:request

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -39,9 +39,20 @@ module Views
                 plain 'hardest, but a full HTTP action is dominated by the Rails middleware stack and (for '
                 plain 'record-backed components) the database — so the render wins matter most for '
                 strong { 'broadcasts' }
-                plain ' (one change fanned out to N subscribers = N renders with no HTTP overhead to '
-                plain 'amortize against). Measure before you optimize; the harness below exists so you '
-                plain 'never have to guess.'
+                plain ', which have no HTTP overhead to amortize against. To be precise about the fan-out: '
+                plain 'a '
+                code { 'broadcast_*_to' }
+                plain ' call renders the component '
+                strong { 'once' }
+                plain ' and hands the finished HTML to the transport, so every subscriber of that stream '
+                plain 'shares one payload (the per-subscriber cost is transport-side, not a render). The '
+                plain 'render cost multiplies per '
+                strong { 'call' }
+                plain ': pushing one change to K different stream keys is K builds + K renders + K token '
+                plain 'signings of byte-identical HTML — and per-viewer content ('
+                code { 'visible_to:' }
+                plain '-style rendering) is the irreducible render-per-viewer case. Measure before you '
+                plain 'optimize; the harness below exists so you never have to guess.'
               end
             end
           end
@@ -267,8 +278,9 @@ module Views
                   plain 'The render path got ~2× faster and halved its allocations — but at the full request '
                   plain 'level that delta is within noise, because routing + middleware + token verify + '
                   plain 'transaction dominate. Do not expect a render optimization to move request '
-                  plain 'throughput; expect it to move broadcast fan-out (N renders, no HTTP) and to cut GC '
-                  plain 'pressure under load.'
+                  plain 'throughput; expect it to move broadcast-heavy code — one render per broadcast '
+                  plain 'call, so K stream keys (or per-viewer rendering) = K renders with no HTTP — and '
+                  plain 'to cut GC pressure under load.'
                 end
                 li do
                   plain 'Record-backed actions are ~1.4× slower than state-backed — that is the GlobalID '

--- a/spec/requests/csrf_form_reactive_spec.rb
+++ b/spec/requests/csrf_form_reactive_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Reactive action re-rendering a CSRF form (issue #42)", type: :re
     expect(response.body).to include("data-reactive-token-value=")
   end
 
-  # The broadcast path is where the off-request render matters most (N
-  # subscribers = N renders, no HTTP request on the stack). A broadcast of a
+  # The broadcast path is where the off-request render matters most (renders
+  # once per broadcast call, no HTTP request on the stack). A broadcast of a
   # CSRF-form component must render through the request-bound context too.
   it "broadcasts the CSRF form component without crashing" do
     broadcasts = capture_turbo_stream_broadcasts(todo) do


### PR DESCRIPTION
## Summary
- Corrects every "N subscribers = N renders" claim to the verified model: `broadcast_*_to` renders ONCE per call; subscribers share the payload; the render cost is per call (K-key fan-out = K renders + K token HMACs), with per-viewer `visible_to:` content as the irreducible case. Fixed in the docs performance page, `benchmark/micro/render.rb`, `CLAUDE.md`, and a spec comment carrying the same claim.
- Repoints stale `docs/performance.md` references (docs moved into the docs app) in `CLAUDE.md`, `.claude/rules/performance.md`, `.claude/commands/perf.md`, and `benchmark/request/derailed.rb`.

Docs/comments only — no behavior change. RuboCop + fast suite green.

## Reviewer note
The 0.2.x-era release-history entry in CHANGELOG still carries the old claim; left untouched as release history.

Closes #78