### PR TITLE
feat(component): on() event modifiers — window:, once:, outside:, throttle:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`on(...)` event modifiers — `window:`, `once:`, `outside:`, `throttle:`
+  (#80).** Four trigger patterns that previously forced a hand-written Stimulus
+  controller are now declarable on `on(...)`. `outside: true` fires the action
+  only for events whose target is OUTSIDE the component's root — the
+  close-a-dropdown-on-outside-click pattern; an event inside the root is a
+  complete client-side no-op (bailing before `preventDefault` and before the
+  `reactive:before-dispatch` lifecycle event). It implies `window: true`, which
+  binds the trigger via Stimulus's native `@window` descriptor for page-level
+  events (`scroll`/`resize`). Window-bound triggers are NEVER
+  `preventDefault`-ed — a mounted dropdown must not kill native link clicks
+  elsewhere on the page — and skip the forced `type="button"`; the client
+  decides this from `data-reactive-window-param` (emitted as an explicit
+  `"true"` string — Phlex renders a boolean `true` attribute VALUELESS, which
+  Stimulus's param reader sees as `""`, falsy). `once: true` appends Stimulus's
+  `:once` action option (fire at most once, then unbind). `throttle:`
+  (milliseconds) rate-limits LEADING-EDGE — the first event fires immediately,
+  further events are dropped until the window elapses — the mirror of
+  `debounce:` (trailing-edge); passing both raises `ArgumentError`. Suppression
+  timers are keyed on action + target (window scroll events all share
+  `event.target === document`, so two window-bound triggers on one component
+  must not collide) and torn down on `disconnect()`. The bare `on(:x)` emission
+  is pinned byte-identical by spec — the four names become RESERVED `on(...)`
+  kwargs, no longer usable as free action params.
+
 - **Single include + a default `#id` for record-backed components (#81).**
   `include Phlex::Reactive::Component` now pulls in
   `Phlex::Reactive::Streamable` automatically (ActiveSupport::Concern's

--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:action, event: "keydown.enter")` | Fire only on a specific key — Enter-to-submit / Escape-to-cancel — via Stimulus's native keyboard filter (`event:` passes straight through). See [Keyboard triggers](#keyboard-triggers-enter-to-submit--escape-to-cancel). |
 | `on(:action, confirm: "Sure?")` | Gate a destructive trigger behind a confirmation. Defaults to `window.confirm`; override the dialog with [`setConfirmResolver`](#custom-confirmation-dialogs-setconfirmresolver). |
 | `on(:search, listnav: "[role=option]")` | Add combobox keyboard navigation — Arrow keys move a client-side highlight, Enter picks (clicks the option's own trigger), Escape clears. See [Combobox keyboard navigation](#combobox-keyboard-navigation-listnav). |
+| `on(:close_menu, outside: true)` | Fire only for events **outside** this component's root (close-a-dropdown-on-outside-click). Window-bound; never `preventDefault`s, so links elsewhere keep navigating. |
+| `on(:track, event: "scroll", window: true, throttle: 250)` | `window:` binds the trigger to the window (page-level scroll/resize); `throttle:` rate-limits leading-edge — first event fires, the rest drop until the window elapses. Mutually exclusive with `debounce:`. |
+| `on(:action, once: true)` | Fire at most once, then unbind (Stimulus's native `:once`). |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
@@ -433,6 +436,36 @@ Omit `debounce:` for the immediate-dispatch default.
 # Recompute a total live as the user types, without hammering the endpoint.
 input(**mix(on(:update, event: "input", debounce: 300), name: "quantity", value: @item.quantity))
 ```
+
+**Event modifiers — `outside:`, `window:`, `once:`, `throttle:`.** Four more
+`on(...)` options cover the page-level trigger patterns that otherwise need a
+hand-written Stimulus controller:
+
+- `outside: true` fires the action only for events whose target is **outside**
+  this component's root — the close-a-dropdown-on-outside-click pattern. An
+  event inside the root is a complete client-side no-op. Implies `window:`.
+- `window: true` binds the trigger to the window (Stimulus's native `@window`)
+  for page-level events like `scroll`/`resize`. Window-bound triggers are
+  **never `preventDefault`-ed** — a mounted dropdown must not kill link clicks
+  elsewhere on the page — and skip the forced `type="button"`.
+- `once: true` fires at most once, then unbinds (Stimulus's `:once`).
+- `throttle: 250` rate-limits **leading-edge**: the first event fires
+  immediately, further events are dropped until the window elapses. The mirror
+  of `debounce:` (trailing-edge) — passing both raises `ArgumentError`.
+
+```ruby
+# A dropdown that closes itself on any click outside — no Stimulus controller.
+div(**mix(reactive_root, on(:close_menu, outside: true))) do
+  button(**on(:toggle_menu)) { "Menu" }
+  ul { menu_items } if @open
+end
+
+# Throttled page-scroll tracking.
+div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 500)))
+```
+
+These four (like `debounce:`/`confirm:`/`listnav:`) are **reserved keyword
+names** on `on(...)` — no longer usable as free action params.
 
 **Auto-collected sibling fields — the read contract.** A reactive action doesn't
 just receive its own trigger's value: the client gathers **every named control**

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -143,6 +143,7 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+  #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
 
   // Mark that a reactive controller actually connected, so the registration
@@ -171,8 +172,12 @@ export default class extends Controller {
   // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't
   // fired yet would later call #enqueue on a disconnected controller — a round
   // trip against a detached element / stale token (issue #17 follow-up).
+  // Throttle suppression timers (issue #80) are torn down the same way — a
+  // leading-edge timer holds no pending POST, but leaving it running would leak
+  // it past the element's life.
   disconnect() {
     this.#clearAllDebounces()
+    this.#clearAllThrottles()
   }
 
   // Serialize requests per component. Each round trip rewrites the signed
@@ -182,8 +187,20 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params, debounce, confirm } = event.params
+    // `window` (renamed: never shadow the global) and `outside` are the event-
+    // modifier params (issue #80). The client decides preventDefault behavior
+    // from event.params — set by the Ruby on() — never by sniffing the
+    // Stimulus descriptor.
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound } = event.params
     if (!action) return
+
+    // Outside guard FIRST (issue #80): an outside: trigger only fires for
+    // events whose target is OUTSIDE this component's ROOT (containment against
+    // this.element — .contains includes the root itself). An event inside the
+    // root must be a COMPLETE no-op — before preventDefault (the page's native
+    // click behavior is untouched) and before the reactive:before-dispatch
+    // lifecycle event (nothing to announce, nothing to veto).
+    if (outside && this.element.contains(event.target)) return
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -194,14 +211,19 @@ export default class extends Controller {
     // for debounced triggers too — the round trip is deferred, but the native
     // default must still be prevented now. (Moved ahead of the confirm branch in
     // issue #55: an async resolver means we can't preventDefault after awaiting.)
-    event.preventDefault()
+    //
+    // ONLY for element-bound triggers: a window-bound trigger (window:/outside:,
+    // issue #80) hears EVERY matching event on the page — preventDefault-ing
+    // those would kill every link click while a dropdown is mounted. The page's
+    // native behavior proceeds alongside the reactive round trip.
+    if (!windowBound) event.preventDefault()
 
     // Capture the trigger element now; #proceed runs in a later microtask (after
     // the confirm resolver settles), by which point event.target may be reset.
     const target = event.target
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -218,7 +240,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce)
+        if (ok) this.#proceed(target, action, params, debounce, throttle)
       })
   }
 
@@ -380,13 +402,14 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce) {
+  #proceed(target, action, params, debounce, throttle) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
-    // per user gesture — post-preventDefault, post-confirm, PRE-debounce.
-    // event.preventDefault() skips the debounce AND the enqueue entirely
-    // (nothing is scheduled). retry() re-enters the queue directly, so this
-    // does NOT refire on a retry. detail.params are the trigger's explicit
-    // params; sibling fields are collected later, at send time.
+    // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
+    // PRE-throttle, the same timing). event.preventDefault() skips the
+    // debounce/throttle AND the enqueue entirely (nothing is scheduled).
+    // retry() re-enters the queue directly, so this does NOT refire on a retry.
+    // detail.params are the trigger's explicit params; sibling fields are
+    // collected later, at send time.
     const before = this.#emit("reactive:before-dispatch", {
       action,
       params: this.#parseParams(params),
@@ -399,6 +422,14 @@ export default class extends Controller {
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
     const ms = Number(debounce) || 0
     if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
+
+    // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
+    // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
+    // event immediately, drop the rest until the window elapses. debounce and
+    // throttle are mutually exclusive (the Ruby on() raises on both).
+    const throttleMs = Number(throttle) || 0
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params)
+
     return this.#enqueue(action, params)
   }
 
