### PR TITLE
feat(component): on_client + the js op builder — client-side DOM commands, zero round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`on_client(event, ops)` + the `js` op builder — client-side DOM commands
+  with ZERO round trips (#95).** Purely-visual interactions (tabs, dropdowns,
+  accordions, class toggles) no longer cost a signed server round trip or a
+  hand-written Stimulus controller. `js` is an immutable, chainable builder of
+  declared DOM operations — `show`/`hide`/`toggle` (the `hidden` attribute) and
+  `add_class`/`remove_class`/`toggle_class` — and `on_client(:click, js.…)`
+  binds them to a DOM event the ONE generic controller applies locally via a
+  new `runOps` action: **no token, no params, no fetch, ever** (the system spec
+  wraps `window.fetch` with a counter and asserts zero). The op vocabulary is a
+  fixed whitelist mirrored client-side: an unknown op name warns and is skipped
+  while the rest of the chain still applies (client-side default-deny —
+  `Object.hasOwn`-guarded so inherited Object members can't masquerade as ops),
+  and malformed ops JSON degrades to a no-op. Targets are CSS selectors
+  resolved WITHIN the component's root — nested reactive roots are never
+  touched (the issue-#15 ownership rule) — with `:root` for the root element
+  itself and a per-op `global: true` document escape. `window:`/`once:`/
+  `outside:` compose exactly like `on(...)`'s #80 modifiers (outside-click
+  closes a dropdown; window-bound triggers never `preventDefault`). Builder
+  validation is loud at render time (a non-selector target or an empty class
+  list raises; `on_client` rejects a non-`Phlex::Reactive::JS` or empty chain)
+  rather than silent in the browser. Client ops are EPHEMERAL UI by design: any
+  server re-render resets them — the LiveView JS-commands caveat, documented in
+  the README — so state that must survive a re-render stays a signed `action`.
+  Same-machine `rake bench` before/after: the token/render/coerce hot paths are
+  untouched (state-backed token 201k → within noise; allocations byte-identical
+  at 11/47 per token, 113 per render) — `on_client` is a new, separate path.
+
 - **`on(...)` event modifiers — `window:`, `once:`, `outside:`, `throttle:`
   (#80).** Four trigger patterns that previously forced a hand-written Stimulus
   controller are now declarable on `on(...)`. `outside: true` fires the action

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:close_menu, outside: true)` | Fire only for events **outside** this component's root (close-a-dropdown-on-outside-click). Window-bound; never `preventDefault`s, so links elsewhere keep navigating. |
 | `on(:track, event: "scroll", window: true, throttle: 250)` | `window:` binds the trigger to the window (page-level scroll/resize); `throttle:` rate-limits leading-edge — first event fires, the rest drop until the window elapses. Mutually exclusive with `debounce:`. |
 | `on(:action, once: true)` | Fire at most once, then unbind (Stimulus's native `:once`). |
+| `on_client(:click, js.toggle("#menu"))` | **Client-only** trigger: applies declared DOM ops with ZERO round trip — no token, no POST, ever. Takes the same `window:`/`once:`/`outside:` modifiers. See [Client-only ops](#client-only-ops-on_client--js--zero-round-trips). |
+| `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute) and `add_class`/`remove_class`/`toggle_class`, chainable. |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
@@ -466,6 +468,50 @@ div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 500
 
 These four (like `debounce:`/`confirm:`/`listnav:`) are **reserved keyword
 names** on `on(...)` — no longer usable as free action params.
+
+### Client-only ops (`on_client` + `js`) — zero round trips
+
+Not every interaction needs the server. A tab switch, a dropdown, an accordion
+— purely visual state — used to mean either a wasteful signed round trip or the
+very Stimulus controller this gem exists to eliminate. `on_client` binds a DOM
+event to a chain of **declared DOM operations** that the one generic controller
+applies locally: **no token, no params, no POST, ever.**
+
+```ruby
+def view_template
+  div(**mix(reactive_root, on_client(:click, js.hide("#menu"), outside: true))) do
+    # Tabs: one op chain per tab — hide all panels, show one, restyle the tabs.
+    button(**on_client(:click, js.hide(".panel").show("#panel-2")
+      .remove_class(".tab", "active").add_class("#tab-2", "active"))) { "Tab 2" }
+
+    # A menu that opens client-side and closes on ANY outside click (the root
+    # carries the window-bound trigger above).
+    button(**on_client(:click, js.show("#menu"))) { "Menu" }
+    div(id: "menu", hidden: true) { menu_items }
+  end
+end
+```
+
+The `js` builder is immutable (each verb returns a new chain) and its
+vocabulary is a fixed whitelist mirrored by the client: `show`/`hide`/`toggle`
+flip the `hidden` attribute; `add_class`/`remove_class`/`toggle_class` take one
+or more classes. Targets are CSS selectors resolved **within the component's
+root** (nested reactive components are never touched — same ownership rule as
+field collection); `:root` targets the root element itself; `global: true` on
+an op escapes to the whole document. An op name the client doesn't recognize
+logs a warning and is skipped — the rest of the chain still applies.
+
+`window:`, `once:`, and `outside:` compose exactly like `on(...)`'s event
+modifiers: the dropdown above closes on any click outside the component, and
+window-bound triggers never `preventDefault`, so links elsewhere keep working.
+
+**Client ops are ephemeral UI — the one contract to internalize.** Any server
+re-render of the component (an action reply, a broadcast, a morph) rebuilds
+from server state and resets whatever the ops toggled: the menu closes, the tab
+snaps back. That is by design — the same caveat LiveView's JS commands carry.
+For state that must survive a re-render (an edit mode, a selection the server
+should know about), use a signed `action` instead; `on_client` is for state the
+server should never care about.
 
 **Auto-collected sibling fields — the read contract.** A reactive action doesn't
 just receive its own trigger's value: the client gathers **every named control**

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -133,6 +133,28 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 }
 
