### PR TITLE
feat(client): lifecycle CustomEvents — reactive:before-dispatch / reactive:applied / reactive:error with retry()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   coercion path does zero extra work (nil collector, early-return guards) —
   `rake bench:one[coerce_params]` before/after is unchanged within noise
 
+- **Client lifecycle CustomEvents — `reactive:before-dispatch` /
+  `reactive:applied` / `reactive:error` with `retry()` (#79).** The generic
+  controller now dispatches three bubbling, composed events around every action
+  round trip, so an app can toast an error, veto a dispatch, instrument latency,
+  or build retry UI without forking the one controller.
+  `reactive:before-dispatch` is cancelable and fires once per user gesture —
+  post-`preventDefault`, post-`confirm:`, PRE-debounce — with
+  `{ action, params, element }`; `event.preventDefault()` skips the round trip
+  entirely (nothing is scheduled, debounced or not). `reactive:applied` fires
+  with `{ action, params, html }` after the fresh token was captured and the
+  streams were handed to `Turbo.renderStreamMessage` (Turbo applies them
+  asynchronously — listen to Turbo's own events for post-morph timing).
+  `reactive:error` fires in all four failure branches with
+  `{ action, params, kind, status?, body?, retry }` where `kind` is
+  `redirected | http | content-type | network`; `retry()` re-enters the request
+  queue — re-reading the freshest signed token and re-collecting the fields at
+  send time, refiring no second before-dispatch — and no-ops with a
+  `console.warn` once the component left the DOM. Events go out via raw
+  `dispatchEvent` (Stimulus's `this.dispatch` helper is shadowed by the
+  controller's own `dispatch` action method) on the root element, falling back
+  to `document` when a plain replace detached it; the existing `console.error`
+  logging is unchanged. Composes with plain Stimulus listening —
+  `data-action="reactive:error->toast#show"` on an ancestor. Covered by unit
+  (JS) and real-browser system specs; README "Failure UX & lifecycle events"
+  and the security docs page document the contract.
+
 - **Combobox keyboard navigation — `on(:search, …, listnav: "[role=option]")` (#72).**
   A search/combobox trigger can now declare client-side list navigation: Arrow
   Up/Down move a highlight among the option elements IN-BROWSER (no round trip),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `{ action, params, kind, status?, body?, retry? }` where `kind` is one of
   `redirected | http | content-type | network` (all retriable) or `apply` —
   the fetch itself succeeded and the server already completed the mutation,
-  but something AFTER it threw (a malformed response, a Turbo render error, a
-  throwing `reactive:applied` listener); `apply` carries NO `retry` at all,
-  since retrying would re-POST an action that already succeeded. `retry()`
+  but something AFTER it threw INSIDE THE CONTROLLER (a malformed response, a
+  Turbo render error — NOT a throwing `reactive:applied` listener, whose
+  exception `dispatchEvent` never propagates back per the DOM spec, so it
+  can't reach this catch); `apply` carries NO `retry` at all, since retrying
+  would re-POST an action that already succeeded. `retry()`
   (when present) re-enters the request queue — re-reading the freshest signed
   token and re-collecting the fields at send time, refiring no second
   before-dispatch — and no-ops with a `console.warn` once the component left

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,12 +91,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with `{ action, params, html }` after the fresh token was captured and the
   streams were handed to `Turbo.renderStreamMessage` (Turbo applies them
   asynchronously — listen to Turbo's own events for post-morph timing).
-  `reactive:error` fires in all four failure branches with
-  `{ action, params, kind, status?, body?, retry }` where `kind` is
-  `redirected | http | content-type | network`; `retry()` re-enters the request
-  queue — re-reading the freshest signed token and re-collecting the fields at
-  send time, refiring no second before-dispatch — and no-ops with a
-  `console.warn` once the component left the DOM. Events go out via raw
+  `reactive:error` fires in every failure branch with
+  `{ action, params, kind, status?, body?, retry? }` where `kind` is one of
+  `redirected | http | content-type | network` (all retriable) or `apply` —
+  the fetch itself succeeded and the server already completed the mutation,
+  but something AFTER it threw (a malformed response, a Turbo render error, a
+  throwing `reactive:applied` listener); `apply` carries NO `retry` at all,
+  since retrying would re-POST an action that already succeeded. `retry()`
+  (when present) re-enters the request queue — re-reading the freshest signed
+  token and re-collecting the fields at send time, refiring no second
+  before-dispatch — and no-ops with a `console.warn` once the component left
+  the DOM. Events go out via raw
   `dispatchEvent` (Stimulus's `this.dispatch` helper is shadowed by the
   controller's own `dispatch` action method) on the root element, falling back
   to `document` when a plain replace detached it; the existing `console.error`

--- a/README.md
+++ b/README.md
@@ -760,10 +760,11 @@ latency, veto a dispatch, or build retry UI **without forking the controller**:
 
 | `kind` | Meaning | Extra detail |
 |--------|---------|--------------|
-| `redirected` | the POST was redirected (an auth `before_action` / CSRF guard bounced it) | `status` |
-| `http` | non-2xx response (403 default-deny/authorization, 400 bad token, 404 record gone, 500 …) | `status`, `body` |
-| `content-type` | 200, but not a turbo-stream (an HTML error page, a misconfigured route) | `status` |
-| `network` | `fetch` itself rejected (offline, DNS, connection reset) | — |
+| `redirected` | the POST was redirected (an auth `before_action` / CSRF guard bounced it) | `status`, `retry` |
+| `http` | non-2xx response (403 default-deny/authorization, 400 bad token, 404 record gone, 500 …) | `status`, `body`, `retry` |
+| `content-type` | 200, but not a turbo-stream (an HTML error page, a misconfigured route) | `status`, `retry` |
+| `network` | `fetch` itself rejected (offline, DNS, connection reset) — the server never saw the request | `retry` |
+| `apply` | the server processed the action successfully, but something AFTER the fetch threw (a malformed response, a Turbo render error, a throwing `reactive:applied` listener) | no `retry` |
 
 `detail.retry()` re-enters the controller's request queue: it re-reads the
 **freshest** signed token and re-collects the component's fields at send time,
@@ -771,6 +772,11 @@ so nothing stale is replayed. It fires no second `reactive:before-dispatch`
 (one veto per user gesture), and it no-ops with a `console.warn` once the
 component has left the DOM. The existing `console.error` logging is unchanged —
 the events add hooks, they don't replace the log.
+
+**`kind: "apply"` carries no `retry()` at all** — by the time this fires the
+server has already completed the mutation, so retrying would re-POST an
+action that already succeeded (potentially a non-idempotent one). Only the
+four fetch/response-shaped kinds above are retriable.
 
 The events bubble from the component's root element (or from `document` when
 the root was detached by the failing round trip), so they compose with plain

--- a/README.md
+++ b/README.md
@@ -764,7 +764,14 @@ latency, veto a dispatch, or build retry UI **without forking the controller**:
 | `http` | non-2xx response (403 default-deny/authorization, 400 bad token, 404 record gone, 500 …) | `status`, `body`, `retry` |
 | `content-type` | 200, but not a turbo-stream (an HTML error page, a misconfigured route) | `status`, `retry` |
 | `network` | `fetch` itself rejected (offline, DNS, connection reset) — the server never saw the request | `retry` |
-| `apply` | the server processed the action successfully, but something AFTER the fetch threw (a malformed response, a Turbo render error, a throwing `reactive:applied` listener) | no `retry` |
+| `apply` | the server processed the action successfully, but something AFTER the fetch threw (a malformed response, a Turbo render error) | no `retry` |
+
+`apply` covers a throw in the controller's own post-fetch code — not a
+throwing listener on `reactive:applied` itself. Per the DOM spec,
+`EventTarget#dispatchEvent` never propagates a listener's exception back to
+its caller (it's reported to the console instead), so a listener that throws
+can't surface as `reactive:error` at all — it just logs and the round trip is
+otherwise unaffected.
 
 `detail.retry()` re-enters the controller's request queue: it re-reads the
 **freshest** signed token and re-collects the component's fields at send time,

--- a/README.md
+++ b/README.md
@@ -744,6 +744,66 @@ aren't clobbered. Authorize the record as always — identity is never permissio
 > rendered and auto-escaped through the renderer — or an `html_safe` string for
 > raw HTML you control.
 
+### Failure UX & lifecycle events
+
+The generic controller dispatches three bubbling, composed `CustomEvent`s
+around every action round trip, so an app can toast an error, instrument
+latency, veto a dispatch, or build retry UI **without forking the controller**:
+
+| Event | When | `event.detail` |
+|-------|------|----------------|
+| `reactive:before-dispatch` | after the trigger's `preventDefault`/`confirm:`, **before** debounce/enqueue | `{ action, params, element }` — cancelable: `event.preventDefault()` skips the round trip entirely (nothing is scheduled) |
+| `reactive:applied` | after the response's token was captured and the streams were handed to `Turbo.renderStreamMessage` | `{ action, params, html }` |
+| `reactive:error` | in every failure branch of the round trip | `{ action, params, kind, status?, body?, retry }` |
+
+`reactive:error`'s `kind` tells you **what** failed:
+
+| `kind` | Meaning | Extra detail |
+|--------|---------|--------------|
+| `redirected` | the POST was redirected (an auth `before_action` / CSRF guard bounced it) | `status` |
+| `http` | non-2xx response (403 default-deny/authorization, 400 bad token, 404 record gone, 500 …) | `status`, `body` |
+| `content-type` | 200, but not a turbo-stream (an HTML error page, a misconfigured route) | `status` |
+| `network` | `fetch` itself rejected (offline, DNS, connection reset) | — |
+
+`detail.retry()` re-enters the controller's request queue: it re-reads the
+**freshest** signed token and re-collects the component's fields at send time,
+so nothing stale is replayed. It fires no second `reactive:before-dispatch`
+(one veto per user gesture), and it no-ops with a `console.warn` once the
+component has left the DOM. The existing `console.error` logging is unchanged —
+the events add hooks, they don't replace the log.
+
+The events bubble from the component's root element (or from `document` when
+the root was detached by the failing round trip), so they compose with plain
+Stimulus listening — a global toaster is one attribute on an ancestor:
+
+```html
+<body data-controller="toast" data-action="reactive:error->toast#show">
+```
+
+```js
+// toast_controller.js
+show(event) {
+  const { kind, status, retry } = event.detail
+  this.flash(`Action failed (${kind}${status ? ` ${status}` : ""})`, { onRetry: retry })
+}
+```
+
+Or veto/instrument at the document level:
+
+```js
+document.addEventListener("reactive:before-dispatch", (event) => {
+  if (offline) event.preventDefault()           // cancel: nothing is enqueued
+})
+document.addEventListener("reactive:applied", ({ detail }) => {
+  metrics.count(`reactive.${detail.action}.ok`)
+})
+```
+
+One honest caveat on timing: `reactive:applied` means the turbo-streams were
+**handed to Turbo** — `renderStreamMessage` applies them asynchronously, so the
+DOM mutation may complete a tick later. If you need post-morph timing, listen
+to Turbo's own events (`turbo:before-stream-render` and friends).
+
 ### Reactive collections (add/remove rows + count + empty-state)
 
 An add/remove-row list — line items, attachments, tags, comments, a

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -381,6 +381,19 @@ export default class extends Controller {
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
   #proceed(target, action, params, debounce) {
+    // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
+    // per user gesture — post-preventDefault, post-confirm, PRE-debounce.
+    // event.preventDefault() skips the debounce AND the enqueue entirely
+    // (nothing is scheduled). retry() re-enters the queue directly, so this
+    // does NOT refire on a retry. detail.params are the trigger's explicit
+    // params; sibling fields are collected later, at send time.
+    const before = this.#emit("reactive:before-dispatch", {
+      action,
+      params: this.#parseParams(params),
+      element: this.element,
+    }, { cancelable: true })
+    if (before.defaultPrevented) return
+
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
@@ -422,6 +435,39 @@ export default class extends Controller {
   // the keys first — #clearDebounce mutates the map as it goes.
   #clearAllDebounces() {
     for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
+  }
+
+  // Raw-dispatch a lifecycle CustomEvent (issue #79). Deliberately NOT
+  // Stimulus's this.dispatch() helper — that name is SHADOWED by this
+  // controller's own dispatch(event) action method. Bubbling + composed so a
+  // page-level listener (or `data-action="reactive:error->toast#show"` on an
+  // ancestor) hears it. After a plain (non-morph) replace this.element is a
+  // DETACHED node — a bubbling event on it never reaches document listeners —
+  // so fall back to dispatching on document itself.
+  #emit(name, detail, { cancelable = false } = {}) {
+    const event = new CustomEvent(name, { bubbles: true, composed: true, cancelable, detail })
+    const root = this.element.isConnected ? this.element : document
+    root.dispatchEvent(event)
+    return event
+  }
+
+  // reactive:error detail: { action, params, kind, status?, body?, retry }.
+  // `params` are the FULL params that were sent (collected fields + explicit
+  // trigger params). retry() re-enters the request queue with the ORIGINAL raw
+  // trigger params, so #perform re-reads the freshest token and RE-COLLECTS the
+  // sibling fields — nothing stale is replayed. It does not refire
+  // reactive:before-dispatch (one veto per user gesture), and it no-ops with a
+  // warning once the root has left the DOM (retrying against a detached
+  // element would post a stale token into nowhere).
+  #emitError(action, rawParams, sentParams, extra) {
+    const retry = () => {
+      if (!this.element.isConnected) {
+        console.warn("[phlex-reactive] retry() ignored — the reactive root left the DOM")
+        return
+      }
+      return this.#enqueue(action, rawParams)
+    }
+    this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
   async #perform(action, params) {
@@ -469,16 +515,20 @@ export default class extends Controller {
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
+        this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
       if (!response.ok) {
-        console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, await response.text())
+        const errorBody = await response.text()
+        console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
+        this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
 
       const contentType = response.headers.get("Content-Type") || ""
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
+        this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
 
@@ -491,8 +541,14 @@ export default class extends Controller {
       // replace (Response.morph) or an update morphs in place, preserving the
       // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
+      // Lifecycle hook (issue #79): the streams were HANDED TO Turbo — a
+      // renderStreamMessage applies asynchronously, so the DOM mutation may
+      // complete a tick later. Apps needing post-morph timing listen to Turbo's
+      // own events; this one is for "the action round trip succeeded".
+      this.#emit("reactive:applied", { action, params: allParams, html })
     } catch (error) {
       console.error("[phlex-reactive] action error", error)
+      this.#emitError(action, params, allParams, { kind: "network" })
     } finally {
       this.element.removeAttribute("aria-busy")
     }

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -492,26 +492,41 @@ export default class extends Controller {
     this.element.setAttribute("aria-busy", "true")
 
     try {
-      const headers = {
-        Accept: "text/vnd.turbo-stream.html",
-        "X-CSRF-Token": this.#csrfToken(),
-      }
-      // For JSON we declare the content type; for multipart we must NOT — the
-      // browser sets `multipart/form-data; boundary=…` itself, and overriding it
-      // would strip the boundary and corrupt the body server-side.
-      if (!multipart) headers["Content-Type"] = "application/json"
-      // Send the pgbus SSE connection id (if subscribed) so the server can
-      // exclude this connection from its own broadcast echo — the actor
-      // already gets the action's HTTP response. Harmless without pgbus.
-      const connectionId = this.#connectionId()
-      if (connectionId) headers["X-Pgbus-Connection"] = connectionId
+      let response
+      try {
+        const headers = {
+          Accept: "text/vnd.turbo-stream.html",
+          "X-CSRF-Token": this.#csrfToken(),
+        }
+        // For JSON we declare the content type; for multipart we must NOT — the
+        // browser sets `multipart/form-data; boundary=…` itself, and overriding it
+        // would strip the boundary and corrupt the body server-side.
+        if (!multipart) headers["Content-Type"] = "application/json"
+        // Send the pgbus SSE connection id (if subscribed) so the server can
+        // exclude this connection from its own broadcast echo — the actor
+        // already gets the action's HTTP response. Harmless without pgbus.
+        const connectionId = this.#connectionId()
+        if (connectionId) headers["X-Pgbus-Connection"] = connectionId
 
-      const response = await fetch(this.#actionPath(), {
-        method: "POST",
-        headers,
-        body,
-        credentials: "same-origin",
-      })
+        // ONLY `fetch` itself is the network boundary — offline, DNS, a reset
+        // connection. Everything below this inner try (reading the body,
+        // extracting the token, handing streams to Turbo, the reactive:applied
+        // dispatch) runs AFTER the server already processed the mutation, so
+        // none of it belongs in the `kind: "network"` / retriable bucket
+        // (CodeRabbit review on #89): if renderStreamMessage or a
+        // reactive:applied listener throws, retry()ing would re-POST an
+        // action the server already completed — see the outer catch below.
+        response = await fetch(this.#actionPath(), {
+          method: "POST",
+          headers,
+          body,
+          credentials: "same-origin",
+        })
+      } catch (error) {
+        console.error("[phlex-reactive] action error", error)
+        this.#emitError(action, params, allParams, { kind: "network" })
+        return
+      }
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
@@ -547,8 +562,13 @@ export default class extends Controller {
       // own events; this one is for "the action round trip succeeded".
       this.#emit("reactive:applied", { action, params: allParams, html })
     } catch (error) {
+      // The server already processed this action successfully (we're past the
+      // fetch) — a throw here is a CLIENT-side apply failure (a malformed
+      // response, a broken Turbo render, a throwing reactive:applied
+      // listener), not a transport failure. kind: "apply" carries NO retry() —
+      // retrying would re-POST an action the server already completed.
       console.error("[phlex-reactive] action error", error)
-      this.#emitError(action, params, allParams, { kind: "network" })
+      this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
       this.element.removeAttribute("aria-busy")
     }

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -510,12 +510,14 @@ export default class extends Controller {
 
         // ONLY `fetch` itself is the network boundary — offline, DNS, a reset
         // connection. Everything below this inner try (reading the body,
-        // extracting the token, handing streams to Turbo, the reactive:applied
-        // dispatch) runs AFTER the server already processed the mutation, so
-        // none of it belongs in the `kind: "network"` / retriable bucket
-        // (CodeRabbit review on #89): if renderStreamMessage or a
-        // reactive:applied listener throws, retry()ing would re-POST an
-        // action the server already completed — see the outer catch below.
+        // extracting the token, handing streams to Turbo) runs AFTER the
+        // server already processed the mutation, so none of it belongs in the
+        // `kind: "network"` / retriable bucket (CodeRabbit review on #89): if
+        // renderStreamMessage throws, retry()ing would re-POST an action the
+        // server already completed — see the outer catch below. (NOT a
+        // reactive:applied LISTENER throwing — per the DOM spec, dispatchEvent
+        // never propagates a listener's exception back to its caller, so that
+        // case can't reach this catch at all; verified in the JS test suite.)
         response = await fetch(this.#actionPath(), {
           method: "POST",
           headers,
@@ -564,9 +566,10 @@ export default class extends Controller {
     } catch (error) {
       // The server already processed this action successfully (we're past the
       // fetch) — a throw here is a CLIENT-side apply failure (a malformed
-      // response, a broken Turbo render, a throwing reactive:applied
-      // listener), not a transport failure. kind: "apply" carries NO retry() —
-      // retrying would re-POST an action the server already completed.
+      // response, a broken Turbo render — NOT a reactive:applied listener
+      // throw, which dispatchEvent never propagates here), not a transport
+      // failure. kind: "apply" carries NO retry() — retrying would re-POST an
+      // action the server already completed.
       console.error("[phlex-reactive] action error", error)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -311,11 +311,17 @@ module Views
                   plain ' (all retriable) or '
                   code { 'apply' }
                   plain ' — the server already completed the mutation but something AFTER the fetch threw ' \
-                        '(a malformed response, a Turbo render error, a throwing '
-                  code { 'reactive:applied' }
-                  plain ' listener); it carries NO '
+                        'inside the controller itself (a malformed response, a Turbo render error); it ' \
+                        'carries NO '
                   code { 'retry' }
-                  plain ', since retrying would re-POST an action that already succeeded. '
+                  plain ', since retrying would re-POST an action that already succeeded. A throwing '
+                  code { 'reactive:applied' }
+                  plain ' LISTENER is different — the DOM spec never propagates a listener\'s exception ' \
+                        'back to '
+                  code { 'dispatchEvent' }
+                  plain '\'s caller, so it can\'t surface as '
+                  code { 'reactive:error' }
+                  plain ' at all; it just logs. '
                   code { 'retry()' }
                   plain ' (when present) re-enters the request queue with the freshest token and freshly ' \
                         'collected fields (and no-ops once the component left the DOM).'

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -303,15 +303,22 @@ module Views
                 li do
                   code { 'reactive:error' }
                   plain ' — fired in every failure branch with '
-                  code { '{ action, params, kind, status?, body?, retry }' }
+                  code { '{ action, params, kind, status?, body?, retry? }' }
                   plain '; '
                   code { 'kind' }
                   plain ' is one of '
                   code { 'redirected | http | content-type | network' }
-                  plain '. '
+                  plain ' (all retriable) or '
+                  code { 'apply' }
+                  plain ' — the server already completed the mutation but something AFTER the fetch threw ' \
+                        '(a malformed response, a Turbo render error, a throwing '
+                  code { 'reactive:applied' }
+                  plain ' listener); it carries NO '
+                  code { 'retry' }
+                  plain ', since retrying would re-POST an action that already succeeded. '
                   code { 'retry()' }
-                  plain ' re-enters the request queue with the freshest token and freshly collected fields ' \
-                        '(and no-ops once the component left the DOM).'
+                  plain ' (when present) re-enters the request queue with the freshest token and freshly ' \
+                        'collected fields (and no-ops once the component left the DOM).'
                 end
               end
             end

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -20,6 +20,7 @@ module Views
           secrets_rule
           csrf_auth
           failure_modes
+          failure_ux
           token_lifetime
           checklist
         end
@@ -247,7 +248,11 @@ module Views
                   code { '400 Bad Request' }
                 end
               end
-              p { plain 'The client runtime logs non-OK responses and applies no DOM change.' }
+              p do
+                plain 'The client runtime logs non-OK responses, applies no DOM change, and dispatches a '
+                code { 'reactive:error' }
+                plain ' lifecycle event so your UI can react — see below.'
+              end
               p do
                 plain 'Every failure is warn-logged as '
                 code { '[phlex-reactive] …' }
@@ -265,6 +270,63 @@ module Views
                       'with a hint when a flat name looks like the bracketed twin of a declared nested key. ' \
                       'The flag never changes a status — only the body and the logs.'
               end
+            end
+          end
+        end
+
+        def failure_ux
+          DocsUI::Section('Failure UX — the lifecycle events') do
+            DocsUI::Prose() do
+              p do
+                plain 'The generic controller dispatches three bubbling, composed '
+                code { 'CustomEvent' }
+                plain 's around every action round trip, so an app can toast an error, veto a dispatch, ' \
+                      'instrument latency, or build retry UI without forking the controller:'
+              end
+              ul do
+                li do
+                  code { 'reactive:before-dispatch' }
+                  plain ' — cancelable, fired before debounce/enqueue with '
+                  code { '{ action, params, element }' }
+                  plain '. '
+                  code { 'event.preventDefault()' }
+                  plain ' skips the round trip entirely (nothing is scheduled).'
+                end
+                li do
+                  code { 'reactive:applied' }
+                  plain ' — fired with '
+                  code { '{ action, params, html }' }
+                  plain ' once the streams were handed to '
+                  code { 'Turbo.renderStreamMessage' }
+                  plain ' (Turbo applies them asynchronously — for post-morph timing listen to Turbo\'s own events).'
+                end
+                li do
+                  code { 'reactive:error' }
+                  plain ' — fired in every failure branch with '
+                  code { '{ action, params, kind, status?, body?, retry }' }
+                  plain '; '
+                  code { 'kind' }
+                  plain ' is one of '
+                  code { 'redirected | http | content-type | network' }
+                  plain '. '
+                  code { 'retry()' }
+                  plain ' re-enters the request queue with the freshest token and freshly collected fields ' \
+                        '(and no-ops once the component left the DOM).'
+                end
+              end
+            end
+            DocsUI::Code(<<~JAVASCRIPT, lexer: :javascript)
+              // A page-level toaster: one listener, or plain Stimulus composition —
+              // <body data-controller="toast" data-action="reactive:error->toast#show">
+              document.addEventListener("reactive:error", ({ detail }) => {
+                toast(`Action failed (${detail.kind}${detail.status ? ` ${detail.status}` : ""})`, {
+                  onRetry: detail.retry, // re-enqueues with the freshest signed token
+                })
+              })
+            JAVASCRIPT
+            DocsUI::Callout(:note, title: 'The events are hooks, not the security boundary') do
+              plain 'A 403 still denies the action server-side whether or not anything listens; the existing ' \
+                    'console.error logging is unchanged. The events only make the failure visible to your UI.'
             end
           end
         end

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -94,6 +94,10 @@ class CounterComponent < ApplicationComponent
       button(**mix(on(:bump_via_update), data: { testid: "bump-update" })) { "+1 (update)" }
       button(**mix(on(:reset_with_flash), data: { testid: "reset" })) { "reset" }
       button(**mix(on(:go_home), data: { testid: "go-home" })) { "go home" }
+      # DELIBERATELY undeclared action (no `action :boom`): the endpoint
+      # default-denies it with a 403, which the lifecycle-events system spec
+      # uses to observe a real reactive:error (kind=http) in the browser (#79).
+      button(**mix(on(:boom), data: { testid: "boom" })) { "boom" }
     end
   end
 end

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -381,6 +381,19 @@ export default class extends Controller {
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
   #proceed(target, action, params, debounce) {
+    // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
+    // per user gesture — post-preventDefault, post-confirm, PRE-debounce.
+    // event.preventDefault() skips the debounce AND the enqueue entirely
+    // (nothing is scheduled). retry() re-enters the queue directly, so this
+    // does NOT refire on a retry. detail.params are the trigger's explicit
+    // params; sibling fields are collected later, at send time.
+    const before = this.#emit("reactive:before-dispatch", {
+      action,
+      params: this.#parseParams(params),
+      element: this.element,
+    }, { cancelable: true })
+    if (before.defaultPrevented) return
+
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
@@ -422,6 +435,39 @@ export default class extends Controller {
   // the keys first — #clearDebounce mutates the map as it goes.
   #clearAllDebounces() {
     for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
+  }
+
+  // Raw-dispatch a lifecycle CustomEvent (issue #79). Deliberately NOT
+  // Stimulus's this.dispatch() helper — that name is SHADOWED by this
+  // controller's own dispatch(event) action method. Bubbling + composed so a
+  // page-level listener (or `data-action="reactive:error->toast#show"` on an
+  // ancestor) hears it. After a plain (non-morph) replace this.element is a
+  // DETACHED node — a bubbling event on it never reaches document listeners —
+  // so fall back to dispatching on document itself.
+  #emit(name, detail, { cancelable = false } = {}) {
+    const event = new CustomEvent(name, { bubbles: true, composed: true, cancelable, detail })
+    const root = this.element.isConnected ? this.element : document
+    root.dispatchEvent(event)
+    return event
+  }
+
+  // reactive:error detail: { action, params, kind, status?, body?, retry }.
+  // `params` are the FULL params that were sent (collected fields + explicit
+  // trigger params). retry() re-enters the request queue with the ORIGINAL raw
+  // trigger params, so #perform re-reads the freshest token and RE-COLLECTS the
+  // sibling fields — nothing stale is replayed. It does not refire
+  // reactive:before-dispatch (one veto per user gesture), and it no-ops with a
+  // warning once the root has left the DOM (retrying against a detached
+  // element would post a stale token into nowhere).
+  #emitError(action, rawParams, sentParams, extra) {
+    const retry = () => {
+      if (!this.element.isConnected) {
+        console.warn("[phlex-reactive] retry() ignored — the reactive root left the DOM")
+        return
+      }
+      return this.#enqueue(action, rawParams)
+    }
+    this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
   async #perform(action, params) {
@@ -469,16 +515,20 @@ export default class extends Controller {
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
+        this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
       if (!response.ok) {
-        console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, await response.text())
+        const errorBody = await response.text()
+        console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
+        this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
 
       const contentType = response.headers.get("Content-Type") || ""
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
+        this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
 
@@ -491,8 +541,14 @@ export default class extends Controller {
       // replace (Response.morph) or an update morphs in place, preserving the
       // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
+      // Lifecycle hook (issue #79): the streams were HANDED TO Turbo — a
+      // renderStreamMessage applies asynchronously, so the DOM mutation may
+      // complete a tick later. Apps needing post-morph timing listen to Turbo's
+      // own events; this one is for "the action round trip succeeded".
+      this.#emit("reactive:applied", { action, params: allParams, html })
     } catch (error) {
       console.error("[phlex-reactive] action error", error)
+      this.#emitError(action, params, allParams, { kind: "network" })
     } finally {
       this.element.removeAttribute("aria-busy")
     }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -492,26 +492,41 @@ export default class extends Controller {
     this.element.setAttribute("aria-busy", "true")
 
     try {
-      const headers = {
-        Accept: "text/vnd.turbo-stream.html",
-        "X-CSRF-Token": this.#csrfToken(),
-      }
-      // For JSON we declare the content type; for multipart we must NOT — the
-      // browser sets `multipart/form-data; boundary=…` itself, and overriding it
-      // would strip the boundary and corrupt the body server-side.
-      if (!multipart) headers["Content-Type"] = "application/json"
-      // Send the pgbus SSE connection id (if subscribed) so the server can
-      // exclude this connection from its own broadcast echo — the actor
-      // already gets the action's HTTP response. Harmless without pgbus.
-      const connectionId = this.#connectionId()
-      if (connectionId) headers["X-Pgbus-Connection"] = connectionId
+      let response
+      try {
+        const headers = {
+          Accept: "text/vnd.turbo-stream.html",
+          "X-CSRF-Token": this.#csrfToken(),
+        }
+        // For JSON we declare the content type; for multipart we must NOT — the
+        // browser sets `multipart/form-data; boundary=…` itself, and overriding it
+        // would strip the boundary and corrupt the body server-side.
+        if (!multipart) headers["Content-Type"] = "application/json"
+        // Send the pgbus SSE connection id (if subscribed) so the server can
+        // exclude this connection from its own broadcast echo — the actor
+        // already gets the action's HTTP response. Harmless without pgbus.
+        const connectionId = this.#connectionId()
+        if (connectionId) headers["X-Pgbus-Connection"] = connectionId
 
-      const response = await fetch(this.#actionPath(), {
-        method: "POST",
-        headers,
-        body,
-        credentials: "same-origin",
-      })
+        // ONLY `fetch` itself is the network boundary — offline, DNS, a reset
+        // connection. Everything below this inner try (reading the body,
+        // extracting the token, handing streams to Turbo, the reactive:applied
+        // dispatch) runs AFTER the server already processed the mutation, so
+        // none of it belongs in the `kind: "network"` / retriable bucket
+        // (CodeRabbit review on #89): if renderStreamMessage or a
+        // reactive:applied listener throws, retry()ing would re-POST an
+        // action the server already completed — see the outer catch below.
+        response = await fetch(this.#actionPath(), {
+          method: "POST",
+          headers,
+          body,
+          credentials: "same-origin",
+        })
+      } catch (error) {
+        console.error("[phlex-reactive] action error", error)
+        this.#emitError(action, params, allParams, { kind: "network" })
+        return
+      }
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
@@ -547,8 +562,13 @@ export default class extends Controller {
       // own events; this one is for "the action round trip succeeded".
       this.#emit("reactive:applied", { action, params: allParams, html })
     } catch (error) {
+      // The server already processed this action successfully (we're past the
+      // fetch) — a throw here is a CLIENT-side apply failure (a malformed
+      // response, a broken Turbo render, a throwing reactive:applied
+      // listener), not a transport failure. kind: "apply" carries NO retry() —
+      // retrying would re-POST an action the server already completed.
       console.error("[phlex-reactive] action error", error)
-      this.#emitError(action, params, allParams, { kind: "network" })
+      this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
       this.element.removeAttribute("aria-busy")
     }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -510,12 +510,14 @@ export default class extends Controller {
 
         // ONLY `fetch` itself is the network boundary — offline, DNS, a reset
         // connection. Everything below this inner try (reading the body,
-        // extracting the token, handing streams to Turbo, the reactive:applied
-        // dispatch) runs AFTER the server already processed the mutation, so
-        // none of it belongs in the `kind: "network"` / retriable bucket
-        // (CodeRabbit review on #89): if renderStreamMessage or a
-        // reactive:applied listener throws, retry()ing would re-POST an
-        // action the server already completed — see the outer catch below.
+        // extracting the token, handing streams to Turbo) runs AFTER the
+        // server already processed the mutation, so none of it belongs in the
+        // `kind: "network"` / retriable bucket (CodeRabbit review on #89): if
+        // renderStreamMessage throws, retry()ing would re-POST an action the
+        // server already completed — see the outer catch below. (NOT a
+        // reactive:applied LISTENER throwing — per the DOM spec, dispatchEvent
+        // never propagates a listener's exception back to its caller, so that
+        // case can't reach this catch at all; verified in the JS test suite.)
         response = await fetch(this.#actionPath(), {
           method: "POST",
           headers,
@@ -564,9 +566,10 @@ export default class extends Controller {
     } catch (error) {
       // The server already processed this action successfully (we're past the
       // fetch) — a throw here is a CLIENT-side apply failure (a malformed
-      // response, a broken Turbo render, a throwing reactive:applied
-      // listener), not a transport failure. kind: "apply" carries NO retry() —
-      // retrying would re-POST an action the server already completed.
+      // response, a broken Turbo render — NOT a reactive:applied listener
+      // throw, which dispatchEvent never propagates here), not a transport
+      // failure. kind: "apply" carries NO retry() — retrying would re-POST an
+      // action the server already completed.
       console.error("[phlex-reactive] action error", error)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {

--- a/spec/javascript/reactive_collect_fields.test.js
+++ b/spec/javascript/reactive_collect_fields.test.js
@@ -126,7 +126,7 @@ test("outer root action collects only its own fields, not nested reactive roots'
       text: () => Promise.resolve(""),
     })
   }
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
 
   const controller = buildController(outer)
@@ -162,7 +162,7 @@ test("an action on the nested row still collects that row's own fields", async (
       text: () => Promise.resolve(""),
     })
   }
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
 
   // Dispatch on the INNER row's controller — it owns rowQty, not outerNotes.

--- a/spec/javascript/reactive_confirm.test.js
+++ b/spec/javascript/reactive_confirm.test.js
@@ -59,7 +59,7 @@ function buildController() {
       text: () => Promise.resolve(""),
     })
   }
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
   return { controller, calls: () => calls }
 }

--- a/spec/javascript/reactive_confirm_resolver.test.js
+++ b/spec/javascript/reactive_confirm_resolver.test.js
@@ -63,7 +63,7 @@ function buildController() {
       text: () => Promise.resolve(""),
     })
   }
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
   return { controller, calls: () => calls }
 }

--- a/spec/javascript/reactive_controller.test.js
+++ b/spec/javascript/reactive_controller.test.js
@@ -40,10 +40,14 @@ function makeElement() {
 
 function buildController() {
   const controller = new ReactiveController()
+  // Set the element explicitly (not only via the mocked base-class constructor):
+  // bun runs every spec file in one process, so another file's Controller stub
+  // (with a bare constructor) can win the mock.module race.
+  controller.element = makeElement()
   controller.tokenValue = "tok"
   // Avoid a real network call in the deferred #perform: stub fetch to reject.
   globalThis.fetch = () => Promise.reject(new Error("no network in unit test"))
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   return controller
 }
 

--- a/spec/javascript/reactive_debounce.test.js
+++ b/spec/javascript/reactive_debounce.test.js
@@ -61,7 +61,7 @@ function buildController() {
       text: () => Promise.resolve(""),
     })
   }
-  globalThis.document = { querySelector: () => null }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
   return { controller, calls: () => calls }
 }