@@ -435,6 +466,34 @@ export default class extends Controller {
   // the keys first — #clearDebounce mutates the map as it goes.
   #clearAllDebounces() {
     for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
+  }
+
+  // Leading-edge throttle (issue #80), mirroring #debounceDispatch: the FIRST
+  // event fires immediately; a suppression timer then drops further events
+  // until the window elapses (no trailing fire — dropped, not queued). Timers
+  // are keyed on action + target, NOT target alone: window-bound scroll/resize
+  // events all share event.target === document, so two window-bound triggers
+  // on one component would otherwise collide on one timer.
+  #throttleDispatch(target, ms, action, params) {
+    const timers = this.#throttleTimers.get(target) ?? new Map()
+    if (timers.has(action)) return // inside the window — suppress
+
+    const timer = setTimeout(() => {
+      timers.delete(action)
+      if (timers.size === 0) this.#throttleTimers.delete(target)
+    }, ms)
+    timers.set(action, timer)
+    this.#throttleTimers.set(target, timers)
+    return this.#enqueue(action, params) // leading edge: fire NOW
+  }
+
+  // Clear every throttle suppression timer (used on disconnect, alongside
+  // #clearAllDebounces) so nothing outlives the element.
+  #clearAllThrottles() {
+    for (const timers of this.#throttleTimers.values()) {
+      for (const timer of timers.values()) clearTimeout(timer)
+    }
+    this.#throttleTimers.clear()
   }
 
   // Raw-dispatch a lifecycle CustomEvent (issue #79). Deliberately NOT

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -396,8 +396,38 @@ module Phlex
         "keydown.esc->reactive#listnavClose"
       ].freeze
 
