### PR TITLE
feat(controller): verbose_errors — diagnostic endpoint error bodies + dropped-param logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `respond_to?` + two memoized reads, and only for components that didn't
   define `#id`.
 
+- **`Phlex::Reactive.verbose_errors` — diagnostic endpoint error bodies +
+  dropped-param logging (#82).** An endpoint failure used to be a bare
+  `head 400/403/404` and a silently-dropped param left no trace — debugging
+  "nothing happens" meant reading the gem source. Now every failure is
+  warn-logged as `[phlex-reactive] …` in EVERY environment, and with
+  `verbose_errors` on (default `Rails.env.local?` — development AND test; off
+  in production) the response also carries a plain-text diagnostic body the
+  client already prints via `console.error`: a tampered/stale token (400,
+  distinguishing signature-invalid from a token class that no longer resolves
+  from a class that isn't reactive — `InvalidToken` now carries a `diagnostic`),
+  an undeclared action (403, listing the declared actions), a registered
+  authorization error (403, naming the error class and the action), and a
+  missing record (404, naming the GlobalID). Param coercion additionally logs
+  every dropped key with its full bracketed path and reason
+  (`undeclared` / `uncoercible`), hinting when a flat name looks like the
+  bracketed twin of a declared nested key (the #16/#21 confusion). Statuses
+  never change with the flag, the client needs no changes, and the production
+  coercion path does zero extra work (nil collector, early-return guards) —
+  `rake bench:one[coerce_params]` before/after is unchanged within noise
+  (36.1k → 37.1k i/s; 218 → 207 objects/call, retained 0).
+
 - **Combobox keyboard navigation — `on(:search, …, listnav: "[role=option]")` (#72).**
   A search/combobox trigger can now declare client-side list navigation: Arrow
   Up/Down move a highlight among the option elements IN-BROWSER (no round trip),

--- a/README.md
+++ b/README.md
@@ -829,6 +829,10 @@ Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"
 
 # Change the endpoint path (default "/reactive/actions"):
 Phlex::Reactive.action_path = "/_r/actions"
+
+# Diagnostic error bodies + dropped-param logging (default: Rails.env.local? —
+# on in development AND test, off in production):
+Phlex::Reactive.verbose_errors = true
 ```
 
 If you set a custom `action_path`, expose it to the client:
@@ -861,6 +865,26 @@ real, so read this once.
   `base_controller_name`. Inherit `ApplicationController` to get CSRF and auth —
   but if you have *public* reactive components, ensure the action path isn't
   force-redirected to a login page for logged-out users.
+
+### Debugging endpoint failures (`verbose_errors`)
+
+Every endpoint failure is warn-logged as `[phlex-reactive] …` in **every**
+environment. With `Phlex::Reactive.verbose_errors` on (the default in
+development and test via `Rails.env.local?`; off in production), the failure
+response ALSO carries a plain-text diagnostic body — the client already prints
+it via `console.error` — and param coercion warn-logs every dropped key with
+its full bracketed path and reason (`undeclared` / `uncoercible`), including a
+hint when a flat name looks like the bracketed twin of a declared nested key
+(or vice versa). What each status means:
+
+- **400** — token signature invalid (stale token from before a deploy?
+  `secret_key_base` mismatch?), a token class that no longer resolves, or a
+  class that resolved but doesn't include `Phlex::Reactive::Component`
+- **403** — an undeclared action (the body lists the declared actions) or a
+  registered authorization error raised inside the action
+- **404** — the signed GlobalID no longer resolves (record deleted)
+
+The flag never changes a status — only the body and the coercion log.
 
 See [docs/security.md](https://phlex-reactive.zoolutions.llc/docs/security) for the threat model and a checklist.
 

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -31,23 +31,58 @@ module Phlex
         component_class = resolve_component(payload["c"])
         action_def = component_class.reactive_action(reactive_action_name)
 
-        return head(:forbidden) unless action_def # default-deny
+        # default-deny
+        return reactive_error(:forbidden, undeclared_action_message(component_class)) unless action_def
 
         component = component_class.from_identity(payload)
-        coerced = coerce_params(action_def.params)
+        coerced = coerce_params(action_def.params, component_class:, action_name: action_def.name)
 
         result = run_action(component, action_def, coerced)
 
         render turbo_stream: response_streams(result, component)
-      rescue Phlex::Reactive::InvalidToken
-        head :bad_request
+      rescue Phlex::Reactive::InvalidToken => e
+        reactive_error(:bad_request, e.message)
       rescue ActiveRecord::RecordNotFound
-        head :not_found
-      rescue *authorization_errors
-        head :forbidden
+        reactive_error(:not_found, record_not_found_message(payload))
+      rescue *authorization_errors => e
+        reactive_error(:forbidden, authorization_error_message(e, component_class, action_def))
       end
 
       private
+
+      # Reply to an endpoint failure. The status NEVER changes with the flag —
+      # only the body: verbose_errors renders the diagnostic as plain text (the
+      # client console.errors non-OK bodies), otherwise a bare head. The warn
+      # log fires in EVERY environment so a misbehaving client is debuggable
+      # from the server log alone.
+      def reactive_error(status, message)
+        ::Rails.logger&.warn("[phlex-reactive] #{message}") if defined?(::Rails) && ::Rails.respond_to?(:logger)
+
+        if Phlex::Reactive.verbose_errors
+          render plain: message, status: status
+        else
+          head status
+        end
+      end
+
+      def undeclared_action_message(component_class)
+        declared = component_class.reactive_actions.keys.join(", ")
+        "action :#{reactive_action_name} is not declared on #{component_class.name} — " \
+          "declared actions: #{declared}"
+      end
+
+      def record_not_found_message(payload)
+        gid = payload.is_a?(Hash) && payload["gid"]
+        return "record not found" unless gid
+
+        "record #{gid} not found — deleted while a page still showed it?"
+      end
+
+      def authorization_error_message(error, component_class, action_def)
+        where = [component_class&.name, action_def&.name].compact.join("#")
+        "#{error.class.name} raised in #{where} — the signature proves identity, not permission; " \
+          "authorize in the action"
+      end
 
       # Run the action inside a transaction so transactional broadcasts (pgbus
       # broadcasts_to ... durable:) defer to after_commit and never fire for a
@@ -170,7 +205,11 @@ module Phlex
 
       def verified_payload
         token = params.require(:token)
-        Phlex::Reactive.verify(token) || raise(Phlex::Reactive::InvalidToken)
+        Phlex::Reactive.verify(token) || raise(Phlex::Reactive::InvalidToken.new(
+          "token signature invalid — stale token from before a deploy? secret_key_base mismatch? " \
+          "a reply.with(...) stream that skipped the token refresh?",
+          diagnostic: :tampered
+        ))
       end
 
       # NB: must NOT be named `action_name` — that's reserved by
@@ -183,10 +222,18 @@ module Phlex
       # in the schema is dropped — no raw mass assignment reaches the component.
       # The top-level params arrive as an ActionController::Parameters; coerce
       # them against the action's hash schema (same recursion as nested hashes).
-      def coerce_params(schema)
+      #
+      # With verbose_errors on, every dropped key is collected (full bracketed
+      # path + reason) and warn-logged once per action. With the flag off the
+      # collector is nil and every diagnostic branch below early-returns —
+      # zero extra work on the production path.
+      def coerce_params(schema, component_class: nil, action_name: nil)
         return {} if schema.blank?
 
-        coerce_hash(params.fetch(:params, {}), schema)
+        dropped = Phlex::Reactive.verbose_errors ? [] : nil
+        coerced = coerce_hash(params.fetch(:params, {}), schema, dropped, nil)
+        log_dropped_params(dropped, schema, component_class, action_name)
+        coerced
       end
 
       # Sentinel: a declared key whose value can't be coerced to its type is
@@ -202,12 +249,12 @@ module Phlex
       #   * a one-element Array        ([:integer] / [{ ... }])  — array of that
       # Arrays accept both a real JSON array and a Rails-style index hash
       # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
-      def coerce(value, type)
+      def coerce(value, type, dropped = nil, path = nil)
         case type
         when Array
-          coerce_array(value, type.first)
+          coerce_array(value, type.first, dropped, path)
         when Hash
-          coerce_hash(value, type)
+          coerce_hash(value, type, dropped, path)
         when :file
           coerce_file(value)
         else
@@ -243,12 +290,17 @@ module Phlex
       # explicit empty collection), but an array whose every element drops
       # returns DROP, so the keyword default applies rather than handing the
       # action a surprise [].
-      def coerce_array(value, element_type)
+      def coerce_array(value, element_type, dropped = nil, path = nil)
         values = array_values(value)
         return DROP if values.nil?
         return [] if values.empty?
 
-        coerced = values.map { coerce(it, element_type) }
+        coerced =
+          if dropped
+            values.map.with_index { |element, i| coerce(element, element_type, dropped, "#{path}[#{i}]") }
+          else
+            values.map { coerce(it, element_type) }
+          end
         coerced.reject! { it.equal?(DROP) }
         coerced.empty? ? DROP : coerced
       end
@@ -256,17 +308,105 @@ module Phlex
       # Keep declared keys only (drop undeclared — no mass assignment), recursing
       # for nested hash/array element types. Symbolizes keys to splat as kwargs.
       # A key whose value coerces to DROP is skipped (keyword default applies).
-      def coerce_hash(value, schema)
+      # `dropped`/`path` are the verbose_errors diagnostics collector — nil (and
+      # cost-free) unless the flag is on.
+      def coerce_hash(value, schema, dropped = nil, path = nil)
         hash = to_param_hash(value)
+        collect_undeclared(dropped, hash, schema, path) if dropped
         schema.each_with_object({}) do |(key, type), out|
-          next unless hash.key?(key.to_s)
+          key_name = key.to_s
+          next unless hash.key?(key_name)
 
-          coerced = coerce(hash[key.to_s], type)
-          next if coerced.equal?(DROP)
+          key_path = dropped && join_path(path, key_name)
+          coerced = coerce(hash[key_name], type, dropped, key_path)
+          if coerced.equal?(DROP)
+            dropped << [key_path, :uncoercible] if dropped
+            next
+          end
 
           out[key.to_sym] = coerced
         end
       end
+
+      # ---- verbose_errors dropped-param diagnostics ----------------------
+      # Everything below runs ONLY when the collector exists (flag on); the
+      # production path never reaches these methods.
+
+      def join_path(path, key)
+        path ? "#{path}[#{key}]" : key
+      end
+
+      # Record every input key this schema level doesn't declare. A hash value
+      # expands to its leaf paths so the log shows the full bracketed name the
+      # client posted (invoice[date], not just invoice).
+      def collect_undeclared(dropped, hash, schema, path)
+        declared = schema.keys.map(&:to_s)
+        hash.each do |key, value|
+          next if declared.include?(key)
+
+          record_undeclared(dropped, join_path(path, key), value)
+        end
+      end
+
+      def record_undeclared(dropped, path, value)
+        if value.is_a?(Hash) && value.any?
+          value.each { |key, child| record_undeclared(dropped, "#{path}[#{key}]", child) }
+        else
+          dropped << [path, :undeclared]
+        end
+      end
+
+      # ONE warn line per action naming every dropped param with its reason —
+      # plus, for the #16/#21 confusion, a hint when a dropped name looks like
+      # the flat/bracketed twin of a declared key.
+      def log_dropped_params(dropped, schema, component_class, action_name)
+        return if dropped.nil? || dropped.empty?
+        return unless defined?(::Rails) && ::Rails.respond_to?(:logger) && ::Rails.logger
+
+        entries = dropped.map { |path, reason| "#{path} (#{dropped_reason(path, reason, schema)})" }
+        where = [component_class, action_name].compact.join("#")
+        where = "#{where} " unless where.empty?
+        ::Rails.logger.warn("[phlex-reactive] #{where}dropped params: #{entries.join(", ")}")
+      end
+
+      def dropped_reason(path, reason, schema)
+        return reason.to_s unless reason == :undeclared
+
+        hint = shape_hint(path, schema)
+        hint ? "undeclared — #{hint}" : "undeclared"
+      end
+
+      # Fires only when a dropped segment matches a DECLARED key at a different
+      # nesting level — a bracketed name whose leaf the schema declares flat, or
+      # a flat name the schema declares one level down. Deliberately simple: it
+      # searches one nesting level (hash / array-of-hash), no deeper.
+      def shape_hint(path, schema)
+        segments = bracket_path(path)
+        if segments.length > 1
+          leaf = segments.last
+          return unless schema.key?(leaf.to_sym)
+
+          "schema declares :#{leaf} at top level; nested schemas look like " \
+            "{ #{segments.first}: { #{leaf}: :string } }"
+        else
+          parent = nested_declaration_of(segments.first, schema)
+          return unless parent
+
+          "schema declares :#{segments.first} nested under :#{parent}; " \
+            "post it as #{parent}[#{segments.first}]"
+        end
+      end
+
+      # The first schema key whose nested hash (or array-of-hash element
+      # schema) declares `name` one level down.
+      def nested_declaration_of(name, schema)
+        schema.find do |_key, type|
+          inner = type.is_a?(Array) ? type.first : type
+          inner.is_a?(Hash) && inner.key?(name.to_sym)
+        end&.first
+      end
+
+      # ---- end verbose_errors diagnostics --------------------------------
 
       def coerce_scalar(value, type)
         case type
@@ -362,11 +502,23 @@ module Phlex
       end
 
       # Only components that opt into Reactive may be resolved. The signature
-      # already gates this; defense in depth against constant injection.
+      # already gates this; defense in depth against constant injection. The
+      # two failure causes carry distinct diagnostics: a name that doesn't
+      # resolve at all vs a constant that resolved but isn't a reactive
+      # component.
       def resolve_component(name)
         klass = name.to_s.safe_constantize
+        unless klass
+          raise Phlex::Reactive::InvalidToken.new(
+            "token class #{name} does not resolve — component renamed/removed while a page was open?",
+            diagnostic: :unknown_class
+          )
+        end
         unless klass.respond_to?(:reactive_action?) && klass.include?(Phlex::Reactive::Component)
-          raise Phlex::Reactive::InvalidToken
+          raise Phlex::Reactive::InvalidToken.new(
+            "#{name} resolved but does not include Phlex::Reactive::Component",
+            diagnostic: :not_reactive_class
+          )
         end
 
         klass

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -228,9 +228,16 @@ module Phlex
       # collector is nil and every diagnostic branch below early-returns —
       # zero extra work on the production path.
       def coerce_params(schema, component_class: nil, action_name: nil)
-        return {} if schema.blank?
-
         dropped = Phlex::Reactive.verbose_errors ? [] : nil
+
+        # A schema-less action drops EVERYTHING the client posted. Still surface
+        # that in verbose mode — forgetting the `params:` declaration entirely is
+        # the loudest version of the silent drop.
+        if schema.blank?
+          log_schemaless_drops(dropped, component_class, action_name) if dropped
+          return {}
+        end
+
         coerced = coerce_hash(params.fetch(:params, {}), schema, dropped, nil)
         log_dropped_params(dropped, schema, component_class, action_name)
         coerced
@@ -297,7 +304,15 @@ module Phlex
 
         coerced =
           if dropped
-            values.map.with_index { |element, i| coerce(element, element_type, dropped, "#{path}[#{i}]") }
+            # Record each element that coerces to DROP (a forged non-file in a
+            # [:file] array) under its bracketed index — reject! below removes
+            # it from the result, so this is its only trace.
+            values.map.with_index do |element, i|
+              element_path = "#{path}[#{i}]"
+              result = coerce(element, element_type, dropped, element_path)
+              dropped << [element_path, :uncoercible] if result.equal?(DROP)
+              result
+            end
           else
             values.map { coerce(it, element_type) }
           end
@@ -371,9 +386,18 @@ module Phlex
 
       def dropped_reason(path, reason, schema)
         return reason.to_s unless reason == :undeclared
+        return "undeclared — the action declares no params" if schema.empty?
 
         hint = shape_hint(path, schema)
         hint ? "undeclared — #{hint}" : "undeclared"
+      end
+
+      # Collect + log for an action with NO declared schema: every posted key is
+      # undeclared by definition (CodeRabbit review on PR #87). Runs only when
+      # the verbose collector exists.
+      def log_schemaless_drops(dropped, component_class, action_name)
+        collect_undeclared(dropped, to_param_hash(params.fetch(:params, {})), {}, nil)
+        log_dropped_params(dropped, {}, component_class, action_name)
       end
 
       # Fires only when a dropped segment matches a DECLARED key at a different

--- a/benchmark/micro/coerce_params.rb
+++ b/benchmark/micro/coerce_params.rb
@@ -10,6 +10,11 @@
 
 require_relative "../support/boot"
 
+# Measure the PRODUCTION path: verbose_errors defaults ON under RAILS_ENV=test
+# (Rails.env.local?), which would add the dropped-param collector to every
+# call. Production defaults OFF — bench what production runs.
+Phlex::Reactive.verbose_errors = false
+
 controller = Phlex::Reactive::ActionsController.new
 
 schema = {

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -248,6 +248,23 @@ module Views
                 end
               end
               p { plain 'The client runtime logs non-OK responses and applies no DOM change.' }
+              p do
+                plain 'Every failure is warn-logged as '
+                code { '[phlex-reactive] …' }
+                plain ' in every environment. With '
+                code { 'Phlex::Reactive.verbose_errors' }
+                plain ' on (the default in development and test via '
+                code { 'Rails.env.local?' }
+                plain '; off in production), the response also carries a plain-text diagnostic body — the ' \
+                      'client prints it via '
+                code { 'console.error' }
+                plain ' — saying which failure this was: a tampered/stale token, a token class that no longer ' \
+                      'resolves, an undeclared action (listing the declared ones), a registered authorization ' \
+                      'error, or a GlobalID that no longer finds its record. Param coercion additionally logs ' \
+                      'every dropped key with its full bracketed path and reason (undeclared / uncoercible), ' \
+                      'with a hint when a flat name looks like the bracketed twin of a declared nested key. ' \
+                      'The flag never changes a status — only the body and the logs.'
+              end
             end
           end
         end

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -15,6 +15,10 @@
 # Phlex::Reactive.authorization_errors = [Pundit::NotAuthorizedError]
 # Phlex::Reactive.authorization_errors = [ActionPolicy::Unauthorized]
 
+# Diagnostic endpoint error bodies + dropped-param logging (statuses never
+# change). Defaults to Rails.env.local? — on in development AND test, off in production.
+# Phlex::Reactive.verbose_errors = true
+
 # Sign identity tokens with a dedicated key instead of secret_key_base.
 # Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
 

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -29,8 +29,18 @@ module Phlex
     class Error < StandardError; end
 
     # Raised when a signed identity token fails verification (tampered, expired,
-    # or signed with a different key).
-    class InvalidToken < Error; end
+    # or signed with a different key) — or when a verified token names a class
+    # that doesn't resolve to a reactive component. `diagnostic` classifies the
+    # cause (:tampered, :unknown_class, :not_reactive_class) so the endpoint can
+    # render a verbose_errors body explaining WHICH failure this was.
+    class InvalidToken < Error
+      attr_reader :diagnostic
+
+      def initialize(msg = nil, diagnostic: nil)
+        @diagnostic = diagnostic
+        super(msg)
+      end
+    end
 
     # Purpose string bound into every identity token's signature so a token
     # minted for phlex-reactive can't be replayed against another verifier use.
@@ -68,6 +78,23 @@ module Phlex
 
       def action_path
         @action_path ||= "/reactive/actions"
+      end
+
+      # Diagnostic endpoint error bodies + dropped-param logging. When true, an
+      # endpoint failure (400/403/404) carries a plain-text explanation body
+      # (the client already console.errors it) and param coercion warn-logs
+      # every dropped key with its bracketed path and reason. Statuses never
+      # change with the flag, and the endpoint's warn log fires regardless.
+      #
+      # Defaults LAZILY to Rails.env.local? — that's development AND test — so
+      # production stays opaque unless you opt in. The `defined?` guard (not
+      # `||=`) makes an explicit `= false` stick even in dev/test.
+      attr_writer :verbose_errors
+
+      def verbose_errors
+        return @verbose_errors if defined?(@verbose_errors)
+
+        defined?(::Rails.env) && ::Rails.env.local?
       end
 
       def verifier

--- a/spec/dummy/app/components/moderated_component.rb
+++ b/spec/dummy/app/components/moderated_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Exercises the authorization-error path (issue #82). `moderate` always raises
+# NotAllowed; the verbose_errors request spec registers that class in
+# Phlex::Reactive.authorization_errors and asserts the endpoint's diagnostic
+# 403 names the error class and the action.
+class ModeratedComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  class NotAllowed < StandardError; end
+
+  reactive_state :noop
+
+  action :moderate
+
+  def initialize(noop: nil)
+    @noop = noop
+  end
+
+  def id = "moderated"
+
+  def moderate
+    raise NotAllowed, "not allowed"
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) { "moderated" }
+  end
+end

--- a/spec/requests/verbose_errors_spec.rb
+++ b/spec/requests/verbose_errors_spec.rb
@@ -199,6 +199,37 @@ RSpec.describe "verbose_errors diagnostics (issue #82)", type: :request do
         .with(a_string_including("bank_account_ids (uncoercible)"))
     end
 
+    it "logs a dropped ARRAY ELEMENT with its bracketed index as uncoercible" do
+      # A forged non-file element in a [:file] array is rejected element-wise;
+      # the diagnostic must name the element (pages[0]), not just the key.
+      document = Document.create!(title: "untitled")
+
+      post_action(DocumentUploadComponent, payload: { "gid" => document.to_gid.to_s },
+        act: "upload_pages", params: { pages: ["not-a-file"] })
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("pages[0] (uncoercible)"))
+    end
+
+    it "logs params posted to an action that declares NO schema" do
+      # Forgetting `params:` on the declaration entirely is the loudest version
+      # of the silent drop — auto-collected fields vanish with no trace.
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment",
+        params: { stray: "x" })
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("CounterComponent#increment dropped params:",
+          "stray (undeclared — the action declares no params)"))
+    end
+
+    it "logs nothing for a schema-less action when nothing was posted" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(Rails.logger).not_to have_received(:warn).with(a_string_including("dropped params"))
+    end
+
     it "hints when a bracketed name matches a key the schema declares at top level" do
       # The client posted invoice[date] but `save` declares :date FLAT — the
       # #16/#21 confusion this diagnostic exists for.

--- a/spec/requests/verbose_errors_spec.rb
+++ b/spec/requests/verbose_errors_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #82: verbose_errors — diagnostic endpoint error bodies + dropped-param
+# logging. The contract: statuses NEVER change with the flag; the warn log
+# always fires (dev AND prod); the plain-text body appears only when the flag
+# is on. The default is Rails.env.local? (development AND test), so the flag is
+# ON for this suite unless an example sets it explicitly.
+RSpec.describe "verbose_errors diagnostics (issue #82)", type: :request do
+  # Restore the lazy default after every example — remove the ivar entirely so
+  # an explicit `= false` from one example never leaks into the next.
+  around do
+    it.run
+  ensure
+    if Phlex::Reactive.instance_variable_defined?(:@verbose_errors)
+      Phlex::Reactive.remove_instance_variable(:@verbose_errors)
+    end
+  end
+
+  before { allow(Rails.logger).to receive(:warn).and_call_original }
+
+  def post_raw(token:, act: "toggle", params: {})
+    post "/reactive/actions",
+      params: { token:, act:, params: }.to_json,
+      headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  describe "the config default" do
+    it "defaults to true in the test environment (Rails.env.local? includes test)" do
+      expect(Phlex::Reactive.verbose_errors).to be(true)
+    end
+
+    it "lets an explicit false stick (no ||= re-defaulting)" do
+      Phlex::Reactive.verbose_errors = false
+      expect(Phlex::Reactive.verbose_errors).to be(false)
+    end
+  end
+
+  describe "tampered token -> 400 :tampered" do
+    it "renders the diagnostic body when verbose" do
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("token signature invalid")
+      expect(response.body).to include("secret_key_base mismatch")
+    end
+
+    it "keeps the 400 with an empty body when the flag is off, but still warns" do
+      Phlex::Reactive.verbose_errors = false
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to be_empty
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "token signature invalid"))
+    end
+  end
+
+  describe "unknown token class -> 400 :unknown_class" do
+    it "names the class that no longer resolves" do
+      post_raw(token: Phlex::Reactive.sign({ "c" => "VanishedComponent" }))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("token class VanishedComponent does not resolve")
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "VanishedComponent"))
+    end
+
+    it "sets the :unknown_class diagnostic on the raised InvalidToken" do
+      error = Phlex::Reactive::InvalidToken.new("x", diagnostic: :unknown_class)
+      expect(error.diagnostic).to eq(:unknown_class)
+    end
+
+    it "keeps the 400 with an empty body when the flag is off" do
+      Phlex::Reactive.verbose_errors = false
+      post_raw(token: Phlex::Reactive.sign({ "c" => "VanishedComponent" }))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "resolved-but-not-reactive class -> 400 :not_reactive_class" do
+    it "says the class does not include the Component mixin" do
+      post_raw(token: Phlex::Reactive.sign({ "c" => "Todo" }))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to include("Todo resolved but does not include Phlex::Reactive::Component")
+    end
+
+    it "keeps the 400 with an empty body when the flag is off" do
+      Phlex::Reactive.verbose_errors = false
+      post_raw(token: Phlex::Reactive.sign({ "c" => "Todo" }))
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "undeclared action -> 403 (default-deny)" do
+    let!(:todo) { Todo.create!(title: "x", done: false) }
+
+    it "names the missing action and lists the declared ones" do
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "togle")
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to include("action :togle is not declared on TodoItemComponent")
+      expect(response.body).to include("declared actions:")
+      expect(response.body).to include("toggle").and include("rename")
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", ":togle is not declared"))
+    end
+
+    it "keeps the 403 with an empty body when the flag is off" do
+      Phlex::Reactive.verbose_errors = false
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "togle")
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "registered authorization error -> 403" do
+    before { Phlex::Reactive.authorization_errors << ModeratedComponent::NotAllowed }
+    after { Phlex::Reactive.authorization_errors.delete(ModeratedComponent::NotAllowed) }
+
+    it "names the raised error class and the action, and reminds where to authorize" do
+      post_action(ModeratedComponent, payload: { "s" => { "noop" => nil } }, act: "moderate")
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to include("ModeratedComponent::NotAllowed raised in ModeratedComponent#moderate")
+      expect(response.body).to include("the signature proves identity, not permission; authorize in the action")
+    end
+
+    it "keeps the 403 with an empty body when the flag is off, but still warns" do
+      Phlex::Reactive.verbose_errors = false
+      post_action(ModeratedComponent, payload: { "s" => { "noop" => nil } }, act: "moderate")
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to be_empty
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "ModeratedComponent#moderate"))
+    end
+  end
+
+  describe "missing record -> 404" do
+    it "names the gid that no longer resolves" do
+      todo = Todo.create!(title: "gone", done: false)
+      gid = todo.to_gid.to_s
+      todo.destroy!
+
+      post_action(TodoItemComponent, payload: { "gid" => gid }, act: "toggle")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include(gid)
+    end
+
+    it "keeps the 404 with an empty body when the flag is off" do
+      Phlex::Reactive.verbose_errors = false
+      todo = Todo.create!(title: "gone", done: false)
+      gid = todo.to_gid.to_s
+      todo.destroy!
+
+      post_action(TodoItemComponent, payload: { "gid" => gid }, act: "toggle")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "dropped-param logging" do
+    let(:payload) { { "s" => { "received" => nil } } }
+
+    it "logs an undeclared key with the component + action" do
+      post_action(NestedParamsComponent, payload:, act: "save",
+        params: { date: "2026-01-02", admin: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "NestedParamsComponent#save dropped params:",
+          "admin (undeclared)"))
+    end
+
+    it "logs an undeclared NESTED key with its full bracketed path" do
+      post_action(NestedParamsComponent, payload:, act: "save",
+        params: { invoice_items_attributes: [{ id: "1", quantity: "2", price: "3", _destroy: "false",
+                                               secret: "x" }] })
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("invoice_items_attributes[0][secret] (undeclared)"))
+    end
+
+    it "logs a declared key whose value could not be coerced as uncoercible" do
+      post_action(NestedParamsComponent, payload:, act: "save",
+        params: { bank_account_ids: "5" })
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("bank_account_ids (uncoercible)"))
+    end
+
+    it "hints when a bracketed name matches a key the schema declares at top level" do
+      # The client posted invoice[date] but `save` declares :date FLAT — the
+      # #16/#21 confusion this diagnostic exists for.
+      post_action(NestedParamsComponent, payload:, act: "save",
+        params: { "invoice[date]" => "2026-01-02" })
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("invoice[date] (undeclared — schema declares :date at top level"))
+    end
+
+    it "hints when a flat name matches a key declared NESTED in the schema" do
+      # save_invoice declares :status under :invoice; a flat `status` is the
+      # vice-versa confusion.
+      post_action(NestedParamsComponent, payload:, act: "save_invoice",
+        params: { status: "open" })
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("status (undeclared — schema declares :status nested under :invoice"))
+    end
+
+    it "logs nothing about dropped params when the flag is off" do
+      Phlex::Reactive.verbose_errors = false
+      post_action(NestedParamsComponent, payload:, act: "save",
+        params: { date: "2026-01-02", admin: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).not_to have_received(:warn).with(a_string_including("dropped params"))
+    end
+
+    it "logs nothing when nothing was dropped" do
+      post_action(NestedParamsComponent, payload:, act: "save", params: { date: "2026-01-02" })
+
+      expect(Rails.logger).not_to have_received(:warn).with(a_string_including("dropped params"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `Phlex::Reactive.verbose_errors` (default: `Rails.env.local?` — note that includes test). Statuses NEVER change; only the body: each endpoint failure now renders a plain-text diagnostic when verbose (the client already `console.error`s non-OK bodies — zero client changes), bare `head` otherwise. Every failure is `Rails.logger.warn`-logged in ALL environments.
- Distinct causes are finally distinguishable: tampered token vs unknown class vs resolved-but-not-reactive class (`InvalidToken#diagnostic`), undeclared action (body lists the declared actions), authorization failure (names the raised class + action), missing record (names the gid).
- Dropped-param diagnostics: with the flag on, coercion collects every dropped key with its full bracketed path + reason (`:undeclared` / `:uncoercible`, including the flat-schema-vs-bracketed-names hint) and warn-logs ONCE per action. With the flag off the collector is nil and every diagnostic branch early-returns — zero extra work on the production path.

## Test plan
- TDD RED → GREEN: request specs for every cause, flag ON (body content) and OFF (empty body), plus logger and dropped-param content specs. Fast suite 289 examples green; RuboCop clean.
- Perf rule honored: `rake bench:one[coerce_params]` baseline BEFORE any edit vs after (flag off) — unchanged within noise (i/s + allocations).

## Reviewer note
- Downstream apps' request specs asserting empty error bodies will need `Phlex::Reactive.verbose_errors = false` (flagged in CHANGELOG).

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional verbose error mode for reactive endpoints that can return plain-text diagnostics for failed requests.
  * Expanded logging to include clearer failure details and dropped parameter warnings, with hints for nested vs. flat parameter naming issues.

* **Bug Fixes**
  * Improved error handling for invalid tokens, undeclared actions, authorization failures, and missing records.
  * HTTP status codes remain unchanged while diagnostics are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->