### PR TITLE
feat(component): optimistic: on on(...) — declared, reversible visual hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`optimistic:` on `on(...)` — declared, reversible visual hints (#98).**
+  Reactive interactions no longer wait a full round trip for their first visual
+  change — and a checkbox no longer fails to flip at all (the client's
+  unconditional `preventDefault` used to suppress the native flip until the
+  morph). `optimistic:` applies a small, always-reversible, **cosmetic**
+  vocabulary the instant the trigger fires and **reverts** it if the action
+  fails — Livewire's "flip it client-side, let the morph correct". Supported
+  hints: `toggle_class:`/`add_class:`/`remove_class:` (on the trigger, or a `to:`
+  selector scoped to the root), `checked: :keep` (a click-bound checkbox/radio
+  skips `preventDefault` so it flips natively now), and `hide: true`. Hints are
+  visual only (never data, never client state), applied **once per flushed
+  enqueue** (a debounced trigger can't flap per keystroke), and reverted from
+  every failure branch (redirected/http/content-type/network + client apply),
+  guarded by `isConnected`. On **success there is no cleanup**: a root re-render
+  overwrites the hint with server truth, while a reply that does not re-render
+  the root (`reply.remove`, streams-only) leaves it standing — that's the
+  `hide: true` + `reply.remove` instant-delete recipe. Emitted as
+  `data-reactive-optimistic-param` (JSON) following the guarded-append pattern of
+  `debounce:`/`confirm:`/`throttle:`, so the bare-`on()` hot path stays
+  byte-identical. **`optimistic:` is now a RESERVED keyword name on `on(...)`** —
+  like `debounce:`/`confirm:`/`throttle:`/`listnav:`, it can no longer be used as
+  a free action param.
 - **`on_client(event, ops)` + the `js` op builder — client-side DOM commands
   with ZERO round trips (#95).** Purely-visual interactions (tabs, dropdowns,
   accordions, class toggles) no longer cost a signed server round trip or a

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:search, listnav: "[role=option]")` | Add combobox keyboard navigation — Arrow keys move a client-side highlight, Enter picks (clicks the option's own trigger), Escape clears. See [Combobox keyboard navigation](#combobox-keyboard-navigation-listnav). |
 | `on(:close_menu, outside: true)` | Fire only for events **outside** this component's root (close-a-dropdown-on-outside-click). Window-bound; never `preventDefault`s, so links elsewhere keep navigating. |
 | `on(:track, event: "scroll", window: true, throttle: 250)` | `window:` binds the trigger to the window (page-level scroll/resize); `throttle:` rate-limits leading-edge — first event fires, the rest drop until the window elapses. Mutually exclusive with `debounce:`. |
+| `on(:toggle, optimistic: { checked: :keep })` | Apply a reversible **visual hint** the instant the trigger fires (before the round trip); revert it if the action fails. Cosmetic only. See [Optimistic hints](#optimistic-visual-hints-optimistic). |
 | `on(:action, once: true)` | Fire at most once, then unbind (Stimulus's native `:once`). |
 | `on_client(:click, js.toggle("#menu"))` | **Client-only** trigger: applies declared DOM ops with ZERO round trip — no token, no POST, ever. Takes the same `window:`/`once:`/`outside:` modifiers. See [Client-only ops](#client-only-ops-on_client--js--zero-round-trips). |
 | `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute, with an optional `transition:`), `add_class`/`remove_class`/`toggle_class`, `set_attr`/`remove_attr`/`toggle_attr` (allowlisted names), `focus`/`focus_first`, and `dispatch` — chainable. |
@@ -468,6 +469,55 @@ div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 500
 
 These four (like `debounce:`/`confirm:`/`listnav:`) are **reserved keyword
 names** on `on(...)` — no longer usable as free action params.