-      def on(action_name, event: "click", debounce: nil, confirm: nil, listnav: nil, **params)
-        action = "#{event}->reactive#dispatch"
+      # Event modifiers (issue #80) — window:, once:, outside:, throttle: are
+      # RESERVED keyword names on on() (no longer usable as free action params):
+      #
+      # `window: true` binds the trigger to the window (Stimulus's native
+      # `@window` descriptor suffix) — for page-level events like scroll/resize.
+      # `once: true` appends Stimulus's `:once` option, so the trigger fires at
+      # most one round trip and then unbinds. Both are pure descriptor
+      # composition. A window-bound trigger is NOT preventDefault-ed by the
+      # client (it would kill every native click/submit on the page), and it
+      # skips the forced type="button" (it isn't an in-form button trigger).
+      #
+      # `outside: true` fires the action only for events OUTSIDE this
+      # component's ROOT (containment against the reactive root element) — the
+      # close-a-dropdown-on-outside-click pattern. It implies `window: true`;
+      # an event inside the root is a complete client-side no-op:
+      #   div(**mix(reactive_root, on(:close_menu, outside: true))) { ... }
+      #
+      # `throttle:` (milliseconds) rate-limits a hot trigger LEADING-EDGE: the
+      # first event fires immediately, further events are suppressed until the
+      # window elapses (scroll/mousemove). Mutually exclusive with `debounce:`
+      # (trailing-edge) — passing both raises ArgumentError.
+      #   div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 250)))
+      def on(action_name, event: "click", debounce: nil, throttle: nil, confirm: nil, listnav: nil,
+             window: false, once: false, outside: false, **params)
+        if debounce && throttle
+          raise ArgumentError,
+            "on(#{action_name.inspect}) got both debounce: and throttle: — they are mutually " \
+            "exclusive (debounce is trailing-edge, throttle is leading-edge); pick one"
+        end
+
+        window_bound = window || outside
+        action = "#{event}#{"@window" if window_bound}->reactive#dispatch#{":once" if once}"
         action = "#{action} #{LISTNAV_ACTIONS.join(" ")}" if listnav
         attrs = {
           data: {
@@ -407,9 +437,18 @@ module Phlex
           }
         }
         attrs[:data][:reactive_debounce_param] = debounce if debounce
+        attrs[:data][:reactive_throttle_param] = throttle if throttle
         attrs[:data][:reactive_confirm_param] = confirm if confirm
         attrs[:data][:reactive_listnav_option_param] = listnav if listnav
-        attrs[:type] = "button" if event == "click"
+        # STRING "true", not boolean: Phlex renders a `true` attribute VALUELESS
+        # (data-reactive-outside-param), which Stimulus's param reader sees as ""
+        # — falsy in JS, so the guard silently never fires. The explicit ="true"
+        # typecasts to a real boolean on the client.
+        attrs[:data][:reactive_outside_param] = "true" if outside
+        # The client decides preventDefault behavior from event.params (never by
+        # sniffing the descriptor), so EVERY window binding flags the param.
+        attrs[:data][:reactive_window_param] = "true" if window_bound
+        attrs[:type] = "button" if event == "click" && !window_bound
         attrs
       end
 

