### PR TITLE
feat(component): js ops — allowlisted attr ops, focus, dispatch, transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Same-machine `rake bench` before/after: the token/render/coerce hot paths are
   untouched (state-backed token 201k → within noise; allocations byte-identical
   at 11/47 per token, 113 per render) — `on_client` is a new, separate path.
+- **`js` client ops: allowlisted attribute ops, focus, dispatch, and animated
+  transitions (#96).** The client-only vocabulary from #95 grows to cover the
+  interactions apps otherwise fall back to hand-written Stimulus for. New builder
+  verbs: `set_attr(to, name, value)` / `remove_attr(to, name)` /
+  `toggle_attr(to, name)` for attribute state (the value rides as a string, so a
+  boolean flag is a real `"true"`, never a valueless attribute); `focus(to)` and
+  `focus_first(to)` (the first focusable descendant of the match — the opened-menu
+  → first-menuitem case); and `dispatch(name, to: nil, detail: {})`, a **bubbling
+  `CustomEvent`** other components/controllers can react to (raw
+  `element.dispatchEvent` — the shared controller SHADOWS Stimulus's `this.dispatch`
+  helper). `show`/`hide`/`toggle` gain a `transition: [during, from, to]` keyword:
+  the class lists are applied around the visibility flip and cleaned up on
+  `animationend`, with a `setTimeout` fallback so a non-animated element never
+  leaves them stuck and never hangs the chain (later ops run immediately —
+  cleanup is fire-and-forget). The **attribute-name allowlist is the
+  security-critical part, enforced on BOTH sides (two-sided default-deny)**: at
+  build time in `js.rb` (an offending name raises `ArgumentError`) and again in the
+  client interpreter (a forged/hand-built op is `console.warn`-ed and skipped, so
+  it can't bypass the Ruby guard). Refused, case-insensitively: event handlers
+  (`/\Aon/i` → XSS), the URL-bearing set (`href`, `src`, `srcdoc`, `action`,
+  `formaction`, `xlink:href` → a `javascript:` navigation surface), and `style`
+  (CSS injection). The intended surface — class ops plus `hidden`, `disabled`,
+  `open`, `selected`, `aria-*`, `data-*` — is documented in the README. Covered by
+  Ruby specs (each verb's JSON shape; the allowlist raises for every refused name,
+  case-insensitively), bun tests (attr ops apply; the interpret-time allowlist
+  warns + skips a forged op; focus lands; `dispatch` emits a bubbling event with
+  detail; the transition swaps `from`→`to` on the next frame and cleans up on both
+  `animationend` and the timeout fallback), and a system spec that opens a drawer
+  with a real fade, sets `aria-expanded`, and focuses the first control under Puma
+  AND Falcon. Refs #96.
 
 - **`on(...)` event modifiers — `window:`, `once:`, `outside:`, `throttle:`
   (#80).** Four trigger patterns that previously forced a hand-written Stimulus

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:track, event: "scroll", window: true, throttle: 250)` | `window:` binds the trigger to the window (page-level scroll/resize); `throttle:` rate-limits leading-edge — first event fires, the rest drop until the window elapses. Mutually exclusive with `debounce:`. |
 | `on(:action, once: true)` | Fire at most once, then unbind (Stimulus's native `:once`). |
 | `on_client(:click, js.toggle("#menu"))` | **Client-only** trigger: applies declared DOM ops with ZERO round trip — no token, no POST, ever. Takes the same `window:`/`once:`/`outside:` modifiers. See [Client-only ops](#client-only-ops-on_client--js--zero-round-trips). |
-| `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute) and `add_class`/`remove_class`/`toggle_class`, chainable. |
+| `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute, with an optional `transition:`), `add_class`/`remove_class`/`toggle_class`, `set_attr`/`remove_attr`/`toggle_attr` (allowlisted names), `focus`/`focus_first`, and `dispatch` — chainable. |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
@@ -500,6 +500,38 @@ root** (nested reactive components are never touched — same ownership rule as
 field collection); `:root` targets the root element itself; `global: true` on
 an op escapes to the whole document. An op name the client doesn't recognize
 logs a warning and is skipped — the rest of the chain still applies.
+
+**Attributes, focus, dispatch, and transitions.** Beyond visibility and classes,
+the same chain covers the rest of the client-only vocabulary:
+
+```ruby
+button(**on_client(:click, js
+  .toggle("#menu", transition: %w[transition-opacity opacity-0 opacity-100])
+  .toggle_attr(:root, "aria-expanded")   # accessible disclosure state
+  .focus_first("#menu")                   # move focus into the opened menu
+  .dispatch("app:menu-toggled", detail: { open: true }))) { "Menu" }
+```
+
+- **`set_attr(to, name, value)` / `remove_attr(to, name)` / `toggle_attr(to, name)`**
+  mutate an attribute. The **attribute name is allowlisted, enforced twice** — at
+  build time in Ruby (an offending name raises) and again in the client
+  interpreter (a hand-built op is warned and skipped). Refused: **event handlers**
+  (`on*` → XSS), **URL-bearing** names (`href`, `src`, `srcdoc`, `action`,
+  `formaction`, `xlink:href` → a `javascript:` navigation surface), and **`style`**
+  (CSS injection — use classes). The **intended surface** is class ops plus
+  `hidden`, `disabled`, `open`, `selected`, and any `aria-*` / `data-*` attribute.
+- **`focus(to)`** focuses the first match; **`focus_first(to)`** focuses the first
+  focusable descendant of the match (e.g. the first menuitem inside an opened
+  menu).
+- **`dispatch(name, to: nil, detail: {})`** emits a **bubbling `CustomEvent`** so
+  another component or a plain Stimulus controller can react to a client-only
+  interaction — `to:` picks the element (default: the component root), `detail:`
+  is the payload.
+- **`transition: [during, from, to]`** on `show`/`hide`/`toggle` animates the
+  visibility flip: `during`+`from` are applied, then `from`→`to` swaps on the next
+  frame, and the helper classes are cleaned up on `animationend` (with a timeout
+  fallback, so an element with no animation never leaves them stuck). The op chain
+  is never blocked — later ops (a `focus`, a `dispatch`) run immediately.
 
 `window:`, `once:`, and `outside:` compose exactly like `on(...)`'s event
 modifiers: the dropdown above closes on any click outside the component, and

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -133,7 +133,46 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 }
 
-// The client-op whitelist behind on_client (issue #95). Mirrors
+// The interpret-time attribute-name allowlist (issue #96) — the SECOND half of
+// the two-sided default-deny. The Ruby builder already refuses these at build
+// time; this guards a hand-built / forged ops attr from bypassing it. Refused:
+// event handlers (on*, XSS), URL-bearing names (a javascript: navigation
+// surface), and style (CSS injection). Case-insensitive, mirroring js.rb.
+const REFUSED_ATTR_URL = new Set(["href", "src", "srcdoc", "action", "formaction", "xlink:href", "style"])
+function attrRefused(name) {
+  const lower = String(name).toLowerCase()
+  return lower.startsWith("on") || REFUSED_ATTR_URL.has(lower)
+}
+
+// Run an animated visibility change (issue #96 `transition:`). `flip` performs
+// the actual hidden-flag change; `[during, from, to]` are class lists applied
+// AROUND it. Cleanup (removing during+to) is awaited via `animationend` OR a
+// setTimeout fallback — whichever comes first — so an element with NO animation
+// never leaves the helper classes stuck (the op chain itself is not blocked:
+// cleanup is fire-and-forget, later ops run immediately). The fallback and the
+// listener share a one-shot `done` guard so cleanup runs exactly once.
+function runTransition(el, transition, flip) {
+  const [during, from, to] = transition
+  el.classList.add(during, from)
+  flip()
+  requestAnimationFrame(() => {
+    el.classList.remove(from)
+    el.classList.add(to)
+  })
+
+  let done = false
+  const cleanup = () => {
+    if (done) return
+    done = true
+    el.classList.remove(during, to)
+  }
+  el.addEventListener("animationend", cleanup, { once: true })
+  // ~10% over a common 300ms transition; also the ONLY path for a non-animated
+  // element (animationend never fires there), so it must always be scheduled.
+  setTimeout(cleanup, 350)
+}
+
+// The client-op whitelist behind on_client (issue #95, extended in #96). Mirrors
 // Phlex::Reactive::JS's vocabulary; an op name not in this map is
 // warn-and-skipped by #applyOps (client-side default-deny — a stale or newer
 // ops attr must never break the page). Each op is a pure, local DOM mutation:
@@ -141,19 +180,63 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
 // registered into it at runtime — extending the vocabulary is a gem change,
 // not an app hook.
 const CLIENT_OPS = Object.freeze({
-  show: (el) => {
-    el.hidden = false
-  },
-  hide: (el) => {
-    el.hidden = true
-  },
-  toggle: (el) => {
-    el.hidden = !el.hidden
-  },
+  show: (el, args) => setHidden(el, false, args),
+  hide: (el, args) => setHidden(el, true, args),
+  toggle: (el, args) => setHidden(el, !el.hidden, args),
   add_class: (el, args) => el.classList.add(...(args.classes ?? [])),
   remove_class: (el, args) => el.classList.remove(...(args.classes ?? [])),
   toggle_class: (el, args) => (args.classes ?? []).forEach((c) => el.classList.toggle(c)),
+
+  // Attribute ops (issue #96), interpret-time allowlisted. set_attr writes the
+  // (already-stringified) value; toggle_attr adds a missing attr (value "") or
+  // removes a present one; remove_attr removes it. A refused name warns + skips.
+  set_attr: (el, args) => {
+    if (guardAttr(args.name)) el.setAttribute(args.name, args.value ?? "")
+  },
+  remove_attr: (el, args) => {
+    if (guardAttr(args.name)) el.removeAttribute(args.name)
+  },
+  toggle_attr: (el, args) => {
+    if (!guardAttr(args.name)) return
+    if (el.hasAttribute(args.name)) el.removeAttribute(args.name)
+    else el.setAttribute(args.name, "")
+  },
+
+  // Focus ops (issue #96). focus targets the match itself; focus_first targets
+  // its first focusable descendant (opened-menu → first menuitem).
+  focus: (el) => el.focus?.(),
+  focus_first: (el) => firstFocusable(el)?.focus?.(),
+
+  // Dispatch a bubbling CustomEvent (issue #96). RAW element.dispatchEvent — the
+  // controller SHADOWS Stimulus's this.dispatch helper, so it must not be used.
+  dispatch: (el, args) => {
+    el.dispatchEvent(new CustomEvent(args.name, { bubbles: true, composed: true, detail: args.detail ?? {} }))
+  },
 })
+
+// Apply a hidden-flag change, optionally animated by a [during, from, to]
+// transition (issue #96). Split out so show/hide/toggle share it.
+function setHidden(el, hidden, args) {
+  if (args?.transition) runTransition(el, args.transition, () => (el.hidden = hidden))
+  else el.hidden = hidden
+}
+
+// The interpret-time attribute guard: refuse (warn + skip) a name off the
+// allowlist. Returns true when the op may proceed.
+function guardAttr(name) {
+  if (!attrRefused(name)) return true
+  console.warn(`[phlex-reactive] refused client attr op on ${JSON.stringify(name)} — skipped`)
+  return false
+}
+
+// The first focusable descendant of `el`, in document order — the natural
+// keyboard target inside an opened menu/dialog. Covers the standard focusable
+// set; :not([tabindex="-1"]) drops explicitly-removed nodes. Returns null when
+// nothing inside is focusable (focus_first then no-ops).
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+function firstFocusable(el) {
+  return el.querySelectorAll?.(FOCUSABLE)?.[0] ?? null
+}
 
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with

--- a/lib/phlex/reactive/js.rb
+++ b/lib/phlex/reactive/js.rb
@@ -30,6 +30,20 @@ module Phlex
       # Serialized stand-in for "the component's own root element".
       ROOT_SENTINEL = "@root"
 
+      # The attribute-name allowlist (issue #96) — the security-critical part of
+      # the attr ops, enforced HERE at build time AND again in the client
+      # interpreter (two-sided default-deny: a hand-built ops attr must not
+      # bypass it either). Rejected:
+      #   * /\Aon/i        — event-handler attributes (onclick, onmouseover) → XSS.
+      #   * the URL set     — href/src/srcdoc/action/formaction/xlink:href can carry
+      #                       a `javascript:` payload; setting them from client ops
+      #                       is a navigation/injection surface, not a UI toggle.
+      #   * style           — inline CSS injection; use classes (add_class/...).
+      # The INTENDED surface is class ops plus boolean/state attributes:
+      #   hidden, disabled, open, selected, aria-*, data-*.
+      URL_BEARING_ATTRS = %w[href src srcdoc action formaction xlink:href].freeze
+      EVENT_HANDLER_ATTR = /\Aon/i
+
       # The accumulated [name, args] op pairs, oldest first. Frozen.
       attr_reader :ops
 
@@ -39,17 +53,23 @@ module Phlex
       end
 
       # --- Visibility (the `hidden` attribute) ---
+      #
+      # `transition:` (issue #96) — an optional [during, from, to] class triple
+      # animated around the visibility flip: `during`+`from` are applied, then on
+      # the next frame `from`→`to` swaps, and the whole set is awaited via
+      # `animationend` (with a setTimeout fallback so a non-animated element never
+      # hangs the op chain). Omit it for the instant flip.
 
-      def show(to, global: false)
-        append("show", target_args(to, global:))
+      def show(to, global: false, transition: nil)
+        append("show", target_args(to, global:, transition:))
       end
 
-      def hide(to, global: false)
-        append("hide", target_args(to, global:))
+      def hide(to, global: false, transition: nil)
+        append("hide", target_args(to, global:, transition:))
       end
 
-      def toggle(to, global: false)
-        append("toggle", target_args(to, global:))
+      def toggle(to, global: false, transition: nil)
+        append("toggle", target_args(to, global:, transition:))
       end
 
       # --- Classes ---
@@ -64,6 +84,54 @@ module Phlex
 
       def toggle_class(to, *classes, global: false)
         append("toggle_class", class_args(to, classes, global:))
+      end
+
+      # --- Attributes (issue #96) — allowlisted names only ---
+      #
+      # set_attr(to, name, value) / remove_attr(to, name) / toggle_attr(to, name).
+      # The value is stringified (a Phlex-style flag rides as the string "true",
+      # never a valueless attribute). The name is checked against the allowlist at
+      # build time — an event-handler, URL-bearing, or style name raises here.
+
+      def set_attr(to, name, value, global: false)
+        append("set_attr", attr_args(to, name, global:, value:))
+      end
+
+      def remove_attr(to, name, global: false)
+        append("remove_attr", attr_args(to, name, global:))
+      end
+
+      def toggle_attr(to, name, global: false)
+        append("toggle_attr", attr_args(to, name, global:))
+      end
+
+      # --- Focus (issue #96) ---
+      #
+      # focus(to)        — focus the FIRST match of the selector.
+      # focus_first(to)  — focus the first FOCUSABLE DESCENDANT of the match
+      #                    (e.g. focus the first menuitem inside an opened menu).
+
+      def focus(to, global: false)
+        append("focus", target_args(to, global:))
+      end
+
+      def focus_first(to, global: false)
+        append("focus_first", target_args(to, global:))
+      end
+
+      # --- Dispatch a bubbling CustomEvent (issue #96) ---
+      #
+      # dispatch(name, to: nil, detail: {}) — emit a bubbling CustomEvent so other
+      # components/controllers can react to a client-only interaction without a
+      # round trip. `to:` picks the element to dispatch ON (nil → the component
+      # root, serialized as the @root sentinel so the client resolves it
+      # uniformly); `detail:` is the event's `detail` payload. The client uses raw
+      # element.dispatchEvent — the shared controller SHADOWS Stimulus's
+      # this.dispatch helper, so the interpreter must not use it.
+      def dispatch(name, to: nil, detail: {}, global: false)
+        args = { "name" => name.to_s, "to" => normalize_target(to.nil? ? :root : to), "detail" => detail }
+        args["global"] = true if global
+        append("dispatch", args.freeze)
       end
 
       # The wire format: a JSON array of [op, args] pairs, applied in order.
@@ -83,10 +151,50 @@ module Phlex
         self.class.new([*@ops, [name, args].freeze].freeze)
       end
 
-      def target_args(to, global:)
+      def target_args(to, global:, transition: nil)
         args = { "to" => normalize_target(to) }
         args["global"] = true if global
+        args["transition"] = normalize_transition(transition) if transition
         args.freeze
+      end
+
+      # An attr op's args: the target, the allowlisted name, an optional
+      # (stringified) value. The name is validated LOUDLY at build time.
+      def attr_args(to, name, global:, value: :__none)
+        name = name.to_s
+        assert_allowed_attr(name)
+        args = { "to" => normalize_target(to), "name" => name }
+        args["value"] = value.to_s unless value == :__none
+        args["global"] = true if global
+        args.freeze
+      end
+
+      # The attribute-name allowlist (issue #96), case-insensitive. Enforced here
+      # AND in the client interpreter — two-sided default-deny.
+      def assert_allowed_attr(name)
+        lower = name.downcase
+        if name.match?(EVENT_HANDLER_ATTR)
+          raise ArgumentError,
+            "#{self.class}: attribute #{name.inspect} is an event handler (on*) — refused (XSS). " \
+            "Client attr ops target hidden/disabled/open/selected/aria-*/data-* and classes."
+        end
+        return unless URL_BEARING_ATTRS.include?(lower) || lower == "style"
+
+        raise ArgumentError,
+          "#{self.class}: attribute #{name.inspect} is refused — URL-bearing attributes " \
+          "(#{URL_BEARING_ATTRS.join(", ")}) and `style` can't be set from client ops " \
+          "(injection surface). Use classes for styling; target aria-*/data-*/boolean attrs."
+      end
+
+      # A transition must be exactly [during, from, to] class lists (strings).
+      def normalize_transition(transition)
+        list = Array(transition)
+        unless list.size == 3
+          raise ArgumentError,
+            "#{self.class}: transition: must be [during, from, to] class lists, got #{transition.inspect}"
+        end
+
+        list.map(&:to_s).freeze
       end
 
       def class_args(to, classes, global:)

--- a/spec/dummy/app/components/client_tabs_component.rb
+++ b/spec/dummy/app/components/client_tabs_component.rb
@@ -17,6 +17,7 @@ class ClientTabsComponent < ApplicationComponent
       tabs
       panels
       menu
+      drawer
     end
   end
 
@@ -49,5 +50,23 @@ class ClientTabsComponent < ApplicationComponent
   def menu
     button(**mix(on_client(:click, js.show("#ct-menu")), data: { testid: "menu-open" })) { "Menu" }
     div(id: "ct-menu", hidden: true, data: { testid: "menu" }) { span { "menu content" } }
+  end
+
+  # Issue #96: a drawer opened with a TRANSITION (animated fade), an
+  # aria-expanded attr op on the trigger, and a FOCUS op landing on the first
+  # focusable control inside the drawer — the exact "I had to write Stimulus"
+  # accessible-disclosure pattern, now one op chain.
+  def drawer
+    open = js
+      .toggle("#ct-drawer", transition: %w[ct-fade ct-fade-from ct-fade-to])
+      .set_attr(:root, "aria-expanded", "true")
+      .focus_first("#ct-drawer")
+
+    button(**mix(on_client(:click, open),
+      id: "ct-drawer-trigger", data: { testid: "drawer-open" })) { "Open drawer" }
+    div(id: "ct-drawer", hidden: true, data: { testid: "drawer" }) do
+      button(data: { testid: "drawer-first" }) { "First action" }
+      button(data: { testid: "drawer-second" }) { "Second action" }
+    end
   end
 end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -81,15 +81,20 @@ class DemosController < ActionController::Base
     render html: component + outside.html_safe, layout: true
   end
 
-  # Pure client-side interactivity (issue #95): on_client + js ops. The page
-  # carries an outside area so the spec can prove the outside-close op — and a
-  # fetch spy proves NOTHING is ever posted.
+  # Pure client-side interactivity (issue #95, extended in #96): on_client + js
+  # ops. The page carries an outside area so the spec can prove the outside-close
+  # op, a fetch spy proves NOTHING is ever posted, and a real @keyframes fade
+  # (ct-fade-to) drives the #96 transition op so animationend actually fires.
   def client_tabs
     component = render_to_string(ClientTabsComponent.new, layout: false)
-    outside = <<~HTML
+    extras = <<~HTML
+      <style>
+        @keyframes ct-fade-in { from { opacity: 0 } to { opacity: 1 } }
+        .ct-fade-to { animation: ct-fade-in 40ms ease-out }
+      </style>
       <div data-testid="outside-area" style="padding: 4rem">outside the tabs</div>
     HTML
-    render html: component + outside.html_safe, layout: true
+    render html: component + extras.html_safe, layout: true
   end
 
   def confirm

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -133,7 +133,46 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
   }
 }
 
-// The client-op whitelist behind on_client (issue #95). Mirrors
+// The interpret-time attribute-name allowlist (issue #96) — the SECOND half of
+// the two-sided default-deny. The Ruby builder already refuses these at build
+// time; this guards a hand-built / forged ops attr from bypassing it. Refused:
+// event handlers (on*, XSS), URL-bearing names (a javascript: navigation
+// surface), and style (CSS injection). Case-insensitive, mirroring js.rb.
+const REFUSED_ATTR_URL = new Set(["href", "src", "srcdoc", "action", "formaction", "xlink:href", "style"])
+function attrRefused(name) {
+  const lower = String(name).toLowerCase()
+  return lower.startsWith("on") || REFUSED_ATTR_URL.has(lower)
+}
+
+// Run an animated visibility change (issue #96 `transition:`). `flip` performs
+// the actual hidden-flag change; `[during, from, to]` are class lists applied
+// AROUND it. Cleanup (removing during+to) is awaited via `animationend` OR a
+// setTimeout fallback — whichever comes first — so an element with NO animation
+// never leaves the helper classes stuck (the op chain itself is not blocked:
+// cleanup is fire-and-forget, later ops run immediately). The fallback and the
+// listener share a one-shot `done` guard so cleanup runs exactly once.
+function runTransition(el, transition, flip) {
+  const [during, from, to] = transition
+  el.classList.add(during, from)
+  flip()
+  requestAnimationFrame(() => {
+    el.classList.remove(from)
+    el.classList.add(to)
+  })
+
+  let done = false
+  const cleanup = () => {
+    if (done) return
+    done = true
+    el.classList.remove(during, to)
+  }
+  el.addEventListener("animationend", cleanup, { once: true })
+  // ~10% over a common 300ms transition; also the ONLY path for a non-animated
+  // element (animationend never fires there), so it must always be scheduled.
+  setTimeout(cleanup, 350)
+}
+
+// The client-op whitelist behind on_client (issue #95, extended in #96). Mirrors
 // Phlex::Reactive::JS's vocabulary; an op name not in this map is
 // warn-and-skipped by #applyOps (client-side default-deny — a stale or newer
 // ops attr must never break the page). Each op is a pure, local DOM mutation:
@@ -141,19 +180,63 @@ if (typeof window !== "undefined" && typeof document !== "undefined") {
 // registered into it at runtime — extending the vocabulary is a gem change,
 // not an app hook.
 const CLIENT_OPS = Object.freeze({
-  show: (el) => {
-    el.hidden = false
-  },
-  hide: (el) => {
-    el.hidden = true
-  },
-  toggle: (el) => {
-    el.hidden = !el.hidden
-  },
+  show: (el, args) => setHidden(el, false, args),
+  hide: (el, args) => setHidden(el, true, args),
+  toggle: (el, args) => setHidden(el, !el.hidden, args),
   add_class: (el, args) => el.classList.add(...(args.classes ?? [])),
   remove_class: (el, args) => el.classList.remove(...(args.classes ?? [])),
   toggle_class: (el, args) => (args.classes ?? []).forEach((c) => el.classList.toggle(c)),
+
+  // Attribute ops (issue #96), interpret-time allowlisted. set_attr writes the
+  // (already-stringified) value; toggle_attr adds a missing attr (value "") or
+  // removes a present one; remove_attr removes it. A refused name warns + skips.
+  set_attr: (el, args) => {
+    if (guardAttr(args.name)) el.setAttribute(args.name, args.value ?? "")
+  },
+  remove_attr: (el, args) => {
+    if (guardAttr(args.name)) el.removeAttribute(args.name)
+  },
+  toggle_attr: (el, args) => {
+    if (!guardAttr(args.name)) return
+    if (el.hasAttribute(args.name)) el.removeAttribute(args.name)
+    else el.setAttribute(args.name, "")
+  },
+
+  // Focus ops (issue #96). focus targets the match itself; focus_first targets
+  // its first focusable descendant (opened-menu → first menuitem).
+  focus: (el) => el.focus?.(),
+  focus_first: (el) => firstFocusable(el)?.focus?.(),
+
+  // Dispatch a bubbling CustomEvent (issue #96). RAW element.dispatchEvent — the
+  // controller SHADOWS Stimulus's this.dispatch helper, so it must not be used.
+  dispatch: (el, args) => {
+    el.dispatchEvent(new CustomEvent(args.name, { bubbles: true, composed: true, detail: args.detail ?? {} }))
+  },
 })
+
+// Apply a hidden-flag change, optionally animated by a [during, from, to]
+// transition (issue #96). Split out so show/hide/toggle share it.
+function setHidden(el, hidden, args) {
+  if (args?.transition) runTransition(el, args.transition, () => (el.hidden = hidden))
+  else el.hidden = hidden
+}
+
+// The interpret-time attribute guard: refuse (warn + skip) a name off the
+// allowlist. Returns true when the op may proceed.
+function guardAttr(name) {
+  if (!attrRefused(name)) return true
+  console.warn(`[phlex-reactive] refused client attr op on ${JSON.stringify(name)} — skipped`)
+  return false
+}
+
+// The first focusable descendant of `el`, in document order — the natural
+// keyboard target inside an opened menu/dialog. Covers the standard focusable
+// set; :not([tabindex="-1"]) drops explicitly-removed nodes. Returns null when
+// nothing inside is focusable (focus_first then no-ops).
+const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+function firstFocusable(el) {
+  return el.querySelectorAll?.(FOCUSABLE)?.[0] ?? null
+}
 
 // Register this controller eagerly (not lazily) so a click immediately after
 // page load is never missed. The phlex-reactive engine auto-pins it with

--- a/spec/javascript/reactive_run_ops_extended.test.js
+++ b/spec/javascript/reactive_run_ops_extended.test.js
@@ -1,0 +1,359 @@
+// Unit tests for the issue #96 client ops — attribute ops, focus, dispatch, and
+// animated transitions — layered on the #95 runOps interpreter. Like
+// reactive_run_ops.test.js they NEVER fetch (the stub throws), scope to owned
+// matches (issue #15), and warn-and-skip the unknown.
+//
+// Focus of this file:
+//   * set/remove/toggle_attr mutate attributes, and the INTERPRET-time allowlist
+//     (defense in depth) warns + skips a forged event-handler/URL/style op even
+//     though the Ruby builder would never emit one.
+//   * focus / focus_first move focus to the right node.
+//   * dispatch emits a BUBBLING CustomEvent via element.dispatchEvent (NOT
+//     Stimulus's shadowed this.dispatch) with the given detail.
+//   * a transition triple applies `during`+`from`, swaps to `to` on the next
+//     frame, and cleans up on `animationend` — with a setTimeout fallback so a
+//     NON-animated element never hangs (fake timers prove the fallback fires).
+//
+// Per the DOM-spec trap noted in reactive_lifecycle_events.test.js, no test here
+// asserts a THROWING dispatch listener's behavior — bun:test fails on any
+// surfaced exception, so that case can't be asserted cleanly in this runner.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, afterEach } from "bun:test"
+
+let ReactiveController
+
+// The transition tests stub the timer/frame globals. bun runs every test file
+// in ONE shared process, so a stub left in place would break the debounce /
+// throttle / confirm tests (they rely on REAL setTimeout). Snapshot the
+// originals once and restore them after every test.
+const REAL = {
+  setTimeout: globalThis.setTimeout,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  CustomEvent: globalThis.CustomEvent,
+}
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+afterEach(() => {
+  globalThis.setTimeout = REAL.setTimeout
+  globalThis.requestAnimationFrame = REAL.requestAnimationFrame
+  globalThis.CustomEvent = REAL.CustomEvent
+})
+
+// A richer fake node than reactive_run_ops.test.js's: it also models attributes,
+// focus(), addEventListener (for animationend), and dispatchEvent (records the
+// events it received). `closest` returns the nearest reactive root (`owner`).
+function makeEl({ owner = null } = {}) {
+  const el = {
+    hidden: false,
+    classes: new Set(),
+    attrs: new Map(),
+    focused: 0,
+    dispatched: [],
+    listeners: new Map(),
+    closest: () => owner,
+    getAttribute: (n) => (el.attrs.has(n) ? el.attrs.get(n) : null),
+    setAttribute: (n, v) => el.attrs.set(n, String(v)),
+    removeAttribute: (n) => el.attrs.delete(n),
+    hasAttribute: (n) => el.attrs.has(n),
+    focus: () => {
+      el.focused += 1
+      globalThis.document.activeElement = el
+    },
+    dispatchEvent: (event) => {
+      el.dispatched.push(event)
+      return true
+    },
+    addEventListener: (name, cb, opts) => el.listeners.set(name, { cb, opts }),
+    querySelectorAll: () => [],
+  }
+  el.classList = {
+    add: (...cs) => cs.forEach((c) => el.classes.add(c)),
+    remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
+    toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+    contains: (c) => el.classes.has(c),
+  }
+  return el
+}
+
+function makeRoot(matches = {}) {
+  const root = makeEl({ owner: null })
+  root.isConnected = true
+  root.id = "tabs"
+  root.contains = (el) => el?.__inside === true
+  root.querySelectorAll = (sel) => matches[sel] ?? []
+  return root
+}
+
+function buildController(root, { documentMatches = {} } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root
+  globalThis.fetch = () => {
+    throw new Error("runOps must NEVER fetch")
+  }
+  globalThis.document = {
+    activeElement: null,
+    querySelector: () => null,
+    querySelectorAll: (sel) => documentMatches[sel] ?? [],
+    dispatchEvent: () => {},
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  // A CustomEvent stand-in that records name/detail/bubbles for dispatch tests.
+  globalThis.CustomEvent = class {
+    constructor(type, init = {}) {
+      this.type = type
+      this.detail = init.detail
+      this.bubbles = !!init.bubbles
+      this.composed = !!init.composed
+    }
+  }
+  return controller
+}
+
+function fire(controller, { ops, target } = {}) {
+  const event = {
+    params: { ops },
+    target: target ?? { __inside: false },
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+  controller.runOps(event)
+  return event
+}
+
+function captureWarnings(fn) {
+  const warns = []
+  const original = console.warn
+  console.warn = (...args) => warns.push(args.join(" "))
+  try {
+    fn()
+  } finally {
+    console.warn = original
+  }
+  return warns
+}
+
+// --- attribute ops ----------------------------------------------------------
+
+test("set_attr sets, remove_attr removes, on every owned match", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  el.setAttribute("disabled", "true")
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["set_attr", { to: "#x", name: "aria-expanded", value: "true" }]] })
+  expect(el.getAttribute("aria-expanded")).toBe("true")
+
+  fire(controller, { ops: [["remove_attr", { to: "#x", name: "disabled" }]] })
+  expect(el.hasAttribute("disabled")).toBe(false)
+})
+
+test("toggle_attr adds a missing attr (value '') and removes a present one", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["toggle_attr", { to: "#x", name: "aria-expanded" }]] })
+  expect(el.hasAttribute("aria-expanded")).toBe(true)
+
+  fire(controller, { ops: [["toggle_attr", { to: "#x", name: "aria-expanded" }]] })
+  expect(el.hasAttribute("aria-expanded")).toBe(false)
+})
+
+// --- interpret-time allowlist (defense in depth) ----------------------------
+
+test("a forged event-handler attr op warns and is skipped (interpret-time deny)", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+
+  const warns = captureWarnings(() =>
+    // A hand-built ops attr the Ruby builder would have refused at build time.
+    fire(controller, { ops: [["set_attr", { to: "#x", name: "onclick", value: "alert(1)" }]] }),
+  )
+
+  expect(el.hasAttribute("onclick")).toBe(false)
+  expect(warns.length).toBe(1)
+  expect(warns[0]).toContain("onclick")
+})
+
+test("forged URL-bearing and style attr ops are skipped (case-insensitive)", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+
+  captureWarnings(() => {
+    fire(controller, { ops: [["set_attr", { to: "#x", name: "HREF", value: "javascript:evil()" }]] })
+    fire(controller, { ops: [["set_attr", { to: "#x", name: "style", value: "color:red" }]] })
+    fire(controller, { ops: [["toggle_attr", { to: "#x", name: "SRC" }]] })
+  })
+
+  expect(el.hasAttribute("HREF")).toBe(false)
+  expect(el.hasAttribute("style")).toBe(false)
+  expect(el.hasAttribute("SRC")).toBe(false)
+})
+
+test("a safe attr op still applies while a forged sibling op is skipped", () => {
+  const root = makeRoot()
+  const el = makeEl({ owner: root })
+  root.querySelectorAll = () => [el]
+  const controller = buildController(root)
+
+  captureWarnings(() =>
+    fire(controller, {
+      ops: [
+        ["set_attr", { to: "#x", name: "onclick", value: "x" }], // skipped
+        ["set_attr", { to: "#x", name: "aria-hidden", value: "true" }], // applies
+      ],
+    }),
+  )
+
+  expect(el.getAttribute("aria-hidden")).toBe("true")
+})
+
+// --- focus ------------------------------------------------------------------
+
+test("focus moves focus to the first match", () => {
+  const root = makeRoot()
+  const item = makeEl({ owner: root })
+  root.querySelectorAll = (sel) => (sel === "#menu [role=menuitem]" ? [item] : [])
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["focus", { to: "#menu [role=menuitem]" }]] })
+
+  expect(item.focused).toBe(1)
+  expect(globalThis.document.activeElement).toBe(item)
+})
+
+test("focus_first focuses the first focusable descendant of the match", () => {
+  const root = makeRoot()
+  const menu = makeEl({ owner: root })
+  const firstItem = makeEl({ owner: root })
+  // The menu's focusable descendants, in document order.
+  menu.querySelectorAll = () => [firstItem]
+  root.querySelectorAll = (sel) => (sel === "#menu" ? [menu] : [])
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["focus_first", { to: "#menu" }]] })
+
+  expect(firstItem.focused).toBe(1)
+})
+
+// --- dispatch ---------------------------------------------------------------
+
+test("dispatch emits a bubbling CustomEvent on the root by default, with detail", () => {
+  const root = makeRoot()
+  const controller = buildController(root)
+
+  // The Ruby builder serializes a nil target as the @root sentinel.
+  fire(controller, { ops: [["dispatch", { name: "app:menu-toggled", to: "@root", detail: { open: true } }]] })
+
+  expect(root.dispatched.length).toBe(1)
+  const event = root.dispatched[0]
+  expect(event.type).toBe("app:menu-toggled")
+  expect(event.bubbles).toBe(true)
+  expect(event.detail).toEqual({ open: true })
+})
+
+test("dispatch with a target emits on the owned match", () => {
+  const root = makeRoot()
+  const panel = makeEl({ owner: root })
+  root.querySelectorAll = (sel) => (sel === "#panel" ? [panel] : [])
+  const controller = buildController(root)
+
+  fire(controller, { ops: [["dispatch", { name: "app:x", to: "#panel", detail: {} }]] })
+
+  expect(panel.dispatched.length).toBe(1)
+  expect(root.dispatched.length).toBe(0)
+})
+
+// --- transitions ------------------------------------------------------------
+
+test("a transition applies during+from, then swaps from->to on the next frame", () => {
+  const root = makeRoot()
+  const menu = makeEl({ owner: root })
+  menu.hidden = true
+  root.querySelectorAll = () => [menu]
+  const controller = buildController(root)
+
+  // Capture the rAF callback instead of running it, so we can assert the two
+  // phases (initial classes, then the swap) deterministically.
+  let rafCb = null
+  globalThis.requestAnimationFrame = (cb) => {
+    rafCb = cb
+    return 1
+  }
+
+  fire(controller, {
+    ops: [["toggle", { to: "#menu", transition: ["transition-opacity", "opacity-0", "opacity-100"] }]],
+  })
+
+  // Phase 1: visibility flipped, during+from applied, `to` not yet.
+  expect(menu.hidden).toBe(false)
+  expect(menu.classes.has("transition-opacity")).toBe(true)
+  expect(menu.classes.has("opacity-0")).toBe(true)
+  expect(menu.classes.has("opacity-100")).toBe(false)
+
+  // Phase 2: the next frame swaps from -> to.
+  rafCb()
+  expect(menu.classes.has("opacity-0")).toBe(false)
+  expect(menu.classes.has("opacity-100")).toBe(true)
+})
+
+test("transition classes are cleaned up on animationend", () => {
+  const root = makeRoot()
+  const menu = makeEl({ owner: root })
+  root.querySelectorAll = () => [menu]
+  const controller = buildController(root)
+  globalThis.requestAnimationFrame = (cb) => (cb(), 1)
+
+  fire(controller, {
+    ops: [["show", { to: "#menu", transition: ["t-fade", "from", "to"] }]],
+  })
+
+  // The op registered an animationend listener; firing it removes the transition
+  // classes (both the `during` helper and the `to` end-state marker).
+  const listener = menu.listeners.get("animationend")
+  expect(listener).toBeDefined()
+  listener.cb()
+
+  expect(menu.classes.has("t-fade")).toBe(false)
+  expect(menu.classes.has("to")).toBe(false)
+})
+
+test("a non-animated element does NOT hang: the setTimeout fallback cleans up", () => {
+  const root = makeRoot()
+  const menu = makeEl({ owner: root })
+  root.querySelectorAll = () => [menu]
+  const controller = buildController(root)
+  globalThis.requestAnimationFrame = (cb) => (cb(), 1)
+
+  // Fake timer: capture the fallback so we can fire it without real time.
+  let timeoutCb = null
+  globalThis.setTimeout = (cb) => {
+    timeoutCb = cb
+    return 1
+  }
+
+  fire(controller, {
+    ops: [["hide", { to: "#menu", transition: ["t-fade", "from", "to"] }]],
+  })
+
+  expect(menu.classes.has("t-fade")).toBe(true) // still mid-transition
+  timeoutCb() // the fallback fires (animationend never came)
+  expect(menu.classes.has("t-fade")).toBe(false)
+})

--- a/spec/phlex/reactive/js_spec.rb
+++ b/spec/phlex/reactive/js_spec.rb
@@ -60,4 +60,145 @@ RSpec.describe Phlex::Reactive::JS do
       expect { js.add_class(".tab") }.to raise_error(ArgumentError, /at least one class/)
     end
   end
+
+  # --- Issue #96: attribute ops (the security-critical build-time allowlist) ---
+
+  describe "attribute ops (#set_attr / #remove_attr / #toggle_attr)" do
+    it "serializes set_attr with the name and stringified value" do
+      expect(JSON.parse(js.set_attr("#x", "aria-expanded", true).to_json))
+        .to eq([["set_attr", { "to" => "#x", "name" => "aria-expanded", "value" => "true" }]])
+    end
+
+    it "serializes remove_attr with just the name" do
+      expect(JSON.parse(js.remove_attr(:root, "disabled").to_json))
+        .to eq([["remove_attr", { "to" => "@root", "name" => "disabled" }]])
+    end
+
+    it "serializes toggle_attr with the name (no value needed)" do
+      expect(JSON.parse(js.toggle_attr("#x", "aria-expanded").to_json))
+        .to eq([["toggle_attr", { "to" => "#x", "name" => "aria-expanded" }]])
+    end
+
+    it "carries global: true through an attr op when asked" do
+      expect(JSON.parse(js.set_attr("#x", "data-open", "1", global: true).to_json).dig(0, 1))
+        .to include("global" => true)
+    end
+
+    it "coerces a symbol attribute name to a string" do
+      expect(JSON.parse(js.toggle_attr("#x", :hidden).to_json).dig(0, 1, "name")).to eq("hidden")
+    end
+  end
+
+  describe "the attribute-name allowlist (two-sided default-deny; build side raises)" do
+    it "rejects event-handler attributes (/\\Aon/i) — XSS vector" do
+      expect { js.set_attr("#x", "onclick", "alert(1)") }.to raise_error(ArgumentError, /onclick/)
+      expect { js.toggle_attr("#x", "onmouseover") }.to raise_error(ArgumentError, /onmouseover/)
+      expect { js.remove_attr("#x", "onload") }.to raise_error(ArgumentError, /onload/)
+    end
+
+    it "is case-insensitive about the on* prefix (OnClick, ONCLICK)" do
+      expect { js.set_attr("#x", "OnClick", "x") }.to raise_error(ArgumentError)
+      expect { js.set_attr("#x", "ONCLICK", "x") }.to raise_error(ArgumentError)
+    end
+
+    # Each block iterates attribute NAMES; the inner expect { } blocks reference
+    # that outer `name`, so the ItBlockParameter cop's implicit-`it` rewrite would
+    # shadow it (the same trap vendored_controller_sync_spec.rb documents).
+    # rubocop:disable Style/ItBlockParameter
+    it "rejects every URL-bearing attribute (javascript:-injection surface)" do
+      %w[href src srcdoc action formaction xlink:href].each do |name|
+        expect { js.set_attr("#x", name, "javascript:evil()") }
+          .to raise_error(ArgumentError, /#{Regexp.escape(name)}/),
+            "expected #{name} to be rejected"
+      end
+    end
+
+    it "is case-insensitive about URL-bearing names (HREF, Src)" do
+      expect { js.set_attr("#x", "HREF", "x") }.to raise_error(ArgumentError)
+      expect { js.remove_attr("#x", "Src") }.to raise_error(ArgumentError)
+    end
+
+    it "rejects style (CSS injection — use classes)" do
+      expect { js.set_attr("#x", "style", "color:red") }.to raise_error(ArgumentError, /style/)
+      expect { js.set_attr("#x", "STYLE", "x") }.to raise_error(ArgumentError)
+    end
+
+    it "allows the intended surface: hidden, disabled, open, selected, aria-*, data-*" do
+      %w[hidden disabled open selected aria-expanded aria-hidden data-state data-open].each do |name|
+        expect { js.set_attr("#x", name, "true") }.not_to raise_error
+        expect { js.toggle_attr("#x", name) }.not_to raise_error
+        expect { js.remove_attr("#x", name) }.not_to raise_error
+      end
+    end
+    # rubocop:enable Style/ItBlockParameter
+  end
+
+  # --- Issue #96: focus ops ---
+
+  describe "focus ops (#focus / #focus_first)" do
+    it "serializes focus with its target" do
+      expect(JSON.parse(js.focus("#menu [role=menuitem]").to_json))
+        .to eq([["focus", { "to" => "#menu [role=menuitem]" }]])
+    end
+
+    it "serializes focus_first with its target" do
+      expect(JSON.parse(js.focus_first("#menu").to_json))
+        .to eq([["focus_first", { "to" => "#menu" }]])
+    end
+
+    it "accepts :root and global: on focus ops" do
+      expect(JSON.parse(js.focus(:root).to_json).dig(0, 1, "to")).to eq("@root")
+      expect(JSON.parse(js.focus("#x", global: true).to_json).dig(0, 1)).to include("global" => true)
+    end
+  end
+
+  # --- Issue #96: dispatch a bubbling CustomEvent ---
+
+  describe "dispatch (#dispatch) — a bubbling CustomEvent" do
+    it "serializes name, detail, and a nil target as @root (dispatch on the root)" do
+      expect(JSON.parse(js.dispatch("app:menu-toggled", detail: { open: true }).to_json))
+        .to eq([["dispatch", { "name" => "app:menu-toggled", "to" => "@root", "detail" => { "open" => true } }]])
+    end
+
+    it "carries an explicit target when given" do
+      expect(JSON.parse(js.dispatch("app:x", to: "#panel").to_json).dig(0, 1))
+        .to include("name" => "app:x", "to" => "#panel")
+    end
+
+    it "defaults detail to an empty hash" do
+      expect(JSON.parse(js.dispatch("app:x").to_json).dig(0, 1, "detail")).to eq({})
+    end
+
+    it "accepts :root and global: on a targeted dispatch" do
+      expect(JSON.parse(js.dispatch("app:x", to: :root).to_json).dig(0, 1, "to")).to eq("@root")
+      expect(JSON.parse(js.dispatch("app:x", to: "#x", global: true).to_json).dig(0, 1))
+        .to include("global" => true)
+    end
+  end
+
+  # --- Issue #96: the transition: kwarg on show/hide/toggle ---
+
+  describe "transition: kwarg on show/hide/toggle" do
+    it "carries [during, from, to] class lists on the visibility op" do
+      ops = js.toggle("#menu", transition: %w[transition-opacity opacity-0 opacity-100]).to_json
+      expect(JSON.parse(ops).dig(0, 1, "transition"))
+        .to eq(%w[transition-opacity opacity-0 opacity-100])
+    end
+
+    it "works on show and hide too" do
+      expect(JSON.parse(js.show("#x", transition: %w[t f to]).to_json).dig(0, 1, "transition"))
+        .to eq(%w[t f to])
+      expect(JSON.parse(js.hide("#x", transition: %w[t f to]).to_json).dig(0, 1, "transition"))
+        .to eq(%w[t f to])
+    end
+
+    it "omits the transition key when not asked (lean default)" do
+      expect(JSON.parse(js.toggle("#x").to_json).dig(0, 1)).not_to have_key("transition")
+    end
+
+    it "rejects a transition list that is not exactly [during, from, to]" do
+      expect { js.toggle("#x", transition: %w[only two]) }
+        .to raise_error(ArgumentError, /during, from, to/)
+    end
+  end
 end

--- a/spec/system/client_ops_spec.rb
+++ b/spec/system/client_ops_spec.rb
@@ -50,4 +50,26 @@ RSpec.describe "Client-only ops (issue #95 — on_client + js)", type: :system d
     expect(page.evaluate_script("window.__fetchCount")).to eq(0)
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end
+
+  # Issue #96: the transition op reveals the drawer with an animated fade, the
+  # attr op flips aria-expanded on the root, and the focus op lands on the
+  # drawer's first control — all client-side, zero fetches.
+  it "opens a drawer with a transition, sets aria-expanded, and focuses the first control" do
+    visit "/client_tabs"
+    install_fetch_spy
+
+    expect(page).to have_css("[data-testid='drawer']", visible: :hidden)
+
+    find("[data-testid='drawer-open']").click
+
+    # The transition op flipped `hidden` and applied the end-state class; the
+    # drawer is now visible (Capybara waits through the 40ms fade).
+    expect(page).to have_css("[data-testid='drawer']")
+    # The attr op set aria-expanded="true" on the reactive root.
+    expect(page).to have_css("#client-tabs[aria-expanded='true']")
+    # The focus op landed on the drawer's first focusable control.
+    expect(page.evaluate_script("document.activeElement.dataset.testid")).to eq("drawer-first")
+
+    expect(page.evaluate_script("window.__fetchCount")).to eq(0)
+  end
 end


### PR DESCRIPTION
## Summary

Extends the `on_client` / `js` client-op vocabulary (#95) with the interactions apps otherwise fall back to hand-written Stimulus for: attribute state, focus management, cross-component events, and animated show/hide. Zero round trips, no client state, still one generic controller.

New `js` builder verbs:

- **`set_attr(to, name, value)` / `remove_attr(to, name)` / `toggle_attr(to, name)`** — attribute state. The value rides as a string, so a boolean flag is a real `"true"`, never a Phlex valueless attribute.
- **`focus(to)`** (first match) / **`focus_first(to)`** (first focusable descendant of the match — opened-menu → first menuitem).
- **`dispatch(name, to: nil, detail: {})`** — a bubbling `CustomEvent` other components/controllers can react to. The client uses raw `element.dispatchEvent` (the shared controller SHADOWS Stimulus's `this.dispatch` helper).
- **`transition: [during, from, to]`** on `show`/`hide`/`toggle` — class lists applied around the visibility flip, cleaned up on `animationend` with a `setTimeout` fallback so a non-animated element never leaves them stuck and never hangs the chain (cleanup is fire-and-forget; later ops run immediately).

## The attribute-name allowlist (the security-critical part)

Enforced on **both sides — two-sided default-deny**:

1. **Build time** (`js.rb`): an offending name raises `ArgumentError` at render.
2. **Interpret time** (client): a forged/hand-built op is `console.warn`-ed and skipped, so it can't bypass the Ruby guard.

Refused, case-insensitively:

| Refused | Why |
|---------|-----|
| `/\Aon/i` (event handlers) | XSS |
| `href`, `src`, `srcdoc`, `action`, `formaction`, `xlink:href` | `javascript:` navigation surface |
| `style` | CSS injection — use classes |

**Intended surface** (documented in the README): class ops plus `hidden`, `disabled`, `open`, `selected`, `aria-*`, `data-*`.

## API sketch

```ruby
button(**on_client(:click, js
  .toggle("#menu", transition: %w[transition-opacity opacity-0 opacity-100])
  .toggle_attr(:root, "aria-expanded")
  .focus_first("#menu")
  .dispatch("app:menu-toggled", detail: { open: true }))) { "Menu" }
```

`js.set_attr("#x", "onclick", "…")` raises `ArgumentError` at render time.

## Test coverage

- **Ruby specs** (`spec/phlex/reactive/js_spec.rb`): each verb's JSON shape; the allowlist raises for `/\Aon/i`, every URL-bearing name, and `style`; case-insensitivity (`OnClick`, `HREF`, `Src`, `STYLE`); the intended surface is allowed.
- **bun tests** (`spec/javascript/reactive_run_ops_extended.test.js`, RED first): set/remove/toggle_attr apply; the interpret-time allowlist warns + skips a forged event-handler / URL / `style` op (fed as a raw op list); a safe sibling op still applies; focus lands (`document.activeElement`); `dispatch` emits a bubbling `CustomEvent` with detail (on the root by default, on a target when given); the transition swaps `from`→`to` on the next frame and cleans up on **both** `animationend` and the `setTimeout` fallback (fake timers).
- **System spec** (`spec/system/client_ops_spec.rb`): opens a drawer with a real `@keyframes` fade, sets `aria-expanded` on the root, and focuses the first control — green under **Puma AND Falcon**, zero fetches.

## Notes on the known traps (from the issue)

- No bun test asserts a throwing `dispatch` listener's behavior — per the DOM spec `dispatchEvent` never propagates a listener's throw, and `bun:test` fails on any surfaced exception, so that case can't be asserted cleanly in the runner (documented in `reactive_lifecycle_events.test.js`).
- Flag params (`aria-expanded`) are explicit `"true"` strings, never valueless attributes.
- The extended bun test snapshots and restores the timer/frame globals in `afterEach` — bun runs every file in one process, so a leaked `setTimeout` stub would break the debounce/throttle/confirm tests.

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests` — 359 examples, 0 failures
- [x] `bun test spec/javascript` — 122 pass, 0 fail
- [x] `bundle exec rspec spec/system` (Puma) — 37 examples, 0 failures
- [x] `CAPYBARA_SERVER=falcon bundle exec rspec spec/system` — 37 examples, 0 failures
- [x] `bundle exec rubocop` — clean (126 files)
- [x] Vendored client re-synced (byte-identical guard passes)
- [x] README allowed-attribute surface + detailed CHANGELOG entry

**Invariants preserved:** no client state · two-sided default-deny · ONE generic controller · pgbus optional (untouched) · self-targeting `#id`. Backwards compatible — every existing `on_client` chain works verbatim.

Closes #96