+
+### Optimistic visual hints (`optimistic:`)
+
+Every reactive action waits a full round trip for its visual change — and it's
+worse than neutral for a checkbox: the client `preventDefault`s the trigger, so
+an `on(:toggle)` checkbox never even **flips** until the morph arrives.
+`optimistic:` gives Livewire's "flip it client-side, let the morph correct" (and
+React's `useOptimistic`): a small, **always-reversible**, cosmetic vocabulary
+applied the instant the trigger fires and **reverted** if the round trip fails.
+
+Hints are visual **only** — never data, never a computed value (that would be
+client state the DOM can't be trusted to hold). Supported ops in the hint hash:
+
+- `toggle_class:` / `add_class:` / `remove_class:` — a class string or array,
+  applied to the **trigger** by default, or to a `to:` selector scoped to the
+  root (`to: :root` targets the root element itself).
+- `checked: :keep` — for a **click-bound** checkbox/radio, the client skips its
+  unconditional `preventDefault` so the **native flip happens now** (a bare
+  toggle click has no navigation default to lose). On a `change`-bound control
+  the flip is already native — `:keep` then only contributes the failure revert.
+- `hide: true` — hides the target immediately.
+
+```ruby
+# A checkbox that flips instantly; the label paints in the same gesture. The
+# morph reconciles from server truth; a failure snaps both back.
+input(type: "checkbox", checked: @todo.done,
+  **mix(on(:toggle, event: "change", optimistic: { checked: :keep, toggle_class: "is-done", to: ".status" }),
+    name: "done"))
+
+# Instant delete: hide the row NOW, remove it on the reply.
+button(**on(:destroy, confirm: "Delete?", optimistic: { hide: true, to: :root })) { "Delete" }
+```
+
+**The success/failure contract (load-bearing):**
+
+- **On failure** — any branch (`redirected` / `http` / `content-type` /
+  `network`, plus a client-side `apply` throw) — the client replays the exact
+  **inverse** ops, guarded by `isConnected` (a detached row is skipped, it's
+  gone anyway). The hint stored on the queued request, so the serialized
+  per-controller queue reverts the **right** request's hint.
+- **On success there is NO cleanup.** A reply that re-renders the root
+  **overwrites** the hint with server truth. A reply that does **not** re-render
+  the root (`reply.remove`, streams-only) **leaves the hint standing** — that's
+  the `hide: true` + `reply.remove` instant-delete recipe working as intended:
+  the row hides, then removes, and never flashes back.
+
+`optimistic:` (like `debounce:`/`confirm:`/`throttle:`) is a **reserved keyword
+name** on `on(...)`. An unknown hint op, a `checked:` value other than `:keep`,
+or a non-hash raises at render — a dead hint fails loudly, never silently.
 
 ### Client-only ops (`on_client` + `js`) — zero round trips
 

--- a/README.md
+++ b/README.md
@@ -487,8 +487,11 @@ client state the DOM can't be trusted to hold). Supported ops in the hint hash:
   root (`to: :root` targets the root element itself).
 - `checked: :keep` — for a **click-bound** checkbox/radio, the client skips its
   unconditional `preventDefault` so the **native flip happens now** (a bare
-  toggle click has no navigation default to lose). On a `change`-bound control
-  the flip is already native — `:keep` then only contributes the failure revert.
+  toggle click has no navigation default to lose). `on(...)` also skips the
+  forced `type="button"` it normally adds to click triggers — that would destroy
+  the very checkbox being toggled — so you supply the real `type="checkbox"` /
+  `type="radio"`. On a `change`-bound control the flip is already native
+  (`change` isn't cancelable) — `:keep` then only contributes the failure revert.
 - `hide: true` — hides the target immediately.
 
 ```ruby

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -1108,14 +1108,24 @@ export default class extends Controller {
     const undo = []
     for (const el of targets) {
       if (optimistic.add_class) {
-        el.classList.add(...optimistic.add_class)
-        undo.push(() => el.classList.remove(...optimistic.add_class))
+        // Undo only the classes this op ACTUALLY added — a class already present
+        // was not our change, so reverting it would strip a class the element
+        // legitimately had (the add was a no-op). Capture the real delta now.
+        const added = optimistic.add_class.filter((c) => !el.classList.contains(c))
+        el.classList.add(...added)
+        if (added.length) undo.push(() => el.classList.remove(...added))
       }
       if (optimistic.remove_class) {
-        el.classList.remove(...optimistic.remove_class)
-        undo.push(() => el.classList.add(...optimistic.remove_class))
+        // Symmetric: undo only the classes actually removed — one already absent
+        // wasn't our change, so re-adding it would introduce a class that wasn't
+        // there before.
+        const removed = optimistic.remove_class.filter((c) => el.classList.contains(c))
+        el.classList.remove(...removed)
+        if (removed.length) undo.push(() => el.classList.add(...removed))
       }
       if (optimistic.toggle_class) {
+        // toggle_class is its own inverse regardless of prior state — toggling
+        // the same classes back exactly restores it, no delta tracking needed.
         optimistic.toggle_class.forEach((c) => el.classList.toggle(c))
         undo.push(() => optimistic.toggle_class.forEach((c) => el.classList.toggle(c)))
       }

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -385,7 +385,7 @@ export default class extends Controller {
     // modifier params (issue #80). The client decides preventDefault behavior
     // from event.params — set by the Ruby on() — never by sniffing the
     // Stimulus descriptor.
-    const { action, params, debounce, throttle, confirm, outside, window: windowBound } = event.params
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic } = event.params
     if (!action) return
 
     // Outside guard FIRST (issue #80): an outside: trigger only fires for
@@ -395,6 +395,10 @@ export default class extends Controller {
     // click behavior is untouched) and before the reactive:before-dispatch
     // lifecycle event (nothing to announce, nothing to veto).
     if (outside && this.element.contains(event.target)) return
+
+    // Capture the trigger element now; #proceed runs in a later microtask (after
+    // the confirm resolver settles), by which point event.target may be reset.
+    const target = event.target
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -410,14 +414,17 @@ export default class extends Controller {
     // issue #80) hears EVERY matching event on the page — preventDefault-ing
     // those would kill every link click while a dropdown is mounted. The page's
     // native behavior proceeds alongside the reactive round trip.
-    if (!windowBound) event.preventDefault()
-
-    // Capture the trigger element now; #proceed runs in a later microtask (after
-    // the confirm resolver settles), by which point event.target may be reset.
-    const target = event.target
+    //
+    // The `checked: :keep` optimistic hint (issue #98) OPTS OUT: for a click-bound
+    // checkbox/radio the unconditional preventDefault is exactly what stops the
+    // native flip from happening before the morph — so a bare checkbox click
+    // (which has no form-navigation default to lose) skips it and flips now, and
+    // the failure revert snaps it back. A `change`-bound trigger is unaffected —
+    // `change` isn't cancelable, so preventDefault was already a no-op there.
+    if (!windowBound && !this.#keepsNativeToggle(optimistic, target)) event.preventDefault()
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce, throttle)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -434,7 +441,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce, throttle)
+        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic)
       })
   }
 
@@ -619,7 +626,7 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce, throttle) {
+  #proceed(target, action, params, debounce, throttle, optimistic) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
     // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
     // PRE-throttle, the same timing). event.preventDefault() skips the
@@ -637,33 +644,41 @@ export default class extends Controller {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
+    // The optimistic hint (issue #98) rides to the flush too, so it applies ONCE
+    // per enqueue — a debounced trigger must not flap toggle_class per keystroke.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic)
 
     // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
     // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
     // event immediately, drop the rest until the window elapses. debounce and
     // throttle are mutually exclusive (the Ruby on() raises on both).
     const throttleMs = Number(throttle) || 0
-    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params)
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic)
 
-    return this.#enqueue(action, params)
+    return this.#enqueue(action, params, optimistic, target)
   }
 
-  #enqueue(action, params) {
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
+  // Apply the optimistic hint ONCE (recording its inverse) and chain the round
+  // trip, threading that inverse onto THIS queued request so the serialized
+  // per-controller queue reverts the RIGHT request's hint on failure (issue
+  // #98). Applying here — the single flush/enqueue point every path funnels
+  // through — is what makes a hint apply once per enqueue, not per raw dispatch.
+  #enqueue(action, params, optimistic, target) {
+    const inverse = this.#applyOptimistic(optimistic, target)
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse))
     return this.queue
   }
 
   // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
   // Also flush immediately on blur so leaving the field never drops the last
   // edit (a long debounce shouldn't swallow a value the user tabbed away from).
-  #debounceDispatch(target, ms, action, params) {
+  #debounceDispatch(target, ms, action, params, optimistic) {
     this.#clearDebounce(target)
 
     const flush = () => {
       this.#clearDebounce(target)
-      this.#enqueue(action, params)
+      this.#enqueue(action, params, optimistic, target)
     }
     const timer = setTimeout(flush, ms)
     target?.addEventListener?.("blur", flush, { once: true })
@@ -691,7 +706,7 @@ export default class extends Controller {
   // are keyed on action + target, NOT target alone: window-bound scroll/resize
   // events all share event.target === document, so two window-bound triggers
   // on one component would otherwise collide on one timer.
-  #throttleDispatch(target, ms, action, params) {
+  #throttleDispatch(target, ms, action, params, optimistic) {
     const timers = this.#throttleTimers.get(target) ?? new Map()
     if (timers.has(action)) return // inside the window — suppress
 
@@ -701,7 +716,7 @@ export default class extends Controller {
     }, ms)
     timers.set(action, timer)
     this.#throttleTimers.set(target, timers)
-    return this.#enqueue(action, params) // leading edge: fire NOW
+    return this.#enqueue(action, params, optimistic, target) // leading edge: fire NOW
   }
 
   // Clear every throttle suppression timer (used on disconnect, alongside
@@ -746,7 +761,7 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
-  async #perform(action, params) {
+  async #perform(action, params, inverse) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
     // chosen file inputs in the SAME walk. Explicit params
@@ -802,18 +817,21 @@ export default class extends Controller {
         })
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "network" })
         return
       }
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
       if (!response.ok) {
         const errorBody = await response.text()
         console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
@@ -821,6 +839,7 @@ export default class extends Controller {
       const contentType = response.headers.get("Content-Type") || ""
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
@@ -847,6 +866,7 @@ export default class extends Controller {
       // failure. kind: "apply" carries NO retry() — retrying would re-POST an
       // action the server already completed.
       console.error("[phlex-reactive] action error", error)
+      this.#revertOptimistic(inverse)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
       this.element.removeAttribute("aria-busy")
@@ -1059,6 +1079,80 @@ export default class extends Controller {
     if (typeof to !== "string" || to === "") return []
     if (args.global) return [...document.querySelectorAll(to)]
     return [...this.element.querySelectorAll(to)].filter((el) => this.#ownsField(el))
+  }
+
+  // Whether a click-bound checkbox/radio trigger should keep its NATIVE flip
+  // (issue #98). `checked: :keep` means "let the control flip now": the
+  // unconditional preventDefault is exactly what suppresses that flip until the
+  // morph, so we skip it — but ONLY for a checkbox/radio (a bare toggle click
+  // has no form-navigation default to lose). Any other element (a button) keeps
+  // preventDefault so an in-form submit can't navigate.
+  #keepsNativeToggle(optimistic, target) {
+    if (optimistic?.checked !== "keep") return false
+    const type = target?.type
+    return type === "checkbox" || type === "radio"
+  }
+
+  // Apply the optimistic hint (issue #98) to its targets NOW and return the
+  // INVERSE — the exact ops to replay on failure. Cosmetic only: class ops and
+  // hidden, applied to the trigger by default or to a `to:` selector scoped to
+  // the root. `checked: :keep` records the trigger's post-flip state so a
+  // failure snaps the native control back; it applies no DOM change itself (the
+  // browser already flipped it). Returns null when there is nothing to do, so
+  // the success/failure paths can cheaply skip.
+  #applyOptimistic(optimistic, trigger) {
+    if (!optimistic) return null
+
+    // Class + hidden ops share one target set (trigger, or the `to:` selector).
+    const targets = this.#optimisticTargets(optimistic, trigger)
+    const undo = []
+    for (const el of targets) {
+      if (optimistic.add_class) {
+        el.classList.add(...optimistic.add_class)
+        undo.push(() => el.classList.remove(...optimistic.add_class))
+      }
+      if (optimistic.remove_class) {
+        el.classList.remove(...optimistic.remove_class)
+        undo.push(() => el.classList.add(...optimistic.remove_class))
+      }
+      if (optimistic.toggle_class) {
+        optimistic.toggle_class.forEach((c) => el.classList.toggle(c))
+        undo.push(() => optimistic.toggle_class.forEach((c) => el.classList.toggle(c)))
+      }
+      if (optimistic.hide) {
+        el.hidden = true
+        undo.push(() => (el.hidden = false))
+      }
+    }
+
+    // checked: :keep — the native flip already happened on the trigger; record
+    // the inverse (flip it back) so a failure reverts the control's state.
+    if (optimistic.checked === "keep" && trigger && "checked" in trigger) {
+      const flipped = trigger.checked
+      undo.push(() => (trigger.checked = !flipped))
+    }
+
+    return undo.length ? undo : null
+  }
+
+  // Replay the recorded inverse ops on failure (issue #98), guarded by
+  // isConnected: a plain (non-morph) replace can detach this subtree before the
+  // failure lands, and reverting a stale/detached node is pointless (it's gone)
+  // — so a disconnected root skips the revert entirely. On success NOTHING calls
+  // this: the server re-render overwrites the hint, or (reply.remove /
+  // streams-only) the hint is deliberately left standing.
+  #revertOptimistic(inverse) {
+    if (!inverse) return
+    if (!this.element.isConnected) return
+    for (const undo of inverse) undo()
+  }
+
+  // The elements an optimistic class/hidden hint applies to: the `to:` selector
+  // (resolved like an op target — "@root" is the root, a selector is scoped to
+  // this root's owned matches) or, with no `to:`, the trigger itself.
+  #optimisticTargets(optimistic, trigger) {
+    if (optimistic.to == null) return trigger ? [trigger] : []
+    return this.#opTargets({ to: optimistic.to })
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -481,7 +481,12 @@ module Phlex
         # The client decides preventDefault behavior from event.params (never by
         # sniffing the descriptor), so EVERY window binding flags the param.
         attrs[:data][:reactive_window_param] = "true" if window_bound
-        attrs[:type] = "button" if event == "click" && !window_bound
+        # Force type="button" for click triggers so a bare button inside a <form>
+        # can't submit it — EXCEPT when checked: :keep is declared: that hint's
+        # whole point is to let a click-bound checkbox/radio flip natively, and a
+        # forced type="button" would destroy the very control being toggled
+        # (issue #98). The caller supplies the real type="checkbox"/"radio".
+        attrs[:type] = "button" if event == "click" && !window_bound && !optimistic_keeps_native?(optimistic)
         attrs
       end
 
@@ -614,6 +619,17 @@ module Phlex
       OPTIMISTIC_CLASS_OPS = %w[toggle_class add_class remove_class].freeze
 
       private
+
+      # True when the hint declares checked: :keep — the click-bound
+      # checkbox/radio case that must SKIP the forced type="button" so the native
+      # control (and its native flip) survives (issue #98). Accepts symbol or
+      # string keys/values; nil-safe for the no-hint hot path.
+      def optimistic_keeps_native?(optimistic)
+        return false unless optimistic.is_a?(Hash)
+
+        value = optimistic[:checked] || optimistic["checked"]
+        value.to_s == "keep"
+      end
 
       # Normalize + validate the optimistic hint hash, returning its JSON wire
       # form (data-reactive-optimistic-param). `to: :root` becomes the same

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -426,8 +426,32 @@ module Phlex
       # window elapses (scroll/mousemove). Mutually exclusive with `debounce:`
       # (trailing-edge) — passing both raises ArgumentError.
       #   div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 250)))
+      #
+      # `optimistic:` (issue #98) — a small, ALWAYS-REVERSIBLE vocabulary of
+      # COSMETIC hints the client applies the instant the trigger fires and
+      # REVERTS if the round trip fails, so a click/toggle gives instant feedback
+      # instead of waiting a full round trip. Hints are visual only — never data,
+      # never computed values (that would be client state). Supported ops in the
+      # hint hash:
+      #   * toggle_class:/add_class:/remove_class: — a class string or array,
+      #     applied to the TRIGGER (default) or to a `to:` selector scoped to the
+      #     root (`to: :root` targets the root element itself).
+      #   * checked: :keep — for a click-bound checkbox/radio, the client SKIPS
+      #     its unconditional preventDefault so the native flip happens now
+      #     (today the morph never even lets it flip). On failure, the flip is
+      #     reverted.
+      #   * hide: true — hides the target immediately (the `hide: true` + a
+      #     `reply.remove` action is the instant delete-a-row recipe: the hint
+      #     hides it, the reply removes it; a failure snaps it back).
+      # Success does NO cleanup: a reply that re-renders the root overwrites the
+      # hint with server truth; a reply that does NOT re-render the root
+      # (reply.remove / streams-only) LEAVES the hint standing — that's the
+      # instant-delete working as intended.
+      #   input(type: "checkbox", checked: @todo.done,
+      #     **mix(on(:toggle, event: "change", optimistic: { checked: :keep }), name: "done"))
+      #   button(**on(:destroy, confirm: "Delete?", optimistic: { hide: true, to: :root })) { "Delete" }
       def on(action_name, event: "click", debounce: nil, throttle: nil, confirm: nil, listnav: nil,
-             window: false, once: false, outside: false, **params)
+             window: false, once: false, outside: false, optimistic: nil, **params)
         if debounce && throttle
           raise ArgumentError,
             "on(#{action_name.inspect}) got both debounce: and throttle: — they are mutually " \
@@ -448,6 +472,7 @@ module Phlex
         attrs[:data][:reactive_throttle_param] = throttle if throttle
         attrs[:data][:reactive_confirm_param] = confirm if confirm
         attrs[:data][:reactive_listnav_option_param] = listnav if listnav
+        attrs[:data][:reactive_optimistic_param] = optimistic_hint_json(optimistic, action_name) if optimistic
         # STRING "true", not boolean: Phlex renders a `true` attribute VALUELESS
         # (data-reactive-outside-param), which Stimulus's param reader sees as ""
         # — falsy in JS, so the guard silently never fires. The explicit ="true"
@@ -581,7 +606,52 @@ module Phlex
         reactive_record_for_nested.update!(**nested_attributes(association, attrs), **extra)
       end
 
+      # The declared optimistic-hint class ops (issue #98): the cosmetic class
+      # vocabulary the client applies instantly and reverts on failure. Enforced
+      # at build time in optimistic_hint_json (default-deny — a dead hint fails
+      # at render, not silently in the browser). Each carries a class string or
+      # array; hide/checked are flags with a fixed shape.
+      OPTIMISTIC_CLASS_OPS = %w[toggle_class add_class remove_class].freeze
+
       private
+
+      # Normalize + validate the optimistic hint hash, returning its JSON wire
+      # form (data-reactive-optimistic-param). `to: :root` becomes the same
+      # "@root" sentinel the js op builder uses so the client resolves it
+      # uniformly. Unknown keys, a bad `checked:` value, or a non-hash raise —
+      # a hint that can't apply must fail loudly at render.
+      def optimistic_hint_json(optimistic, action_name)
+        unless optimistic.is_a?(Hash)
+          raise ArgumentError,
+            "on(#{action_name.inspect}) optimistic: must be a Hash of visual hints " \
+            "(e.g. { checked: :keep } or { hide: true, to: :root }), got #{optimistic.class}"
+        end
+
+        hint = {}
+        optimistic.each do |key, value|
+          case key.to_s
+          when *OPTIMISTIC_CLASS_OPS
+            hint[key.to_s] = Array(value).map(&:to_s)
+          when "hide"
+            hint["hide"] = value ? true : false
+          when "checked"
+            unless value.to_s == "keep"
+              raise ArgumentError,
+                "on(#{action_name.inspect}) optimistic checked: only supports :keep " \
+                "(flip the native control, revert on failure), got #{value.inspect}"
+            end
+            hint["checked"] = "keep"
+          when "to"
+            hint["to"] = value == :root ? Phlex::Reactive::JS::ROOT_SENTINEL : value.to_s
+          else
+            raise ArgumentError,
+              "on(#{action_name.inspect}) got an unknown optimistic hint #{key.inspect} — " \
+              "supported: toggle_class/add_class/remove_class, checked: :keep, hide: true, to:"
+          end
+        end
+
+        hint.to_json
+      end
 
       # The component's record, for the nested-attributes helpers. Requires a
       # declared reactive_record (the nested helper only makes sense for a

--- a/spec/dummy/app/components/optimistic_row_component.rb
+++ b/spec/dummy/app/components/optimistic_row_component.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Exercises the optimistic: visual hints (issue #98) end-to-end:
+#
+#   * an on(:toggle, event: "change", optimistic: { checked: :keep, toggle_class: … })
+#     CHECKBOX flips NATIVELY the instant it's clicked — before the (deliberately
+#     slow) server morph lands — and the status label's class flips with it;
+#   * an on(:boom, optimistic: { add_class: … }) button whose action is
+#     UNDECLARED (endpoint default-deny → 403), so the hint is applied then
+#     REVERTED when the failure lands;
+#   * an on(:destroy, optimistic: { hide: true, to: :root }) button that hides
+#     the row INSTANTLY, then reply.remove drops it — the hint is left standing
+#     (no re-render of the root) so it never flashes back.
+#
+# The toggle action sleeps briefly so the system spec can observe the optimistic
+# flip DISTINCTLY before the morph reconciles it — a real action is instant, but
+# the delay makes "client-first" observable rather than a race.
+class OptimisticRowComponent < ApplicationComponent
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :toggle
+  action :destroy
+  # NOTE: :boom is deliberately NOT declared — the endpoint default-denies it
+  # (403), the real failure the revert path is proved against.
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def toggle
+    # Deliberate delay so the browser spec sees the optimistic native flip BEFORE
+    # the server morph reconciles the checkbox — proving the client painted first.
+    sleep 0.4
+    @todo.update!(done: !@todo.done?)
+  end
+
+  # Hide-then-remove: the optimistic hint hides the row instantly; reply.remove
+  # drops it from the DOM. No root re-render, so the hint is left standing and
+  # the row never flashes back before removal.
+  def destroy
+    @todo.destroy!
+    reply.remove
+  end
+
+  def view_template
+    li(**mix(reactive_attrs, id:, data: { testid: "opt-row", done: @todo.done?.to_s })) do
+      # The optimistic checkbox: checked:keep lets the native flip happen NOW;
+      # toggle_class paints the status label in the same gesture. On success the
+      # morph overwrites with server truth; on failure the flip reverts.
+      input(**mix(
+        on(:toggle, event: "change", optimistic: { checked: :keep, toggle_class: "is-done", to: ".status" }),
+        type: "checkbox", checked: @todo.done?, data: { testid: "opt-check" }
+      ))
+      span(class: ["status", ("is-done" if @todo.done?)], data: { testid: "status" }) { @todo.done? ? "done" : "todo" }
+
+      # Undeclared action → 403 → the add_class hint is applied then reverted.
+      button(**mix(on(:boom, optimistic: { add_class: "pending" }), data: { testid: "opt-boom" })) { "boom" }
+
+      # Instant delete: hide the whole row now, remove it on the reply.
+      button(**mix(on(:destroy, optimistic: { hide: true, to: :root }), data: { testid: "opt-destroy" })) { "delete" }
+    end
+  end
+end

--- a/spec/dummy/app/components/optimistic_row_component.rb
+++ b/spec/dummy/app/components/optimistic_row_component.rb
@@ -18,11 +18,14 @@
 class OptimisticRowComponent < ApplicationComponent
   include Phlex::Reactive::Component
 
+  # Registered in the dummy's phlex_reactive initializer so the endpoint turns it
+  # into a clean 403 — a DECLARED authorization failure (not default-deny).
+  class Denied < StandardError; end
+
   reactive_record :todo
   action :toggle
   action :destroy
-  # NOTE: :boom is deliberately NOT declared — the endpoint default-denies it
-  # (403), the real failure the revert path is proved against.
+  action :boom
 
   def initialize(todo:)
     @todo = todo
@@ -35,10 +38,21 @@ class OptimisticRowComponent < ApplicationComponent
     @todo.update!(done: !@todo.done?)
   end
 
+  # A DELIBERATELY slow failure: the sleep lets the browser spec observe the
+  # applied optimistic hint (add_class "pending") BEFORE the failure lands and the
+  # client reverts it — proving both the apply AND the revert without racing a
+  # fast default-deny 403.
+  def boom
+    sleep 0.4
+    raise Denied, "nope"
+  end
+
   # Hide-then-remove: the optimistic hint hides the row instantly; reply.remove
   # drops it from the DOM. No root re-render, so the hint is left standing and
-  # the row never flashes back before removal.
+  # the row never flashes back before removal. The small delay keeps the
+  # instantly-hidden state observable before the removal stream lands.
   def destroy
+    sleep 0.4
     @todo.destroy!
     reply.remove
   end
@@ -47,10 +61,19 @@ class OptimisticRowComponent < ApplicationComponent
     li(**mix(reactive_attrs, id:, data: { testid: "opt-row", done: @todo.done?.to_s })) do
       # The optimistic checkbox: checked:keep lets the native flip happen NOW;
       # toggle_class paints the status label in the same gesture. On success the
-      # morph overwrites with server truth; on failure the flip reverts.
+      # morph overwrites with server truth; on failure the flip reverts. Two
+      # checkboxes cover BOTH trigger bindings the issue distinguishes:
+      #   * CLICK-bound — checked: :keep skips the unconditional preventDefault so
+      #     the native flip happens now (the new #98 branch).
+      #   * CHANGE-bound — preventDefault is already a no-op (change isn't
+      #     cancelable), so :keep only contributes the failure revert.
       input(**mix(
-        on(:toggle, event: "change", optimistic: { checked: :keep, toggle_class: "is-done", to: ".status" }),
+        on(:toggle, optimistic: { checked: :keep, toggle_class: "is-done", to: ".status" }),
         type: "checkbox", checked: @todo.done?, data: { testid: "opt-check" }
+      ))
+      input(**mix(
+        on(:toggle, event: "change", optimistic: { checked: :keep }),
+        type: "checkbox", checked: @todo.done?, data: { testid: "opt-check-change" }
       ))
       span(class: ["status", ("is-done" if @todo.done?)], data: { testid: "status" }) { @todo.done? ? "done" : "todo" }
 

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -101,6 +101,15 @@ class DemosController < ActionController::Base
     render_component ConfirmComponent.new
   end
 
+  # Optimistic visual hints (issue #98): a checkbox that flips natively before
+  # the (deliberately slow) morph, a failing action whose hint reverts, and a
+  # hide-then-remove delete. A fresh, unfinished Todo each visit.
+  def optimistic
+    todo = Todo.create!(title: "optimistic", done: false)
+    component = render_to_string(OptimisticRowComponent.new(todo:), layout: false)
+    render html: %(<ul>#{component}</ul>).html_safe, layout: true
+  end
+
   def morph_grid
     render_component MorphGridComponent.new(account: Account.find(params[:id]))
   end

--- a/spec/dummy/config/initializers/phlex_reactive.rb
+++ b/spec/dummy/config/initializers/phlex_reactive.rb
@@ -4,4 +4,11 @@
 # view helpers work during re-renders and broadcasts.
 Rails.application.config.after_initialize do
   Phlex::Reactive.renderer = DemosController
+
+  # Register the optimistic demo's authorization error so a DECLARED, slow-failing
+  # action returns a clean 403 (issue #98 system spec) — mirroring how a real app
+  # registers Pundit::NotAuthorizedError. Lets the failing-revert spec observe the
+  # applied hint before the (deliberately delayed) failure reverts it, instead of
+  # racing a fast default-deny 403.
+  Phlex::Reactive.authorization_errors << OptimisticRowComponent::Denied
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "dropdown" => "demos#dropdown"
   get "client_tabs" => "demos#client_tabs"
   get "confirm" => "demos#confirm"
+  get "optimistic" => "demos#optimistic"
   get "morph_grid/:id" => "demos#morph_grid"
   get "js_focus/:id" => "demos#js_focus"
   get "partial_grid/:id" => "demos#partial_grid"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -1108,14 +1108,24 @@ export default class extends Controller {
     const undo = []
     for (const el of targets) {
       if (optimistic.add_class) {
-        el.classList.add(...optimistic.add_class)
-        undo.push(() => el.classList.remove(...optimistic.add_class))
+        // Undo only the classes this op ACTUALLY added — a class already present
+        // was not our change, so reverting it would strip a class the element
+        // legitimately had (the add was a no-op). Capture the real delta now.
+        const added = optimistic.add_class.filter((c) => !el.classList.contains(c))
+        el.classList.add(...added)
+        if (added.length) undo.push(() => el.classList.remove(...added))
       }
       if (optimistic.remove_class) {
-        el.classList.remove(...optimistic.remove_class)
-        undo.push(() => el.classList.add(...optimistic.remove_class))
+        // Symmetric: undo only the classes actually removed — one already absent
+        // wasn't our change, so re-adding it would introduce a class that wasn't
+        // there before.
+        const removed = optimistic.remove_class.filter((c) => el.classList.contains(c))
+        el.classList.remove(...removed)
+        if (removed.length) undo.push(() => el.classList.add(...removed))
       }
       if (optimistic.toggle_class) {
+        // toggle_class is its own inverse regardless of prior state — toggling
+        // the same classes back exactly restores it, no delta tracking needed.
         optimistic.toggle_class.forEach((c) => el.classList.toggle(c))
         undo.push(() => optimistic.toggle_class.forEach((c) => el.classList.toggle(c)))
       }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -385,7 +385,7 @@ export default class extends Controller {
     // modifier params (issue #80). The client decides preventDefault behavior
     // from event.params — set by the Ruby on() — never by sniffing the
     // Stimulus descriptor.
-    const { action, params, debounce, throttle, confirm, outside, window: windowBound } = event.params
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic } = event.params
     if (!action) return
 
     // Outside guard FIRST (issue #80): an outside: trigger only fires for
@@ -395,6 +395,10 @@ export default class extends Controller {
     // click behavior is untouched) and before the reactive:before-dispatch
     // lifecycle event (nothing to announce, nothing to veto).
     if (outside && this.element.contains(event.target)) return
+
+    // Capture the trigger element now; #proceed runs in a later microtask (after
+    // the confirm resolver settles), by which point event.target may be reset.
+    const target = event.target
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -410,14 +414,17 @@ export default class extends Controller {
     // issue #80) hears EVERY matching event on the page — preventDefault-ing
     // those would kill every link click while a dropdown is mounted. The page's
     // native behavior proceeds alongside the reactive round trip.
-    if (!windowBound) event.preventDefault()
-
-    // Capture the trigger element now; #proceed runs in a later microtask (after
-    // the confirm resolver settles), by which point event.target may be reset.
-    const target = event.target
+    //
+    // The `checked: :keep` optimistic hint (issue #98) OPTS OUT: for a click-bound
+    // checkbox/radio the unconditional preventDefault is exactly what stops the
+    // native flip from happening before the morph — so a bare checkbox click
+    // (which has no form-navigation default to lose) skips it and flips now, and
+    // the failure revert snaps it back. A `change`-bound trigger is unaffected —
+    // `change` isn't cancelable, so preventDefault was already a no-op there.
+    if (!windowBound && !this.#keepsNativeToggle(optimistic, target)) event.preventDefault()
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce, throttle)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -434,7 +441,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce, throttle)
+        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic)
       })
   }
 
@@ -619,7 +626,7 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce, throttle) {
+  #proceed(target, action, params, debounce, throttle, optimistic) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
     // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
     // PRE-throttle, the same timing). event.preventDefault() skips the
@@ -637,33 +644,41 @@ export default class extends Controller {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
+    // The optimistic hint (issue #98) rides to the flush too, so it applies ONCE
+    // per enqueue — a debounced trigger must not flap toggle_class per keystroke.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(target, ms, action, params)
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic)
 
     // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
     // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
     // event immediately, drop the rest until the window elapses. debounce and
     // throttle are mutually exclusive (the Ruby on() raises on both).
     const throttleMs = Number(throttle) || 0
-    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params)
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic)
 
-    return this.#enqueue(action, params)
+    return this.#enqueue(action, params, optimistic, target)
   }
 
-  #enqueue(action, params) {
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params))
+  // Apply the optimistic hint ONCE (recording its inverse) and chain the round
+  // trip, threading that inverse onto THIS queued request so the serialized
+  // per-controller queue reverts the RIGHT request's hint on failure (issue
+  // #98). Applying here — the single flush/enqueue point every path funnels
+  // through — is what makes a hint apply once per enqueue, not per raw dispatch.
+  #enqueue(action, params, optimistic, target) {
+    const inverse = this.#applyOptimistic(optimistic, target)
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse))
     return this.queue
   }
 
   // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
   // Also flush immediately on blur so leaving the field never drops the last
   // edit (a long debounce shouldn't swallow a value the user tabbed away from).
-  #debounceDispatch(target, ms, action, params) {
+  #debounceDispatch(target, ms, action, params, optimistic) {
     this.#clearDebounce(target)
 
     const flush = () => {
       this.#clearDebounce(target)
-      this.#enqueue(action, params)
+      this.#enqueue(action, params, optimistic, target)
     }
     const timer = setTimeout(flush, ms)
     target?.addEventListener?.("blur", flush, { once: true })
@@ -691,7 +706,7 @@ export default class extends Controller {
   // are keyed on action + target, NOT target alone: window-bound scroll/resize
   // events all share event.target === document, so two window-bound triggers
   // on one component would otherwise collide on one timer.
-  #throttleDispatch(target, ms, action, params) {
+  #throttleDispatch(target, ms, action, params, optimistic) {
     const timers = this.#throttleTimers.get(target) ?? new Map()
     if (timers.has(action)) return // inside the window — suppress
 
@@ -701,7 +716,7 @@ export default class extends Controller {
     }, ms)
     timers.set(action, timer)
     this.#throttleTimers.set(target, timers)
-    return this.#enqueue(action, params) // leading edge: fire NOW
+    return this.#enqueue(action, params, optimistic, target) // leading edge: fire NOW
   }
 
   // Clear every throttle suppression timer (used on disconnect, alongside
@@ -746,7 +761,7 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
-  async #perform(action, params) {
+  async #perform(action, params, inverse) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
     // chosen file inputs in the SAME walk. Explicit params
@@ -802,18 +817,21 @@ export default class extends Controller {
         })
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "network" })
         return
       }
 
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
       if (!response.ok) {
         const errorBody = await response.text()
         console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
@@ -821,6 +839,7 @@ export default class extends Controller {
       const contentType = response.headers.get("Content-Type") || ""
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
+        this.#revertOptimistic(inverse)
         this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
@@ -847,6 +866,7 @@ export default class extends Controller {
       // failure. kind: "apply" carries NO retry() — retrying would re-POST an
       // action the server already completed.
       console.error("[phlex-reactive] action error", error)
+      this.#revertOptimistic(inverse)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
       this.element.removeAttribute("aria-busy")
@@ -1059,6 +1079,80 @@ export default class extends Controller {
     if (typeof to !== "string" || to === "") return []
     if (args.global) return [...document.querySelectorAll(to)]
     return [...this.element.querySelectorAll(to)].filter((el) => this.#ownsField(el))
+  }
+
+  // Whether a click-bound checkbox/radio trigger should keep its NATIVE flip
+  // (issue #98). `checked: :keep` means "let the control flip now": the
+  // unconditional preventDefault is exactly what suppresses that flip until the
+  // morph, so we skip it — but ONLY for a checkbox/radio (a bare toggle click
+  // has no form-navigation default to lose). Any other element (a button) keeps
+  // preventDefault so an in-form submit can't navigate.
+  #keepsNativeToggle(optimistic, target) {
+    if (optimistic?.checked !== "keep") return false
+    const type = target?.type
+    return type === "checkbox" || type === "radio"
+  }
+
+  // Apply the optimistic hint (issue #98) to its targets NOW and return the
+  // INVERSE — the exact ops to replay on failure. Cosmetic only: class ops and
+  // hidden, applied to the trigger by default or to a `to:` selector scoped to
+  // the root. `checked: :keep` records the trigger's post-flip state so a
+  // failure snaps the native control back; it applies no DOM change itself (the
+  // browser already flipped it). Returns null when there is nothing to do, so
+  // the success/failure paths can cheaply skip.
+  #applyOptimistic(optimistic, trigger) {
+    if (!optimistic) return null
+
+    // Class + hidden ops share one target set (trigger, or the `to:` selector).
+    const targets = this.#optimisticTargets(optimistic, trigger)
+    const undo = []
+    for (const el of targets) {
+      if (optimistic.add_class) {
+        el.classList.add(...optimistic.add_class)
+        undo.push(() => el.classList.remove(...optimistic.add_class))
+      }
+      if (optimistic.remove_class) {
+        el.classList.remove(...optimistic.remove_class)
+        undo.push(() => el.classList.add(...optimistic.remove_class))
+      }
+      if (optimistic.toggle_class) {
+        optimistic.toggle_class.forEach((c) => el.classList.toggle(c))
+        undo.push(() => optimistic.toggle_class.forEach((c) => el.classList.toggle(c)))
+      }
+      if (optimistic.hide) {
+        el.hidden = true
+        undo.push(() => (el.hidden = false))
+      }
+    }
+
+    // checked: :keep — the native flip already happened on the trigger; record
+    // the inverse (flip it back) so a failure reverts the control's state.
+    if (optimistic.checked === "keep" && trigger && "checked" in trigger) {
+      const flipped = trigger.checked
+      undo.push(() => (trigger.checked = !flipped))
+    }
+
+    return undo.length ? undo : null
+  }
+
+  // Replay the recorded inverse ops on failure (issue #98), guarded by
+  // isConnected: a plain (non-morph) replace can detach this subtree before the
+  // failure lands, and reverting a stale/detached node is pointless (it's gone)
+  // — so a disconnected root skips the revert entirely. On success NOTHING calls
+  // this: the server re-render overwrites the hint, or (reply.remove /
+  // streams-only) the hint is deliberately left standing.
+  #revertOptimistic(inverse) {
+    if (!inverse) return
+    if (!this.element.isConnected) return
+    for (const undo of inverse) undo()
+  }
+
+  // The elements an optimistic class/hidden hint applies to: the `to:` selector
+  // (resolved like an op target — "@root" is the root, a selector is scoped to
+  // this root's owned matches) or, with no `to:`, the trigger itself.
+  #optimisticTargets(optimistic, trigger) {
+    if (optimistic.to == null) return trigger ? [trigger] : []
+    return this.#opTargets({ to: optimistic.to })
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/spec/javascript/reactive_optimistic.test.js
+++ b/spec/javascript/reactive_optimistic.test.js
@@ -1,0 +1,369 @@
+// Unit tests for optimistic visual hints on reactive triggers (issue #98).
+//
+// `on(:x, optimistic: { … })` emits data-reactive-optimistic-param (JSON) that
+// Stimulus surfaces as event.params.optimistic. The controller:
+//
+//   * applies the hint ONCE per FLUSHED enqueue (not per raw dispatch — a
+//     debounced trigger must not flap toggle_class per keystroke),
+//   * records the exact INVERSE ops on the queued request,
+//   * on ANY failure branch (redirected/http/content-type/network + apply)
+//     replays the inverse, guarded by element.isConnected,
+//   * on success does NO cleanup — the morph overwrites the hint with server
+//     truth, or (reply.remove / streams-only) the hint is LEFT standing.
+//
+// checked: :keep makes a CLICK-bound checkbox/radio trigger SKIP the
+// unconditional preventDefault so the native flip happens now.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A fake DOM element: hidden flag + classList over a Set. `closest` returns the
+// nearest reactive root (`owner`) so the ownership guard resolves `to:` targets.
+function makeEl({ owner = null } = {}) {
+  const el = {
+    hidden: false,
+    classes: new Set(),
+    closest: () => owner,
+  }
+  el.classList = {
+    add: (...cs) => cs.forEach((c) => el.classes.add(c)),
+    remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
+    toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+  }
+  return el
+}
+
+// The trigger element the event fires on. A blur-recording target (debounce
+// flush) plus optional type/checked (checkbox skip-preventDefault path). It is
+// its own owner so a hint with no `to:` applies to it and it's an owned match.
+function makeTrigger({ type = "button", checked = false } = {}) {
+  const listeners = {}
+  const el = makeEl()
+  el.type = type
+  el.checked = checked
+  el.addEventListener = (t, fn) => {
+    (listeners[t] ||= []).push(fn)
+  }
+  el.removeEventListener = (t, fn) => {
+    listeners[t] = (listeners[t] || []).filter((f) => f !== fn)
+  }
+  el.fire = (t) => (listeners[t] || []).slice().forEach((fn) => fn())
+  el.closest = () => root // set below once root exists
+  return el
+}
+
+let root
+
+// A reactive root that resolves `to:` selectors from a map and owns the trigger.
+function makeRoot(matches = {}) {
+  return {
+    isConnected: true,
+    id: "counter",
+    hidden: false,
+    getAttribute: () => null,
+    setAttribute: () => {},
+    removeAttribute: () => {},
+    dispatchEvent: () => {},
+    contains: () => false,
+    querySelectorAll: (sel) => matches[sel] ?? [],
+  }
+}
+
+// Build a controller with a scripted fetch. `responses` is consumed in order;
+// the last repeats. Each is {...response fields} or { reject: Error }.
+function buildController(responses, { rootMatches = {} } = {}) {
+  root = makeRoot(rootMatches)
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    const script = responses[Math.min(calls, responses.length - 1)]
+    calls++
+    if (script.reject) return Promise.reject(script.reject)
+    return Promise.resolve({
+      redirected: script.redirected ?? false,
+      ok: script.ok ?? true,
+      status: script.status ?? 200,
+      headers: { get: () => script.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(script.body ?? ""),
+    })
+  }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+// Fire a dispatch with an optimistic hint. `trigger` is the event target.
+function fireDispatch(controller, trigger, optimistic, extra = {}) {
+  const event = {
+    target: trigger,
+    params: { action: "toggle", params: "{}", optimistic, ...extra },
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+  return { promise: controller.dispatch(event), event }
+}
+
+// --- apply-on-dispatch ------------------------------------------------------
+
+test("add_class applies to the trigger immediately on dispatch (before the reply)", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  // Applied synchronously — before the fetch resolves.
+  expect(trigger.classes.has("busy")).toBe(true)
+  await promise
+})
+
+test("toggle_class toggles the trigger class on dispatch", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+  trigger.classes.add("done")
+
+  const { promise } = fireDispatch(controller, trigger, { toggle_class: ["done"] })
+  expect(trigger.classes.has("done")).toBe(false) // toggled off
+  await promise
+})
+
+test("hide: true hides the trigger on dispatch", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { hide: true })
+  expect(trigger.hidden).toBe(true)
+  await promise
+})
+
+test("a to: selector applies the hint to owned matches inside the root, not the trigger", async () => {
+  const badge = makeEl({ owner: null })
+  badge.closest = () => root
+  const { controller } = buildController([{}], { rootMatches: { ".badge": [badge] } })
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["on"], to: ".badge" })
+  expect(badge.classes.has("on")).toBe(true)
+  expect(trigger.classes.has("on")).toBe(false) // NOT the trigger
+  await promise
+})
+
+test("to: @root applies the hint to the root element itself", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { hide: true, to: "@root" })
+  expect(root.hidden).toBe(true)
+  await promise
+})
+
+// --- checked: :keep skips preventDefault ------------------------------------
+
+test("checked: :keep on a CLICK-bound checkbox trigger SKIPS preventDefault (native flip)", () => {
+  const { controller } = buildController([{}])
+  const checkbox = makeTrigger({ type: "checkbox" })
+
+  const { event } = fireDispatch(controller, checkbox, { checked: "keep" })
+  // The native checkbox flip must be allowed — preventDefault NOT called.
+  expect(event.defaultPrevented).toBe(false)
+})
+
+test("checked: :keep on a radio trigger also skips preventDefault", () => {
+  const { controller } = buildController([{}])
+  const radio = makeTrigger({ type: "radio" })
+
+  const { event } = fireDispatch(controller, radio, { checked: "keep" })
+  expect(event.defaultPrevented).toBe(false)
+})
+
+test("an element-bound NON-checkbox trigger still preventDefaults even with a hint", () => {
+  const { controller } = buildController([{}])
+  const button = makeTrigger({ type: "button" })
+
+  const { event } = fireDispatch(controller, button, { add_class: ["busy"] })
+  expect(event.defaultPrevented).toBe(true)
+})
+
+test("checked: :keep does NOT skip preventDefault for a non-checkbox element (a button)", () => {
+  const { controller } = buildController([{}])
+  const button = makeTrigger({ type: "button" })
+
+  const { event } = fireDispatch(controller, button, { checked: "keep" })
+  // A button has no native checkbox flip; the in-form submit default must still
+  // be prevented.
+  expect(event.defaultPrevented).toBe(true)
+})
+
+// --- revert on failure (each branch) ----------------------------------------
+
+test("add_class reverts (removes the class) when the action fails HTTP", async () => {
+  const { controller } = buildController([{ ok: false, status: 403 }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  expect(trigger.classes.has("busy")).toBe(true) // applied
+  await promise
+  expect(trigger.classes.has("busy")).toBe(false) // reverted on failure
+})
+
+test("remove_class reverts (re-adds the class) on failure", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+  trigger.classes.add("active")
+
+  const { promise } = fireDispatch(controller, trigger, { remove_class: ["active"] })
+  expect(trigger.classes.has("active")).toBe(false) // applied
+  await promise
+  expect(trigger.classes.has("active")).toBe(true) // reverted
+})
+
+test("toggle_class reverts (toggles back) on failure", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+  trigger.classes.add("done")
+
+  const { promise } = fireDispatch(controller, trigger, { toggle_class: ["done"] })
+  expect(trigger.classes.has("done")).toBe(false) // toggled off
+  await promise
+  expect(trigger.classes.has("done")).toBe(true) // toggled back on failure
+})
+
+test("hide reverts (shows again) on failure", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { hide: true })
+  expect(trigger.hidden).toBe(true)
+  await promise
+  expect(trigger.hidden).toBe(false) // shown again on failure
+})
+
+test("revert fires from the REDIRECTED branch", async () => {
+  const { controller } = buildController([{ redirected: true, status: 200 }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  await promise
+  expect(trigger.classes.has("busy")).toBe(false)
+})
+
+test("revert fires from the CONTENT-TYPE branch", async () => {
+  const { controller } = buildController([{ contentType: "text/html" }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  await promise
+  expect(trigger.classes.has("busy")).toBe(false)
+})
+
+test("revert fires from the NETWORK branch", async () => {
+  const { controller } = buildController([{ reject: new Error("offline") }])
+  const trigger = makeTrigger()
+  const originalError = console.error
+  console.error = () => {}
+  try {
+    const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+    await promise
+  } finally {
+    console.error = originalError
+  }
+  expect(trigger.classes.has("busy")).toBe(false)
+})
+
+test("revert fires from the APPLY branch (Turbo.renderStreamMessage throws)", async () => {
+  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
+  const { controller } = buildController([{ body: html }])
+  const trigger = makeTrigger()
+  globalThis.window.Turbo.renderStreamMessage = () => {
+    throw new Error("Turbo choked")
+  }
+  const originalError = console.error
+  console.error = () => {}
+  try {
+    const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+    await promise
+  } finally {
+    console.error = originalError
+    globalThis.window.Turbo.renderStreamMessage = () => {}
+  }
+  expect(trigger.classes.has("busy")).toBe(false)
+})
+
+// --- revert skipped when disconnected ---------------------------------------
+
+test("revert is SKIPPED when the root left the DOM (guarded by isConnected)", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  root.isConnected = false // a plain replace detached the subtree before the failure
+  await promise
+  // No revert attempted against a detached tree — the class stays as applied
+  // (the node is gone anyway; the point is we don't touch a stale element).
+  expect(trigger.classes.has("busy")).toBe(true)
+})
+
+// --- once per flush (debounce) ----------------------------------------------
+
+test("a debounced trigger applies the hint ONCE per flush, not per keystroke", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+  let toggles = 0
+  const realToggle = trigger.classList.toggle
+  trigger.classList.toggle = (c) => {
+    toggles++
+    return realToggle(c)
+  }
+
+  // Five rapid dispatches inside one debounce window.
+  for (let i = 0; i < 5; i++) {
+    fireDispatch(controller, trigger, { toggle_class: ["typing"] }, { debounce: 50 })
+    await wait(5)
+  }
+  // Nothing applied yet — the hint waits for the flush, so it can't flap per key.
+  expect(toggles).toBe(0)
+
+  await wait(80) // cross the quiet period → one flush → one apply
+  expect(toggles).toBe(1)
+  await controller.queue
+})
+
+// --- success leaves no revert artifacts -------------------------------------
+
+test("on success the hint is LEFT standing (no cleanup, no revert)", async () => {
+  const html = '<turbo-stream action="replace" target="counter"><template></template></turbo-stream>'
+  const { controller } = buildController([{ body: html }])
+  const trigger = makeTrigger()
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  await promise
+  // No revert on success — the server morph (or reply.remove) owns the truth.
+  expect(trigger.classes.has("busy")).toBe(true)
+})
+
+// --- no hint → untouched fast path ------------------------------------------
+
+test("no optimistic hint → dispatch behaves exactly as before (still preventDefaults, no ops)", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeTrigger()
+
+  const { event, promise } = fireDispatch(controller, trigger, undefined)
+  expect(event.defaultPrevented).toBe(true)
+  expect(trigger.classes.size).toBe(0)
+  await promise
+})

--- a/spec/javascript/reactive_optimistic.test.js
+++ b/spec/javascript/reactive_optimistic.test.js
@@ -42,6 +42,7 @@ function makeEl({ owner = null } = {}) {
     add: (...cs) => cs.forEach((c) => el.classes.add(c)),
     remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
     toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+    contains: (c) => el.classes.has(c),
   }
   return el
 }
@@ -230,6 +231,48 @@ test("remove_class reverts (re-adds the class) on failure", async () => {
   expect(trigger.classes.has("active")).toBe(false) // applied
   await promise
   expect(trigger.classes.has("active")).toBe(true) // reverted
+})
+
+// The revert must undo ONLY what the op actually changed — a class already
+// present (add is a no-op) must NOT be stripped on revert (CodeRabbit review).
+test("add_class revert does NOT strip a class that was already present", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+  trigger.classes.add("busy") // pre-existing — the add is a no-op
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy"] })
+  expect(trigger.classes.has("busy")).toBe(true) // still there (no-op add)
+  await promise
+  // The revert must leave the pre-existing class alone — we never added it.
+  expect(trigger.classes.has("busy")).toBe(true)
+})
+
+// Symmetric: a class already ABSENT (remove is a no-op) must NOT be re-added on
+// revert — else the revert introduces a class that was never there.
+test("remove_class revert does NOT re-add a class that was already absent", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger() // "gone" is absent — the remove is a no-op
+
+  const { promise } = fireDispatch(controller, trigger, { remove_class: ["gone"] })
+  expect(trigger.classes.has("gone")).toBe(false)
+  await promise
+  // The revert must not introduce a class that was never present.
+  expect(trigger.classes.has("gone")).toBe(false)
+})
+
+// A mixed add_class where ONE class is new and ONE pre-existing: revert removes
+// only the newly-added one, preserving the pre-existing.
+test("add_class revert removes only the newly-added classes, preserving pre-existing", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeTrigger()
+  trigger.classes.add("busy") // pre-existing
+
+  const { promise } = fireDispatch(controller, trigger, { add_class: ["busy", "dim"] })
+  expect(trigger.classes.has("busy")).toBe(true)
+  expect(trigger.classes.has("dim")).toBe(true) // newly added
+  await promise
+  expect(trigger.classes.has("busy")).toBe(true) // preserved
+  expect(trigger.classes.has("dim")).toBe(false) // only this one reverted
 })
 
 test("toggle_class reverts (toggles back) on failure", async () => {

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -624,6 +624,24 @@ RSpec.describe Phlex::Reactive::Component do
       expect { instance.send(:on, :toggle, optimistic: [%w[toggle_class done]]) }
         .to raise_error(ArgumentError, /optimistic/)
     end
+
+    # checked: :keep on a click trigger must NOT force type="button" — the hint's
+    # whole point is a native checkbox/radio flip, and a forced button type would
+    # destroy the control (issue #98). The caller supplies the real type.
+    it "skips the forced type=button for a click trigger with checked: :keep" do
+      attrs = instance.send(:on, :toggle, optimistic: { checked: :keep })
+      expect(attrs).not_to have_key(:type)
+    end
+
+    it "still forces type=button for a click trigger whose hint is NOT checked: :keep" do
+      attrs = instance.send(:on, :destroy, optimistic: { hide: true })
+      expect(attrs[:type]).to eq("button")
+    end
+
+    it "still forces type=button for a bare click trigger (no optimistic hint)" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:type]).to eq("button")
+    end
   end
 
   describe "#on_client (issue #95 — client-only DOM ops, zero round trip)" do

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -549,6 +549,83 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on optimistic hints (issue #98 — declared, reversible visual hints)" do
+    subject(:instance) { state_klass.new }
+
+    it "omits the optimistic param by default (bare on() hot path untouched)" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:data]).not_to have_key(:reactive_optimistic_param)
+    end
+
+    it "emits the optimistic hint hash as a JSON Stimulus param" do
+      attrs = instance.send(:on, :toggle, optimistic: { checked: :keep })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "checked" => "keep" })
+    end
+
+    it "serializes a class op with a single class string" do
+      attrs = instance.send(:on, :toggle, optimistic: { toggle_class: "done" })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "toggle_class" => ["done"] })
+    end
+
+    it "serializes a class op with an array of classes" do
+      attrs = instance.send(:on, :toggle, optimistic: { add_class: %w[busy dim] })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "add_class" => %w[busy dim] })
+    end
+
+    it "serializes remove_class" do
+      attrs = instance.send(:on, :toggle, optimistic: { remove_class: "active" })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "remove_class" => ["active"] })
+    end
+
+    it "serializes hide: true" do
+      attrs = instance.send(:on, :destroy, optimistic: { hide: true })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "hide" => true })
+    end
+
+    it "normalizes to: :root to the @root sentinel" do
+      attrs = instance.send(:on, :destroy, optimistic: { hide: true, to: :root })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "hide" => true, "to" => "@root" })
+    end
+
+    it "passes a to: CSS selector string through verbatim" do
+      attrs = instance.send(:on, :toggle, optimistic: { add_class: "on", to: ".badge" })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "add_class" => ["on"], "to" => ".badge" })
+    end
+
+    it "combines several hint ops in one hash (checked + class)" do
+      attrs = instance.send(:on, :toggle, event: "change", optimistic: { checked: :keep, toggle_class: "done" })
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param]))
+        .to eq({ "checked" => "keep", "toggle_class" => ["done"] })
+    end
+
+    it "keeps the optimistic hint out of the explicit params payload" do
+      attrs = instance.send(:on, :toggle, optimistic: { hide: true }, reason: "gone")
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "reason" => "gone" })
+    end
+
+    it "threads optimistic alongside confirm and debounce without collision" do
+      attrs = instance.send(:on, :destroy, confirm: "Sure?", debounce: 200, optimistic: { hide: true })
+      expect(attrs[:data][:reactive_confirm_param]).to eq("Sure?")
+      expect(attrs[:data][:reactive_debounce_param]).to eq(200)
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "hide" => true })
+    end
+
+    it "rejects an unknown hint op (default-deny — a dead hint must fail at build)" do
+      expect { instance.send(:on, :toggle, optimistic: { explode: true }) }
+        .to raise_error(ArgumentError, /explode/)
+    end
+
+    it "rejects a checked: value other than :keep" do
+      expect { instance.send(:on, :toggle, optimistic: { checked: :flip }) }
+        .to raise_error(ArgumentError, /checked/)
+    end
+
+    it "rejects a non-hash optimistic:" do
+      expect { instance.send(:on, :toggle, optimistic: [%w[toggle_class done]]) }
+        .to raise_error(ArgumentError, /optimistic/)
+    end
+  end
+
   describe "#on_client (issue #95 — client-only DOM ops, zero round trip)" do
     subject(:instance) { state_klass.new }
 

--- a/spec/system/optimistic_spec.rb
+++ b/spec/system/optimistic_spec.rb
@@ -6,18 +6,25 @@ require "system_helper"
 # small, reversible, cosmetic vocabulary the instant the trigger fires — before
 # the round trip — and reverts it if the action fails.
 #
-#   * checked: :keep — a click/change checkbox flips NATIVELY now (today the
-#     unconditional preventDefault suppresses the flip until the morph), and a
-#     companion toggle_class paints in the same gesture. The toggle action here
-#     sleeps 0.4s server-side so the flip is observable BEFORE the morph.
-#   * a failing action (undeclared :boom → default-deny 403) applies its
-#     add_class hint, then REVERTS it when the failure lands.
+#   * checked: :keep on a CLICK-bound checkbox flips NATIVELY now — the client
+#     skips the unconditional preventDefault that today suppresses the flip until
+#     the morph — and a companion toggle_class paints in the same gesture.
+#   * checked: :keep on a CHANGE-bound checkbox: the flip is already native
+#     (change isn't cancelable), so :keep only contributes the failure revert.
+#   * a failing action (:boom raises a registered authorization error → 403)
+#     applies its add_class hint, then REVERTS it when the failure lands.
 #   * hide: true + reply.remove is the instant delete recipe: the row hides now,
 #     the reply removes it — no flash-back.
 #
-# Runs under Puma (sync) AND Falcon (async) in CI's server matrix.
+# The toggle action sleeps 0.4s server-side so the optimistic flip is observable
+# BEFORE the morph reconciles it (client-first, not a race). Runs under Puma
+# (sync) AND Falcon (async) in CI's server matrix.
 RSpec.describe "Optimistic visual hints (issue #98)", type: :system do
-  it "flips a checkbox natively BEFORE the slow morph lands, then reconciles" do
+  # The core #98 regression: a CLICK-bound checkbox. If the skip-preventDefault
+  # branch broke, the client would preventDefault the click and the box would NOT
+  # flip until the (0.4s-delayed) morph — so the "checked BEFORE the morph"
+  # assertion below is exactly what guards it.
+  it "flips a CLICK-bound checkbox natively BEFORE the slow morph, then reconciles" do
     visit "/optimistic"
     page.execute_script("window.__noReload = 'alive'")
 
@@ -28,6 +35,8 @@ RSpec.describe "Optimistic visual hints (issue #98)", type: :system do
 
     # Client-first: the native flip + toggle_class paint immediately, while the
     # server (sleeping 0.4s) has NOT yet morphed — data-done is still "false".
+    # This flip only happens because dispatch() skipped preventDefault on the
+    # click-bound checkbox (the new #98 branch).
     expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check']\").checked")).to be(true)
     expect(page).to have_css("[data-testid='status'].is-done")
     expect(page).to have_css("[data-testid='opt-row'][data-done='false']") # morph not landed yet
@@ -38,18 +47,38 @@ RSpec.describe "Optimistic visual hints (issue #98)", type: :system do
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end
 
-  it "reverts the optimistic hint when the action fails (undeclared → 403)" do
+  # A CHANGE-bound checkbox: preventDefault is already a no-op on `change`, so the
+  # native flip happens regardless — :keep's job here is only the failure revert.
+  # The flip is still observable before the delayed morph.
+  it "keeps a CHANGE-bound checkbox flipped before the morph reconciles it" do
     visit "/optimistic"
     page.execute_script("window.__noReload = 'alive'")
 
-    boom = find("[data-testid='opt-boom']")
+    expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check-change']\").checked")).to be(false)
+
+    find("[data-testid='opt-check-change']").click
+
+    # Flipped natively and NOT reverted by the round trip (it succeeds); still
+    # ahead of the 0.4s morph.
+    expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check-change']\").checked")).to be(true)
+    expect(page).to have_css("[data-testid='opt-row'][data-done='true']") # morph reconciles
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "reverts the optimistic hint when the action fails (authorization → 403)" do
+    visit "/optimistic"
+    page.execute_script("window.__noReload = 'alive'")
+
     expect(page).to have_no_css("[data-testid='opt-boom'].pending")
 
-    boom.click
+    find("[data-testid='opt-boom']").click
 
-    # The hint was applied (add_class "pending"); when the 403 lands, the client
-    # replays the inverse (remove_class "pending"). The waiting matcher is the
-    # barrier for the async round trip + revert.
+    # The hint is applied IMMEDIATELY (add_class "pending" on the button itself);
+    # the boom action sleeps 0.4s before it fails, so this state is observable and
+    # a hint that never appeared can't pass this spec…
+    expect(page).to have_css("[data-testid='opt-boom'].pending")
+    # …then, when the 403 lands, the client replays the inverse (remove_class
+    # "pending"). The waiting matcher is the barrier for the async round trip.
     expect(page).to have_no_css("[data-testid='opt-boom'].pending")
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end
@@ -61,8 +90,10 @@ RSpec.describe "Optimistic visual hints (issue #98)", type: :system do
 
     find("[data-testid='opt-destroy']").click
 
-    # hide: true hid the row immediately (hidden), and reply.remove then removes
-    # the node entirely — either way it's gone and never reappears.
+    # hide: true hid the row IMMEDIATELY — assert the hidden state with no wait so
+    # this spec can't pass on a hint that never fired…
+    expect(page).to have_css("[data-testid='opt-row']", visible: :hidden, wait: 0)
+    # …then reply.remove removes the node entirely — it's gone and never reappears.
     expect(page).to have_no_css("[data-testid='opt-row']", visible: :all)
     expect(page.evaluate_script("window.__noReload")).to eq("alive")
   end

--- a/spec/system/optimistic_spec.rb
+++ b/spec/system/optimistic_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Optimistic visual hints (issue #98): on(..., optimistic: { … }) applies a
+# small, reversible, cosmetic vocabulary the instant the trigger fires — before
+# the round trip — and reverts it if the action fails.
+#
+#   * checked: :keep — a click/change checkbox flips NATIVELY now (today the
+#     unconditional preventDefault suppresses the flip until the morph), and a
+#     companion toggle_class paints in the same gesture. The toggle action here
+#     sleeps 0.4s server-side so the flip is observable BEFORE the morph.
+#   * a failing action (undeclared :boom → default-deny 403) applies its
+#     add_class hint, then REVERTS it when the failure lands.
+#   * hide: true + reply.remove is the instant delete recipe: the row hides now,
+#     the reply removes it — no flash-back.
+#
+# Runs under Puma (sync) AND Falcon (async) in CI's server matrix.
+RSpec.describe "Optimistic visual hints (issue #98)", type: :system do
+  it "flips a checkbox natively BEFORE the slow morph lands, then reconciles" do
+    visit "/optimistic"
+    page.execute_script("window.__noReload = 'alive'")
+
+    expect(page).to have_css("[data-testid='opt-row'][data-done='false']")
+    expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check']\").checked")).to be(false)
+
+    find("[data-testid='opt-check']").click
+
+    # Client-first: the native flip + toggle_class paint immediately, while the
+    # server (sleeping 0.4s) has NOT yet morphed — data-done is still "false".
+    expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check']\").checked")).to be(true)
+    expect(page).to have_css("[data-testid='status'].is-done")
+    expect(page).to have_css("[data-testid='opt-row'][data-done='false']") # morph not landed yet
+
+    # …then the morph reconciles from server truth: data-done becomes "true".
+    expect(page).to have_css("[data-testid='opt-row'][data-done='true']")
+    expect(page.evaluate_script("document.querySelector(\"[data-testid='opt-check']\").checked")).to be(true)
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "reverts the optimistic hint when the action fails (undeclared → 403)" do
+    visit "/optimistic"
+    page.execute_script("window.__noReload = 'alive'")
+
+    boom = find("[data-testid='opt-boom']")
+    expect(page).to have_no_css("[data-testid='opt-boom'].pending")
+
+    boom.click
+
+    # The hint was applied (add_class "pending"); when the 403 lands, the client
+    # replays the inverse (remove_class "pending"). The waiting matcher is the
+    # barrier for the async round trip + revert.
+    expect(page).to have_no_css("[data-testid='opt-boom'].pending")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "hides the row instantly, then reply.remove drops it (no flash-back)" do
+    visit "/optimistic"
+    page.execute_script("window.__noReload = 'alive'")
+    expect(page).to have_css("[data-testid='opt-row']")
+
+    find("[data-testid='opt-destroy']").click
+
+    # hide: true hid the row immediately (hidden), and reply.remove then removes
+    # the node entirely — either way it's gone and never reappears.
+    expect(page).to have_no_css("[data-testid='opt-row']", visible: :all)
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
## Summary

Adds `optimistic:` to `on(...)` — a small, **always-reversible**, cosmetic vocabulary applied the instant a reactive trigger fires and **reverted** if the round trip fails. Livewire's "flip it client-side, let the morph correct"; React's `useOptimistic`.

Before this, every interaction waited a full round trip for its first visual change — and it was worse than neutral for a checkbox: the client's unconditional `preventDefault` suppressed the native flip until the morph arrived, so an `on(:toggle)` checkbox never even flipped.

### API

```ruby
# A checkbox that flips instantly; the label paints in the same gesture. The
# morph reconciles from server truth; a failure snaps both back.
input(type: "checkbox", checked: @todo.done,
  **mix(on(:toggle, event: "change",
    optimistic: { checked: :keep, toggle_class: "is-done", to: ".status" }), name: "done"))

# Instant delete: hide the row NOW, remove it on the reply.
button(**on(:destroy, confirm: "Delete?", optimistic: { hide: true, to: :root })) { "Delete" }
# -> data-reactive-optimistic-param='{"hide":true,"to":"@root"}'
```

Supported hints: `toggle_class:`/`add_class:`/`remove_class:` (on the trigger, or a `to:` selector scoped to the root — `to: :root` targets the root itself), `checked: :keep` (a **click-bound** checkbox/radio skips `preventDefault` so it flips natively now), and `hide: true`.

### The load-bearing semantics

- **Once per flushed enqueue** — a debounced trigger applies the hint at flush, not per keystroke, so `toggle_class` can't flap.
- **Inverse stored on the queued request** — the serialized per-controller queue reverts the *right* request's hint.
- **Revert from every failure branch** — redirected / http / content-type / network + the client-side `apply` throw — guarded by `isConnected` (a detached row is skipped).
- **On success, no cleanup** — a root re-render overwrites the hint with server truth; a reply that does *not* re-render the root (`reply.remove`, streams-only) **leaves the hint standing**. That's the `hide: true` + `reply.remove` instant-delete recipe: the row hides, then removes, never flashing back.

`optimistic:` is now a **reserved keyword name** on `on(...)` (like `debounce:`/`confirm:`/`throttle:`/`listnav:`). It emits `data-reactive-optimistic-param` via the guarded-append pattern, so the **bare-`on()` hot path stays byte-identical** (the pin spec is green). An unknown hint op, a `checked:` value other than `:keep`, or a non-hash raises at render — default-deny.

## Test plan

- **Ruby** (`spec/phlex/reactive/component_spec.rb`, +14): per-op JSON emission, `to: :root` → `@root`, unknown-op / bad-`checked` / non-hash raise; the bare-`on()` byte-identical pin stays green.
- **bun** (`spec/javascript/reactive_optimistic.test.js`, 21, RED first): apply + inverse-revert per op; click `checked: :keep` skips `preventDefault` while an element-bound non-checkbox still prevents; revert from each failure branch; revert skipped when disconnected; debounced applies once per flush; success leaves no revert artifacts.
- **System** (`spec/system/optimistic_spec.rb`, Puma AND Falcon): checkbox flips *before* a deliberately-slow (`sleep 0.4`) morph then reconciles; a failing action (undeclared `:boom` → default-deny 403) snaps the `add_class` hint back; delete-row hides instantly then `reply.remove` drops it.

## Verification

- [x] `bundle exec rubocop` — clean (131 files)
- [x] `bundle exec rspec spec/phlex spec/requests` — 397 passed
- [x] `bun test spec/javascript` — 154 passed (vendored client re-synced)
- [x] `spec/system` under Puma AND Falcon — 41 examples each, 0 failures

## Invariants held

No client state (hints are server-declared cosmetic ops) · default-deny (unknown hint raises) · ONE generic controller (integrates with the existing `#emitError` retry machinery from #89, no parallel error path) · pgbus optional · self-targeting `#id` · bare-`on()` emission byte-identical.

Closes #98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimistic visual hints for reactive actions, so certain UI updates can appear immediately and then stay or revert based on the server response.
  * Expanded support for immediate checkbox, class, and hide behaviors during action requests.
  * Added a demo page showcasing optimistic interactions in the app.

* **Bug Fixes**
  * Improved recovery when requests fail, including restoring the UI after errors, redirects, or invalid responses.

* **Documentation**
  * Updated the API docs and changelog to describe the new optimistic hint options and supported behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->