--- a/spec/dummy/app/components/dropdown_menu_component.rb
+++ b/spec/dummy/app/components/dropdown_menu_component.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Exercises the outside: event modifier (issue #80): the canonical
+# close-a-dropdown-on-outside-click. While the menu is OPEN the root binds
+# on(:close_menu, outside: true) — a window-bound click that fires only for
+# targets OUTSIDE this root. A click inside the root is a complete client-side
+# no-op, and the window binding never preventDefaults, so links elsewhere on
+# the page keep navigating. `closes` counts how many times close_menu actually
+# ran, so the spec can prove an inside click contributed nothing.
+class DropdownMenuComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :open, :closes
+
+  action :toggle_menu
+  action :close_menu
+
+  def initialize(open: false, closes: 0)
+    @open = open
+    @closes = closes
+  end
+
+  def id = "dropdown"
+
+  def toggle_menu
+    @open = !@open
+  end
+
+  def close_menu
+    @open = false
+    @closes += 1
+  end
+
+  def view_template
+    div(**root_attrs) do
+      button(**mix(on(:toggle_menu), data: { testid: "menu-button" })) { "Menu" }
+      span(data: { testid: "closes" }) { @closes.to_s }
+      if @open
+        ul(data: { testid: "menu" }) do
+          li(data: { testid: "menu-item" }) { "Item one" }
+        end
+      end
+    end
+  end
+
+  private
+
+  # Bind the outside-click close ONLY while open — a closed menu shouldn't
+  # round-trip on every stray page click.
+  def root_attrs
+    return reactive_root unless @open
+
+    mix(reactive_root, on(:close_menu, outside: true))
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -65,6 +65,22 @@ class DemosController < ActionController::Base
     render_component DebounceComponent.new
   end
 
+  # The outside-click dropdown (issue #80). The page carries content OUTSIDE the
+  # reactive root — a plain area to click and a real link — so the system spec
+  # can prove the outside close fires AND that the window-bound trigger never
+  # preventDefaults native navigation elsewhere on the page.
+  def dropdown
+    component = render_to_string(DropdownMenuComponent.new, layout: false)
+    outside = <<~HTML
+      <div data-testid="outside-area" style="padding: 4rem">outside the menu</div>
+      <a href="/nav_probe" data-testid="outside-link">elsewhere</a>
+    HTML
+    # render_to_string returns a SafeBuffer whose #to_s returns SELF, so a
+    # `component.to_s + outside` concat ESCAPES the raw fixture into visible
+    # text. Appending an html_safe right-hand side concatenates verbatim.
+    render html: component + outside.html_safe, layout: true
+  end
+
   def confirm
     render_component ConfirmComponent.new
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "nested_editor" => "demos#nested_editor"
   get "nested_params" => "demos#nested_params"
   get "debounce" => "demos#debounce"
+  get "dropdown" => "demos#dropdown"
   get "confirm" => "demos#confirm"
   get "morph_grid/:id" => "demos#morph_grid"
   get "partial_grid/:id" => "demos#partial_grid"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -143,6 +143,7 @@ export default class extends Controller {
 
   #tokenCache // freshest token, threaded synchronously across queued requests
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
+  #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
 
   // Mark that a reactive controller actually connected, so the registration
@@ -171,8 +172,12 @@ export default class extends Controller {
   // (Turbo morph/navigation removes the element). Otherwise a timer that hasn't
   // fired yet would later call #enqueue on a disconnected controller — a round
   // trip against a detached element / stale token (issue #17 follow-up).
+  // Throttle suppression timers (issue #80) are torn down the same way — a
+  // leading-edge timer holds no pending POST, but leaving it running would leak
+  // it past the element's life.
   disconnect() {
     this.#clearAllDebounces()
+    this.#clearAllThrottles()
   }
 
   // Serialize requests per component. Each round trip rewrites the signed
@@ -182,8 +187,20 @@ export default class extends Controller {
   // a per-controller promise makes each dispatch wait for the previous one, so
   // it always uses the freshest token.
   dispatch(event) {
-    const { action, params, debounce, confirm } = event.params
+    // `window` (renamed: never shadow the global) and `outside` are the event-
+    // modifier params (issue #80). The client decides preventDefault behavior
+    // from event.params — set by the Ruby on() — never by sniffing the
+    // Stimulus descriptor.
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound } = event.params
     if (!action) return
+
+    // Outside guard FIRST (issue #80): an outside: trigger only fires for
+    // events whose target is OUTSIDE this component's ROOT (containment against
+    // this.element — .contains includes the root itself). An event inside the
+    // root must be a COMPLETE no-op — before preventDefault (the page's native
+    // click behavior is untouched) and before the reactive:before-dispatch
+    // lifecycle event (nothing to announce, nothing to veto).
+    if (outside && this.element.contains(event.target)) return
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -194,14 +211,19 @@ export default class extends Controller {
     // for debounced triggers too — the round trip is deferred, but the native
     // default must still be prevented now. (Moved ahead of the confirm branch in
     // issue #55: an async resolver means we can't preventDefault after awaiting.)
-    event.preventDefault()
+    //
+    // ONLY for element-bound triggers: a window-bound trigger (window:/outside:,
+    // issue #80) hears EVERY matching event on the page — preventDefault-ing
+    // those would kill every link click while a dropdown is mounted. The page's
+    // native behavior proceeds alongside the reactive round trip.
+    if (!windowBound) event.preventDefault()
 
     // Capture the trigger element now; #proceed runs in a later microtask (after
     // the confirm resolver settles), by which point event.target may be reset.
     const target = event.target
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -218,7 +240,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce)
+        if (ok) this.#proceed(target, action, params, debounce, throttle)
       })
   }
 
@@ -380,13 +402,14 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce) {
+  #proceed(target, action, params, debounce, throttle) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
-    // per user gesture — post-preventDefault, post-confirm, PRE-debounce.
-    // event.preventDefault() skips the debounce AND the enqueue entirely
-    // (nothing is scheduled). retry() re-enters the queue directly, so this
-    // does NOT refire on a retry. detail.params are the trigger's explicit
-    // params; sibling fields are collected later, at send time.
+    // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
+    // PRE-throttle, the same timing). event.preventDefault() skips the
+    // debounce/throttle AND the enqueue entirely (nothing is scheduled).
+    // retry() re-enters the queue directly, so this does NOT refire on a retry.
+    // detail.params are the trigger's explicit params; sibling fields are
+    // collected later, at send time.
     const before = this.#emit("reactive:before-dispatch", {
       action,
       params: this.#parseParams(params),
@@ -399,6 +422,14 @@ export default class extends Controller {
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
     const ms = Number(debounce) || 0
     if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
+
+    // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
+    // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
+    // event immediately, drop the rest until the window elapses. debounce and
+    // throttle are mutually exclusive (the Ruby on() raises on both).
+    const throttleMs = Number(throttle) || 0
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params)
+
     return this.#enqueue(action, params)
   }
 
