### PR TITLE
feat(component): reply.js + broadcast_js_to — server-pushed DOM ops over a reactive:js stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `animationend` and the timeout fallback), and a system spec that opens a drawer
   with a real fade, sets `aria-expanded`, and focuses the first control under Puma
   AND Falcon. Refs #96.
+- **`reply.js(...)` + `broadcast_js_to` — server-pushed DOM ops over a
+  `reactive:js` stream action (#97).** The server can now tell the client to do
+  something other than swap HTML — focus the next field after a save, dispatch an
+  app event to a toast host, add an unread badge in every viewer's tab — WITHOUT
+  re-rendering to make it happen. `Response#js(ops)` (surfaced on the reply facade
+  as `reply.<verb>.js(ops)`) chains a `reactive:js` op stream onto ANY reply via
+  the immutable `stream()` plumbing, and `Streamable.broadcast_js_to(*streamables,
+  ops, exclude:, visible_to:, target:)` pushes the SAME ops to every subscriber of
+  a stream over `Turbo::StreamsChannel` (Action Cable AND pgbus — transport opts
+  pass through `broadcast_transport_opts` like every other broadcast). `ops` is a
+  `js` chain (or a raw `[[op, args]]` array), interpreted by the SAME frozen
+  `CLIENT_OPS` whitelist as `on_client` through a THIRD custom stream action
+  (`registerReactiveJs`, a sibling of `reactive:visit`/`reactive:token`): an
+  unknown op warns + is skipped (client-side default-deny). **The ordering contract
+  is correctness-critical**: the op stream is emitted AFTER all render streams, so
+  a `focus("[name=next]")` op sees the post-render/post-morph DOM (Turbo applies
+  streams in document order) — a system spec proves focus lands on a freshly
+  morphed field under Puma AND Falcon. **The broadcast builder REJECTS focus-class
+  ops** (`focus`/`focus_first` → `ArgumentError`): broadcasting focus would steal
+  it in every subscriber's tab, so focus is an actor-reply concern only. The ops
+  attribute is HTML-escaped exactly like `to_stream_token` (a raw interpolation
+  would be an injection vector), and `reactive:js` is NOT a self-render — it never
+  trips `#extractToken` or `carries_token_for?`, so the reply's token refresh is
+  untouched (pinned by a bun test and a request spec). Covered by Ruby specs
+  (immutable chaining; ops-last ordering; escaping; the broadcast focus rejection;
+  transport-opt pass-through with the pgbus-absent path unchanged), bun tests (the
+  handler applies ops via the shared interpreter; `target` root scoping; token
+  safety), a request spec (both streams in order with the token intact), and the
+  focus system spec. Refs #97.
 
 - **`on(...)` event modifiers — `window:`, `once:`, `outside:`, `throttle:`
   (#80).** Four trigger patterns that previously forced a hand-written Stimulus

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
 | `reactive_collection :name, item:, container:, count:, empty:, size:` | Declare an add/remove-row list once; actions call `reply.append`/`prepend`/`remove`. See [Reactive collections](#reactive-collections-addremove-rows--count--empty-state). |
-| `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` | Return from an action to control the reply (flash, remove, redirect, multi-stream). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
+| `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` / `.js(ops)` | Return from an action to control the reply (flash, remove, redirect, multi-stream, server-pushed client ops). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
 | `reply.append(name, model)` / `.prepend(...)` / `.remove(name, model)` | Add/remove a row in a declared `reactive_collection` (row + count + empty-state in one reply). |
 
 Param types: `:string` (default), `:integer`, `:float`, `:boolean`, `:file`.
@@ -774,6 +774,7 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 | `reply.remove` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `reply.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
 | `reply.streams(*streams)` | **partial update** — emit exactly these streams (no full-self replace) + a tiny token-only refresh, so live inputs survive; for per-field grid editing (issue #30) |
+| `.js(ops, target: …)` | also push **client DOM ops** (focus, dispatch, class/attr toggles) over a `reactive:js` stream, applied AFTER the render — `reply.morph.js(js.focus("[name=next]"))` focuses the morphed field (issue #97) |
 | `reply.with(*streams)` / `#stream(*more)` | multi-stream (self re-render still injected for the token) |
 
 `.flash`/`.stream`/`.also_*` are additive on a self-replace, so the component's
@@ -811,6 +812,50 @@ reply.replace.flash(:error, Alert.new(level: :error, message: msg))
 #    (instantiated new(level:, content:)); component content still bypasses it:
 Phlex::Reactive.flash_component = MyFlash   # default nil → the built-in wrapper
 ```
+
+#### Server-pushed client ops (`reply.js` + `broadcast_js_to`, issue #97)
+
+Sometimes the server needs the client to do something other than swap HTML —
+focus the next field after a save, dispatch an app event to a toast host, add an
+unread badge — WITHOUT re-rendering to make it happen. `reply.<verb>.js(ops)`
+chains a `reactive:js` stream carrying declared client DOM ops (the same `js`
+builder as [`on_client`](#client-only-ops-on_client--js--zero-round-trips))
+onto any reply. The op stream rides **after** the render streams, so a focus op
+sees the freshly rendered/morphed DOM:
+
+```ruby
+def save(title:)
+  @todo.update!(title:)
+  # Morph in place, THEN focus the next field + tell a toast host we saved:
+  reply.morph.js(js.focus("[name=next_field]").dispatch("app:saved", detail: { id: @todo.id }))
+end
+```
+
+`target:` scopes op resolution on the client; it defaults to the bound
+component's id for `replace`/`morph`/`update` (so `@root` and component-relative
+selectors just work), and to document-scope for a subject-free `reply.with`.
+
+The same ops broadcast to **every** subscriber of a stream over the usual
+transport (Action Cable **or** pgbus) — a background nudge to all viewers:
+
+```ruby
+# In a model/job: light up the bell in every viewer's tab, minus the actor's own.
+Notifications::Badge.broadcast_js_to(user, :alerts,
+  js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+```
+
+`broadcast_js_to` **refuses focus-class ops** (`focus`/`focus_first` raise
+`ArgumentError`): broadcasting focus would steal it in every subscriber's tab, so
+focus is an actor-reply concern only. Everything else is a fair broadcast (class
+and attribute toggles, `dispatch`). As with `on_client`, the ops are
+whitelist-interpreted client-side — an unknown op warns and is skipped — and the
+ops attribute is HTML-escaped, so a value can't break out of it. `reactive:js`
+is not a self-render: it never counts toward the token refresh, so the reply's
+signed token still rolls forward exactly as it would without the ops.
+
+> **Ephemeral by design.** Like `on_client`, server-pushed ops are transient UI:
+> the next server re-render of the component resets whatever they toggled. State
+> that must survive a re-render belongs in a signed `action`, not an op.
 
 #### Record-authorized, transient-state actions (issue #64)
 

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -73,9 +73,44 @@ export function registerReactiveToken() {
   }
 }
 
+// Custom turbo-stream action: SERVER-PUSHED client DOM ops (issue #97). The
+// server-side sibling of on_client's runOps — a reply (reply.<verb>.js(ops)) or
+// a broadcast (Streamable.broadcast_js_to) emits
+//
+//   <turbo-stream action="reactive:js" target="<optional root id>"
+//                 data-reactive-ops="[[op, args], ...]"></turbo-stream>
+//
+// and Turbo invokes this handler with `this` bound to that <turbo-stream>
+// element. It runs the ops through the SAME frozen CLIENT_OPS whitelist as
+// runOps (client-side default-deny — an unknown op warns + is skipped), so a
+// forged/stale ops attr can never break the page or execute anything off the
+// vocabulary. NO token, NO fetch — a pure local DOM mutation.
+//
+// `target` (optional, an element id) scopes op resolution to that root: "@root"
+// resolves to the target element itself and a selector resolves WITHIN it.
+// Without a target, ops resolve document-wide (a broadcast op like
+// add_class("#bell", ...) that isn't anchored to one component). The op stream
+// is emitted AFTER all render streams in the reply (the endpoint appends it
+// last), so focus("[name=next]") sees the freshly morphed DOM — Turbo applies
+// streams in document order.
+export function registerReactiveJs() {
+  const actions = window.Turbo?.StreamActions
+  if (!actions || actions["reactive:js"]) return
+  actions["reactive:js"] = function () {
+    const list = parseOps(this.getAttribute("data-reactive-ops"))
+    if (!list.length) return
+    const targetId = this.getAttribute("target")
+    // With a target: scope to that element (missing → no-op). Without: document.
+    const root = targetId ? document.getElementById(targetId) : null
+    if (targetId && !root) return
+    applyOps(list, (args) => streamOpTargets(args, root))
+  }
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
+  registerReactiveJs()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -236,6 +271,60 @@ function guardAttr(name) {
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 function firstFocusable(el) {
   return el.querySelectorAll?.(FOCUSABLE)?.[0] ?? null
+}
+
+// Parse a [[name, args], ...] op list from a raw attr/param. An array passes
+// through; a JSON string is parsed; anything malformed degrades to [] — a bad
+// ops attr must NEVER break the page (client-side default-deny). Shared by the
+// controller's runOps and the reactive:js stream action (issue #97).
+function parseOps(raw) {
+  if (Array.isArray(raw)) return raw
+  if (typeof raw !== "string") return []
+  try {
+    const list = JSON.parse(raw)
+    return Array.isArray(list) ? list : []
+  } catch {
+    return []
+  }
+}
+
+// Interpret a [[name, args], ...] op list against the frozen CLIENT_OPS
+// whitelist (issues #95/#96/#97). `resolveTargets(args)` returns the element(s)
+// an op applies to — the controller scopes to its root (excluding nested
+// reactive roots); the reactive:js stream action scopes to its target root (or
+// the document). An unknown name warns and is SKIPPED while the rest of the
+// chain still applies — client-side default-deny, one bad op never takes down
+// its siblings. Object.hasOwn (not a bare read) so inherited Object members
+// ("constructor") can't masquerade as ops.
+function applyOps(list, resolveTargets) {
+  for (const entry of list) {
+    if (!Array.isArray(entry)) continue
+    const [name, args = {}] = entry
+    if (!Object.hasOwn(CLIENT_OPS, name)) {
+      console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
+      continue
+    }
+    for (const el of resolveTargets(args)) CLIENT_OPS[name](el, args)
+  }
+}
+
+// Resolve a reactive:js op's targets against its `target` root (issue #97).
+// "@root" is the root element itself; a selector resolves WITHIN it; a bare
+// selector with no root (no `target` attr on the stream) resolves document-wide
+// — a broadcast op anchored by a global selector (#bell) rather than a
+// component. Unlike the controller path there is no nested-reactive-root
+// ownership filter: a server-pushed op names its own scope explicitly.
+function streamOpTargets(args, root) {
+  const to = args.to
+  if (root) {
+    if (to === "@root") return [root]
+    if (typeof to !== "string" || to === "") return []
+    return [...root.querySelectorAll(to)]
+  }
+  // No target root: document-scoped. "@root" is meaningless here (nothing to
+  // anchor to) → no-op; a selector matches document-wide.
+  if (typeof to !== "string" || to === "" || to === "@root") return []
+  return [...document.querySelectorAll(to)]
 }
 
 // Register this controller eagerly (not lazily) so a click immediately after
@@ -944,35 +1033,20 @@ export default class extends Controller {
   }
 
   // Stimulus typecasts a JSON param to the parsed array already; a raw string
-  // (hand-built attr, non-typecasting harness) is parsed here. Anything
-  // malformed degrades to [] — a bad ops attr must never break the page.
+  // (hand-built attr, non-typecasting harness) is parsed here. Delegates to the
+  // shared parseOps so the controller and the reactive:js stream action (issue
+  // #97) treat a malformed ops attr identically (→ [], never a throw).
   #parseOps(raw) {
-    if (Array.isArray(raw)) return raw
-    if (typeof raw !== "string") return []
-    try {
-      const list = JSON.parse(raw)
-      return Array.isArray(list) ? list : []
-    } catch {
-      return []
-    }
+    return parseOps(raw)
   }
 
-  // Interpret a [[name, args], ...] op list against this root (issue #95). The
-  // vocabulary is the frozen CLIENT_OPS whitelist; an unknown name warns and is
-  // SKIPPED while the rest of the chain still applies — client-side
-  // default-deny, and one bad op never takes down its siblings. Object.hasOwn
-  // (not a bare property read) so inherited Object members ("constructor")
-  // can't masquerade as ops.
+  // Interpret a [[name, args], ...] op list against this root (issue #95),
+  // scoping each op's targets to this controller's own root via #opTargets (the
+  // nested-reactive-root ownership filter, issue #15). The whitelist + skip
+  // logic lives in the shared applyOps so runOps and the reactive:js stream
+  // action interpret the SAME vocabulary the SAME way (client-side default-deny).
   #applyOps(list) {
-    for (const entry of list) {
-      if (!Array.isArray(entry)) continue
-      const [name, args = {}] = entry
-      if (!Object.hasOwn(CLIENT_OPS, name)) {
-        console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
-        continue
-      }
-      for (const el of this.#opTargets(args)) CLIENT_OPS[name](el, args)
-    }
+    applyOps(list, (args) => this.#opTargets(args))
   }
 
   // Resolve an op's targets: "@root" is this element; a selector resolves

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -132,7 +132,7 @@ module Views
                   plain '.'
                 end
                 li do
-                  code { '.broadcast_js_to(*streamables, ops, target:)' }
+                  code { '.broadcast_js_to(*streamables, ops, exclude:, visible_to:, target:)' }
                   plain ' — push '
                   strong { 'client DOM ops' }
                   plain ' (class/attr toggles, '

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -21,6 +21,7 @@ module Views
           actor_echo
           transactional
           removing_actor
+          js_ops
           presence
         end
 
@@ -129,6 +130,14 @@ module Views
                   plain ' — remove the element with id '
                   code { 'component.id' }
                   plain '.'
+                end
+                li do
+                  code { '.broadcast_js_to(*streamables, ops, target:)' }
+                  plain ' — push '
+                  strong { 'client DOM ops' }
+                  plain ' (class/attr toggles, '
+                  code { 'dispatch' }
+                  plain ') to every subscriber. Refuses focus ops (see below).'
                 end
               end
             end
@@ -326,6 +335,42 @@ module Views
                 strong { 'reply' }
                 plain ' API for the full set of reply controls.'
               end
+            end
+          end
+        end
+
+        def js_ops
+          DocsUI::Section('Pushing client DOM ops (broadcast_js_to)') do
+            DocsUI::Prose() do
+              p do
+                plain 'Sometimes a broadcast should nudge the UI rather than swap HTML — light up a bell, ' \
+                      'toggle a class, dispatch an app event. '
+                code { 'broadcast_js_to' }
+                plain ' pushes the same '
+                code { 'js' }
+                plain ' ops as '
+                code { 'reply.js' }
+                plain ' to every subscriber, over the same transport (Action Cable or pgbus):'
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby)
+              # Light up the bell in every viewer's tab, minus the actor's own connection.
+              Notifications::Badge.broadcast_js_to(user, :alerts,
+                js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+            RUBY
+            DocsUI::Callout(:warning) do
+              plain 'Focus ops are refused. '
+              code { 'broadcast_js_to' }
+              plain ' raises '
+              code { 'ArgumentError' }
+              plain ' for '
+              code { 'focus' }
+              plain '/'
+              code { 'focus_first' }
+              plain " — broadcasting focus would steal it in every subscriber's tab. Focus is an " \
+                    'actor-reply concern (use '
+              code { 'reply.js' }
+              plain ').'
             end
           end
         end

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -17,14 +17,15 @@ module Phlex
     #   Response.redirect(article_url(@article))        # slug changed -> Turbo.visit the new URL
     #   Response.replace(self).stream(Totals.update(@order))  # multi-stream
     class Response
-      attr_reader :streams, :redirect_url, :token_component
+      attr_reader :streams, :redirect_url, :token_component, :subject_component
 
       class << self
         # Re-render the component in place (explicit form of today's default).
         # `morph: true` morphs the subtree (preserves the focused input + caret)
         # instead of an outerHTML swap — see .morph (issue #28).
         def replace(component, morph: false)
-          new(streams: [morph ? component.to_stream_morph : component.to_stream_replace])
+          new(streams: [morph ? component.to_stream_morph : component.to_stream_replace],
+            subject_component: component)
         end
 
         # Re-render the component in place via Idiomorph (issue #28). Emits
@@ -33,10 +34,10 @@ module Phlex
         # per-field reactive editing (a "spreadsheet" grid where a debounced save
         # fires while the user is still typing/tabbing). The morphed root still
         # carries the fresh signed token, so the next action verifies.
-        def morph(component) = new(streams: [component.to_stream_morph])
+        def morph(component) = new(streams: [component.to_stream_morph], subject_component: component)
 
         # Morph only inner HTML (preserves the root element + its token attr).
-        def update(component) = new(streams: [component.to_stream_update])
+        def update(component) = new(streams: [component.to_stream_update], subject_component: component)
 
         # Remove the component's element from the DOM. Uses the instance
         # to_stream_remove (the component already knows its own #id — no
@@ -221,6 +222,37 @@ data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
           Phlex::Reactive.flash_builder.update(target, html: render_html(content))
         end
 
+        # Build a `reactive:js` turbo-stream carrying server-pushed client DOM
+        # ops (issue #97). `ops` is a Phlex::Reactive::JS chain or a raw
+        # [[op, args], ...] array; `target` (an element id or nil) scopes op
+        # resolution on the client (nil → document-scoped). The ops JSON is
+        # HTML-escaped into the attribute exactly like to_stream_token — a raw
+        # interpolation would be an injection vector. The client's registered
+        # reactive:js handler runs the ops through the SAME whitelist interpreter
+        # as on_client (default-deny), so an unknown op is warn-and-skipped there.
+        def js_stream(ops, target: nil)
+          json = js_ops_json(ops)
+          target_attr = target ? %( target="#{ERB::Util.html_escape(target)}") : ""
+          %(<turbo-stream action="reactive:js"#{target_attr} \
+data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
+        end
+
+        # Normalize `ops` to its JSON wire form, rejecting an empty chain — a
+        # reactive:js stream with no ops is a dead stream (a mistake at the call
+        # site), so fail loudly rather than emit an inert tag.
+        def js_ops_json(ops)
+          if ops.is_a?(Phlex::Reactive::JS)
+            raise ArgumentError, "js(...) got no ops — a dead reactive:js stream" if ops.empty?
+
+            ops.to_json
+          else
+            list = Array(ops)
+            raise ArgumentError, "js(...) got no ops — a dead reactive:js stream" if list.empty?
+
+            list.to_json
+          end
+        end
+
         # Resolve `content` to the HTML for a turbo-stream's `html:`. Two forms,
         # both SAFE against injection by default:
         #   * a Phlex component instance — rendered through the configured
@@ -244,11 +276,19 @@ data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
       # OUT of the full-self replace but still needs the token refreshed. The
       # endpoint appends this component's tiny to_stream_token instead, so the
       # token rolls forward without re-rendering (and clobbering) the children.
-      def initialize(streams: [], redirect_url: nil, render_self: true, token_component: nil)
+      #
+      # subject_component: the component a self-targeting builder (replace/morph/
+      # update) re-renders (issue #97). Distinct from token_component so it does
+      # NOT trip refresh_token? — it exists only to default #js's target to the
+      # bound component's id, so reply.morph.js(js.focus("@root")) scopes to the
+      # morphed root without the caller repeating the id.
+      def initialize(streams: [], redirect_url: nil, render_self: true, token_component: nil,
+                     subject_component: nil)
         @streams = streams.freeze
         @redirect_url = redirect_url
         @render_self = render_self
         @token_component = token_component
+        @subject_component = subject_component
         freeze
       end
 
@@ -259,8 +299,28 @@ data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
           streams: @streams + more.flatten,
           redirect_url: @redirect_url,
           render_self: @render_self,
-          token_component: @token_component
+          token_component: @token_component,
+          subject_component: @subject_component
         )
+      end
+
+      # Chain a `reactive:js` op stream — server-pushed client DOM ops (issue
+      # #97) — onto this reply, so a focus/dispatch/class toggle runs on the
+      # client after the render applies:
+      #
+      #   reply.morph.js(js.focus("[name=next]").dispatch("app:saved"))
+      #
+      # `ops` is a Phlex::Reactive::JS chain (or a raw [[op, args], ...] array).
+      # `target` (an element id) scopes op resolution on the client; it defaults
+      # to the bound component's id (subject_component/token_component) so
+      # self-scoped ops (@root, a component-relative selector) just work, and is
+      # nil (document-scoped) for a subject-free reply.with. Returns a NEW
+      # Response (immutable) — the op stream rides the same stream() plumbing, so
+      # the endpoint emits it LAST (after all render streams) and a focus op sees
+      # the post-render DOM.
+      def js(ops, target: :__default)
+        resolved = target == :__default ? default_js_target : target
+        stream(self.class.js_stream(ops, target: resolved))
       end
 
       # Append a flash turbo-stream into a host-app container (default
@@ -299,6 +359,16 @@ data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
       # but still needs the token rolled forward — the endpoint appends the bound
       # component's tiny token-only stream (issue #30).
       def refresh_token? = !@token_component.nil?
+
+      private
+
+      # The default `target` for #js: the bound component's id when this reply is
+      # component-scoped (replace/morph/update set subject_component; .streams and
+      # collections set token_component), else nil — a subject-free reply.with is
+      # document-scoped unless the caller passes target: explicitly.
+      def default_js_target
+        (@subject_component || @token_component)&.id
+      end
     end
   end
 end

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -33,6 +33,10 @@ module Phlex
       # up without ever sharing a mutable context across threads.
       ThreadViewContext = Struct.new(:view_context, :builder, :renderer, :generation)
 
+      # Focus ops are actor-only (they steal focus): broadcast_js_to rejects a
+      # broadcast that carries one. Names mirror Phlex::Reactive::JS's focus verbs.
+      BROADCAST_REFUSED_OPS = %w[focus focus_first].freeze
+
       # Every class that includes Streamable, so the engine can flush their
       # memoized view contexts on a Rails code reload (dev) in one pass. A
       # WeakMap used as a set (the class is the key) so a class reloaded by
@@ -223,7 +227,53 @@ module Phlex
           )
         end
 
+        # Push server-side client DOM ops to EVERY subscriber of a stream (issue
+        # #97) — the broadcast sibling of Response#js. Rides a `reactive:js`
+        # custom stream action over Turbo::StreamsChannel, so it works on Action
+        # Cable AND pgbus (transport opts pass through broadcast_transport_opts
+        # exactly like every other broadcast):
+        #
+        #   Notifications::Badge.broadcast_js_to(user, :alerts,
+        #     js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+        #
+        # `ops` is a Phlex::Reactive::JS chain (or a raw [[op, args], ...] array);
+        # `target` (an element id) scopes op resolution on the client (nil →
+        # document-scoped). The ops JSON is HTML-escaped through the TagBuilder's
+        # attributes: path (data-reactive-ops), so a value can't break out of the
+        # attribute.
+        #
+        # The builder REJECTS focus-class ops (focus/focus_first) outright:
+        # broadcasting a focus steals focus in every subscriber's tab. Focus is an
+        # actor-reply concern only (Response#js), so it raises ArgumentError here
+        # rather than silently shipping a hostile-feeling broadcast.
+        def broadcast_js_to(*streamables, ops, exclude: nil, visible_to: nil, target: nil)
+          json = broadcast_js_ops_json(ops)
+          ::Turbo::StreamsChannel.broadcast_action_to(
+            *streamables,
+            action: "reactive:js",
+            target: target,
+            attributes: { data: { reactive_ops: json } },
+            render: false,
+            **broadcast_transport_opts(exclude:, visible_to:)
+          )
+        end
+
         private
+
+        # Validate + serialize broadcast ops: reject focus-class ops (they steal
+        # focus in every tab) and an empty chain (a dead broadcast), then return
+        # the JSON wire form. Works on a JS chain (inspect .ops) and a raw array.
+        def broadcast_js_ops_json(ops)
+          pairs = ops.is_a?(Phlex::Reactive::JS) ? ops.ops : Array(ops)
+          refused = pairs.map { |name, _| name.to_s } & Phlex::Reactive::Streamable::BROADCAST_REFUSED_OPS
+          unless refused.empty?
+            raise ArgumentError,
+              "broadcast_js_to refuses focus op(s) #{refused.join(", ")} — broadcasting focus " \
+              "steals it in every subscriber's tab. Focus is an actor-reply concern (reply.js)."
+          end
+
+          Phlex::Reactive::Response.js_ops_json(ops)
+        end
 
         def build(model, options)
           new(**(model ? component_args(model, options) : options))

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -17,6 +17,7 @@ class CounterComponent < ApplicationComponent
   action :bump_via_partial
   action :bump_with_sibling
   action :bump_with_self_stream
+  action :bump_with_js
 
   def initialize(count: 0)
     @count = count
@@ -84,6 +85,16 @@ class CounterComponent < ApplicationComponent
   def bump_with_self_stream
     @count += 1
     reply.streams(self.class.replace(count: @count))
+  end
+
+  # Reply: re-render self (morph) + push a server-side client DOM op (issue #97).
+  # The reactive:js stream must ride AFTER the render stream and must NOT count as
+  # a self-render (its action name is reactive:js, not replace/update) — so the
+  # morph's own token refresh is untouched. REQUEST-spec fixture; the end-to-end
+  # focus example is the system spec.
+  def bump_with_js
+    @count += 1
+    reply.morph.js(js.focus("@root").dispatch("app:bumped", detail: { count: @count }))
   end
 
   def view_template

--- a/spec/dummy/app/components/js_focus_component.rb
+++ b/spec/dummy/app/components/js_focus_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Issue #97: server-pushed client DOM ops via reply.<verb>.js(...). Saving the
+# first field morphs the whole component in place, then a reactive:js stream —
+# emitted AFTER the morph — focuses the SECOND field. The ORDERING contract is
+# the point: the op stream rides last, so focus("[name=next]") lands on the
+# freshly morphed field rather than a node about to be replaced.
+#
+# The morph re-renders the root (its data-reactive-token-value refreshes), and
+# the reactive:js stream targets the same id (self-scoped ops) WITHOUT counting
+# as a self-render, so the token machinery is untouched (see the request spec).
+class JsFocusComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :account
+
+  action :save, params: { first: :string }
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def id = dom_id(@account)
+
+  # Persist the first field, morph in place, then focus the SECOND field on the
+  # client. The morph reads the saved value back so the browser spec can prove
+  # the round trip landed; the js op proves focus moved to the morphed field.
+  def save(first:)
+    @account.update!(name: first) if first.present?
+    reply.morph.js(js.focus("[name=next]"))
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      input(**mix(name: "first", value: @account.name, data: { testid: "first" }))
+      # A button (not the field) triggers the save, so the FIELD that receives
+      # focus is not the one the user last interacted with — the focus move is
+      # unambiguously the server op, not a leftover browser default.
+      button(**mix(on(:save), data: { testid: "save" })) { "Save" }
+      input(name: "next", data: { testid: "next" })
+      span(data: { testid: "saved" }) { @account.name }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -105,6 +105,13 @@ class DemosController < ActionController::Base
     render_component MorphGridComponent.new(account: Account.find(params[:id]))
   end
 
+  # Issue #97: post-save focus lands on the freshly morphed field via
+  # reply.morph.js(js.focus(...)) — the reactive:js op stream rides AFTER the
+  # morph so focus targets the morphed node.
+  def js_focus
+    render_component JsFocusComponent.new(account: Account.find(params[:id]))
+  end
+
   def partial_grid
     render_component PartialGridComponent.new(line_item: LineItem.find(params[:id]))
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "client_tabs" => "demos#client_tabs"
   get "confirm" => "demos#confirm"
   get "morph_grid/:id" => "demos#morph_grid"
+  get "js_focus/:id" => "demos#js_focus"
   get "partial_grid/:id" => "demos#partial_grid"
   get "document_upload/:id" => "demos#document_upload"
   # Nav probe: where a NON-intercepted form submit would land. Accept POST (and

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -73,9 +73,44 @@ export function registerReactiveToken() {
   }
 }
 
+// Custom turbo-stream action: SERVER-PUSHED client DOM ops (issue #97). The
+// server-side sibling of on_client's runOps — a reply (reply.<verb>.js(ops)) or
+// a broadcast (Streamable.broadcast_js_to) emits
+//
+//   <turbo-stream action="reactive:js" target="<optional root id>"
+//                 data-reactive-ops="[[op, args], ...]"></turbo-stream>
+//
+// and Turbo invokes this handler with `this` bound to that <turbo-stream>
+// element. It runs the ops through the SAME frozen CLIENT_OPS whitelist as
+// runOps (client-side default-deny — an unknown op warns + is skipped), so a
+// forged/stale ops attr can never break the page or execute anything off the
+// vocabulary. NO token, NO fetch — a pure local DOM mutation.
+//
+// `target` (optional, an element id) scopes op resolution to that root: "@root"
+// resolves to the target element itself and a selector resolves WITHIN it.
+// Without a target, ops resolve document-wide (a broadcast op like
+// add_class("#bell", ...) that isn't anchored to one component). The op stream
+// is emitted AFTER all render streams in the reply (the endpoint appends it
+// last), so focus("[name=next]") sees the freshly morphed DOM — Turbo applies
+// streams in document order.
+export function registerReactiveJs() {
+  const actions = window.Turbo?.StreamActions
+  if (!actions || actions["reactive:js"]) return
+  actions["reactive:js"] = function () {
+    const list = parseOps(this.getAttribute("data-reactive-ops"))
+    if (!list.length) return
+    const targetId = this.getAttribute("target")
+    // With a target: scope to that element (missing → no-op). Without: document.
+    const root = targetId ? document.getElementById(targetId) : null
+    if (targetId && !root) return
+    applyOps(list, (args) => streamOpTargets(args, root))
+  }
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
+  registerReactiveJs()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -236,6 +271,60 @@ function guardAttr(name) {
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 function firstFocusable(el) {
   return el.querySelectorAll?.(FOCUSABLE)?.[0] ?? null
+}
+
+// Parse a [[name, args], ...] op list from a raw attr/param. An array passes
+// through; a JSON string is parsed; anything malformed degrades to [] — a bad
+// ops attr must NEVER break the page (client-side default-deny). Shared by the
+// controller's runOps and the reactive:js stream action (issue #97).
+function parseOps(raw) {
+  if (Array.isArray(raw)) return raw
+  if (typeof raw !== "string") return []
+  try {
+    const list = JSON.parse(raw)
+    return Array.isArray(list) ? list : []
+  } catch {
+    return []
+  }
+}
+
+// Interpret a [[name, args], ...] op list against the frozen CLIENT_OPS
+// whitelist (issues #95/#96/#97). `resolveTargets(args)` returns the element(s)
+// an op applies to — the controller scopes to its root (excluding nested
+// reactive roots); the reactive:js stream action scopes to its target root (or
+// the document). An unknown name warns and is SKIPPED while the rest of the
+// chain still applies — client-side default-deny, one bad op never takes down
+// its siblings. Object.hasOwn (not a bare read) so inherited Object members
+// ("constructor") can't masquerade as ops.
+function applyOps(list, resolveTargets) {
+  for (const entry of list) {
+    if (!Array.isArray(entry)) continue
+    const [name, args = {}] = entry
+    if (!Object.hasOwn(CLIENT_OPS, name)) {
+      console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
+      continue
+    }
+    for (const el of resolveTargets(args)) CLIENT_OPS[name](el, args)
+  }
+}
+
+// Resolve a reactive:js op's targets against its `target` root (issue #97).
+// "@root" is the root element itself; a selector resolves WITHIN it; a bare
+// selector with no root (no `target` attr on the stream) resolves document-wide
+// — a broadcast op anchored by a global selector (#bell) rather than a
+// component. Unlike the controller path there is no nested-reactive-root
+// ownership filter: a server-pushed op names its own scope explicitly.
+function streamOpTargets(args, root) {
+  const to = args.to
+  if (root) {
+    if (to === "@root") return [root]
+    if (typeof to !== "string" || to === "") return []
+    return [...root.querySelectorAll(to)]
+  }
+  // No target root: document-scoped. "@root" is meaningless here (nothing to
+  // anchor to) → no-op; a selector matches document-wide.
+  if (typeof to !== "string" || to === "" || to === "@root") return []
+  return [...document.querySelectorAll(to)]
 }
 
 // Register this controller eagerly (not lazily) so a click immediately after
@@ -944,35 +1033,20 @@ export default class extends Controller {
   }
 
   // Stimulus typecasts a JSON param to the parsed array already; a raw string
-  // (hand-built attr, non-typecasting harness) is parsed here. Anything
-  // malformed degrades to [] — a bad ops attr must never break the page.
+  // (hand-built attr, non-typecasting harness) is parsed here. Delegates to the
+  // shared parseOps so the controller and the reactive:js stream action (issue
+  // #97) treat a malformed ops attr identically (→ [], never a throw).
   #parseOps(raw) {
-    if (Array.isArray(raw)) return raw
-    if (typeof raw !== "string") return []
-    try {
-      const list = JSON.parse(raw)
-      return Array.isArray(list) ? list : []
-    } catch {
-      return []
-    }
+    return parseOps(raw)
   }
 
-  // Interpret a [[name, args], ...] op list against this root (issue #95). The
-  // vocabulary is the frozen CLIENT_OPS whitelist; an unknown name warns and is
-  // SKIPPED while the rest of the chain still applies — client-side
-  // default-deny, and one bad op never takes down its siblings. Object.hasOwn
-  // (not a bare property read) so inherited Object members ("constructor")
-  // can't masquerade as ops.
+  // Interpret a [[name, args], ...] op list against this root (issue #95),
+  // scoping each op's targets to this controller's own root via #opTargets (the
+  // nested-reactive-root ownership filter, issue #15). The whitelist + skip
+  // logic lives in the shared applyOps so runOps and the reactive:js stream
+  // action interpret the SAME vocabulary the SAME way (client-side default-deny).
   #applyOps(list) {
-    for (const entry of list) {
-      if (!Array.isArray(entry)) continue
-      const [name, args = {}] = entry
-      if (!Object.hasOwn(CLIENT_OPS, name)) {
-        console.warn(`[phlex-reactive] unknown client op ${JSON.stringify(name)} — skipped`)
-        continue
-      }
-      for (const el of this.#opTargets(args)) CLIENT_OPS[name](el, args)
-    }
+    applyOps(list, (args) => this.#opTargets(args))
   }
 
   // Resolve an op's targets: "@root" is this element; a selector resolves

--- a/spec/javascript/reactive_js_stream.test.js
+++ b/spec/javascript/reactive_js_stream.test.js
@@ -1,0 +1,228 @@
+// Unit tests for the `reactive:js` custom Turbo StreamAction (issue #97) — the
+// server-pushed sibling of runOps. The server emits
+//
+//   <turbo-stream action="reactive:js" data-reactive-ops="[[...ops...]]"
+//                 target="<optional root id>"></turbo-stream>
+//
+// and Turbo invokes the registered handler with `this` bound to that
+// <turbo-stream> element. The handler:
+//
+//   * reads data-reactive-ops (the SAME serialized op format as #95/#96),
+//   * scopes op resolution to `target` (an element id) when present, else the
+//     document,
+//   * runs them through the SAME whitelist interpreter as runOps (an unknown op
+//     warns + is skipped — client-side default-deny), and
+//   * NEVER fetches, NEVER touches a token.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let registerReactiveJs
+let registerReactiveActions
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  const mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  registerReactiveJs = mod.registerReactiveJs
+  registerReactiveActions = mod.registerReactiveActions
+})
+
+// A fake element: hidden flag, classList over a Set, focus tracking, and a
+// dispatchEvent recorder. `id` + membership are answered by the fake document.
+function makeEl(id) {
+  const el = {
+    id,
+    hidden: false,
+    classes: new Set(),
+    focused: false,
+    dispatched: [],
+    focus() {
+      el.focused = true
+    },
+    dispatchEvent(event) {
+      el.dispatched.push(event)
+    },
+  }
+  el.classList = {
+    add: (...cs) => cs.forEach((c) => el.classes.add(c)),
+    remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
+    toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+  }
+  el.querySelectorAll = () => []
+  return el
+}
+
+// Build a fake document whose getElementById + querySelectorAll answer from
+// maps. A scoped root's querySelectorAll and the document's querySelectorAll are
+// kept distinct so we can prove `target` scopes op resolution to that root.
+function stubDocument({ byId = {}, docMatches = {} } = {}) {
+  globalThis.document = {
+    getElementById: (id) => byId[id] ?? null,
+    querySelectorAll: (sel) => docMatches[sel] ?? [],
+  }
+  return globalThis.document
+}
+
+// A real CustomEvent-ish stand-in (bun has CustomEvent, but keep the interpreter
+// honest by not relying on its exact shape).
+function stubTurbo() {
+  globalThis.window = { Turbo: { StreamActions: {} } }
+  return globalThis.window.Turbo.StreamActions
+}
+
+// A fake <turbo-stream> element carrying the ops attr + optional target.
+function streamEl({ ops, target } = {}) {
+  const attrs = { "data-reactive-ops": ops }
+  if (target != null) attrs.target = target
+  return {
+    getAttribute: (name) => attrs[name] ?? null,
+  }
+}
+
+function invoke(actions, el) {
+  // Turbo calls the action with `this` bound to the stream element.
+  actions["reactive:js"].call(el)
+}
+
+// --- registration -----------------------------------------------------------
+
+test("registerReactiveJs installs the reactive:js StreamAction (idempotent)", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  expect(typeof actions["reactive:js"]).toBe("function")
+
+  const first = actions["reactive:js"]
+  registerReactiveJs()
+  expect(actions["reactive:js"]).toBe(first) // not re-registered
+})
+
+test("registerReactiveActions wires reactive:js alongside visit + token", () => {
+  const actions = stubTurbo()
+  registerReactiveActions()
+  expect(typeof actions["reactive:visit"]).toBe("function")
+  expect(typeof actions["reactive:token"]).toBe("function")
+  expect(typeof actions["reactive:js"]).toBe("function")
+})
+
+// --- op execution through the shared whitelist ------------------------------
+
+test("runs ops through the shared interpreter (class + focus + dispatch)", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  const bell = makeEl("bell")
+  const field = makeEl("field")
+  stubDocument({ docMatches: { "#bell": [bell], "[name=next]": [field] } })
+
+  invoke(
+    actions,
+    streamEl({
+      ops: JSON.stringify([
+        ["add_class", { to: "#bell", classes: ["has-unread"] }],
+        ["focus", { to: "[name=next]" }],
+      ]),
+    }),
+  )
+
+  expect([...bell.classes]).toEqual(["has-unread"])
+  expect(field.focused).toBe(true)
+})
+
+test("target scopes op resolution to that root (querySelectorAll on the root, not document)", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  const scopedMatch = makeEl("inside")
+  const root = makeEl("todo_7")
+  root.querySelectorAll = (sel) => (sel === ".panel" ? [scopedMatch] : [])
+  // The document must NOT be consulted when a target root is given.
+  const doc = stubDocument({ byId: { todo_7: root } })
+  doc.querySelectorAll = () => {
+    throw new Error("must resolve within the target root, not the document")
+  }
+
+  invoke(actions, streamEl({ ops: JSON.stringify([["hide", { to: ".panel" }]]), target: "todo_7" }))
+
+  expect(scopedMatch.hidden).toBe(true)
+})
+
+test("@root with a target resolves to the target element itself", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  const root = makeEl("panel")
+  stubDocument({ byId: { panel: root } })
+
+  invoke(actions, streamEl({ ops: JSON.stringify([["toggle", { to: "@root" }]]), target: "panel" }))
+
+  expect(root.hidden).toBe(true)
+})
+
+test("a missing target element is a no-op (never throws)", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  stubDocument({ byId: {} })
+
+  expect(() =>
+    invoke(actions, streamEl({ ops: JSON.stringify([["hide", { to: "@root" }]]), target: "gone" })),
+  ).not.toThrow()
+})
+
+// --- default-deny + resilience ----------------------------------------------
+
+test("an unknown op warns + is skipped; the rest of the chain still applies", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  const el = makeEl("x")
+  stubDocument({ docMatches: { "#x": [el] } })
+  const warns = []
+  const original = console.warn
+  console.warn = (...args) => warns.push(args.join(" "))
+
+  try {
+    invoke(
+      actions,
+      streamEl({ ops: JSON.stringify([["explode", { to: "#x" }], ["hide", { to: "#x" }]]) }),
+    )
+  } finally {
+    console.warn = original
+  }
+
+  expect(warns.length).toBe(1)
+  expect(warns[0]).toContain("explode")
+  expect(el.hidden).toBe(true)
+})
+
+test("a refused attr op (event handler) warns + is skipped by the interpreter", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  const el = makeEl("x")
+  el.setAttribute = () => {
+    throw new Error("must not set a refused attr")
+  }
+  el.hasAttribute = () => false
+  stubDocument({ docMatches: { "#x": [el] } })
+  const warns = []
+  const original = console.warn
+  console.warn = (...args) => warns.push(args.join(" "))
+
+  try {
+    invoke(actions, streamEl({ ops: JSON.stringify([["set_attr", { to: "#x", name: "onclick", value: "alert(1)" }]]) }))
+  } finally {
+    console.warn = original
+  }
+
+  expect(warns.length).toBe(1)
+  expect(warns[0]).toContain("onclick")
+})
+
+test("a missing/garbage ops attr degrades to a no-op", () => {
+  const actions = stubTurbo()
+  registerReactiveJs()
+  stubDocument({})
+
+  expect(() => invoke(actions, streamEl({ ops: null }))).not.toThrow()
+  expect(() => invoke(actions, streamEl({ ops: "not json" }))).not.toThrow()
+  expect(() => invoke(actions, streamEl({ ops: "{}" }))).not.toThrow()
+})

--- a/spec/javascript/reactive_js_token_safety.test.js
+++ b/spec/javascript/reactive_js_token_safety.test.js
@@ -1,0 +1,115 @@
+// Token-safety pin for the `reactive:js` stream action (issue #97).
+//
+// A reply may carry a `reactive:js` stream that TARGETS the component's own id
+// (e.g. reply.morph.js(js.focus("@root"))). #extractToken must NOT treat that
+// stream as a token-bearing self-render: its action name is "reactive:js", not
+// replace/update/reactive:token, so it can never match the self-token or
+// token-only regexes. If it DID, a stale/absent token would be adopted and the
+// next dispatch would 400.
+//
+// We drive two real dispatch()es. The first response is a genuine self morph
+// (carrying SELF-FRESH) PLUS a trailing reactive:js stream at the SAME target.
+// The second dispatch must POST SELF-FRESH — proving the reactive:js stream
+// neither shadowed nor overrode the real self token.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+function fakeRoot(id) {
+  const attrs = {}
+  return {
+    id,
+    querySelectorAll: () => [],
+    setAttribute: (name, value) => {
+      attrs[name] = value
+    },
+    removeAttribute: (name) => {
+      delete attrs[name]
+    },
+    getAttribute: (name) => attrs[name] ?? null,
+  }
+}
+
+function buildController(rootEl, initialToken) {
+  const controller = new ReactiveController()
+  controller.element = rootEl
+  controller.tokenValue = initialToken
+  return controller
+}
+
+function stubEnv() {
+  globalThis.document = {
+    querySelector: (sel) => {
+      if (sel.includes("action-path")) return { content: "/reactive/actions" }
+      if (sel.includes("csrf-token")) return { content: "csrf-abc" }
+      return null
+    },
+    dispatchEvent: () => {},
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+}
+
+function stubFetchReturning(body, captured) {
+  globalThis.fetch = (path, opts) => {
+    captured.push(JSON.parse(opts.body))
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(body),
+    })
+  }
+}
+
+test("a reactive:js stream at OUR target does not shadow the real self token", async () => {
+  const root = fakeRoot("counter")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  // A real self morph carrying SELF-FRESH, then a reactive:js op stream at the
+  // SAME target. Ordering mirrors the endpoint (ops LAST).
+  const body =
+    `<turbo-stream action="replace" method="morph" target="counter">` +
+    `<template><div id="counter" data-controller="reactive" data-reactive-token-value="SELF-FRESH">1</div></template>` +
+    `</turbo-stream>` +
+    `<turbo-stream action="reactive:js" target="counter" data-reactive-ops="[[&quot;focus&quot;,{&quot;to&quot;:&quot;@root&quot;}]]"></turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "save", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "save", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("SELF-FRESH")
+})
+
+test("a reactive:js stream ALONE at our target never becomes the next token", async () => {
+  // No self-render present — only a reactive:js op stream targeting our id.
+  // Since reactive:js is not a self-render action, #extractToken finds no self
+  // token and KEEPS the existing one (never adopts anything from the js stream).
+  const root = fakeRoot("counter")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  const body =
+    `<turbo-stream action="reactive:js" target="counter" data-reactive-ops="[[&quot;add_class&quot;,{&quot;to&quot;:&quot;@root&quot;,&quot;classes&quot;:[&quot;flash&quot;]}]]"></turbo-stream>`
+
+  const captured = []
+  stubFetchReturning(body, captured)
+
+  await controller.dispatch({ params: { action: "ping", params: "{}" }, preventDefault: () => {} })
+  await controller.dispatch({ params: { action: "ping", params: "{}" }, preventDefault: () => {} })
+
+  expect(captured[1].token).toBe("TOKEN-INITIAL")
+})

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -300,4 +300,84 @@ RSpec.describe Phlex::Reactive::Response do
       expect(response.token_component).to eq(counter)
     end
   end
+
+  # Issue #97: Response#js(ops) chains a `reactive:js` op stream — server-pushed
+  # client DOM ops (focus, dispatch, class/attr toggles) — onto any reply. The
+  # ops attr is HTML-escaped (a raw interpolation would be an injection vector),
+  # emitted via the immutable stream() plumbing, and — crucially — LAST, so a
+  # focus op sees the post-render DOM (the endpoint guarantees ordering; here we
+  # assert the chain shape + escaping).
+  describe "js (issue #97 — server-pushed client DOM ops)" do
+    let(:ops) { CounterComponent.new(count: 0).js.focus("[name=next]").dispatch("app:saved") }
+
+    it "chains a reactive:js op stream onto a replace, immutably" do
+      base = described_class.replace(counter)
+      response = base.js(ops)
+
+      expect(response).not_to equal(base)
+      expect(base.streams.size).to eq(1) # original unchanged
+      expect(response.streams.size).to eq(2)
+      expect(response.streams.last).to include('action="reactive:js"')
+      expect(response.render_self?).to be(true)
+    end
+
+    it "emits the op stream LAST (after the render stream)" do
+      response = described_class.morph(counter).js(ops)
+
+      expect(response.streams.first).to include('action="replace"') # the morph render
+      expect(response.streams.last).to include('action="reactive:js"')
+    end
+
+    it "carries the ops as an HTML-escaped data-reactive-ops attribute" do
+      stream = described_class.with.js(ops).streams.first
+
+      # The wire format is the JSON op list, HTML-escaped (quotes → &quot;).
+      expect(stream).to include("data-reactive-ops=")
+      expect(stream).to include("&quot;focus&quot;")
+      expect(stream).to include("&quot;app:saved&quot;")
+      # The raw double-quotes of the JSON must NOT appear unescaped inside the attr.
+      expect(stream).not_to include('data-reactive-ops="[["focus"')
+    end
+
+    it "escapes a hostile op payload (no attribute break-out)" do
+      hostile = CounterComponent.new(count: 0).js.dispatch(%(x"><script>alert(1)</script>))
+      stream = described_class.with.js(hostile).streams.first
+
+      expect(stream).not_to include('"><script>')
+      expect(stream).to include("&quot;")
+    end
+
+    it "defaults the stream target to the bound component's id (self-scoped ops)" do
+      # replace/morph/update bind the component, so js ops scope to its root by
+      # default — reply.morph.js(js.focus("@root")) focuses the morphed root.
+      stream = described_class.replace(counter).js(ops).streams.last
+      expect(stream).to include('target="counter"')
+    end
+
+    it "accepts an explicit target: override" do
+      stream = described_class.with.js(ops, target: "sidebar").streams.first
+      expect(stream).to include('target="sidebar"')
+    end
+
+    it "omits target entirely for a subject-free reply with no explicit target (document-scoped)" do
+      stream = described_class.with.js(ops).streams.first
+      expect(stream).not_to include("target=")
+    end
+
+    it "accepts a raw op array as well as a JS chain" do
+      stream = described_class.with.js([["focus", { "to" => "@root" }]]).streams.first
+      expect(stream).to include("&quot;focus&quot;")
+    end
+
+    it "rejects an empty op chain (a dead reactive:js stream is a mistake)" do
+      empty = CounterComponent.new(count: 0).js
+      expect { described_class.with.js(empty) }.to raise_error(ArgumentError, /no ops/)
+    end
+
+    it "chains alongside flash (ops stay after the render, flash after that)" do
+      response = described_class.replace(counter).flash(:notice, "saved").js(ops)
+      expect(response.streams.size).to eq(3)
+      expect(response.streams.last).to include('action="reactive:js"')
+    end
+  end
 end

--- a/spec/requests/js_broadcast_spec.rb
+++ b/spec/requests/js_broadcast_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "turbo/broadcastable/test_helper"
+
+# Issue #97: Streamable.broadcast_js_to pushes server-side client DOM ops to
+# EVERY subscriber of a stream over the SAME transport as every other broadcast
+# (Turbo::StreamsChannel → Action Cable here, pgbus in a real app). It rides a
+# `reactive:js` custom stream action carrying the HTML-escaped ops.
+#
+# The builder REJECTS focus-class ops outright: broadcasting a focus steals
+# focus in every viewer's tab. Focus is an actor-reply concern (Response#js).
+RSpec.describe "broadcast_js_to (issue #97)", type: :request do
+  include Turbo::Broadcastable::TestHelper
+
+  let(:ops) { TodoItemComponent.new(todo: Todo.new).js.add_class("#bell", "has-unread") }
+
+  it "broadcasts a reactive:js stream carrying the ops to the stream" do
+    broadcasts = capture_turbo_stream_broadcasts("alerts") do
+      TodoItemComponent.broadcast_js_to("alerts", ops)
+    end
+
+    html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+    expect(html).to include('action="reactive:js"')
+    expect(html).to include("data-reactive-ops=")
+    expect(html).to include("add_class")
+    expect(html).to include("has-unread")
+  end
+
+  it "accepts a target for root scoping" do
+    broadcasts = capture_turbo_stream_broadcasts("alerts") do
+      TodoItemComponent.broadcast_js_to("alerts", ops, target: "sidebar")
+    end
+
+    html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+    expect(html).to include('target="sidebar"')
+  end
+
+  it "rejects a focus op (broadcasting focus steals focus in every tab)" do
+    focus_ops = TodoItemComponent.new(todo: Todo.new).js.focus("#field")
+
+    expect { TodoItemComponent.broadcast_js_to("alerts", focus_ops) }
+      .to raise_error(ArgumentError, /focus/)
+  end
+
+  it "rejects a focus_first op the same way" do
+    focus_ops = TodoItemComponent.new(todo: Todo.new).js.focus_first("#menu")
+
+    expect { TodoItemComponent.broadcast_js_to("alerts", focus_ops) }
+      .to raise_error(ArgumentError, /focus/)
+  end
+
+  it "rejects focus even when it is mixed among allowed ops (no partial broadcast)" do
+    mixed = TodoItemComponent.new(todo: Todo.new).js.add_class("#bell", "unread").focus("#field")
+
+    expect { TodoItemComponent.broadcast_js_to("alerts", mixed) }
+      .to raise_error(ArgumentError, /focus/)
+  end
+
+  it "rejects an empty op chain (a dead reactive:js broadcast is a mistake)" do
+    empty = TodoItemComponent.new(todo: Todo.new).js
+
+    expect { TodoItemComponent.broadcast_js_to("alerts", empty) }
+      .to raise_error(ArgumentError, /no ops/)
+  end
+
+  # Transport opts (exclude:/visible_to:) pass through broadcast_transport_opts
+  # to the stream — the pgbus SSE dispatcher reads them; Action Cable ignores
+  # them. We assert the call threads them through (the same contract every other
+  # broadcast_*_to method upholds), so the pgbus-present path suppresses the
+  # actor's own echo and the pgbus-absent path is unaffected.
+  describe "transport opts pass-through (pgbus-present vs pgbus-absent)" do
+    it "forwards exclude: to Turbo::StreamsChannel.broadcast_action_to" do
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+
+      TodoItemComponent.broadcast_js_to("alerts", ops, exclude: "conn-actor-1")
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to)
+        .with("alerts", hash_including(action: "reactive:js", exclude: "conn-actor-1"))
+    end
+
+    it "forwards visible_to: when given" do
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+
+      TodoItemComponent.broadcast_js_to("alerts", ops, visible_to: "user:7")
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to)
+        .with("alerts", hash_including(visible_to: "user:7"))
+    end
+
+    it "omits transport opts entirely when none given (pgbus-absent path unchanged)" do
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+
+      TodoItemComponent.broadcast_js_to("alerts", ops)
+
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to) do |*, **kwargs|
+        expect(kwargs).not_to have_key(:exclude)
+        expect(kwargs).not_to have_key(:visible_to)
+      end
+    end
+  end
+
+  it "still broadcasts to the stream when no transport opts are passed (real transport)" do
+    expect do
+      capture_turbo_stream_broadcasts("alerts") do
+        TodoItemComponent.broadcast_js_to("alerts", ops)
+      end
+    end.not_to raise_error
+  end
+end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -328,6 +328,53 @@ RSpec.describe "Reactive actions", type: :request do
         expect(response.body.scan("data-reactive-token-value=").size).to eq(1)
       end
     end
+
+    # Issue #97: reply.<verb>.js(ops) pushes server-side client DOM ops over a
+    # reactive:js stream. The op stream must ride AFTER the render stream (so a
+    # focus op sees the post-render DOM — Turbo applies streams in document
+    # order) and must NOT count as a self-render (its action name is reactive:js,
+    # not replace/update/reactive:token), so the morph's own token refresh is
+    # untouched.
+    describe "js (issue #97 — server-pushed client DOM ops)" do
+      it "emits the reactive:js op stream AFTER the render stream" do
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_js")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+
+        render_at = response.body.index('action="replace"')
+        js_at = response.body.index('action="reactive:js"')
+        expect(render_at).not_to be_nil
+        expect(js_at).not_to be_nil
+        expect(js_at).to be > render_at # ops LAST — focus sees the morphed DOM
+      end
+
+      it "keeps the morph's token refresh intact (reactive:js is not a self-render)" do
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_js")
+
+        # The morph carries the fresh token; the endpoint must NOT append an extra
+        # reactive:token, and the reactive:js stream must NOT suppress the refresh.
+        expect(response.body).to include("data-reactive-token-value=")
+        expect(response.body).not_to include('action="reactive:token"')
+        # The morph re-renders self (carries the token); the js stream targets self
+        # too, but only the morph is a token-bearing self-render.
+        expect(response.body.scan("data-reactive-token-value=").size).to eq(1)
+      end
+
+      it "carries the ops HTML-escaped (no attribute break-out)" do
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_js")
+
+        expect(response.body).to include("data-reactive-ops=")
+        expect(response.body).to include("&quot;focus&quot;")
+        expect(response.body).to include("&quot;app:bumped&quot;")
+      end
+
+      it "scopes the op stream to the component's own id (self-scoped @root)" do
+        post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_with_js")
+
+        expect(response.body).to include('<turbo-stream action="reactive:js" target="counter"')
+      end
+    end
   end
 
   describe "tampering" do

--- a/spec/system/js_focus_spec.rb
+++ b/spec/system/js_focus_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #97: reply.<verb>.js(...) pushes server-side client DOM ops over a
+# reactive:js stream, emitted AFTER the render streams. The decisive end-to-end
+# proof: after a save that morphs the component AND focuses a sibling field, the
+# freshly morphed field is the active element — which only holds if the op stream
+# ran on the POST-morph DOM (ops last, per the ordering contract). If the op ran
+# before the morph, it would focus a node about to be replaced and focus would be
+# lost.
+#
+# Runs under BOTH real servers (Puma default, Falcon via CAPYBARA_SERVER=falcon):
+# a reactive round trip must work sync AND async.
+RSpec.describe "reply.js focus lands on the morphed field (issue #97)", type: :system do
+  it "focuses the next field after a morph save (server-pushed js op)" do
+    account = Account.create!(name: "start")
+    visit "/js_focus/#{account.id}"
+    page.execute_script("window.__noReload = 'alive'")
+
+    # Nothing is focused yet (the trigger is a button, not either field).
+    fill_in "first", with: "typed value"
+    click_button("Save")
+
+    # The morphed render reads the saved value back — proving the round trip
+    # landed and the morph applied (the field the op targets is now the fresh one).
+    expect(page).to have_css("[data-testid='saved']", text: "typed value")
+    expect(account.reload.name).to eq("typed value")
+
+    # The decisive assertion: after the reply, focus is on the SECOND field —
+    # moved there by the reactive:js op running on the post-morph DOM.
+    active_testid = page.evaluate_script("document.activeElement && document.activeElement.dataset.testid")
+    expect(active_testid).to eq("next")
+
+    # No full-page reload happened.
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
Closes #97

## Summary

The server could only ever tell the client to swap HTML. This adds a third custom Turbo StreamAction — `reactive:js` — so a reply or a broadcast can push **whitelisted client DOM ops** (focus the next field, dispatch an app event, toggle a class/attr) with **zero extra round trip and no re-render**.

- **`Response#js(ops)`** — surfaced on the reply facade as `reply.<verb>.js(ops)`. Chains a `reactive:js` op stream onto **any** reply via the immutable `stream()` plumbing.
- **`Streamable.broadcast_js_to(*streamables, ops, exclude:, visible_to:, target:)`** — pushes the same ops to **every** subscriber over `Turbo::StreamsChannel` (Action Cable **and** pgbus; transport opts pass through `broadcast_transport_opts` like every other broadcast).
- **Client `registerReactiveJs()`** — a sibling of `reactive:visit`/`reactive:token`. Runs the ops through the **same** frozen `CLIENT_OPS` whitelist as `on_client` (the interpreter was extracted into module-level `applyOps`/`parseOps`, shared by `runOps` and the stream action). An unknown op warns + is skipped (client-side default-deny). `target` scopes op resolution to that root; without it, ops are document-scoped.

```ruby
def save(title:)
  @todo.update!(title:)
  reply.morph.js(js.focus("[name=next_field]").dispatch("app:saved", detail: { id: @todo.id }))
end

# In a model/job — light up the bell in every viewer's tab, minus the actor's own:
Notifications::Badge.broadcast_js_to(user, :alerts,
  js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
```

## Correctness invariants

- **Ordering** — the op stream is emitted **after** all render streams, so `focus("[name=next]")` sees the post-render/post-morph DOM (Turbo applies streams in document order). A system spec proves focus lands on a freshly morphed field.
- **Token machinery untouched** — `reactive:js` is **not** a self-render: it never trips the client `#extractToken` regexes or the endpoint's `carries_token_for?`, so the reply's signed token still rolls forward exactly as before.
- **Focus is actor-only** — `broadcast_js_to` **rejects** `focus`/`focus_first` with `ArgumentError` (broadcasting focus would steal it in every subscriber's tab).
- **Escaping** — the `data-reactive-ops` attribute is HTML-escaped exactly like `to_stream_token` (a raw interpolation would be an injection vector).
- **pgbus optionality** — transport opts are forwarded only when given; the pgbus-absent path is unchanged.

## Test plan

| Layer | Spec | Proves |
|---|---|---|
| Unit (Ruby) | `spec/phlex/reactive/response_spec.rb` | `Response#js` chains immutably; ops emitted last; escaping; target default/override; empty-chain rejection |
| Unit (bun) | `spec/javascript/reactive_js_stream.test.js` | handler applies ops via the shared interpreter; `target` root scoping; unknown/refused ops warn + skip; garbage degrades to no-op |
| Unit (bun) | `spec/javascript/reactive_js_token_safety.test.js` | a `reactive:js` stream at our target never shadows or becomes the next token |
| Request | `spec/requests/reactive_actions_spec.rb` | endpoint emits render + op streams in order, token intact, escaped, self-scoped |
| Broadcast | `spec/requests/js_broadcast_spec.rb` | broadcast rides `reactive:js`; focus rejection; transport-opt pass-through (pgbus-present) **and** omission (pgbus-absent) |
| System | `spec/system/js_focus_spec.rb` | post-save focus lands on the morphed field — **Puma AND Falcon** |

## Verification

- [x] `bundle exec rubocop` (gem + `docs/`) passes
- [x] `bundle exec rspec spec/phlex spec/requests` passes
- [x] `bun test spec/javascript` passes (133)
- [x] `bundle exec rspec spec/system` passes under **Puma AND Falcon** (38 examples each)
- [x] Vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`)
- [x] README + broadcasting docs + CHANGELOG updated
- [x] Backwards compatible — every existing component/spec passes verbatim; pgbus optionality preserved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-pushed client DOM operations via `reply.js(...)` and `broadcast_js_to`, including scoped targets and HTML-escaped payloads.
  * Introduced `reactive:js` streaming to apply supported operations after render updates.
  * Added docs and example components demonstrating post-morph focus behavior.
* **Bug Fixes**
  * Refuses focus-related operations in broadcast (`focus` / `focus_first`).
  * Ensures JS op payloads can’t break out of stream attributes.
  * Preserves existing token refresh behavior and correct stream ordering.
* **Tests**
  * Added request, system, Ruby, and Bun test coverage for `reactive:js` behavior and token safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->