+// The client-op whitelist behind on_client (issue #95). Mirrors
+// Phlex::Reactive::JS's vocabulary; an op name not in this map is
+// warn-and-skipped by #applyOps (client-side default-deny — a stale or newer
+// ops attr must never break the page). Each op is a pure, local DOM mutation:
+// nothing is read back, nothing is sent anywhere. Frozen so nothing can be
+// registered into it at runtime — extending the vocabulary is a gem change,
+// not an app hook.
+const CLIENT_OPS = Object.freeze({
+  show: (el) => {
+    el.hidden = false
+  },
+  hide: (el) => {
+    el.hidden = true
+  },
+  toggle: (el) => {
+    el.hidden = !el.hidden
+  },
+  add_class: (el, args) => el.classList.add(...(args.classes ?? [])),
+  remove_class: (el, args) => el.classList.remove(...(args.classes ?? [])),
+  toggle_class: (el, args) => (args.classes ?? []).forEach((c) => el.classList.toggle(c)),
+})
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.
@@ -242,6 +264,29 @@ export default class extends Controller {
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce, throttle)
       })
+  }
+
+  // CLIENT-ONLY trigger entry point (issue #95) — the zero-round-trip sibling
+  // of dispatch(). Wired by on_client: applies the declared op chain
+  // (data-reactive-ops-param, built by Phlex::Reactive::JS) locally. NO token,
+  // NO params, NO fetch, ever. Ops are ephemeral UI: any server re-render of
+  // the component resets whatever they toggled (by design — a signed action
+  // owns state that must survive re-renders).
+  runOps(event) {
+    const { ops, outside, window: windowBound } = event.params
+
+    // Outside guard FIRST — identical semantics to dispatch() (issue #80): an
+    // outside: trigger is a COMPLETE no-op for events inside this root, before
+    // preventDefault and before any op runs.
+    if (outside && this.element.contains(event.target)) return
+
+    // Element-bound triggers preventDefault (a bare button inside a <form>
+    // must not submit it); window-bound triggers (window:/outside:) never do —
+    // they hear every matching event on the page, and preventDefault-ing those
+    // would kill native clicks site-wide (issue #80 rationale).
+    if (!windowBound) event.preventDefault()
+
+    this.#applyOps(this.#parseOps(ops))
   }
 
   // Client-side compute (data binding). Wired by reactive_compute: an `input`
@@ -813,6 +858,50 @@ export default class extends Controller {
     } catch {
       return {}
     }
