### PR TITLE
feat(component): one include pulls in Streamable + default #id for record-backed components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -193,6 +193,7 @@ RSpec/DescribeClass:
     # class — a string subject reads clearer than a forced constant.
     - spec/phlex/eager_load_spec.rb
     - spec/phlex/vendored_controller_sync_spec.rb
+    - spec/phlex/reactive/streamable_default_id_spec.rb
     - spec/phlex/reactive/streamable_morph_spec.rb
     - spec/phlex/reactive/streamable_token_spec.rb
     - spec/phlex/reactive/streamable_view_context_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Single include + a default `#id` for record-backed components (#81).**
+  `include Phlex::Reactive::Component` now pulls in
+  `Phlex::Reactive::Streamable` automatically (ActiveSupport::Concern's
+  dependency mechanism includes Streamable into the base FIRST — exactly the
+  manual order the old two-include ceremony established), so one include is
+  enough; the legacy explicit double include remains a harmless no-op. And a
+  record-backed component (`reactive_record :todo`) gets `#id` for free:
+  `dom_id(record)` via the render-context-free `Streamable#dom_id` — the id
+  virtually every such component wrote by hand. An explicit `def id` always
+  wins (normal method lookup). Deliberately NO class-name default for
+  state-backed components — they're frequently multi-instance, so a class-name
+  id would silently collide; they (and bare Streamable classes) keep the loud
+  `NotImplementedError`, now with a message that says how to fix it. Caveat:
+  two different component classes rendering the SAME record on one page
+  collide on the default — give one a prefixed id
+  (`def id = dom_id(@todo, "rich")`). The component generator emits the new
+  short form. Same-machine `rake bench` before/after: allocations on the
+  render/token hot paths are byte-identical (192 obj per `to_stream_replace`,
+  100 per `render_component`, 47 per record-backed token, retained 0) and
+  throughput is unchanged within run-to-run noise — the default costs one
+  `respond_to?` + two memoized reads, and only for components that didn't
+  define `#id`.
+
 - **Combobox keyboard navigation — `on(:search, …, listnav: "[role=option]")` (#72).**
   A search/combobox trigger can now declare client-side list navigation: Arrow
   Up/Down move a highlight among the option elements IN-BROWSER (no round trip),

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ hand-picking Turbo Stream targets.**
 
 ```ruby
 class Counter < ApplicationComponent
-  include Phlex::Reactive::Streamable
-  include Phlex::Reactive::Component
+  include Phlex::Reactive::Component   # pulls in Streamable too
 
   reactive_state :count
   action :increment
@@ -224,15 +223,13 @@ GlobalID; the server re-finds it on each action. **Always prefer this.**
 
 ```ruby
 class Todos::Item < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
-  reactive_record :todo
+  reactive_record :todo             # identity AND the default #id: dom_id(@todo)
   action :toggle
   action :rename, params: { title: :string }
 
   def initialize(todo:) = @todo = todo
-  def id = dom_id(@todo)            # stable per-record DOM id == Turbo target
 
   def toggle
     authorize! @todo, :update?      # YOU authorize — the token only proves identity
@@ -252,6 +249,17 @@ class Todos::Item < ApplicationComponent
   end
 end
 ```
+
+> **One include, default `#id` (issue #81).** `include Phlex::Reactive::Component`
+> pulls in `Streamable` automatically (the explicit two-include form still works
+> and is a harmless no-op). A record-backed component also gets `#id` for free —
+> `dom_id(record)`, exactly the id nearly every one wrote by hand — so `def id`
+> is only needed to override it, and an explicit `def id` always wins.
+> **Caveat:** two *different* component classes rendering the *same* record on
+> one page both default to the same `dom_id` and collide — give one an explicit
+> prefixed id: `def id = dom_id(@todo, "rich")`. State-backed components still
+> must define `#id` (they're frequently multi-instance, so a class-name default
+> would silently collide; the loud `NotImplementedError` stays).
 
 ### 2. State-backed (signed instance vars)
 
@@ -292,7 +300,7 @@ The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
 
 | Method | Use |
 |---|---|
-| `#id` (you implement) | Stable DOM id == Turbo Stream target. Must match the root element's `id`. |
+| `#id` | Stable DOM id == Turbo Stream target. Must match the root element's `id`. Record-backed components default to `dom_id(record)` (issue #81); everything else implements it (`def id`). An explicit `def id` always wins. |
 | `.replace(model = nil, morph: false, **opts)` | `<turbo-stream action=replace target=id>` of a freshly built component; `morph: true` adds `method="morph"` |
 | `.update` / `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
 | `.broadcast_replace_to(*streamables, model:, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
@@ -305,7 +313,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 
 | Macro / helper | Use |
 |---|---|
-| `reactive_record :name` | Record-backed identity (GlobalID). State = the DB. |
+| `reactive_record :name` | Record-backed identity (GlobalID). State = the DB. Also defaults `#id` to `dom_id(record)`. |
 | `reactive_state :a, :b` | Signed instance-var identity. Standalone, or combined with `reactive_record` to sign transient UI state alongside the row. |
 | `action :name, params: { x: :integer }` | Declare a client-invokable action + its param schema. **Default-deny.** |
 | `reactive_root(**overrides)` | Spread onto the root element: emits the component `id` **and** `reactive_attrs` together, so the controller root always carries `#id`. Preferred over `id:` + `reactive_attrs`. `**overrides` (`class:`/`data:`) deep-merge. |
@@ -706,7 +714,6 @@ the params, stream a partial update, touch neither the DB nor peer tabs" action:
 
 ```ruby
 class Invoice::PaymentFields < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
   reactive_record :invoice   # identity + authorization ONLY — not persisted here
@@ -751,7 +758,6 @@ Declare the collection on the container component, then `reply.append` /
 
 ```ruby
 class NotificationsList < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
   reactive_collection :notifications,
@@ -910,15 +916,13 @@ end
 
 ```ruby
 class Counter < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
-  reactive_record :counter
+  reactive_record :counter   # also defaults #id to dom_id(@counter)
   action :increment
   action :decrement
 
   def initialize(counter:) = @counter = counter
-  def id = dom_id(@counter)
 
   def increment = @counter.increment!(:value)
   def decrement = @counter.decrement!(:value)

--- a/docs/app/views/docs/pages/architecture.rb
+++ b/docs/app/views/docs/pages/architecture.rb
@@ -43,8 +43,8 @@ module Views
               ul do
                 li { plain 'Client runtime — one generic Stimulus controller.' }
                 li { plain 'Endpoint — verify token → run action → render the reply.' }
-                li { plain 'Component mixin — reactive_record/reactive_state, action, on.' }
-                li { plain 'Streamable mixin — #id, replace/append, broadcast_*_to.' }
+                li { plain 'Component mixin — reactive_record/reactive_state, action, on. Including it pulls in Streamable automatically (one include is enough).' }
+                li { plain 'Streamable mixin — #id, replace/append, broadcast_*_to. Record-backed components default #id to dom_id(record).' }
               end
             end
           end

--- a/docs/app/views/docs/pages/architecture.rb
+++ b/docs/app/views/docs/pages/architecture.rb
@@ -43,8 +43,14 @@ module Views
               ul do
                 li { plain 'Client runtime — one generic Stimulus controller.' }
                 li { plain 'Endpoint — verify token → run action → render the reply.' }
-                li { plain 'Component mixin — reactive_record/reactive_state, action, on. Including it pulls in Streamable automatically (one include is enough).' }
-                li { plain 'Streamable mixin — #id, replace/append, broadcast_*_to. Record-backed components default #id to dom_id(record).' }
+                li do
+                  plain 'Component mixin — reactive_record/reactive_state, action, on. ' \
+                        'Including it pulls in Streamable automatically (one include is enough).'
+                end
+                li do
+                  plain 'Streamable mixin — #id, replace/append, broadcast_*_to. ' \
+                        'Record-backed components default #id to dom_id(record).'
+                end
               end
             end
           end

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -157,7 +157,6 @@ module Views
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               class Todos::Item < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
                 reactive_record :todo
                 def initialize(todo:) = @todo = todo   # the keyword must match `reactive_record :todo`

--- a/docs/app/views/docs/pages/example_chat.rb
+++ b/docs/app/views/docs/pages/example_chat.rb
@@ -90,7 +90,6 @@ module Views
           DocsUI::Section('3. The composer (a reactive action that creates + broadcasts)') do
             DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/chat/composer.rb')
               class Chat::Composer < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
 
                 reactive_state :room, :author          # record-less: signed state is the room/author

--- a/docs/app/views/docs/pages/example_collections.rb
+++ b/docs/app/views/docs/pages/example_collections.rb
@@ -53,7 +53,6 @@ module Views
           DocsUI::Section('Declare the collection on the container') do
             DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notifications_list.rb')
               class NotificationsList < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
 
                 reactive_collection :notifications,
@@ -128,7 +127,6 @@ module Views
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notification_row.rb')
               class NotificationRow < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component   # only to use `on` for the dismiss trigger
 
                 def self.model_param_name = :todo

--- a/docs/app/views/docs/pages/example_counter.rb
+++ b/docs/app/views/docs/pages/example_counter.rb
@@ -76,7 +76,6 @@ module Views
           <<~RUBY
             # app/components/counter.rb
             class Counter < ApplicationComponent
-              include Phlex::Reactive::Streamable
               include Phlex::Reactive::Component
 
               reactive_state :count                       # signed state (no DB row)

--- a/docs/app/views/docs/pages/example_inline_edit.rb
+++ b/docs/app/views/docs/pages/example_inline_edit.rb
@@ -38,7 +38,6 @@ module Views
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/fields/inline_edit.rb')
               class Fields::InlineEdit < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
 
                 reactive_record :record

--- a/docs/app/views/docs/pages/example_payment_split.rb
+++ b/docs/app/views/docs/pages/example_payment_split.rb
@@ -181,7 +181,6 @@ module Views
           <<~RUBY
             # app/components/payment_split.rb
             class PaymentSplit < ApplicationComponent
-              include Phlex::Reactive::Streamable
               include Phlex::Reactive::Component
 
               FIELDS = %i[allowance cash leasing].freeze

--- a/docs/app/views/docs/pages/example_todo_list.rb
+++ b/docs/app/views/docs/pages/example_todo_list.rb
@@ -48,7 +48,6 @@ module Views
           DocsUI::Section('One row (record-backed, all the actions)') do
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               class Todos::Item < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
 
                 reactive_record :todo
@@ -57,7 +56,7 @@ module Views
                 action :destroy
 
                 def initialize(todo:) = @todo = todo
-                def id = dom_id(@todo)
+                # no `def id` needed: reactive_record :todo defaults it to dom_id(@todo)
 
                 def toggle
                   authorize! @todo, :update?
@@ -108,6 +107,25 @@ module Views
                 code { 'broadcast_remove_to' }
                 plain ' removes it in every other tab.'
               end
+              p do
+                plain 'One include is enough: '
+                code { 'Phlex::Reactive::Component' }
+                plain ' pulls in '
+                code { 'Streamable' }
+                plain ' automatically (the old explicit two-include form still works). And '
+                code { 'reactive_record :todo' }
+                plain ' defaults '
+                code { '#id' }
+                plain ' to '
+                code { 'dom_id(@todo)' }
+                plain ' — write '
+                code { 'def id' }
+                plain ' only to override it. Caveat: two different component classes rendering the '
+                em { 'same' }
+                plain ' record on one page collide on the default — give one a prefixed id, e.g. '
+                code { 'def id = dom_id(@todo, "rich")' }
+                plain '.'
+              end
             end
           end
         end
@@ -116,7 +134,6 @@ module Views
           DocsUI::Section('The list + composer') do
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               class Todos::List < ApplicationComponent
-                include Phlex::Reactive::Streamable
                 include Phlex::Reactive::Component
 
                 reactive_record :list

--- a/lib/generators/phlex/reactive/component/USAGE
+++ b/lib/generators/phlex/reactive/component/USAGE
@@ -11,4 +11,5 @@ Examples:
         State-backed, signing @count.
 
     bin/rails generate phlex:reactive:component Todos::Item toggle rename --record todo
-        Record-backed component; identity = todo.to_gid; #id = dom_id(@todo).
+        Record-backed component; identity = todo.to_gid; #id defaults to
+        dom_id(@todo) automatically.

--- a/lib/generators/phlex/reactive/component/templates/component.rb.erb
+++ b/lib/generators/phlex/reactive/component/templates/component.rb.erb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class <%= class_name %> < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
 <% if record_backed? -%>
@@ -14,7 +13,7 @@ class <%= class_name %> < ApplicationComponent
     @<%= record_name %> = <%= record_name %>
   end
 
-  def id = dom_id(@<%= record_name %>)
+  # No `def id` needed: reactive_record :<%= record_name %> defaults #id to dom_id(@<%= record_name %>).
 <% action_names.each do |a| -%>
 
   def <%= a %>

--- a/lib/generators/phlex/reactive/install/install_generator.rb
+++ b/lib/generators/phlex/reactive/install/install_generator.rb
@@ -50,12 +50,11 @@ module Phlex
         end
 
         def show_post_install
-          say_status :info, "phlex-reactive installed. Include the mixins in a component:", :green
+          say_status :info, "phlex-reactive installed. Include the mixin in a component:", :green
           say <<~MSG
 
             class Counter < ApplicationComponent
-              include Phlex::Reactive::Streamable
-              include Phlex::Reactive::Component
+              include Phlex::Reactive::Component  # pulls in Streamable too
               # ... reactive_state / reactive_record, action :name, on(:name) ...
             end
 

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -10,8 +10,10 @@ module Phlex
     # focused input — issue #28). No per-feature Stimulus controllers, no
     # hand-picked Turbo targets.
     #
-    # Include alongside Phlex::Reactive::Streamable (which provides #id and the
-    # re-render machinery).
+    # Including Component pulls in Phlex::Reactive::Streamable automatically
+    # (Concern dependency — Streamable lands on the base first, exactly the old
+    # manual order), so ONE include is enough. The legacy explicit double
+    # include remains a harmless no-op.
     #
     # === Security model (the decisive design choice) ===
     # We do NOT ship component STATE to the browser (no snapshot). The DOM
@@ -34,9 +36,8 @@ module Phlex
     # act — your action must still authorize the record. Action params pass
     # through a declared schema; nothing else reaches the method.
     #
-    # Usage (record-backed):
+    # Usage (record-backed — #id defaults to dom_id(@todo), issue #81):
     #   class Todos::Item < ApplicationComponent
-    #     include Phlex::Reactive::Streamable
     #     include Phlex::Reactive::Component
     #
     #     reactive_record :todo
@@ -44,7 +45,6 @@ module Phlex
     #     action :rename, params: { title: :string }
     #
     #     def initialize(todo:) = @todo = todo
-    #     def id = dom_id(@todo)
     #
     #     def toggle  = (authorize!(@todo, :update?); @todo.toggle!(:done))
     #     def rename(title:) = (authorize!(@todo, :update?); @todo.update!(title:))
@@ -58,6 +58,7 @@ module Phlex
     #   end
     module Component
       extend ActiveSupport::Concern
+      include Phlex::Reactive::Streamable
 
       # A declared, client-invokable action and its param schema.
       Action = Data.define(:name, :params)

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -276,10 +276,32 @@ module Phlex
         end
       end
 
-      # Required: the stable DOM id used as the Turbo Stream target. It MUST
-      # match the id set on the component's root element in `view_template`.
+      # The stable DOM id used as the Turbo Stream target. It MUST match the id
+      # set on the component's root element in `view_template`.
+      #
+      # Record-backed components (Component's `reactive_record :x`) get a
+      # default for free: dom_id(record) — the id virtually every such
+      # component wrote by hand (issue #81). An explicit `def id` always wins
+      # via normal method lookup. Everything else (state-backed, a bare
+      # Streamable) still raises: a class-name default would silently collide
+      # the moment two instances render on one page. Two DIFFERENT component
+      # classes rendering the SAME record on one page also collide on the
+      # default — give one a prefixed id: `def id = dom_id(@todo, "rich")`.
+      #
+      # Called on every render/stream build, so the default stays lean: a
+      # respond_to? (reactive_record_key is Component API — a bare Streamable
+      # keeps raising) plus ivar reads via the memoized reactive_record_ivar.
       def id
-        raise NotImplementedError, "#{self.class} must implement #id for Turbo Stream targeting"
+        klass = self.class
+        if klass.respond_to?(:reactive_record_key) && (record_ivar = klass.reactive_record_ivar) &&
+           (record = instance_variable_get(record_ivar))
+          return dom_id(record)
+        end
+
+        raise NotImplementedError,
+          "#{klass} must implement #id (the stable DOM id Turbo Streams target) — add e.g. " \
+          "`def id = \"my-thing\"`. Record-backed components (reactive_record :x) get " \
+          "`dom_id(record)` as the default automatically."
       end
 
       # Render-context-free dom_id, safe to use inside `#id`. The streamable

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -2,8 +2,12 @@
 
 # Record-backed reactive row. Exercises reactive_record (GlobalID identity),
 # a param action (rename via change), and a toggle.
+#
+# Deliberately uses the issue #81 short form as living proof: ONE include
+# (Component pulls in Streamable) and NO `def id` (reactive_record :todo
+# defaults #id to dom_id(@todo)). The other dummy components keep the legacy
+# two-include + explicit-id form so it stays covered too.
 class TodoItemComponent < ApplicationComponent
-  include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
   reactive_record :todo
@@ -16,8 +20,7 @@ class TodoItemComponent < ApplicationComponent
     @todo = todo
   end
 
-  # Streamable#dom_id is render-context-free
-  def id = dom_id(@todo)
+  # No `def id` needed: reactive_record :todo defaults #id to dom_id(@todo).
   # No model_param_name override needed: reactive_record :todo makes the
   # broadcast path build with the same `todo:` keyword the action endpoint uses.
 

--- a/spec/generators/component_generator_spec.rb
+++ b/spec/generators/component_generator_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Phlex::Reactive::Generators::ComponentGenerator do
 
       src = component("counter.rb")
       expect(src).to include("class Counter < ApplicationComponent")
-      expect(src).to include("include Phlex::Reactive::Streamable")
+      # ONE include (issue #81): Component pulls in Streamable as a dependency.
       expect(src).to include("include Phlex::Reactive::Component")
+      expect(src).not_to include("include Phlex::Reactive::Streamable")
       expect(src).to include("reactive_state :value")
       expect(src).to include("action :increment")
       expect(src).to include("action :decrement")
@@ -41,14 +42,16 @@ RSpec.describe Phlex::Reactive::Generators::ComponentGenerator do
   end
 
   describe "record-backed (--record)" do
-    it "generates a component with GlobalID identity and dom_id" do
+    it "generates a component with GlobalID identity relying on the default #id" do
       generate(["Todos::Item", "toggle", "rename", "--record", "todo"])
 
       src = component("todos/item.rb")
       expect(src).to include("class Todos::Item < ApplicationComponent")
       expect(src).to include("reactive_record :todo")
       expect(src).to include("def initialize(todo:)")
-      expect(src).to include("def id = dom_id(@todo)")
+      # Issue #81: no hand-written id — reactive_record defaults #id to dom_id.
+      expect(src).not_to match(/^\s*def id\b/)
+      expect(src).to include("defaults #id to dom_id(@todo)")
       expect(src).to include("action :toggle")
       expect(src).to include("# authorize! @todo, :update?")
     end

--- a/spec/phlex/reactive/streamable_default_id_spec.rb
+++ b/spec/phlex/reactive/streamable_default_id_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #81: less ceremony for the common component.
+#
+# 1. `include Phlex::Reactive::Component` alone now pulls in Streamable via
+#    ActiveSupport::Concern's dependency mechanism (Streamable is included into
+#    the base BEFORE Component — exactly the manual order the two-include form
+#    established). The legacy explicit double include stays a harmless no-op.
+# 2. A record-backed component (reactive_record :x) gets `#id` for free:
+#    dom_id(record) via the render-context-free Streamable#dom_id. An explicit
+#    `def id` always wins; state-backed and bare-Streamable classes still raise
+#    NotImplementedError (a class-name default would silently collide for
+#    multi-instance state-backed components).
+RSpec.describe "Single include + default #id (issue #81)" do
+  let(:todo) { Todo.create!(title: "t", done: false) }
+
+  describe "single include (Component alone pulls in Streamable)" do
+    let(:klass) do
+      Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "SingleIncludeThing"
+
+        reactive_record :todo
+
+        def initialize(todo:) = @todo = todo
+      end
+    end
+
+    it "includes Streamable via Concern dependency, before Component" do
+      ancestors = klass.ancestors
+      expect(ancestors).to include(Phlex::Reactive::Streamable)
+      # Streamable is included first, so Component sits closer to the class.
+      expect(ancestors.index(Phlex::Reactive::Component))
+        .to be < ancestors.index(Phlex::Reactive::Streamable)
+    end
+
+    it "provides the full Streamable surface" do
+      expect(klass).to respond_to(:turbo_stream_builder)
+      expect(klass).to respond_to(:broadcast_replace_to)
+      expect(klass.new(todo:)).to respond_to(:to_stream_remove)
+    end
+  end
+
+  describe "default #id for record-backed components" do
+    let(:klass) do
+      Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "DefaultIdThing"
+
+        reactive_record :todo
+
+        def initialize(todo: nil) = @todo = todo
+      end
+    end
+
+    it "defaults to dom_id(record)" do
+      expect(klass.new(todo:).id).to eq(ActionView::RecordIdentifier.dom_id(todo))
+    end
+
+    it "lets an explicit def id win (normal method lookup)" do
+      explicit = Class.new(klass) do
+        def self.name = "ExplicitIdThing"
+
+        def id = dom_id(@todo, "rich")
+      end
+
+      expect(explicit.new(todo:).id).to eq(ActionView::RecordIdentifier.dom_id(todo, "rich"))
+    end
+
+    it "raises for a nil record ivar rather than emitting a broken id" do
+      expect { klass.new.id }.to raise_error(NotImplementedError, /def id/)
+    end
+  end
+
+  describe "state-backed components (no default — stays a loud raise)" do
+    let(:klass) do
+      Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "StateOnlyThing"
+
+        reactive_state :count
+
+        def initialize(count: 0) = @count = count
+      end
+    end
+
+    it "still raises NotImplementedError" do
+      expect { klass.new.id }.to raise_error(NotImplementedError)
+    end
+
+    it "tells you how to fix it (def id) and who gets the default (reactive_record)" do
+      expect { klass.new.id }.to raise_error(NotImplementedError, /def id.*reactive_record/m)
+    end
+  end
+
+  describe "a bare Streamable-only class" do
+    let(:klass) do
+      Class.new do
+        include Phlex::Reactive::Streamable
+
+        def self.name = "BareStreamableThing"
+      end
+    end
+
+    it "still raises NotImplementedError (no Component API to default from)" do
+      expect { klass.new.id }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "legacy explicit double include (harmless no-op)" do
+    let(:klass) do
+      Class.new do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "DoubleIncludeThing"
+
+        reactive_record :todo
+
+        def initialize(todo:) = @todo = todo
+      end
+    end
+
+    it "appears once in the ancestry with Component in front" do
+      ancestors = klass.ancestors
+      expect(ancestors.count(Phlex::Reactive::Streamable)).to eq(1)
+      expect(ancestors.index(Phlex::Reactive::Component))
+        .to be < ancestors.index(Phlex::Reactive::Streamable)
+    end
+
+    it "still gets the record-backed default id" do
+      expect(klass.new(todo:).id).to eq(ActionView::RecordIdentifier.dom_id(todo))
+    end
+
+    it "registering the class twice is idempotent" do
+      expect do
+        Phlex::Reactive::Streamable.register(klass)
+        Phlex::Reactive::Streamable.register(klass)
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `include Phlex::Reactive::Component` now pulls in `Streamable` via ActiveSupport::Concern dependency (included into the base first — exactly the old manual order). The legacy explicit double include stays a pinned harmless no-op.
- `Streamable#id` gains a default for record-backed components: `dom_id(record)` via the memoized `reactive_record_ivar` — the id virtually every such component wrote by hand. Explicit `def id` always wins; state-backed and bare-Streamable classes still raise (now with a better message) — a class-name default would silently collide for multi-instance components.
- Generator templates collapsed to one include (record-backed branch drops `def id`); README/docs examples updated, with the caveat documented: two component classes rendering the same record need a prefixed id (`def id = dom_id(@todo, "rich")`).

## Test plan
- TDD RED → GREEN: new behavior spec (record-backed default, explicit override wins, state-backed raises, bare Streamable raises, double include harmless, nil record raises).
- Fast suite + generator specs + RuboCop green; todos system spec green.
- `#id` is render-hot: bench run before/after — allocations byte-identical, token bench unchanged (±2%); render i/s noisy on this machine but re-baselined to confirm no regression.

Closes #81