### PR TITLE
fix(docs): bump docs-kit — sidebar caret alignment

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mhenrixon/daisyui.git
-  revision: 292ee81fcc2238b068750986139461b167cf968a
+  revision: 9a2e2b551604fa32e49022ee7f28c3a2ee01c36c
   specs:
     daisyui (1.2.0)
       phlex (~> 2.0, >= 2.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/mhenrixon/docs-kit.git
-  revision: 5a67bfa7e13d57160d335dfaac2cad2b796f7993
+  revision: 73e52fd390a4236f460b984dc4c22b9ba3b2252f
   specs:
     docs-kit (0.1.0)
       daisyui (>= 1.2)

--- a/docs/spec/system/docs_nav_spec.rb
+++ b/docs/spec/system/docs_nav_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'Docs sidebar collapse persistence', type: :system do
   it 'remembers a collapsed sub-group across navigation', :desktop_only do
     visit '/docs/installation'
 
-    # The "Examples" sub-group is a <details open> with a menu-title summary.
-    examples = find('summary.menu-title', text: 'Examples')
+    # The "Examples" sub-group is a <details open> whose <summary> is the label.
+    examples = find('summary', text: 'Examples')
     examples_details = examples.find(:xpath, './..') # the <details>
 
     expect(examples_details['open']).to be_truthy
@@ -26,7 +26,7 @@ RSpec.describe 'Docs sidebar collapse persistence', type: :system do
     # section OPEN by default, but the controller restores the collapsed state.
     visit '/docs/architecture'
 
-    restored = find('summary.menu-title', text: 'Examples').find(:xpath, './..')
+    restored = find('summary', text: 'Examples').find(:xpath, './..')
     expect(restored['open']).to be_falsey
   end
 


### PR DESCRIPTION
## Summary

Bumps docs-kit to `73e52fd`, picking up the sidebar caret-alignment fix: sub-group
carets (`Guide`, `Examples`, …) now right-align in the same column as the
top-level group caret. Previously `.menu-title` on the collapsible summary broke
daisyUI grid layout and dropped the caret below-left.

Lockfile-only change.

## Test plan

- `CI=true bundle exec rspec spec/requests` — 43 green
- `bun run build:css` rebuilt; no summary carries `.menu-title`