+  }
+
+  // Stimulus typecasts a JSON param to the parsed array already; a raw string
+  // (hand-built attr, non-typecasting harness) is parsed here. Anything
+  // malformed degrades to [] — a bad ops attr must never break the page.
+  #parseOps(raw) {
+    if (Array.isArray(raw)) return raw
+    if (typeof raw !== "string") return []
+    try {
+      const list = JSON.parse(raw)
+      return Array.isArray(list) ? list : []
+    } catch {
+      return []
+    }
+  }
+
+  // Interpret a [[name, args], ...] op list against this root (issue #95). The
+  // vocabulary is the frozen CLIENT_OPS whitelist; an unknown name warns and is
+  // SKIPPED while the rest of the chain still applies — client-side
+  // default-deny, and one bad op never takes down its siblings. Object.hasOwn
+  // (not a bare property read) so inherited Object members ("constructor")
+  // can't masquerade as ops.
+  #applyOps(list) {
+    for (const entry of list) {
+      if (!Array.isArray(entry)) continue
+      const [name, args = {}] = entry
+      if (!Object.hasOwn(CLIENT_OPS, name)) {
+        console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
+        continue
+      }
+      for (const el of this.#opTargets(args)) CLIENT_OPS[name](el, args)
+    }
+  }
+
+  // Resolve an op's targets: "@root" is this element; a selector resolves
+  // WITHIN this root and excludes nested reactive roots' subtrees (issue #15
+  // semantics — the same nearest-root ownership check the field walk uses);
+  // global: true opts a single op out to document-wide.
+  #opTargets(args) {
+    const to = args.to
+    if (to === "@root") return [this.element]
+    if (typeof to !== "string" || to === "") return []
+    if (args.global) return [...document.querySelectorAll(to)]
+    return [...this.element.querySelectorAll(to)].filter((el) => this.#ownsField(el))
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/docs/app/views/docs/pages/architecture.rb
+++ b/docs/app/views/docs/pages/architecture.rb
@@ -44,7 +44,8 @@ module Views
                 li { plain 'Client runtime — one generic Stimulus controller.' }
                 li { plain 'Endpoint — verify token → run action → render the reply.' }
                 li do
-                  plain 'Component mixin — reactive_record/reactive_state, action, on. ' \
+                  plain 'Component mixin — reactive_record/reactive_state, action, on, and on_client ' \
+                        '(declared client-only DOM ops via the js builder — zero round trip). ' \
                         'Including it pulls in Streamable automatically (one include is enough).'
                 end
                 li do

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -320,6 +320,8 @@ loader.tag = "phlex-reactive"
 # (lib/phlex/reactive/foo.rb -> Phlex::Reactive::Foo).
 lib = File.expand_path("..", __dir__)
 loader.push_dir(lib)
+# js.rb defines JS (an acronym), not the default-inflected `Js`.
+loader.inflector.inflect("js" => "JS")
 # The gem-name shim (`require "phlex-reactive"`) is a plain require, not a
 # managed file.
 loader.ignore("#{lib}/phlex-reactive.rb")

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -307,6 +307,14 @@ module Phlex
         Phlex::Reactive::Reply.new(self)
       end
 
+      # An empty client-side op chain (issue #95) — the starting point for
+      # on_client's DOM commands, mirroring how `reply` starts a Response chain:
+      #   button(**on_client(:click, js.toggle("#menu"))) { "Menu" }
+      # Immutable: each verb returns a new chain, so reuse never leaks ops.
+      def js
+        Phlex::Reactive::JS.new
+      end
+
       # Root-element attributes: marks the element reactive and carries the
       # signed identity token. Spread onto the root:
       #   div(id:, **reactive_attrs) { ... }
@@ -447,6 +455,53 @@ module Phlex
         attrs[:data][:reactive_outside_param] = "true" if outside
         # The client decides preventDefault behavior from event.params (never by
         # sniffing the descriptor), so EVERY window binding flags the param.
+        attrs[:data][:reactive_window_param] = "true" if window_bound
+        attrs[:type] = "button" if event == "click" && !window_bound
+        attrs
+      end
+
+      # Attributes for a CLIENT-ONLY trigger (issue #95): binds a DOM event to a
+      # chain of declarative DOM ops (Phlex::Reactive::JS) that the generic
+      # controller's runOps action applies in the browser — NO token, NO params,
+      # NO POST, ever. The zero-round-trip sibling of on():
+      #
+      #   button(**on_client(:click, js.toggle("#menu"))) { "Menu" }
+      #   # tabs, one line per tab, no Stimulus controller:
+      #   button(**on_client(:click, js.hide(".panel").show("#panel-2")))
+      #
+      # `window:`, `once:`, and `outside:` compose exactly like on()'s event
+      # modifiers (#80): outside-click-to-close a dropdown is
+      #   div(**mix(reactive_root, on_client(:click, js.hide("#menu"), outside: true)))
+      # Window-bound triggers are never preventDefault-ed by the client and skip
+      # the forced type="button".
+      #
+      # Ops are EPHEMERAL UI: any server re-render of the component (an action
+      # reply, a broadcast, a morph) rebuilds from server state and resets
+      # whatever they toggled — by design (the LiveView JS-commands caveat). Use
+      # a signed action for state that must survive re-renders.
+      #
+      # Validation is loud: only a non-empty Phlex::Reactive::JS chain is
+      # accepted — a dead trigger should fail at render, not no-op in the
+      # browser.
+      def on_client(event, ops, window: false, once: false, outside: false)
+        unless ops.is_a?(Phlex::Reactive::JS)
+          raise ArgumentError,
+            "on_client expects a Phlex::Reactive::JS chain (e.g. js.toggle(\"#menu\")), " \
+            "got #{ops.class}"
+        end
+        raise ArgumentError, "on_client(#{event.inspect}) got no ops — a dead trigger" if ops.empty?
+
+        event = event.to_s
+        window_bound = window || outside
+        attrs = {
+          data: {
+            action: "#{event}#{"@window" if window_bound}->reactive#runOps#{":once" if once}",
+            reactive_ops_param: ops.to_json
+          }
+        }
+        # STRING "true", not boolean — same Phlex valueless-attribute trap as
+        # on()'s flags above.
+        attrs[:data][:reactive_outside_param] = "true" if outside
         attrs[:data][:reactive_window_param] = "true" if window_bound
         attrs[:type] = "button" if event == "click" && !window_bound
         attrs

--- a/lib/phlex/reactive/js.rb
+++ b/lib/phlex/reactive/js.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # An immutable, chainable builder of client-side DOM commands (issue #95) —
+    # the ops behind Component#on_client. Each verb returns a NEW frozen
+    # instance; #to_json emits the wire format the generic controller's runOps
+    # action interprets, entirely in the browser:
+    #
+    #   button(**on_client(:click, js.toggle("#menu"))) { "Menu" }
+    #   # -> data-reactive-ops-param='[["toggle",{"to":"#menu"}]]'
+    #
+    # These are declarative DOM OPERATIONS, not state: nothing is shipped back
+    # to the server, nothing is trusted from the client, and any server
+    # re-render of the component resets whatever they toggled (the LiveView
+    # JS-commands caveat — by design; use a signed action for state that must
+    # survive re-renders).
+    #
+    # Targets: a CSS selector string is resolved WITHIN the component's root by
+    # default (nested reactive roots excluded, issue #15 semantics); `:root`
+    # targets the root element itself; `global: true` opts a single op out of
+    # root scoping (document escape hatch, e.g. a page-level overlay).
+    #
+    # The op vocabulary is a fixed whitelist mirrored by the client interpreter
+    # — an op name the client doesn't know is warn-and-skipped there
+    # (client-side default-deny). Validation here is deliberately LOUD: a bad
+    # target or an empty class list raises at render time rather than silently
+    # doing nothing in the browser.
+    class JS
+      # Serialized stand-in for "the component's own root element".
+      ROOT_SENTINEL = "@root"
+
+      # The accumulated [name, args] op pairs, oldest first. Frozen.
+      attr_reader :ops
+
+      def initialize(ops = [].freeze)
+        @ops = ops
+        freeze
+      end
+
+      # --- Visibility (the `hidden` attribute) ---
+
+      def show(to, global: false)
+        append("show", target_args(to, global:))
+      end
+
+      def hide(to, global: false)
+        append("hide", target_args(to, global:))
+      end
+
+      def toggle(to, global: false)
+        append("toggle", target_args(to, global:))
+      end
+
+      # --- Classes ---
+
+      def add_class(to, *classes, global: false)
+        append("add_class", class_args(to, classes, global:))
+      end
+
+      def remove_class(to, *classes, global: false)
+        append("remove_class", class_args(to, classes, global:))
+      end
+
+      def toggle_class(to, *classes, global: false)
+        append("toggle_class", class_args(to, classes, global:))
+      end
+
+      # The wire format: a JSON array of [op, args] pairs, applied in order.
+      def to_json(*)
+        @ops.to_json
+      end
+
+      def empty?
+        @ops.empty?
+      end
+
+      private
+
+      # Immutability: every verb funnels here and returns a NEW frozen chain —
+      # a builder held in a constant or memo can never be mutated by later use.
+      def append(name, args)
+        self.class.new([*@ops, [name, args].freeze].freeze)
+      end
+
+      def target_args(to, global:)
+        args = { "to" => normalize_target(to) }
+        args["global"] = true if global
+        args.freeze
+      end
+
+      def class_args(to, classes, global:)
+        if classes.empty?
+          raise ArgumentError, "#{self.class}: a class op needs at least one class (got none for #{to.inspect})"
+        end
+
+        args = { "to" => normalize_target(to), "classes" => classes.map(&:to_s).freeze }
+        args["global"] = true if global
+        args.freeze
+      end
+
+      # :root -> the sentinel; a String passes through as a CSS selector.
+      # Anything else (a stray symbol, nil) is a bug at the call site — raise at
+      # render time instead of silently matching nothing in the browser.
+      def normalize_target(to)
+        return ROOT_SENTINEL if to == :root
+        return to if to.is_a?(String)
+
+        raise ArgumentError,
+          "#{self.class}: target must be :root or a CSS selector string, got #{to.inspect}"
+      end
+    end
+  end
+end

--- a/spec/dummy/app/components/client_tabs_component.rb
+++ b/spec/dummy/app/components/client_tabs_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Issue #95: a component whose ENTIRE interactivity is client-side on_client
+# ops — tabs that switch panels and a menu that closes on any outside click —
+# with ZERO server round trips. It deliberately declares NO actions: there is
+# no token-bearing trigger anywhere, and the system spec's fetch spy proves
+# nothing is ever posted. The root carries the window-bound outside-close
+# trigger permanently (a client op costs nothing per stray page click, unlike
+# a server action).
+class ClientTabsComponent < ApplicationComponent
+  include Phlex::Reactive::Component
+
+  def id = "client-tabs"
+
+  def view_template
+    div(**mix(reactive_root, on_client(:click, js.hide("#ct-menu"), outside: true))) do
+      tabs
+      panels
+      menu
+    end
+  end
+
+  private
+
+  def tabs
+    div do
+      tab_button(1, "One", active: true)
+      tab_button(2, "Two", active: false)
+    end
+  end
+
+  # One op chain per tab: hide every panel, show the picked one, restyle the
+  # tab buttons — the canonical "I had to write a Stimulus controller" case,
+  # now one line of declared ops.
+  def tab_button(index, label, active:)
+    ops = js.hide(".ct-panel").show("#ct-panel-#{index}")
+      .remove_class(".ct-tab", "active").add_class("#ct-tab-#{index}", "active")
+
+    button(**mix(on_client(:click, ops),
+      id: "ct-tab-#{index}", class: ["ct-tab", active ? "active" : nil].compact,
+      data: { testid: "tab-#{index}" })) { label }
+  end
+
+  def panels
+    div(id: "ct-panel-1", class: "ct-panel", data: { testid: "panel-1" }) { "First panel" }
+    div(id: "ct-panel-2", class: "ct-panel", hidden: true, data: { testid: "panel-2" }) { "Second panel" }
+  end
+
+  def menu
+    button(**mix(on_client(:click, js.show("#ct-menu")), data: { testid: "menu-open" })) { "Menu" }
+    div(id: "ct-menu", hidden: true, data: { testid: "menu" }) { span { "menu content" } }
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -81,6 +81,17 @@ class DemosController < ActionController::Base
     render html: component + outside.html_safe, layout: true
   end
 
+  # Pure client-side interactivity (issue #95): on_client + js ops. The page
+  # carries an outside area so the spec can prove the outside-close op — and a
+  # fetch spy proves NOTHING is ever posted.
+  def client_tabs
+    component = render_to_string(ClientTabsComponent.new, layout: false)
+    outside = <<~HTML
+      <div data-testid="outside-area" style="padding: 4rem">outside the tabs</div>
+    HTML
+    render html: component + outside.html_safe, layout: true
+  end
+
   def confirm
     render_component ConfirmComponent.new
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get "nested_params" => "demos#nested_params"
   get "debounce" => "demos#debounce"
   get "dropdown" => "demos#dropdown"
+  get "client_tabs" => "demos#client_tabs"
   get "confirm" => "demos#confirm"
   get "morph_grid/:id" => "demos#morph_grid"
   get "partial_grid/:id" => "demos#partial_grid"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -133,6 +133,28 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 }
 
