### PR TITLE
feat(client): pass the changed field to reactive_compute reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `respond_to?` + two memoized reads, and only for components that didn't
   define `#id`.
 
+- **`reactive_compute` reducers are told which field changed — one reducer can
+  express a multi-way/mutual rebalance (#75).** A compute reducer now receives a
+  second argument, `meta = { changed }`: the name of the declared input the
+  triggering `input` event edited, or `null` (a direct `recompute()` call, or a
+  target this root doesn't own / didn't declare as an input — nested reactive
+  roots stay excluded per #15). That's exactly what the mutual-rebalance shape
+  ("three fields that must always sum to a total") needs — given the same value
+  snapshot, the reducer branches on WHICH field is the free/derived one:
+
+  ```js
+  setComputeReducer("three_way_split", ({ field_a, field_b, field_c, total }, { changed }) => {
+    if (changed === "field_c") return { field_a: total - field_c - field_b }
+    return { field_c: total - field_a - field_b }
+  })
+  ```
+
+  Fully backward compatible: a one-argument reducer just ignores `meta` — no
+  Ruby DSL change, no markup change. One contract to know: because an output
+  write dispatches a real change-guarded `input` event (#76), `recompute`
+  re-enters with `changed` = the OUTPUT field's name (when it's also a declared
+  input), so a branching reducer must be **convergent** — the re-entrant pass
+  must compute the values already in the DOM so the change guard settles the
+  chain (the example above does: deriving `field_a` back from the just-written
+  `field_c` reproduces its current value; no write, no event, settled in one
+  bounce). Documented in `compute.js`'s header and the `reactive_compute` docs;
+  covered by bun unit tests including the issue's three-way rebalance verbatim
+  with a bounded reducer-call count.
+
 - **Combobox keyboard navigation — `on(:search, …, listnav: "[role=option]")` (#72).**
   A search/combobox trigger can now declare client-side list navigation: Arrow
   Up/Down move a highlight among the option elements IN-BROWSER (no round trip),

--- a/app/javascript/phlex/reactive/compute.js
+++ b/app/javascript/phlex/reactive/compute.js
@@ -20,22 +20,48 @@
 //     allowance, leasing, cash: total - allowance - leasing,
 //   }))
 //
-// The reducer receives a plain object of { inputName: Number } and returns a
-// plain object of { outputName: value } — only the outputs it names are written,
-// so it can leave the edited field (and its caret) untouched. Output writes are
-// CHANGE-GUARDED: the controller writes a field and dispatches a bubbling
-// `input` event on it ONLY when the new value differs from the field's current
-// value (real browsers never fire `input` on a programmatic .value write, so
-// the controller dispatches explicitly — that's what drives a chained summary
-// repaint, matching the server's set_value + dispatch("input") contract).
-// Returning the SAME value a field already holds is skipped entirely — no
-// write, no event — which is why a reducer with overlapping inputs/outputs
-// (like payment_split above) settles instead of re-entering itself forever.
+// The reducer's signature is (values, meta):
+//
+//   values — a plain object of { inputName: Number } over the declared inputs
+//   meta   — { changed }: the name (string) of the declared input the
+//            triggering event edited, or null (a direct recompute() call, or a
+//            target this root doesn't own / didn't declare as an input).
+//
+// It returns a plain object of { outputName: value } — only the outputs it
+// names are written, so it can leave the edited field (and its caret)
+// untouched. A one-argument reducer keeps working unchanged (it just ignores
+// meta). `changed` is what makes a MULTI-WAY / MUTUAL rebalance expressible as
+// one reducer (issue #75) — branch on which field the user edited:
+//
+//   setComputeReducer("three_way_split", ({ field_a, field_b, field_c, total }, { changed }) => {
+//     if (changed === "field_c") return { field_a: total - field_c - field_b }
+//     return { field_c: total - field_a - field_b }
+//   })
+//
+// Output writes are CHANGE-GUARDED: the controller writes a field and
+// dispatches a bubbling `input` event on it ONLY when the new value differs
+// from the field's current value (real browsers never fire `input` on a
+// programmatic .value write, so the controller dispatches explicitly — that's
+// what drives a chained summary repaint, matching the server's set_value +
+// dispatch("input") contract). Returning the SAME value a field already holds
+// is skipped entirely — no write, no event — which is why a reducer with
+// overlapping inputs/outputs (like payment_split above) settles instead of
+// re-entering itself forever.
+//
+// CONVERGENCE REQUIREMENT: because an output write dispatches a REAL input
+// event (issue #76), recompute re-enters with changed = that OUTPUT field's
+// name (when it's also a declared input). A branching reducer must therefore
+// be convergent: the re-entrant pass must compute values EQUAL to what the
+// first pass already wrote to the DOM, so the change guard settles the chain.
+// The three_way_split above is: after `changed === "field_a"` writes field_c,
+// the re-entrant `changed === "field_c"` pass derives field_a back to the
+// value it already holds — no write, no event, settled in one bounce.
 
 const reducers = new Map()
 
 // Register (or replace) the reducer for `key`. `fn` is
-// (values: Record<string, number>) => Record<string, unknown>.
+// (values: Record<string, number>, meta: { changed: string | null })
+//   => Record<string, unknown>.
 export function setComputeReducer(key, fn) {
   reducers.set(key, fn)
 }

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -232,7 +232,15 @@ export default class extends Controller {
   // Reads inputs/outputs/reducer from the root's data-reactive-compute-* attrs
   // (set once by reactive_compute_attrs). A missing/unregistered reducer is a
   // no-op — a page must never break because a binding wasn't wired up.
-  recompute() {
+  //
+  // The reducer gets a second argument, meta = { changed } (issue #75): the
+  // name of the declared input the triggering event edited, or null for a
+  // direct call / an unowned or undeclared target. A multi-way rebalance
+  // branches on it (edit c → derive a; else → derive c). Note that a #76
+  // output write dispatches a real input event, so recompute RE-ENTERS with
+  // changed = that output's name — the reducer must be convergent (see
+  // compute.js) so the change guard settles the chain.
+  recompute(event) {
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
     const reduce = computeReducer(key)
@@ -244,7 +252,7 @@ export default class extends Controller {
     const values = {}
     for (const name of inputs) values[name] = this.#numericFieldValue(name)
 
-    const result = reduce(values) || {}
+    const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
@@ -337,6 +345,18 @@ export default class extends Controller {
     } catch {
       return []
     }
+  }
+
+  // The declared compute input the event just edited — the reducer's
+  // meta.changed (issue #75). The triggering field counts only when it is a
+  // named form control OWNED by this root (not a nested reactive root's, issue
+  // #15) AND its name is among the declared compute inputs; anything else
+  // (a direct call, an unowned/undeclared target) yields null.
+  #changedComputeField(event, inputs) {
+    const target = event?.target
+    if (!target?.name || typeof target.closest !== "function") return null
+    if (!inputs.includes(target.name)) return null
+    return this.#ownsField(target) ? target.name : null
   }
 
   // The first named control owned by THIS root (skips nested reactive roots,

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -193,9 +193,20 @@ module Phlex
         #     inputs: %i[allowance cash leasing total],  # fields the JS reducer reads
         #     outputs: %i[allowance cash leasing]        # fields it writes (no round trip)
         #
-        # Register the matching JS once at boot:
+        # Register the matching JS once at boot. The reducer's signature is
+        # (values, meta) — values is { inputName: Number } over the declared
+        # inputs; meta is { changed }, the name of the declared input the
+        # triggering event edited (null on a direct call or an unowned/
+        # undeclared target). A one-argument reducer keeps working (it just
+        # ignores meta); `changed` is what lets ONE reducer express a
+        # multi-way/mutual rebalance (issue #75) — branch on the edited field.
+        # Because an output write dispatches a real `input` event (issue #76),
+        # a branching reducer must be CONVERGENT — the re-entrant pass must
+        # recompute the values already written so the change guard settles it
+        # (see the header of app/javascript/phlex/reactive/compute.js).
+        #
         #   import { setComputeReducer } from "phlex/reactive/compute"
-        #   setComputeReducer("payment_split", ({ allowance, cash, leasing, total }) => ({ … }))
+        #   setComputeReducer("payment_split", ({ allowance, cash, leasing, total }, { changed }) => ({ … }))
         def reactive_compute(name, inputs: nil, outputs: nil, reducer: nil)
           return reactive_computes[name.to_sym] if inputs.nil? && outputs.nil?
 

--- a/spec/dummy/public/vendor/compute.js
+++ b/spec/dummy/public/vendor/compute.js
@@ -20,22 +20,48 @@
 //     allowance, leasing, cash: total - allowance - leasing,
 //   }))
 //
-// The reducer receives a plain object of { inputName: Number } and returns a
-// plain object of { outputName: value } — only the outputs it names are written,
-// so it can leave the edited field (and its caret) untouched. Output writes are
-// CHANGE-GUARDED: the controller writes a field and dispatches a bubbling
-// `input` event on it ONLY when the new value differs from the field's current
-// value (real browsers never fire `input` on a programmatic .value write, so
-// the controller dispatches explicitly — that's what drives a chained summary
-// repaint, matching the server's set_value + dispatch("input") contract).
-// Returning the SAME value a field already holds is skipped entirely — no
-// write, no event — which is why a reducer with overlapping inputs/outputs
-// (like payment_split above) settles instead of re-entering itself forever.
+// The reducer's signature is (values, meta):
+//
+//   values — a plain object of { inputName: Number } over the declared inputs
+//   meta   — { changed }: the name (string) of the declared input the
+//            triggering event edited, or null (a direct recompute() call, or a
+//            target this root doesn't own / didn't declare as an input).
+//
+// It returns a plain object of { outputName: value } — only the outputs it
+// names are written, so it can leave the edited field (and its caret)
+// untouched. A one-argument reducer keeps working unchanged (it just ignores
+// meta). `changed` is what makes a MULTI-WAY / MUTUAL rebalance expressible as
+// one reducer (issue #75) — branch on which field the user edited:
+//
+//   setComputeReducer("three_way_split", ({ field_a, field_b, field_c, total }, { changed }) => {
+//     if (changed === "field_c") return { field_a: total - field_c - field_b }
+//     return { field_c: total - field_a - field_b }
+//   })
+//
+// Output writes are CHANGE-GUARDED: the controller writes a field and
+// dispatches a bubbling `input` event on it ONLY when the new value differs
+// from the field's current value (real browsers never fire `input` on a
+// programmatic .value write, so the controller dispatches explicitly — that's
+// what drives a chained summary repaint, matching the server's set_value +
+// dispatch("input") contract). Returning the SAME value a field already holds
+// is skipped entirely — no write, no event — which is why a reducer with
+// overlapping inputs/outputs (like payment_split above) settles instead of
+// re-entering itself forever.
+//
+// CONVERGENCE REQUIREMENT: because an output write dispatches a REAL input
+// event (issue #76), recompute re-enters with changed = that OUTPUT field's
+// name (when it's also a declared input). A branching reducer must therefore
+// be convergent: the re-entrant pass must compute values EQUAL to what the
+// first pass already wrote to the DOM, so the change guard settles the chain.
+// The three_way_split above is: after `changed === "field_a"` writes field_c,
+// the re-entrant `changed === "field_c"` pass derives field_a back to the
+// value it already holds — no write, no event, settled in one bounce.
 
 const reducers = new Map()
 
 // Register (or replace) the reducer for `key`. `fn` is
-// (values: Record<string, number>) => Record<string, unknown>.
+// (values: Record<string, number>, meta: { changed: string | null })
+//   => Record<string, unknown>.
 export function setComputeReducer(key, fn) {
   reducers.set(key, fn)
 }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -232,7 +232,15 @@ export default class extends Controller {
   // Reads inputs/outputs/reducer from the root's data-reactive-compute-* attrs
   // (set once by reactive_compute_attrs). A missing/unregistered reducer is a
   // no-op — a page must never break because a binding wasn't wired up.
-  recompute() {
+  //
+  // The reducer gets a second argument, meta = { changed } (issue #75): the
+  // name of the declared input the triggering event edited, or null for a
+  // direct call / an unowned or undeclared target. A multi-way rebalance
+  // branches on it (edit c → derive a; else → derive c). Note that a #76
+  // output write dispatches a real input event, so recompute RE-ENTERS with
+  // changed = that output's name — the reducer must be convergent (see
+  // compute.js) so the change guard settles the chain.
+  recompute(event) {
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
     const reduce = computeReducer(key)
@@ -244,7 +252,7 @@ export default class extends Controller {
     const values = {}
     for (const name of inputs) values[name] = this.#numericFieldValue(name)
 
-    const result = reduce(values) || {}
+    const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
@@ -337,6 +345,18 @@ export default class extends Controller {
     } catch {
       return []
     }
+  }
+
+  // The declared compute input the event just edited — the reducer's
+  // meta.changed (issue #75). The triggering field counts only when it is a
+  // named form control OWNED by this root (not a nested reactive root's, issue
+  // #15) AND its name is among the declared compute inputs; anything else
+  // (a direct call, an unowned/undeclared target) yields null.
+  #changedComputeField(event, inputs) {
+    const target = event?.target
+    if (!target?.name || typeof target.closest !== "function") return null
+    if (!inputs.includes(target.name)) return null
+    return this.#ownsField(target) ? target.name : null
   }
 
   // The first named control owned by THIS root (skips nested reactive roots,

--- a/spec/javascript/reactive_compute.test.js
+++ b/spec/javascript/reactive_compute.test.js
@@ -49,6 +49,10 @@ function makeField(name, value) {
     },
     addEventListener: (type, fn) => type === "input" && listeners.push(fn),
     dispatchEvent(event) {
+      // Real DOM: dispatchEvent sets event.target to the dispatching element —
+      // that's what lets a re-entrant recompute see WHICH field just changed.
+      // (defineProperty because Event#target is a read-only prototype getter.)
+      Object.defineProperty(event, "target", { value: this, configurable: true })
       if (event.type === "input") listeners.slice().forEach((fn) => fn(event))
       return true
     },
@@ -273,4 +277,153 @@ test("a chained listener on an output field fires via the dispatched event (summ
 
   controller.recompute({ target: fields.allowance })
   expect(summary).toBe("cash is 400") // the chained repaint saw the new value
+})
+
+// ---------------------------------------------------------------------------
+// Issue #75: the reducer's second argument — meta = { changed } — tells a
+// multi-way/mutual rebalance WHICH declared input the user just edited.
+// ---------------------------------------------------------------------------
+
+test("editing an owned declared input passes its name as meta.changed", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    total: makeField("total", 500),
+  }
+  let meta
+  computeModule.setComputeReducer("split", (_values, m) => {
+    meta = m
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.allowance })
+
+  expect(meta).toEqual({ changed: "allowance" })
+})
+
+test("a direct recompute() call (no event) passes changed: null", () => {
+  const fields = { total: makeField("total", 500) }
+  let meta
+  computeModule.setComputeReducer("split", (_values, m) => {
+    meta = m
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["total"], outputs: [], fields }),
+  )
+  controller.recompute()
+
+  expect(meta).toEqual({ changed: null })
+})
+
+test("an event from a field NOT among the declared inputs passes changed: null", () => {
+  const fields = { total: makeField("total", 500) }
+  const stray = makeField("note", "hello")
+  stray._root = fields.total._root // ownership isn't the problem here — the name is
+  let meta
+  computeModule.setComputeReducer("split", (_values, m) => {
+    meta = m
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["total"], outputs: [], fields }),
+  )
+  stray._root = controller.element
+  controller.recompute({ target: stray })
+
+  expect(meta).toEqual({ changed: null })
+})
+
+test("an event from a field owned by a NESTED reactive root passes changed: null", () => {
+  const fields = { total: makeField("total", 500) }
+  let meta
+  computeModule.setComputeReducer("split", (_values, m) => {
+    meta = m
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["total"], outputs: [], fields }),
+  )
+  // Same name as a declared input, but its nearest reactive root is a nested
+  // one (issue #15) — the outer compute must not treat it as its own edit.
+  const nested = makeField("total", 42)
+  nested._root = { id: "nested-root" }
+  controller.recompute({ target: nested })
+
+  expect(meta).toEqual({ changed: null })
+})
+
+// The issue's three-way rebalance: field_a + field_b + field_c must always sum
+// to total. Editing field_c makes field_a the derived field; editing anything
+// else derives field_c. One reducer, branching on meta.changed. The reducer is
+// CONVERGENT (see compute.js): the output write dispatches a real input event
+// (#76) which re-enters recompute with changed = the output's name — that pass
+// recomputes values already in the DOM, so the change guard settles the chain.
+test("three-way rebalance: one reducer branches on changed; both directions settle", () => {
+  const fields = {
+    field_a: makeField("field_a", 100),
+    field_b: makeField("field_b", 50),
+    field_c: makeField("field_c", 350),
+    total: makeField("total", 500),
+  }
+  let reducerCalls = 0
+  computeModule.setComputeReducer("three_way_split", ({ field_a, field_b, field_c, total }, { changed }) => {
+    reducerCalls++
+    if (changed === "field_c") return { field_a: total - field_c - field_b }
+    return { field_c: total - field_a - field_b }
+  })
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "three_way_split",
+      inputs: ["field_a", "field_b", "field_c", "total"],
+      outputs: ["field_a", "field_c"],
+      fields,
+    }),
+  )
+  // Wire the outputs like the DOM would: the dispatched input event bubbles to
+  // the root and re-enters recompute (input->reactive#recompute).
+  for (const name of ["field_a", "field_b", "field_c"]) {
+    fields[name].addEventListener("input", (e) => controller.recompute(e))
+  }
+
+  // Edit field_a: 100 → 200. field_c is the derived field.
+  fields.field_a.value = 200
+  controller.recompute({ target: fields.field_a })
+  expect(fields.field_c.value).toBe("250") // 500 - 200 - 50
+  expect(fields.field_a.value).toBe("200")
+  // Initial pass + the re-entrant pass from field_c's dispatched input, which
+  // (changed === "field_c") recomputes field_a to its current value → settled.
+  expect(reducerCalls).toBe(2)
+  expect(Number(fields.field_a.value) + Number(fields.field_b.value) + Number(fields.field_c.value)).toBe(500)
+
+  // Edit field_c: 250 → 100. Now field_a is the derived field.
+  reducerCalls = 0
+  fields.field_c.value = 100
+  controller.recompute({ target: fields.field_c })
+  expect(fields.field_a.value).toBe("350") // 500 - 100 - 50
+  expect(fields.field_c.value).toBe("100")
+  expect(reducerCalls).toBe(2) // bounded: initial + one convergent re-entry
+  expect(Number(fields.field_a.value) + Number(fields.field_b.value) + Number(fields.field_c.value)).toBe(500)
+})
+
+test("existing one-arg reducers keep working (backward compatible)", () => {
+  const fields = {
+    allowance: makeField("allowance", 100),
+    cash: makeField("cash", 0),
+    total: makeField("total", 500),
+  }
+  // A pre-#75 reducer: declared with ONE parameter, ignores the meta arg.
+  computeModule.setComputeReducer("split", ({ allowance, total }) => ({ cash: total - allowance }))
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: ["cash"], fields }),
+  )
+
+  controller.recompute({ target: fields.allowance })
+  expect(fields.cash.value).toBe("400")
 })