@@ -435,6 +466,34 @@ export default class extends Controller {
   // the keys first — #clearDebounce mutates the map as it goes.
   #clearAllDebounces() {
     for (const target of [...this.#debounceTimers.keys()]) this.#clearDebounce(target)
+  }
+
+  // Leading-edge throttle (issue #80), mirroring #debounceDispatch: the FIRST
+  // event fires immediately; a suppression timer then drops further events
+  // until the window elapses (no trailing fire — dropped, not queued). Timers
+  // are keyed on action + target, NOT target alone: window-bound scroll/resize
+  // events all share event.target === document, so two window-bound triggers
+  // on one component would otherwise collide on one timer.
+  #throttleDispatch(target, ms, action, params) {
+    const timers = this.#throttleTimers.get(target) ?? new Map()
+    if (timers.has(action)) return // inside the window — suppress
+
+    const timer = setTimeout(() => {
+      timers.delete(action)
+      if (timers.size === 0) this.#throttleTimers.delete(target)
+    }, ms)
+    timers.set(action, timer)
+    this.#throttleTimers.set(target, timers)
+    return this.#enqueue(action, params) // leading edge: fire NOW
+  }
+
+  // Clear every throttle suppression timer (used on disconnect, alongside
+  // #clearAllDebounces) so nothing outlives the element.
+  #clearAllThrottles() {
+    for (const timers of this.#throttleTimers.values()) {
+      for (const timer of timers.values()) clearTimeout(timer)
+    }
+    this.#throttleTimers.clear()
   }
 
   // Raw-dispatch a lifecycle CustomEvent (issue #79). Deliberately NOT