--- a/spec/javascript/reactive_extract_token.test.js
+++ b/spec/javascript/reactive_extract_token.test.js
@@ -72,6 +72,7 @@ function stubEnv() {
       if (sel.includes("csrf-token")) return { content: "csrf-abc" }
       return null
     },
+    dispatchEvent: () => {},
   }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
 }

--- a/spec/javascript/reactive_lifecycle_events.test.js
+++ b/spec/javascript/reactive_lifecycle_events.test.js
@@ -1,0 +1,268 @@
+// Unit tests for the client lifecycle CustomEvents (issue #79):
+//
+//   reactive:before-dispatch  — cancelable veto point, fired in #proceed
+//                               (post-preventDefault, post-confirm, PRE-debounce);
+//                               preventDefault() skips debounce/enqueue entirely.
+//   reactive:applied          — after token extraction + Turbo.renderStreamMessage;
+//                               detail { action, params, html }.
+//   reactive:error            — in all four #perform failure branches, kind:
+//                               redirected | http | content-type | network, with a
+//                               retry() that re-enters the request queue (and
+//                               no-ops with a console.warn when the root left
+//                               the DOM).
+//
+// Events go out via RAW dispatchEvent — Stimulus's this.dispatch() helper is
+// SHADOWED by the controller's own dispatch(event) action method — on the root
+// element when connected, else on document (a bubbling event on a detached node
+// never reaches document listeners).
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A reactive root stub that records every CustomEvent raw-dispatched on it.
+function makeRoot({ connected = true } = {}) {
+  const events = []
+  return {
+    events,
+    isConnected: connected,
+    id: "counter",
+    dispatchEvent: (event) => events.push(event),
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+// Build a controller with a scripted fetch. `responses` is a list of fetch
+// outcomes ({...response fields} or { reject: Error }) consumed in order; the
+// last one repeats.
+function buildController(responses, { root } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root ?? makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    const script = responses[Math.min(calls, responses.length - 1)]
+    calls++
+    if (script.reject) return Promise.reject(script.reject)
+    return Promise.resolve({
+      redirected: script.redirected ?? false,
+      ok: script.ok ?? true,
+      status: script.status ?? 200,
+      headers: { get: () => script.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(script.body ?? ""),
+    })
+  }
+  const documentEvents = []
+  globalThis.document = {
+    querySelector: () => null,
+    dispatchEvent: (event) => documentEvents.push(event),
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls, documentEvents }
+}
+
+function click(controller, extra = {}) {
+  return controller.dispatch({
+    params: { action: "save", params: '{"n":1}', ...extra },
+    preventDefault: () => {},
+  })
+}
+
+function eventsNamed(root, name) {
+  return root.events.filter((event) => event.type === name)
+}
+
+// --- reactive:before-dispatch ---------------------------------------------
+
+test("before-dispatch fires with {action, params, element} and is cancelable", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController([{}], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:before-dispatch")
+  expect(event).toBeDefined()
+  expect(event.cancelable).toBe(true)
+  expect(event.bubbles).toBe(true)
+  expect(event.composed).toBe(true)
+  expect(event.detail.action).toBe("save")
+  expect(event.detail.params).toEqual({ n: 1 })
+  expect(event.detail.element).toBe(root)
+  expect(calls()).toBe(1)
+})
+
+test("before-dispatch preventDefault() cancels the round trip (no fetch)", async () => {
+  const root = makeRoot()
+  root.dispatchEvent = (event) => {
+    root.events.push(event)
+    if (event.type === "reactive:before-dispatch") event.preventDefault()
+  }
+  const { controller, calls } = buildController([{}], { root })
+
+  await click(controller)
+
+  expect(calls()).toBe(0)
+})
+
+test("before-dispatch preventDefault() also skips a DEBOUNCED dispatch (nothing scheduled)", async () => {
+  const root = makeRoot()
+  root.dispatchEvent = (event) => {
+    root.events.push(event)
+    if (event.type === "reactive:before-dispatch") event.preventDefault()
+  }
+  const { controller, calls } = buildController([{}], { root })
+
+  click(controller, { debounce: 10 })
+  await wait(60) // well past the debounce window
+
+  expect(calls()).toBe(0)
+})
+
+// --- reactive:applied -------------------------------------------------------
+
+test("applied fires after renderStreamMessage with {action, params, html}", async () => {
+  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ body: html }], { root })
+  const order = []
+  globalThis.window.Turbo.renderStreamMessage = () => order.push("render")
+  root.dispatchEvent = (event) => {
+    root.events.push(event)
+    if (event.type === "reactive:applied") order.push("applied")
+  }
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:applied")
+  expect(event).toBeDefined()
+  expect(event.cancelable).toBe(false)
+  expect(event.detail.action).toBe("save")
+  expect(event.detail.params).toEqual({ n: 1 })
+  expect(event.detail.html).toBe(html)
+  // The stream was handed to Turbo BEFORE the event fired.
+  expect(order).toEqual(["render", "applied"])
+})
+
+// --- reactive:error — kind mapping per failure branch -----------------------
+
+test("a redirected response fires reactive:error kind=redirected", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ redirected: true, status: 200 }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("redirected")
+  expect(event.detail.action).toBe("save")
+  expect(typeof event.detail.retry).toBe("function")
+})
+
+test("a non-OK response fires reactive:error kind=http with status and body", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ ok: false, status: 403, body: "denied" }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("http")
+  expect(event.detail.status).toBe(403)
+  expect(event.detail.body).toBe("denied")
+})
+
+test("a non-turbo-stream response fires reactive:error kind=content-type", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ contentType: "text/html" }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("content-type")
+})
+
+test("a network failure fires reactive:error kind=network (console.error kept)", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ reject: new Error("offline") }], { root })
+  const errors = []
+  const original = console.error
+  console.error = (...args) => errors.push(args)
+
+  try {
+    await click(controller)
+  } finally {
+    console.error = original
+  }
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("network")
+  // The existing console.error is unconditional — the event ADDS a hook, it
+  // does not replace the log.
+  expect(errors.length).toBe(1)
+})
+
+// --- retry() ----------------------------------------------------------------
+
+test("retry() re-enters the queue and does NOT refire before-dispatch", async () => {
+  const root = makeRoot()
+  // First fetch fails (500), the retried one succeeds.
+  const { controller, calls } = buildController([{ ok: false, status: 500 }, {}], { root })
+
+  await click(controller)
+  expect(calls()).toBe(1)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  await event.detail.retry()
+
+  expect(calls()).toBe(2)
+  // retry() is a queue re-entry, not a new user gesture — ONE before-dispatch.
+  expect(eventsNamed(root, "reactive:before-dispatch").length).toBe(1)
+})
+
+test("retry() no-ops with a console.warn when the root left the DOM", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController([{ ok: false, status: 500 }], { root })
+
+  await click(controller)
+  const [event] = eventsNamed(root, "reactive:error")
+
+  root.isConnected = false // a plain replace detached this node
+  const warnings = []
+  const original = console.warn
+  console.warn = (...args) => warnings.push(args)
+  try {
+    await event.detail.retry()
+  } finally {
+    console.warn = original
+  }
+
+  expect(calls()).toBe(1) // nothing re-enqueued
+  expect(warnings.length).toBe(1)
+})
+
+// --- detached-root fallback ---------------------------------------------------
+
+test("events from a detached root dispatch on document instead", async () => {
+  const root = makeRoot({ connected: false })
+  const { controller, documentEvents } = buildController([{ ok: false, status: 500 }], { root })
+
+  await click(controller)
+
+  expect(root.events.length).toBe(0)
+  const names = documentEvents.map((event) => event.type)
+  expect(names).toContain("reactive:before-dispatch")
+  expect(names).toContain("reactive:error")
+})

