### PR TITLE
chore(claude): tier model pins across slash commands + add /plan

### DIFF
--- a/.claude/commands/architect.md
+++ b/.claude/commands/architect.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Coordinates a change across the phlex-reactive layers. Use when planning a feature that spans the component, the endpoint, and the client runtime."
 argument-hint: "feature or task to coordinate"
 ---

--- a/.claude/commands/github-review-comments.md
+++ b/.claude/commands/github-review-comments.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: "Use when a PR has unresolved review comments that need responses -- evaluates each comment, implements valid fixes, pushes back on incorrect suggestions, and resolves all threads."
 argument-hint: "PR number (e.g., 123 or #123)"
 allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(git log:*), Bash(git blame:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent

--- a/.claude/commands/github-review-failures.md
+++ b/.claude/commands/github-review-failures.md
@@ -1,4 +1,5 @@
 ---
+model: sonnet
 description: "Use when CI checks are failing on a PR — fetches failure logs, diagnoses root causes, implements fixes, and pushes until CI is green."
 argument-hint: "PR number (e.g., 41 or #41)"
 allowed-tools: Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent

--- a/.claude/commands/github-review-pr.md
+++ b/.claude/commands/github-review-pr.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Use when a PR needs full review — fixes CI failures first, then addresses unresolved review comments. Run failures first because comment fixes trigger new CI runs that obscure the original failures."
 argument-hint: "PR number (e.g., 156 or #156)"
 allowed-tools: Bash(gh pr list:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(gh run view:*), Bash(git log:*), Bash(git blame:*), Bash(git diff:*), Bash(git push:*), Bash(git commit:*), Bash(git add:*), Bash(bundle exec:*), Read, Write, Edit, Glob, Grep, Agent

--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Executes full autonomous engineering workflow with verification. Use when implementing complete features, tackling GitHub issues, or running end-to-end development cycles."
 argument-hint: "GitHub issue number/URL or feature description"
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(bundle exec:*), Bash(git:*), Read, Write, Edit, Glob, Grep, Agent

--- a/.claude/commands/perf.md
+++ b/.claude/commands/perf.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Benchmark the current branch against main and report a same-machine before/after. Use when a change touches a hot path (render, token signing, param coercion, broadcast, client dispatch) or when asked to measure performance."
 argument-hint: "optional: a specific hot path or bench name (e.g. render)"
 ---

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,87 @@
+---
+model: fable
+description: "Investigates the codebase, designs a solution, and produces a durable plan artifact — a GitHub issue or a plan markdown under docs/plans/. Read-only: never edits library or app code. Use before /lfg for anything non-trivial."
+argument-hint: "issue <feature or problem> | md <feature or problem> | <feature or problem>"
+allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent
+---
+
+# Plan — design expensive, execute cheap
+
+You are the planning specialist. This command runs on the most capable model deliberately: the thinking happens here, the execution happens later on cheaper models (`/lfg` on Opus, `/tdd` and the review specialists on Sonnet). That split only works if the plan is **self-contained** — an executor with none of this session's context must be able to implement it without guessing.
+
+## Output mode from $ARGUMENTS
+
+| $ARGUMENTS starts with | Artifact |
+|------------------------|----------|
+| `issue` | GitHub issue (default — feeds directly into `/lfg <issue-number>`) |
+| `md` or `file` | Markdown file at `docs/plans/YYYY-MM-DD-<slug>.md` (date from `date +%F`) |
+| anything else | GitHub issue |
+
+## Hard constraints
+
+- **Read-only for source code.** Never edit library (`lib/`, `app/`) or spec code, never commit, never create branches. The only file you may Write is a new plan markdown under `docs/plans/`.
+- **Never reproduce secrets** (keys, tokens, credentials, the `MessageVerifier` secret) in the plan, even redacted ones you encounter while reading config.
+- **Dedupe before creating an issue**: `gh issue list --search "<keywords>"` — if an existing issue covers this, extend it in your summary instead of duplicating.
+
+## Phase 1 — Investigate
+
+Protect this session's context: delegate mechanical exploration to cheaper subagents and keep Fable for judgment.
+
+1. Fan out Explore agents (`subagent_type: Explore`) for file discovery and naming-convention sweeps across the gem (`lib/`, `app/`) and the dummy app (`spec/dummy/`). Launch independent explorations in parallel. If a pgbus primitive is involved, point one at `~/Code/mhenrixon/pgbus` to verify its real signature — don't assume the wire format.
+2. Read the load-bearing files yourself — the ones the design decision actually hinges on. Don't design from subagent summaries alone. The layers: `lib/phlex/reactive/streamable.rb`, `lib/phlex/reactive/component.rb`, `lib/phlex/reactive/response.rb`, `app/controllers/phlex/reactive/actions_controller.rb`, `app/javascript/phlex/reactive/reactive_controller.js`, `lib/phlex/reactive.rb`.
+3. Read `CLAUDE.md` and the matching `.claude/rules/*.md` (coding-style, testing, performance, git-workflow, agents) — the invariants and gotchas live there. The published `docs/` site pages (architecture, security, broadcasting, transport-pgbus, testing, performance) are the deeper reference.
+4. Check `git log` for recent related work; the design should extend it, not fight it.
+
+## Phase 2 — Design
+
+- Develop 2–3 candidate approaches with real tradeoffs. Pick one and say why; record why the others lost.
+- The chosen design must respect the project invariants (see CLAUDE.md "Critical Rules"):
+  - **Signed identity, never state** — the DOM carries `{c, gid}` or `{c, state}`, never raw state; re-find the record server-side.
+  - **Default-deny actions** — only methods declared `action :name` run; mutating actions `authorize!` inside the action.
+  - **Declared, coerced params** — any action taking input declares a `params:` schema; no raw mass assignment.
+  - **The component self-targets via `#id`** — no hand-picked Turbo Stream targets; `#id` is render-context-free (`Streamable#dom_id`, never the Phlex render-time helper).
+  - **pgbus is optional** — capability-gate every pgbus-only feature (`Phlex::Reactive.pgbus_streams?`) and fall back to `Turbo::StreamsChannel`. Must work on Action Cable AND pgbus.
+  - **Re-render through a real view context** — `Phlex::Reactive.renderer` / the controller, never a fabricated context.
+- Decide the test strategy per `.claude/rules/testing.md`: unit (`spec/phlex`), request (`spec/requests`), broadcast (`spec/requests/*_broadcast_spec.rb`), system (`spec/system`, under Puma AND Falcon). Specs are named before the implementation steps they cover (TDD).
+- If the change touches a hot path (render, token signing, param coercion, broadcast, client dispatch), the plan must include a `rake bench` baseline-and-after step per `.claude/rules/performance.md`.
+
+## Phase 3 — Emit the plan artifact
+
+Use this structure for the issue body or markdown file. Every section is load-bearing — an executor uses Context to avoid re-discovery, Steps to act, Gates to verify, Boundaries to stop.
+
+```markdown
+# <Title>
+
+## Problem / Goal
+<What's wrong or missing, who it affects, what done looks like.>
+
+## Context (read these first)
+<Bullet list: `path/to/file.rb` — why it matters to this change. Include the mixin, the endpoint, the client controller, the relevant specs and dummy components. Self-contained: no references to "as discussed" or this session.>
+
+## Decision
+<Chosen approach and rationale. Then: alternatives considered and why each was rejected. Call out the pgbus-present vs pgbus-absent behavior explicitly.>
+
+## Implementation steps
+<Ordered, small, each mapped to a specialist where useful (/tdd, /architect, /perf). Specs come before the code they cover. Name exact files to create or change.>
+
+## Verification gates
+<Exact commands + expected outcome:>
+- `bundle exec rspec spec/phlex spec/requests` — all green
+- `bundle exec rspec spec/system` — green (client-touching changes; also `CAPYBARA_SERVER=falcon` / `rake spec:system_servers` for both real servers)
+- `bundle exec rubocop` — no offenses
+- `bundle exec rake bench` — before/after captured (only if a hot path was touched)
+
+## Out of scope
+<Explicit boundaries — the adjacent things an eager executor must NOT do. E.g. "do not add a hard pgbus dependency", "do not break backwards compatibility for existing components".>
+
+## Execution
+Execute with `/lfg <issue-number>` (or `/lfg docs/plans/<file>.md`).
+```
+
+For GitHub issues: create with `gh issue create --title "..." --body "$(cat <<'EOF' ... EOF)"` — single-quoted heredoc delimiter, backticks unescaped (see `.claude/rules/git-workflow.md`). Apply the `plan` label if it exists (`gh label list`); don't create labels.
+
+For markdown files: Write to `docs/plans/YYYY-MM-DD-<slug>.md`. Leave it uncommitted — committing is the user's call.
+
+## Phase 4 — Handoff
+
+Report back: link to the issue (or file path), the chosen approach in 2–3 sentences, and the exact execute command. Stop there — do not start implementing.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: Review a GitHub pull request for code quality, patterns, and best practices
 argument-hint: "PR URL or number (e.g., 5 or https://github.com/mhenrixon/phlex-reactive/pull/5)"
 ---

--- a/.claude/commands/security.md
+++ b/.claude/commands/security.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Reviews code for security vulnerabilities. Use when auditing the action endpoint, the signed identity, authorization, params, CSRF, or the connection-id."
 argument-hint: "code, feature, or area to review for security"
 ---

--- a/.claude/commands/tdd.md
+++ b/.claude/commands/tdd.md
@@ -1,4 +1,5 @@
 ---
+model: opus
 description: "Use when implementing any feature or fixing any bug — enforces RED-GREEN-REFACTOR: write failing test first, implement minimum code to pass, then refactor."
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ bundle exec rake bench:request                # End-to-end request-cycle bench (
 
 | Command | Purpose |
 |---------|---------|
+| `/plan` | Fable-powered planning → GitHub issue or `docs/plans/` markdown (read-only; execute with `/lfg`) |
 | `/lfg` | Full autonomous workflow: branch → understand → explore → plan → TDD → verify → PR |
 | `/tdd` | Enforce RED → GREEN → REFACTOR |
 | `/perf` | Benchmark the branch vs main (same-machine before/after) and keep perf docs in sync |
@@ -61,6 +62,17 @@ bundle exec rake bench:request                # End-to-end request-cycle bench (
 | `/github-review-pr` | Full PR pass: fix CI failures, then resolve review comments (in that order) |
 | `/github-review-failures` | Fix failing CI checks until green |
 | `/github-review-comments` | Process unresolved PR review comments |
+
+Commands pin a model tier via frontmatter aliases: `haiku` for mechanical/config
+work, `sonnet` for the prescriptive pattern-following passes (`/github-review-comments`,
+`/github-review-failures`), `opus` for orchestration, security, review synthesis,
+and the reasoning-heavy specialists (`/lfg`, `/architect`, `/security`, `/review-pr`,
+`/github-review-pr`, `/tdd`, `/perf`). Fable is pinned only on `/plan` — read-only
+planning that hands execution to cheaper models; otherwise choose it per-session
+with `/model` for architecture and the hardest debugging. Use the tier alias,
+never a full model ID, so commands track the latest model in each tier. When
+spawning subagents for mechanical work (file finding, pattern scans), pass a
+cheaper model explicitly rather than letting them inherit the session model.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Introduces a tier-based `model:` convention across the Claude Code slash commands and adds a new read-only `/plan` command that puts the expensive model where it pays off.

| Tier | Commands | Rationale |
|------|----------|-----------|
| `fable` | `/plan` (new) | Read-only planning: investigates, designs, emits a self-contained GitHub issue or `docs/plans/` markdown for cheaper models to execute |
| `opus` | `/lfg`, `/architect`, `/security`, `/review-pr`, `/github-review-pr`, `/tdd`, `/perf` | Orchestration, security, review synthesis, and the reasoning-heavy specialists |
| `sonnet` | `/github-review-comments`, `/github-review-failures` | Prescriptive pattern-following passes with a fixed runbook |

## Why

- Commands had no `model:` field, so every one inherited the session model — mechanical, pattern-following work ran at the same (top) tier as orchestration and security review.
- Tier aliases (`fable`, `opus`, `sonnet`, `haiku`) instead of full model IDs fix a whole class of staleness permanently: a pin tracks the latest model in its tier, so it never points at an outdated `claude-*-4-x` string.
- `CLAUDE.md` now records the convention so new commands start on the right tier.

## /plan

Design expensive, execute cheap. `/plan` runs on the most capable model, does the thinking, and hands a self-contained artifact to cheaper models for execution:

- Context block with file paths and why each matters, ordered steps mapped to specialists (`/tdd`, `/architect`, `/perf`), verification gates with exact commands and expected outputs, explicit out-of-scope boundaries — so `/lfg <issue-number>` can execute without any of the planning session's context.
- Read-only for source code: never edits `lib/`/`app/`/specs, never commits, never branches; the only file it may write is a plan markdown under `docs/plans/`.
- Dedupes against existing issues; never reproduces secrets.
- The design phase respects this gem's invariants: signed identity (never state), default-deny actions, declared/coerced params, the component self-targeting via `#id`, pgbus optionality (capability-gated with an Action Cable fallback), rendering through a real view context, TDD across the unit/request/broadcast/system layers, and a `rake bench` baseline for any hot-path change.

Workflow: `/plan <feature>` (Fable, ~one issue's worth of tokens) → `/lfg <issue-number>` (Opus) → specialists (Sonnet).

## Test plan

- [x] `grep -rn "claude-opus-4\|claude-sonnet\|claude-haiku\|claude-fable" .claude/ CLAUDE.md` — no full model IDs remain
- [x] All 10 commands have exactly one `model:` tier alias as the first frontmatter key
- [x] `/plan` registers as an available skill
- [x] Frontmatter delimiters intact on every command
- [x] CLAUDE.md tier prose and the per-command pins agree

Docs/config only — no library, app, or spec code touched; no benches or specs affected.