--- a/spec/javascript/reactive_event_modifiers.test.js
+++ b/spec/javascript/reactive_event_modifiers.test.js
@@ -1,0 +1,219 @@
+// Unit tests for the on(...) event modifiers (issue #80): outside:, window:,
+// and throttle:. (window:/once: descriptor composition is pure Ruby — native
+// Stimulus — covered by the component spec; here we test the CLIENT contract.)
+//
+//   outside  — data-reactive-outside-param: the guard runs FIRST in dispatch().
+//              An event whose target is INSIDE this root is a COMPLETE no-op:
+//              no preventDefault, no reactive:before-dispatch, no fetch.
+//              An event outside the root dispatches normally.
+//   window   — data-reactive-window-param: a window-bound trigger must NOT
+//              call event.preventDefault() — a mounted dropdown must not kill
+//              every link click on the page. Element-bound triggers keep the
+//              unconditional preventDefault (issue #11).
+//   throttle — data-reactive-throttle-param: LEADING-EDGE rate limit, mirroring
+//              the debounce suite. The first event fires immediately; further
+//              events are suppressed until the window elapses. Timers are keyed
+//              on action + target (window scroll events share
+//              event.target === document — two window-bound triggers must not
+//              collide) and cleared in disconnect().
+//
+// Real timers with small delays, like the debounce suite.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A reactive root stub that records raw-dispatched CustomEvents (so the tests
+// can assert reactive:before-dispatch did or did not fire) and scripts
+// containment for the outside guard.
+function makeRoot({ containsTarget = false } = {}) {
+  const events = []
+  return {
+    events,
+    isConnected: true,
+    id: "menu",
+    contains: () => containsTarget,
+    dispatchEvent: (event) => events.push(event),
+    querySelectorAll: () => [],
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    getAttribute: () => null,
+  }
+}
+
+function buildController({ root } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root ?? makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    calls++
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+// A dispatchable event stub whose preventDefault flips defaultPrevented, so a
+// test can assert the REAL observable (would the browser's default run?).
+function makeEvent(params, { target = {} } = {}) {
+  return {
+    params,
+    target,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+}
+
+// --- outside: --------------------------------------------------------------
+
+test("an outside click OUTSIDE the root dispatches the action", async () => {
+  const root = makeRoot({ containsTarget: false })
+  const { controller, calls } = buildController({ root })
+
+  await controller.dispatch(makeEvent({ action: "close_menu", params: "{}", outside: true, window: true }))
+
+  expect(calls()).toBe(1)
+})
+
+test("an outside click INSIDE the root is a COMPLETE no-op (no fetch, no before-dispatch, no preventDefault)", async () => {
+  const root = makeRoot({ containsTarget: true })
+  const { controller, calls } = buildController({ root })
+
+  const event = makeEvent({ action: "close_menu", params: "{}", outside: true, window: true })
+  await controller.dispatch(event)
+  await wait(20) // let any (wrongly) scheduled work surface
+
+  expect(calls()).toBe(0)
+  // The guard runs BEFORE the lifecycle event — an inside click must not even
+  // announce itself to reactive:before-dispatch listeners.
+  expect(root.events.filter((e) => e.type === "reactive:before-dispatch").length).toBe(0)
+  // ...and BEFORE preventDefault — the page's native behavior is untouched.
+  expect(event.defaultPrevented).toBe(false)
+})
+
+// --- window: (no preventDefault) --------------------------------------------
+
+test("a window-bound trigger does NOT preventDefault (links elsewhere keep working)", async () => {
+  const root = makeRoot({ containsTarget: false })
+  const { controller, calls } = buildController({ root })
+
+  const event = makeEvent({ action: "close_menu", params: "{}", outside: true, window: true })
+  await controller.dispatch(event)
+
+  expect(event.defaultPrevented).toBe(false) // the round trip still ran...
+  expect(calls()).toBe(1) // ...without hijacking the page's click
+})
+
+test("an element-bound trigger still preventDefaults unconditionally (issue #11)", async () => {
+  const { controller, calls } = buildController()
+
+  const event = makeEvent({ action: "save", params: "{}" })
+  await controller.dispatch(event)
+
+  expect(event.defaultPrevented).toBe(true)
+  expect(calls()).toBe(1)
+})
+
+// --- throttle: ---------------------------------------------------------------
+
+test("throttled dispatches fire LEADING-EDGE: first immediately, burst suppressed, next window fires again", async () => {
+  const { controller, calls } = buildController()
+  const target = {}
+
+  // First event of the burst fires NOW (leading edge)...
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 60 }, { target }))
+  await wait(5)
+  expect(calls()).toBe(1)
+
+  // ...the rest of the burst inside the window is suppressed (dropped, not queued).
+  for (let i = 0; i < 4; i++) {
+    controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 60 }, { target }))
+    await wait(5)
+  }
+  expect(calls()).toBe(1)
+
+  // After the window elapses the next event fires immediately again.
+  await wait(80)
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 60 }, { target }))
+  await wait(5)
+  expect(calls()).toBe(2)
+})
+
+test("throttle timers are keyed on action + target — two actions sharing event.target don't collide", async () => {
+  const { controller, calls } = buildController()
+  // Window-bound scroll events all share event.target === document.
+  const sharedTarget = {}
+
+  controller.dispatch(makeEvent({ action: "track_scroll", params: "{}", throttle: 5000 }, { target: sharedTarget }))
+  controller.dispatch(makeEvent({ action: "track_pointer", params: "{}", throttle: 5000 }, { target: sharedTarget }))
+  await wait(10)
+
+  expect(calls()).toBe(2) // each action got its own leading-edge fire
+
+  controller.disconnect() // tear down the two long timers for suite stability
+})
+
+test("disconnect() clears the throttle timers alongside the debounces", async () => {
+  const { controller, calls } = buildController()
+  const target = {}
+
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 5000 }, { target }))
+  await wait(5)
+  expect(calls()).toBe(1)
+
+  // The element leaves the DOM before the window elapses; the pending
+  // suppression timer must be torn down, not left running.
+  controller.disconnect()
+
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 5000 }, { target }))
+  await wait(5)
+  expect(calls()).toBe(2) // the stale suppression entry is gone
+
+  controller.disconnect() // clean up the fresh timer too
+})
+
+test("no throttle → dispatch fires immediately every time (unchanged behavior)", async () => {
+  const { controller, calls } = buildController()
+
+  await controller.dispatch(makeEvent({ action: "save", params: "{}" }))
+  await controller.dispatch(makeEvent({ action: "save", params: "{}" }))
+
+  expect(calls()).toBe(2)
+})
+
+test("a throttled dispatch still fires reactive:before-dispatch per gesture (pre-throttle, like pre-debounce)", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController({ root })
+  const target = {}
+
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 5000 }, { target }))
+  controller.dispatch(makeEvent({ action: "track", params: "{}", throttle: 5000 }, { target }))
+  await wait(10)
+
+  expect(calls()).toBe(1) // second one throttled away...
+  // ...but the veto point saw both gestures (mirrors debounce's PRE-debounce timing).
+  expect(root.events.filter((e) => e.type === "reactive:before-dispatch").length).toBe(2)
+
+  controller.disconnect()
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -472,6 +472,83 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on event modifiers (issue #80 — window:, once:, outside:, throttle:)" do
+    subject(:instance) { state_klass.new }
+
+    # The hot-path pin: a bare on(:x) — the overwhelmingly common trigger — must
+    # emit EXACTLY today's hash. New modifiers may not perturb the no-modifier
+    # descriptor, params payload, or the forced type="button" by a single byte.
+    it "leaves the bare on(:x) emission byte-identical (no-modifier hot path)" do
+      expect(instance.send(:on, :increment)).to eq(
+        {
+          data: {
+            action: "click->reactive#dispatch",
+            reactive_action_param: "increment",
+            reactive_params_param: "{}"
+          },
+          type: "button"
+        }
+      )
+    end
+
+    it "window: true binds the descriptor to @window and flags the window param" do
+      attrs = instance.send(:on, :track, window: true)
+      expect(attrs[:data][:action]).to eq("click@window->reactive#dispatch")
+      expect(attrs[:data][:reactive_window_param]).to eq("true")
+    end
+
+    it "window: true skips type=button (the trigger isn't an in-form button)" do
+      attrs = instance.send(:on, :track, window: true)
+      expect(attrs).not_to have_key(:type)
+    end
+
+    it "once: true appends Stimulus's :once option to the descriptor" do
+      attrs = instance.send(:on, :dismiss, once: true)
+      expect(attrs[:data][:action]).to eq("click->reactive#dispatch:once")
+    end
+
+    it "composes window: and once: in descriptor order (@window before :once)" do
+      attrs = instance.send(:on, :dismiss, window: true, once: true)
+      expect(attrs[:data][:action]).to eq("click@window->reactive#dispatch:once")
+    end
+
+    it "outside: true implies the window binding" do
+      attrs = instance.send(:on, :close_menu, outside: true)
+      expect(attrs[:data][:action]).to eq("click@window->reactive#dispatch")
+      expect(attrs).not_to have_key(:type)
+    end
+
+    it "outside: true emits BOTH the outside and window Stimulus params" do
+      attrs = instance.send(:on, :close_menu, outside: true)
+      # The client decides preventDefault behavior from event.params (the window
+      # flag), never by sniffing the descriptor — so outside must set both.
+      expect(attrs[:data][:reactive_outside_param]).to eq("true")
+      expect(attrs[:data][:reactive_window_param]).to eq("true")
+    end
+
+    it "throttle: emits the throttle window as a Stimulus param" do
+      attrs = instance.send(:on, :track, event: "scroll", window: true, throttle: 250)
+      expect(attrs[:data][:reactive_throttle_param]).to eq(250)
+    end
+
+    it "raises ArgumentError when both debounce: and throttle: are given" do
+      expect { instance.send(:on, :track, debounce: 300, throttle: 250) }
+        .to raise_error(ArgumentError, /debounce.*throttle/m)
+    end
+
+    it "keeps the modifiers out of the explicit params payload" do
+      attrs = instance.send(:on, :close_menu, outside: true, once: true, throttle: 100, reason: "esc")
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "reason" => "esc" })
+    end
+
+    it "omits every modifier param by default" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:data]).not_to have_key(:reactive_window_param)
+      expect(attrs[:data]).not_to have_key(:reactive_outside_param)
+      expect(attrs[:data]).not_to have_key(:reactive_throttle_param)
+    end
+  end
+
   # A record-backed component whose record is UNSAVED (new_record?) has no
   # GlobalID to sign. reactive_token must not crash calling to_gid on it — it
   # signs the declared state instead (the draft seed), so the client controller