+// The client-op whitelist behind on_client (issue #95). Mirrors
+// Phlex::Reactive::JS's vocabulary; an op name not in this map is
+// warn-and-skipped by #applyOps (client-side default-deny — a stale or newer
+// ops attr must never break the page). Each op is a pure, local DOM mutation:
+// nothing is read back, nothing is sent anywhere. Frozen so nothing can be
+// registered into it at runtime — extending the vocabulary is a gem change,
+// not an app hook.
+const CLIENT_OPS = Object.freeze({
+  show: (el) => {
+    el.hidden = false
+  },
+  hide: (el) => {
+    el.hidden = true
+  },
+  toggle: (el) => {
+    el.hidden = !el.hidden
+  },
+  add_class: (el, args) => el.classList.add(...(args.classes ?? [])),
+  remove_class: (el, args) => el.classList.remove(...(args.classes ?? [])),
+  toggle_class: (el, args) => (args.classes ?? []).forEach((c) => el.classList.toggle(c)),
+})
+
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with
 // preload: true for importmap apps; see the README for esbuild/webpack.
@@ -242,6 +264,29 @@ export default class extends Controller {
       .then((ok) => {
         if (ok) this.#proceed(target, action, params, debounce, throttle)
       })
+  }
+
+  // CLIENT-ONLY trigger entry point (issue #95) — the zero-round-trip sibling
+  // of dispatch(). Wired by on_client: applies the declared op chain
+  // (data-reactive-ops-param, built by Phlex::Reactive::JS) locally. NO token,
+  // NO params, NO fetch, ever. Ops are ephemeral UI: any server re-render of
+  // the component resets whatever they toggled (by design — a signed action
+  // owns state that must survive re-renders).
+  runOps(event) {
+    const { ops, outside, window: windowBound } = event.params
+
+    // Outside guard FIRST — identical semantics to dispatch() (issue #80): an
+    // outside: trigger is a COMPLETE no-op for events inside this root, before
+    // preventDefault and before any op runs.
+    if (outside && this.element.contains(event.target)) return
+
+    // Element-bound triggers preventDefault (a bare button inside a <form>
+    // must not submit it); window-bound triggers (window:/outside:) never do —
+    // they hear every matching event on the page, and preventDefault-ing those
+    // would kill native clicks site-wide (issue #80 rationale).
+    if (!windowBound) event.preventDefault()
+
+    this.#applyOps(this.#parseOps(ops))
   }
 
   // Client-side compute (data binding). Wired by reactive_compute: an `input`