### PR DESCRIPTION
## Summary
- Reducers now receive a second argument: `reduce(values, { changed })`. `changed` is the triggering field's `name` when the event target is a form control owned by this root (nested-root guard reused, issue #15) and declared in `inputs:`; `null` otherwise (direct calls, unowned/undeclared targets). Fully backward compatible — one-arg reducers ignore it; zero Ruby DSL/markup/server changes.
- This makes the mutual/multi-way rebalance expressible as ONE reducer (the issue's three-way `total`-sum case is pinned verbatim in the bun tests, both directions + settle).
- The interaction with #76's dispatched input events is documented as a contract in `compute.js` and the `reactive_compute` docs: an output write re-enters `recompute` with `changed` = the output's name, so a branching reducer must be **convergent** — the re-entrant pass computes values already in the DOM and the change guard settles it.

## Test plan
- TDD RED → GREEN: 6 new bun tests (owned-input name, direct-call null, undeclared-name null, nested-root null, three-way rebalance with bounded reducer calls + sum invariant, one-arg backward-compat pin). Full bun suite 77 pass.
- Fast suite 285 green post-rebase onto main; RuboCop clean; existing order-compute system spec green (Playwright); full browser suite green under Puma.
- Vendored `reactive_controller.js`/`compute.js` re-synced, verified byte-identical.

## Reviewer notes
- Convergence is a documented contract on the reducer author, not machine-enforced — a non-convergent branching reducer can ping-pong until values repeat.
- The issue's snippet destructured `{ a, b, c, total }` while comparing `changed === "field_c"`; the shipped example uses the field names consistently.

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `reactive_compute` reducers now receive a second `meta` argument: `meta.changed` indicates which declared input triggered the recomputation (or `null` for direct `recompute()` / non-owned targets).
  * Supports convergent multi-input “rebalance” reducers by branching on `meta.changed`.
* **Bug Fixes**
  * Improved triggering awareness so recomputation is more accurate for owned declared inputs vs indirect/non-owned updates.
* **Documentation**
  * Updated reducer and controller documentation to reflect the new `(values, meta)` signature.
* **Tests**
  * Added coverage for `meta.changed`, convergence behavior, and one-argument reducer backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->