--- a/spec/system/dropdown_outside_click_spec.rb
+++ b/spec/system/dropdown_outside_click_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #80: on(:close_menu, outside: true) — the close-a-dropdown-on-outside-
+# click pattern. The trigger is window-bound; a click INSIDE the component's
+# root is a complete client-side no-op, a click outside fires the action, and
+# the window binding never preventDefaults — so native navigation elsewhere on
+# the page keeps working while the menu is mounted.
+RSpec.describe "Outside-click dropdown (issue #80)", type: :system do
+  it "closes on an outside click; an inside click is a complete no-op" do
+    visit "/dropdown"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='closes']", text: "0")
+    expect(page).to have_no_css("[data-testid='menu']")
+
+    # Open the menu (an ordinary element-bound trigger).
+    find("[data-testid='menu-button']").click
+    expect(page).to have_css("[data-testid='menu']")
+
+    # A click INSIDE the open menu must not fire close_menu (the outside guard
+    # bails before anything happens). The proof comes below: the closes counter
+    # lands on exactly 1 after the outside click — an inside dispatch would
+    # have made it 2.
+    find("[data-testid='menu-item']").click
+    expect(page).to have_css("[data-testid='menu']")
+
+    # A click OUTSIDE the root closes the menu via the reactive action.
+    find("[data-testid='outside-area']").click
+    expect(page).to have_no_css("[data-testid='menu']")
+    expect(page).to have_css("[data-testid='closes']", text: "1")
+
+    # The whole exchange was reactive round trips, never a full-page reload.
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "does not preventDefault native link navigation while the menu is open" do
+    visit "/dropdown"
+    find("[data-testid='menu-button']").click
+    expect(page).to have_css("[data-testid='menu']")
+
+    # With the window-bound close listener mounted, clicking a link elsewhere
+    # on the page must still NAVIGATE — the client only preventDefaults
+    # element-bound triggers, never window-bound ones.
+    find("[data-testid='outside-link']").click
+    expect(page).to have_css("[data-testid='nav-probe']", text: "NAVIGATED")
+  end
+end