@@ -813,6 +858,50 @@ export default class extends Controller {
     } catch {
       return {}
     }
+  }
+
+  // Stimulus typecasts a JSON param to the parsed array already; a raw string
+  // (hand-built attr, non-typecasting harness) is parsed here. Anything
+  // malformed degrades to [] — a bad ops attr must never break the page.
+  #parseOps(raw) {
+    if (Array.isArray(raw)) return raw
+    if (typeof raw !== "string") return []
+    try {
+      const list = JSON.parse(raw)
+      return Array.isArray(list) ? list : []
+    } catch {
+      return []
+    }
+  }
+
+  // Interpret a [[name, args], ...] op list against this root (issue #95). The
+  // vocabulary is the frozen CLIENT_OPS whitelist; an unknown name warns and is
+  // SKIPPED while the rest of the chain still applies — client-side
+  // default-deny, and one bad op never takes down its siblings. Object.hasOwn
+  // (not a bare property read) so inherited Object members ("constructor")
+  // can't masquerade as ops.
+  #applyOps(list) {
+    for (const entry of list) {
+      if (!Array.isArray(entry)) continue
+      const [name, args = {}] = entry
+      if (!Object.hasOwn(CLIENT_OPS, name)) {
+        console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
+        continue
+      }
+      for (const el of this.#opTargets(args)) CLIENT_OPS[name](el, args)
+    }
+  }
+
+  // Resolve an op's targets: "@root" is this element; a selector resolves
+  // WITHIN this root and excludes nested reactive roots' subtrees (issue #15
+  // semantics — the same nearest-root ownership check the field walk uses);
+  // global: true opts a single op out to document-wide.
+  #opTargets(args) {
+    const to = args.to
+    if (to === "@root") return [this.element]
+    if (typeof to !== "string" || to === "") return []
+    if (args.global) return [...document.querySelectorAll(to)]
+    return [...this.element.querySelectorAll(to)].filter((el) => this.#ownsField(el))
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/spec/javascript/reactive_run_ops.test.js
+++ b/spec/javascript/reactive_run_ops.test.js
@@ -1,0 +1,268 @@
+// Unit tests for runOps + the client-op interpreter (issue #95) — the
+// zero-round-trip half of on_client:
+//
+//   * runOps NEVER fetches: no token, no params, no POST — the fetch stub in
+//     this file THROWS if touched.
+//   * Ops are whitelist-interpreted (CLIENT_OPS); an unknown name warns and is
+//     skipped while the REST of the chain still applies (client-side
+//     default-deny; a stale/newer ops attr must never break the page).
+//   * Selector targets resolve WITHIN this root and exclude nested reactive
+//     roots' subtrees (issue #15 semantics); "@root" is the root itself;
+//     global: true escapes to document.
+//   * outside:/window: mirror dispatch()'s #80 semantics — bail inside the
+//     root before ANYTHING, and never preventDefault a window-bound trigger.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A fake DOM node: hidden flag, classList over a Set, and `closest` returning
+// the nearest reactive root (`owner`) — how the ownership guard decides.
+function makeEl({ owner = null } = {}) {
+  const el = {
+    hidden: false,
+    classes: new Set(),
+    closest: () => owner,
+  }
+  el.classList = {
+    add: (...cs) => cs.forEach((c) => el.classes.add(c)),
+    remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
+    toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+  }
+  return el
+}
+
+// A reactive root whose querySelectorAll answers from a selector -> elements
+// map. `contains` consults the event target's `__inside` flag (outside guard).
+function makeRoot(matches = {}) {
+  return {
+    isConnected: true,
+    id: "tabs",
+    hidden: false,
+    getAttribute: () => null,
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    dispatchEvent: () => {},
+    contains: (el) => el?.__inside === true,
+    querySelectorAll: (sel) => matches[sel] ?? [],
+  }
+}
+
+function buildController(root, { documentMatches = {} } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root
+  globalThis.fetch = () => {
+    throw new Error("runOps must NEVER fetch")
+  }
+  globalThis.document = {
+    querySelector: () => null,
+    querySelectorAll: (sel) => documentMatches[sel] ?? [],
+    dispatchEvent: () => {},
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return controller
+}
+
+function fire(controller, { ops, outside, windowBound, target } = {}) {
+  const event = {
+    params: { ops, outside, window: windowBound },
+    target: target ?? { __inside: false },
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+  controller.runOps(event)
+  return event
+}
+
+// --- the core ops -----------------------------------------------------------
+
+test("show/hide/toggle flip the hidden attribute on owned matches", () => {
+  const root = makeRoot()
+  const a = makeEl({ owner: root })
+  const b = makeEl({ owner: root })
+  b.hidden = true
+  root.querySelectorAll = (sel) => ({ "#a": [a], "#b": [b], ".both": [a, b] })[sel] ?? []
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["hide", { to: "#a" }]] })
+  expect(a.hidden).toBe(true)
+
+  fire(controller, { ops: [["show", { to: "#b" }]] })
+  expect(b.hidden).toBe(false)
+
+  fire(controller, { ops: [["toggle", { to: ".both" }]] })
+  expect(a.hidden).toBe(false)
+  expect(b.hidden).toBe(true)
+})
+
+test("class ops add, remove, and toggle on every owned match", () => {
+  const root = makeRoot()
+  const tab = makeEl({ owner: root })
+  tab.classes.add("stale")
+  root.querySelectorAll = () => [tab]
+  const controller = buildController(root)
+
+  fire(controller, {
+    ops: [
+      ["add_class", { to: ".tab", classes: ["active", "current"] }],
+      ["remove_class", { to: ".tab", classes: ["stale"] }],
+      ["toggle_class", { to: ".tab", classes: ["current"] }],
+    ],
+  })
+
+  expect([...tab.classes].sort()).toEqual(["active"])
+})
+
+test("ops apply in order (hide-then-show tabs pattern lands on the last state)", () => {
+  const root = makeRoot()
+  const panel = makeEl({ owner: root })
+  root.querySelectorAll = () => [panel]
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["hide", { to: ".panel" }], ["show", { to: ".panel" }]] })
+
+  expect(panel.hidden).toBe(false)
+})
+
+// --- target resolution ------------------------------------------------------
+
+test("a nested reactive root's elements are NOT touched (issue #15 semantics)", () => {
+  const root = makeRoot()
+  const nestedRoot = makeRoot()
+  const mine = makeEl({ owner: root })
+  const theirs = makeEl({ owner: nestedRoot })
+  root.querySelectorAll = () => [mine, theirs] // querySelectorAll descends into nested roots
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["hide", { to: ".panel" }]] })
+
+  expect(mine.hidden).toBe(true)
+  expect(theirs.hidden).toBe(false)
+})
+
+test("global: true escapes root scoping and skips the ownership filter", () => {
+  const root = makeRoot()
+  const overlay = makeEl({ owner: null }) // outside any reactive root
+  const controller = buildController(root, { documentMatches: { "#overlay": [overlay] } })
+
+  fire(controller, { ops: [["hide", { to: "#overlay", global: true }]] })
+
+  expect(overlay.hidden).toBe(true)
+})
+
+test('"@root" targets the component root itself', () => {
+  const root = makeRoot()
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["toggle", { to: "@root" }]] })
+
+  expect(root.hidden).toBe(true)
+})
+
+// --- default-deny + resilience ----------------------------------------------
+
+test("an unknown op warns, is skipped, and the REST of the chain still applies", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+  const warns = []
+  const original = console.warn
+  console.warn = (...args) => warns.push(args.join(" "))
+
+  try {
+    fire(controller, { ops: [["explode", { to: ".x" }], ["hide", { to: ".x" }]] })
+  } finally {
+    console.warn = original
+  }
+
+  expect(warns.length).toBe(1)
+  expect(warns[0]).toContain("explode")
+  expect(el.hidden).toBe(true)
+})
+
+test("inherited Object properties are not ops (constructor is unknown, not a gadget)", () => {
+  const root = makeRoot()
+  const controller = buildController(root)
+  const warns = []
+  const original = console.warn
+  console.warn = (...args) => warns.push(args.join(" "))
+
+  try {
+    fire(controller, { ops: [["constructor", { to: "@root" }]] })
+  } finally {
+    console.warn = original
+  }
+
+  expect(warns.length).toBe(1)
+})
+
+test("malformed ops degrade to a no-op (string parses; garbage never throws)", () => {
+  const root = makeRoot()
+  root.hidden = false
+  const controller = buildController(root)
+
+  // A raw JSON string still works (hand-built attr / non-typecasting harness)…
+  fire(controller, { ops: '[["toggle",{"to":"@root"}]]' })
+  expect(root.hidden).toBe(true)
+
+  // …and garbage does nothing rather than throwing.
+  expect(() => fire(controller, { ops: "not json" })).not.toThrow()
+  expect(() => fire(controller, { ops: 42 })).not.toThrow()
+  expect(() => fire(controller, { ops: [["hide"]] })).not.toThrow() // missing args
+  expect(() => fire(controller, { ops: ["not-a-pair"] })).not.toThrow()
+})
+
+// --- outside/window semantics (mirrors dispatch(), issue #80) ----------------
+
+test("outside: bails completely for an event INSIDE the root (no ops, no preventDefault)", () => {
+  const root = makeRoot()
+  root.hidden = false
+  const controller = buildController(root)
+
+  const event = fire(controller, {
+    ops: [["hide", { to: "@root" }]],
+    outside: true,
+    windowBound: true,
+    target: { __inside: true },
+  })
+
+  expect(root.hidden).toBe(false)
+  expect(event.defaultPrevented).toBe(false)
+})
+
+test("outside: applies for an event OUTSIDE the root, and window-bound never preventDefaults", () => {
+  const root = makeRoot()
+  const controller = buildController(root)
+
+  const event = fire(controller, {
+    ops: [["hide", { to: "@root" }]],
+    outside: true,
+    windowBound: true,
+    target: { __inside: false },
+  })
+
+  expect(root.hidden).toBe(true)
+  expect(event.defaultPrevented).toBe(false) // a mounted dropdown must not kill page clicks
+})
+
+test("an element-bound trigger DOES preventDefault (bare button in a form must not submit)", () => {
+  const root = makeRoot()
+  const controller = buildController(root)
+
+  const event = fire(controller, { ops: [["hide", { to: "@root" }]] })
+
+  expect(event.defaultPrevented).toBe(true)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -549,6 +549,56 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on_client (issue #95 — client-only DOM ops, zero round trip)" do
+    subject(:instance) { state_klass.new }
+
+    let(:ops) { instance.js.toggle("#menu") }
+
+    it "exposes the js builder as an instance helper" do
+      expect(instance.js).to be_a(Phlex::Reactive::JS)
+    end
+
+    it "binds the event to runOps and carries ONLY the ops (no token, no action, no params)" do
+      attrs = instance.send(:on_client, :click, ops)
+
+      expect(attrs[:data][:action]).to eq("click->reactive#runOps")
+      expect(attrs[:data][:reactive_ops_param]).to eq('[["toggle",{"to":"#menu"}]]')
+      expect(attrs[:data]).not_to have_key(:reactive_action_param)
+      expect(attrs[:data]).not_to have_key(:reactive_params_param)
+      expect(attrs[:data]).not_to have_key(:reactive_token_value)
+    end
+
+    it "forces type=button for click triggers (a bare button in a form must not submit)" do
+      expect(instance.send(:on_client, :click, ops)[:type]).to eq("button")
+    end
+
+    it "composes window:/once: into the descriptor and skips type=button when window-bound" do
+      attrs = instance.send(:on_client, :click, ops, window: true, once: true)
+
+      expect(attrs[:data][:action]).to eq("click@window->reactive#runOps:once")
+      expect(attrs[:data][:reactive_window_param]).to eq("true")
+      expect(attrs).not_to have_key(:type)
+    end
+
+    it "outside: implies the window binding and emits BOTH flags as string params" do
+      attrs = instance.send(:on_client, :click, ops, outside: true)
+
+      expect(attrs[:data][:action]).to eq("click@window->reactive#runOps")
+      expect(attrs[:data][:reactive_outside_param]).to eq("true")
+      expect(attrs[:data][:reactive_window_param]).to eq("true")
+    end
+
+    it "rejects anything that is not a Phlex::Reactive::JS chain" do
+      expect { instance.send(:on_client, :click, [["toggle", { "to" => "#menu" }]]) }
+        .to raise_error(ArgumentError, /Phlex::Reactive::JS/)
+    end
+
+    it "rejects an empty op chain (a dead trigger must fail loudly at render)" do
+      expect { instance.send(:on_client, :click, instance.js) }
+        .to raise_error(ArgumentError, /no ops/)
+    end
+  end
+
   # A record-backed component whose record is UNSAVED (new_record?) has no
   # GlobalID to sign. reactive_token must not crash calling to_gid on it — it
   # signs the declared state instead (the draft seed), so the client controller

--- a/spec/phlex/reactive/js_spec.rb
+++ b/spec/phlex/reactive/js_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Issue #95: the client-side DOM-command builder behind on_client. Ops compile
+# to a JSON array the generic controller's runOps action interprets —
+# declarative DOM operations with ZERO round trip and no client state.
+RSpec.describe Phlex::Reactive::JS do
+  subject(:js) { described_class.new }
+
+  describe "immutability" do
+    it "returns a NEW frozen instance from every verb (chaining never mutates)" do
+      chained = js.show("#a")
+
+      expect(chained).not_to be(js)
+      expect(js.ops).to be_empty # the original is untouched
+      expect(chained).to be_frozen
+      expect(chained.ops).to be_frozen
+    end
+
+    it "chains ops in call order" do
+      ops = js.hide(".panel").show("#panel-2").ops
+      expect(ops.map(&:first)).to eq(%w[hide show])
+    end
+  end
+
+  describe "wire format (#to_json)" do
+    it "serializes visibility ops with their selector" do
+      expect(JSON.parse(js.toggle("#menu").to_json)).to eq([["toggle", { "to" => "#menu" }]])
+    end
+
+    it "serializes class ops with the class list (symbols coerced)" do
+      expect(JSON.parse(js.add_class(".tab", "active", :current).to_json))
+        .to eq([["add_class", { "to" => ".tab", "classes" => %w[active current] }]])
+    end
+
+    it "serializes remove_class and toggle_class the same way" do
+      expect(JSON.parse(js.remove_class(".tab", "active").to_json).dig(0, 0)).to eq("remove_class")
+      expect(JSON.parse(js.toggle_class(".tab", "active").to_json).dig(0, 0)).to eq("toggle_class")
+    end
+
+    it "serializes :root as the @root sentinel (the component's own root element)" do
+      expect(JSON.parse(js.toggle_class(:root, "open").to_json))
+        .to eq([["toggle_class", { "to" => "@root", "classes" => ["open"] }]])
+    end
+
+    it "carries global: true only when asked (root-scoped is the lean default)" do
+      expect(JSON.parse(js.hide("#overlay", global: true).to_json))
+        .to eq([["hide", { "to" => "#overlay", "global" => true }]])
+      expect(JSON.parse(js.hide("#overlay").to_json).dig(0, 1)).not_to have_key("global")
+    end
+  end
+
+  describe "argument validation (loud at render time, never silent on the client)" do
+    it "rejects a target that is neither :root nor a CSS selector string" do
+      expect { js.show(:menu) }.to raise_error(ArgumentError, /:root or a CSS selector/)
+    end
+
+    it "rejects a class op without at least one class" do
+      expect { js.add_class(".tab") }.to raise_error(ArgumentError, /at least one class/)
+    end
+  end
+end

--- a/spec/system/client_ops_spec.rb
+++ b/spec/system/client_ops_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #95: on_client + js ops — declarative interactivity with ZERO server
+# round trips. A fetch spy wraps window.fetch BEFORE any interaction: the
+# reactive endpoint (or anything else) is never called — tabs switch, the menu
+# toggles, and the outside click closes it, all locally. Client ops are
+# ephemeral by design (a server re-render would reset them); this component
+# declares no actions at all, so there is nothing to re-render it.
+RSpec.describe "Client-only ops (issue #95 — on_client + js)", type: :system do
+  def install_fetch_spy
+    page.execute_script(<<~JS)
+      window.__fetchCount = 0
+      const original = window.fetch
+      window.fetch = (...args) => { window.__fetchCount += 1; return original(...args) }
+    JS
+  end
+
+  it "switches tabs and closes the menu on outside click — zero fetches, no reload" do
+    visit "/client_tabs"
+    page.execute_script("window.__noReload = 'alive'")
+    install_fetch_spy
+
+    # Initial state: panel 1 shown, panel 2 hidden.
+    expect(page).to have_css("[data-testid='panel-1']")
+    expect(page).to have_css("[data-testid='panel-2']", visible: :hidden)
+
+    # Tab switch: hide-all + show-one + class swap, purely client-side.
+    find("[data-testid='tab-2']").click
+    expect(page).to have_css("[data-testid='panel-2']")
+    expect(page).to have_css("[data-testid='panel-1']", visible: :hidden)
+    expect(page).to have_css("#ct-tab-2.active")
+    expect(page).to have_no_css("#ct-tab-1.active")
+
+    # The menu opens via a client op…
+    find("[data-testid='menu-open']").click
+    expect(page).to have_css("[data-testid='menu']")
+
+    # …a click INSIDE the root leaves it open (the outside guard bails)…
+    find("[data-testid='tab-1']").click
+    expect(page).to have_css("[data-testid='menu']")
+    expect(page).to have_css("[data-testid='panel-1']") # the tab op still ran
+
+    # …and a click OUTSIDE the component closes it (window-bound on_client).
+    find("[data-testid='outside-area']").click
+    expect(page).to have_css("[data-testid='menu']", visible: :hidden)
+
+    # The whole exchange was client-side: not one fetch, no full-page reload.
+    expect(page.evaluate_script("window.__fetchCount")).to eq(0)
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

The marquee Tier-2 feature: interactivity **without hitting the server**. Purely-visual interactions — tabs, dropdowns, accordions, class toggles — previously cost either a signed server round trip or exactly the hand-written Stimulus controller this gem promises to eliminate.

- **`Phlex::Reactive::JS`** — an immutable, chainable builder of declared DOM operations: `show`/`hide`/`toggle` (the `hidden` attribute) and `add_class`/`remove_class`/`toggle_class`. Each verb returns a new frozen chain; `#to_json` is the wire format. Validation is loud at render time (non-selector target, empty class list, non-JS/empty chain in `on_client` all raise) rather than silent in the browser.
- **`Component#on_client(event, ops, window:, once:, outside:)`** — binds a chain to a DOM event via a new `runOps` action on the ONE generic controller: **no token, no params, no fetch, ever**. Modifiers compose exactly like `on(...)`'s #80 set (outside-click-to-close needs zero server involvement now); flags are emitted as explicit `"true"` strings per the Phlex valueless-attribute trap.
- **Client interpreter** — a frozen `CLIENT_OPS` whitelist (`Object.hasOwn`-guarded, so `"constructor"` can't masquerade as an op); unknown ops warn + skip while the rest of the chain applies; malformed ops JSON degrades to a no-op. Selector targets resolve within the component root and exclude nested reactive roots (issue-#15 ownership rule), with `:root` for the root itself and per-op `global: true` as the document escape. `#applyOps` is deliberately shaped as the shared substrate for #96 (attribute ops/focus/transitions) and #97 (`reply.js` server push).
- **Ephemerality contract documented** (README + CHANGELOG): any server re-render resets client-toggled state — by design, the LiveView JS-commands caveat. Signed actions own state that must survive.

## Test plan (TDD — RED shown before every GREEN)

- Ruby: 9 new builder specs (immutability, wire format, `:root` sentinel, `global:`, loud validation) + 7 new `on_client` emission specs. Fast suite **337 examples, 0 failures**.
- bun: 12 new interpreter tests — each op, ownership scoping past nested roots, `global:` escape, `@root`, unknown-op warn+skip+continue, prototype-pollution guard, malformed-JSON resilience, outside/window semantics, and a fetch stub that **throws if touched**. Full suite **110 pass**.
- System: new `ClientTabsComponent` dummy (tabs + outside-close menu, declares NO actions) + spec wrapping `window.fetch` with a counter — tab switching, inside-click no-op, outside-click close, **zero fetches**, no reload. Green under **Puma AND Falcon** (`rake spec:system_servers`: 36 examples each, 0 failures).
- RuboCop clean (gem + docs app); vendored controller byte-identical.

## Bench (perf rule 8 — same machine, before/after)

Hot paths untouched; `on_client`/`runOps` are new, separate paths.

| Bench | Before | After | obj/call |
|---|---|---|---|
| state-backed token | 201.3k i/s | 209.1k i/s | 11 (identical) |
| record-backed token | 96.0k i/s | 99.1k i/s | 47 (identical) |
| render_component | 27.1k i/s | 29.1k i/s | 113 (identical) |
| to_stream_replace | 13.7k i/s | 14.8k i/s | 205 (identical) |
| coerce_params | 35.3k i/s | 39.1k i/s | 207 (identical) |

(Deltas are run-to-run noise in the favorable direction; allocations — the noise-free signal — are byte-identical. Retained: 0 everywhere.)

Closes #95