--- a/spec/javascript/reactive_lifecycle_events.test.js
+++ b/spec/javascript/reactive_lifecycle_events.test.js
@@ -214,12 +214,23 @@ test("a network failure fires reactive:error kind=network (console.error kept)",
   expect(errors.length).toBe(1)
 })
 
-// A throw AFTER a successful fetch (token extraction, Turbo rendering, or a
-// throwing reactive:applied listener) must NOT be labeled "network" — the
-// server already processed the mutation, so a retry() there would re-POST an
-// already-completed, potentially non-idempotent action (CodeRabbit review on
-// PR #89). It fires kind="apply" with NO retry() in the detail at all.
-test("a post-response render failure fires reactive:error kind=apply, NOT network, with no retry()", async () => {
+// A throw AFTER a successful fetch (token extraction or Turbo rendering) must
+// NOT be labeled "network" — the server already processed the mutation, so a
+// retry() there would re-POST an already-completed, potentially
+// non-idempotent action (CodeRabbit review on PR #89). It fires kind="apply"
+// with NO retry() in the detail at all.
+//
+// NOTE ON SCOPE: per the WHATWG DOM spec, EventTarget#dispatchEvent does NOT
+// propagate a listener's thrown exception back to the caller — the exception
+// is reported to the global object, dispatchEvent returns normally, and
+// #perform's catch never sees it (verified against a real EventTarget, not
+// this file's mocked root — CodeRabbit review on PR #89, round 2). So a
+// throwing reactive:applied LISTENER can't actually reach kind: "apply" (or
+// any #perform catch) in a real browser; only synchronous code INSIDE
+// #perform's own post-fetch tail (Turbo.renderStreamMessage itself throwing,
+// or in principle #extractToken) can. This test models exactly that reachable
+// case — Turbo.renderStreamMessage throwing — not a listener throw.
+test("Turbo.renderStreamMessage throwing fires reactive:error kind=apply, NOT network, with no retry()", async () => {
   const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
   const root = makeRoot()
   const { controller } = buildController([{ body: html }], { root })
@@ -234,22 +245,21 @@ test("a post-response render failure fires reactive:error kind=apply, NOT networ
   expect(event.detail.retry).toBeUndefined()
 })
 
-// A throwing reactive:applied LISTENER is the same class of bug: the action
-// already succeeded server-side, so this must not surface as retriable.
-test("a throwing reactive:applied listener fires reactive:error kind=apply, not network", async () => {
-  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
-  const root = makeRoot()
-  root.dispatchEvent = (event) => {
-    root.events.push(event)
-    if (event.type === "reactive:applied") throw new Error("listener exploded")
-  }
-  const { controller } = buildController([{ body: html }], { root })
-
-  await click(controller)
-
-  const [event] = eventsNamed(root, "reactive:error")
-  expect(event.detail.kind).toBe("apply")
-})
+// NOTE: NOT re-encoded as a bun:test test. `bun test`'s runner independently
+// reports any exception surfaced during a test body as a FAILURE of that
+// test — including one a listener throws during dispatchEvent — regardless
+// of whether the test's own try/catch observes it. That makes "prove
+// dispatchEvent's caller never sees a listener's throw" impossible to assert
+// cleanly inside this runner without suppressing Bun's own reporter, which
+// isn't worth doing for a spec-compliance sanity check. Verified manually
+// instead (bun -e, outside the test runner):
+//
+//   const target = new EventTarget()
+//   target.addEventListener("boom", () => { throw new Error("boom") })
+//   try { target.dispatchEvent(new CustomEvent("boom")); logged = "no throw" }
+//   catch { logged = "threw" }
+//   // -> "no throw": the exception is reported to the console by dispatchEvent
+//   // itself; the caller's try/catch never runs its catch block.
 
 // --- retry() ----------------------------------------------------------------
 

--- a/spec/javascript/reactive_lifecycle_events.test.js
+++ b/spec/javascript/reactive_lifecycle_events.test.js
@@ -214,6 +214,43 @@ test("a network failure fires reactive:error kind=network (console.error kept)",
   expect(errors.length).toBe(1)
 })
 
+// A throw AFTER a successful fetch (token extraction, Turbo rendering, or a
+// throwing reactive:applied listener) must NOT be labeled "network" — the
+// server already processed the mutation, so a retry() there would re-POST an
+// already-completed, potentially non-idempotent action (CodeRabbit review on
+// PR #89). It fires kind="apply" with NO retry() in the detail at all.
+test("a post-response render failure fires reactive:error kind=apply, NOT network, with no retry()", async () => {
+  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ body: html }], { root })
+  globalThis.window.Turbo.renderStreamMessage = () => {
+    throw new Error("Turbo choked on the stream")
+  }
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("apply")
+  expect(event.detail.retry).toBeUndefined()
+})
+
+// A throwing reactive:applied LISTENER is the same class of bug: the action
+// already succeeded server-side, so this must not surface as retriable.
+test("a throwing reactive:applied listener fires reactive:error kind=apply, not network", async () => {
+  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
+  const root = makeRoot()
+  root.dispatchEvent = (event) => {
+    root.events.push(event)
+    if (event.type === "reactive:applied") throw new Error("listener exploded")
+  }
+  const { controller } = buildController([{ body: html }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("apply")
+})
+
 // --- retry() ----------------------------------------------------------------
 
 test("retry() re-enters the queue and does NOT refire before-dispatch", async () => {

--- a/spec/javascript/reactive_multipart.test.js
+++ b/spec/javascript/reactive_multipart.test.js
@@ -109,6 +109,7 @@ function stubEnv() {
       if (sel.includes("csrf-token")) return { content: "csrf-abc" }
       return null
     },
+    dispatchEvent: () => {},
   }
   globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
 }

--- a/spec/system/lifecycle_events_spec.rb
+++ b/spec/system/lifecycle_events_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Client lifecycle CustomEvents (issue #79). A page-level listener hears
+# reactive:error when an action round trip fails — here forced via a trigger
+# for an UNDECLARED action (the endpoint's default-deny → HTTP 403), the least
+# invasive real failure. The events bubble, so `data-action=
+# "reactive:error->toast#show"` on an ancestor composes the same way.
+RSpec.describe "Lifecycle events (reactive:error)", type: :system do
+  it "dispatches reactive:error with kind/status/retry when the endpoint refuses the action" do
+    visit "/counter"
+    expect(page).to have_css("[data-testid='boom']")
+
+    # Marker proves the failure never triggered a full-page navigation, plus a
+    # page-level probe node the document-level listener writes into.
+    page.execute_script(<<~JS)
+      window.__noReload = "alive"
+      const probe = document.createElement("div")
+      probe.setAttribute("data-testid", "error-probe")
+      document.body.appendChild(probe)
+      document.addEventListener("reactive:error", (event) => {
+        const { kind, status, retry } = event.detail
+        probe.textContent = [kind, status, typeof retry].join(":")
+      })
+    JS
+
+    find("[data-testid='boom']").click
+
+    # Undeclared action → default-deny 403 → kind=http, status=403, retry is a
+    # callable. The waiting matcher is the barrier for the async round trip.
+    expect(page).to have_css("[data-testid='error-probe']", text: "http:403:function")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary
- The generic controller now dispatches three bubbling, composed CustomEvents (raw `dispatchEvent` — Stimulus's `this.dispatch` is shadowed by the controller's `dispatch` action) from the root, falling back to `document` when the root is detached (a plain replace detaches it mid-flight):
  - **`reactive:before-dispatch`** — cancelable, fired in `#proceed` (post-preventDefault, post-confirm, pre-debounce), detail `{action, params, element}`; `preventDefault()` skips debounce + enqueue entirely; never refires on `retry()`.
  - **`reactive:applied`** — after token extraction + `Turbo.renderStreamMessage`, detail `{action, params, html}`; documented honestly as "handed to Turbo" (DOM mutation may land a tick later).
  - **`reactive:error`** — on all four failure branches with `kind: redirected|http|content-type|network`, `status?`, `body?`, and `retry()` that guards `element.isConnected` and re-enters the queue so the freshest token is re-read at send time. Existing `console.error`s kept unconditionally.
- This is the extension seam for error toasts, instrumentation, and retry UI without forking the controller — composes with Stimulus (`data-action="reactive:error->toast#show"`).

## Test plan
- TDD RED → GREEN: 11 new bun tests (cancel-enqueue incl. debounced, kind mapping per branch, applied ordering, retry-through-queue without before-dispatch refire, detached retry no-op, detached-root document fallback). Full bun suite 82 pass (pre-existing test stubs gained `dispatchEvent` no-ops — stubs fixed, not production code).
- New forced-403 system spec (undeclared `on(:boom)` trigger + page-level listener) — RED → GREEN under Puma AND Falcon; full browser suite green under Puma; fast suite 285 green post-rebase; RuboCop clean; docs security page passes the docs app's own RuboCop; vendored copy byte-identical.

## Reviewer notes
- The forced-failure spec adds a small deliberately-undeclared `boom` button to the shared counter demo page (inert for the other specs); happy to move it to a dedicated demo component if you'd rather keep the counter page clean.
- `reactive:applied` fires when streams are handed to Turbo, not post-morph — apps needing post-morph timing should listen to Turbo's own events (documented).

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bubbling, composed lifecycle events for reactive actions: `reactive:before-dispatch` (cancelable), `reactive:applied`, and `reactive:error` with `kind`-specific details.
  * `reactive:error` includes a retry hook for eligible failures (no retry for apply-time errors), with DOM-detached retry safely no-op’ing.
* **Bug Fixes**
  * Improved failure UX by emitting consistent `reactive:error` for redirected, HTTP non-OK, unsupported content-type, network, and apply-time errors.
* **Documentation / Tests**
  * Documented the new “Failure UX & lifecycle events” section (with examples) and expanded unit/system coverage for cancellation, dispatch location, and timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->