### PR DESCRIPTION
> **Stacked on #89** (`feat/lifecycle-events`) — the modifiers compose with the lifecycle events inside `dispatch()`. Merge #89 first; I'll retarget/rebase this onto main after.

## Summary
- Four new `on(...)` kwargs covering the trigger patterns that otherwise force a hand-written Stimulus controller:
  - **`outside: true`** — fires only for events whose target is OUTSIDE the component's root (close-a-dropdown-on-outside-click). An inside event is a complete client-side no-op: the guard bails before `preventDefault` **and** before `reactive:before-dispatch`. Implies `window:`.
  - **`window: true`** — binds via Stimulus's native `@window` for page-level events. Window-bound triggers are **never `preventDefault`-ed** (a mounted dropdown must not kill link clicks page-wide) and skip the forced `type="button"`.
  - **`once: true`** — Stimulus's native `:once` (fire at most once, then unbind).
  - **`throttle: 250`** — leading-edge rate limit mirroring `debounce:` (trailing-edge); both together raise `ArgumentError`. Timers key on action + target (window scroll events share `event.target === document`) and tear down on `disconnect()`.
- The bare `on(:x)` emission is pinned byte-identical by spec; the four names become reserved `on()` kwargs (CHANGELOG notes it).

## The bug the browser suite caught
The first cut emitted `data-reactive-outside-param` as a Ruby boolean — Phlex renders `true` attributes **valueless**, and Stimulus's param reader sees `""` (falsy), silently disabling the guard AND the no-preventDefault branch. Unit/bun layers structurally can't catch this (they feed `event.params` directly); the real-browser dropdown spec failed on both counts. Fixed by emitting explicit `"true"` strings, with a why-comment at the emission site.

## Test plan
- 18 new bun tests (outside inside/outside, no-preventDefault-on-window, element-bound still prevents, throttle leading edge + suppression + teardown); full bun suite 91 pass.
- New dummy `DropdownMenuComponent` + system spec: outside click closes (closes-counter proves the inside click contributed nothing), native link navigation survives while the menu is mounted — green under **Puma and Falcon**.
- Full browser suite 35 examples green; fast suite 296 green; Ruby `on()` emission specs (65 examples in component_spec); RuboCop clean; vendored controller byte-identical.

Closes #80