### PR TITLE
feat(component): declarative loading states — loading:/disable_with: + busy_on (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Declarative loading states — `loading:` / `disable_with:` on `on(...)` +
+  `busy_on(:action)` (#99).** Between the click and the morph the UI was fully
+  live and unchanged: no per-trigger feedback, buttons stayed enabled, and a
+  rapid double-click enqueued a full duplicate POST (the queue serializes tokens,
+  it does not dedupe). This adds Livewire's `wire:loading` + `phx-disable-with`
+  without a Stimulus controller. `disable_with: "Saving…"` disables the trigger
+  and swaps its text while pending — and because a disabled button fires no
+  further clicks, a double-click now enqueues exactly **one** POST (the disable
+  is the dedup). `loading: { disable:, class:, text:, to: }` is the full form:
+  a loading class on the trigger or a `to:` target, plus disable + text. Both
+  apply at **enqueue** (covering the queue wait, not just the fetch) and revert
+  on settle — **guarded** so a disconnected trigger is skipped and a
+  server-rendered new label is never clobbered; the disable/text swap deliberately
+  do NOT apply during a `debounce:` quiet period, so a debounced `input` is not
+  disabled mid-typing. Independently, **every** round trip now carries an
+  always-on busy vocabulary for the whole enqueue→settle window — no Ruby needed:
+  `data-reactive-busy="<action>"` on the trigger and root (a **space-separated
+  set** on the root so concurrent actions don't clobber), `aria-busy` on the root
+  (via a **pending counter**, cleared only when the last request settles), and
+  `busy_on(:action)` to scope `data-reactive-busy` onto a spinner only while that
+  action is in flight. Style it with pure CSS (`[data-reactive-busy] .spinner { … }`).
+  The trigger is now captured from `event.currentTarget` (not `event.target`), so
+  a `<button><span>` click disables/relabels the button, not the inner span.
+  Emitted as `data-reactive-loading-param` (JSON) via the guarded-append pattern,
+  so the bare-`on()` hot path stays byte-identical. **`loading:` and
+  `disable_with:` are now RESERVED keyword names on `on(...)`** — like
+  `debounce:`/`confirm:`/`throttle:`/`optimistic:`, they can no longer be used as
+  free action params.
 - **`optimistic:` on `on(...)` — declared, reversible visual hints (#98).**
   Reactive interactions no longer wait a full round trip for their first visual
   change — and a checkbox no longer fails to flip at all (the client's

--- a/README.md
+++ b/README.md
@@ -326,6 +326,9 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `on(:close_menu, outside: true)` | Fire only for events **outside** this component's root (close-a-dropdown-on-outside-click). Window-bound; never `preventDefault`s, so links elsewhere keep navigating. |
 | `on(:track, event: "scroll", window: true, throttle: 250)` | `window:` binds the trigger to the window (page-level scroll/resize); `throttle:` rate-limits leading-edge — first event fires, the rest drop until the window elapses. Mutually exclusive with `debounce:`. |
 | `on(:toggle, optimistic: { checked: :keep })` | Apply a reversible **visual hint** the instant the trigger fires (before the round trip); revert it if the action fails. Cosmetic only. See [Optimistic hints](#optimistic-visual-hints-optimistic). |
+| `on(:save, disable_with: "Saving…")` | Disable the trigger + swap its text while the action is pending (a disabled button also swallows a rapid double-click). Shorthand for `loading: { disable: true, text: "Saving…" }`. See [Loading states](#declarative-loading-states-loading--disable_with). |
+| `on(:save, loading: { disable: true, class: "opacity-50", text: "…" })` | Full loading form: `disable:`, a loading `class:` (on the trigger or a `to:` target), a `text:` swap. Reverts on settle. |
+| `busy_on(:save)` | Mark any element so it carries `data-reactive-busy` **only while `save` is in flight** — a spinner styled with pure CSS, zero Ruby. See [Loading states](#declarative-loading-states-loading--disable_with). |
 | `on(:action, once: true)` | Fire at most once, then unbind (Stimulus's native `:once`). |
 | `on_client(:click, js.toggle("#menu"))` | **Client-only** trigger: applies declared DOM ops with ZERO round trip — no token, no POST, ever. Takes the same `window:`/`once:`/`outside:` modifiers. See [Client-only ops](#client-only-ops-on_client--js--zero-round-trips). |
 | `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute, with an optional `transition:`), `add_class`/`remove_class`/`toggle_class`, `set_attr`/`remove_attr`/`toggle_attr` (allowlisted names), `focus`/`focus_first`, and `dispatch` — chainable. |
@@ -521,6 +524,81 @@ button(**on(:destroy, confirm: "Delete?", optimistic: { hide: true, to: :root })
 `optimistic:` (like `debounce:`/`confirm:`/`throttle:`) is a **reserved keyword
 name** on `on(...)`. An unknown hint op, a `checked:` value other than `:keep`,
 or a non-hash raises at render — a dead hint fails loudly, never silently.
+
+### Declarative loading states (`loading:` / `disable_with:`)
+
+Between the click and the morph, the user needs to see that something is
+happening — and a mutating button needs to stop a rapid double-click from firing
+twice. `loading:` / `disable_with:` are Livewire's `wire:loading` +
+`phx-disable-with` and LiveView's `phx-click-loading`, without a Stimulus
+controller. Both are **reserved keyword names** on `on(...)`.
+
+The moment a request is **enqueued** — covering the queue wait, not just the
+fetch — the trigger and root get the always-on busy vocabulary, and (if declared)
+the loading hint applies; everything reverts when the round trip settles
+(success **or** failure), guarded so a re-rendered trigger is never clobbered.
+
+**`disable_with:` — the common case.** Disable the trigger and swap its text
+while pending. A disabled button fires no further clicks, so a rapid double-click
+enqueues exactly **one** POST (the queue only serializes tokens — it does not
+dedupe; the disable is what dedupes):
+
+```ruby
+button(**on(:save, disable_with: "Saving…")) { "Save" }
+```
+
+**`loading:` — the full form.** A hash of:
+
+- `disable: true` — disable the trigger while pending.
+- `class: "…"` / `[ … ]` — a loading class on the **trigger**, or on a `to:`
+  selector scoped to the root (`to: :root` targets the root element itself).
+- `text: "Saving…"` — swap the trigger's `textContent` while pending.
+
+```ruby
+button(**on(:destroy, confirm: "Sure?", loading: { disable: true, class: "opacity-50 pointer-events-none" })) { "Delete" }
+```
+
+`disable_with: "Saving…"` is the shorthand for `{ disable: true, text: "Saving…" }`
+and, if you pass both, merges over an explicit `loading:` (its `text`/`disable`
+win). An unknown loading key or a non-hash `loading:` raises at render.
+
+**The `aria-busy` + `data-reactive-busy` contract (always on — zero Ruby).**
+Independent of any `loading:` hint, **every** reactive round trip marks the DOM
+for the whole enqueue→settle window, so you can style spinners and dimming with
+pure CSS:
+
+- the **trigger** and the **root** carry `data-reactive-busy="<action>"` (a
+  **space-separated set** on the root, so two concurrent actions never clobber);
+- the **root** carries `aria-busy="true"` (driven by a pending counter — it
+  clears only when the last in-flight request settles, so overlapping actions
+  don't clear it early);
+- `busy_on(:action)` marks any element inside the root so **it** gets
+  `data-reactive-busy` toggled **only while that action is in flight** — a scoped
+  spinner:
+
+```ruby
+button(**on(:save, disable_with: "Saving…")) { "Save" }
+span(**busy_on(:save), class: "spinner")
+```
+
+phlex-reactive ships **no CSS** for these — you own the styling. A minimal
+example (not shipped — copy into your app's stylesheet):
+
+```css
+/* Reveal a busy_on / aria-busy spinner only while its action is in flight. */
+.spinner { display: none; }
+[data-reactive-busy] .spinner,
+[data-reactive-busy].spinner { display: inline-block; }
+
+/* Dim the whole component during any round trip. */
+[aria-busy="true"] { opacity: 0.6; transition: opacity 120ms ease; }
+```
+
+The disable + text swap apply **only at enqueue**, never during a `debounce:`
+quiet period — so a debounced `input` trigger (whose element *is* the text field)
+is not disabled mid-typing. On settle the text is restored only if it still
+matches what was swapped in; a morph that rendered a **new** server label is left
+alone.
 
 ### Client-only ops (`on_client` + `js`) — zero round trips
 

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -339,6 +339,12 @@ export default class extends Controller {
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
+  // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
+  // refcount correctly and never clobber each other:
+  #busyPending = 0 // root aria-busy pending counter (remove only at zero)
+  #busyActions = new Map() // action -> in-flight count (root's space-separated busy set + busy_on)
+  #busyTokenCounts = new WeakMap() // element -> Map(action -> count): its data-reactive-busy token set
+  #loadingSnapshots = new Map() // trigger element -> { count, disabled, text } refcounted snapshot
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -385,7 +391,8 @@ export default class extends Controller {
     // modifier params (issue #80). The client decides preventDefault behavior
     // from event.params — set by the Ruby on() — never by sniffing the
     // Stimulus descriptor.
-    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic } = event.params
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic, loading } =
+      event.params
     if (!action) return
 
     // Outside guard FIRST (issue #80): an outside: trigger only fires for
@@ -396,9 +403,14 @@ export default class extends Controller {
     // lifecycle event (nothing to announce, nothing to veto).
     if (outside && this.element.contains(event.target)) return
 
-    // Capture the trigger element now; #proceed runs in a later microtask (after
-    // the confirm resolver settles), by which point event.target may be reset.
-    const target = event.target
+    // The trigger is event.currentTarget — the element on(...) was spread onto —
+    // NOT event.target (issue #99). A `<button><span>Save</span></button>` click
+    // has target === the span, which carries no params and is the wrong element
+    // to disable / swap text on. currentTarget is the bound element; fall back to
+    // target for a directly-invoked/synthetic event. Captured now because
+    // #proceed runs in a later microtask (after the confirm resolver), by which
+    // point currentTarget is reset to null.
+    const target = event.currentTarget ?? event.target
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -424,7 +436,7 @@ export default class extends Controller {
     if (!windowBound && !this.#keepsNativeToggle(optimistic, target)) event.preventDefault()
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic, loading)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -441,7 +453,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic)
+        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic, loading)
       })
   }
 
@@ -626,7 +638,7 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce, throttle, optimistic) {
+  #proceed(target, action, params, debounce, throttle, optimistic, loading) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
     // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
     // PRE-throttle, the same timing). event.preventDefault() skips the
@@ -644,19 +656,21 @@ export default class extends Controller {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
-    // The optimistic hint (issue #98) rides to the flush too, so it applies ONCE
-    // per enqueue — a debounced trigger must not flap toggle_class per keystroke.
+    // The optimistic hint (issue #98) and the loading state (issue #99) ride to
+    // the flush too, so they apply ONCE per enqueue — a debounced input must not
+    // flap toggle_class per keystroke, and its element must NOT be disabled
+    // during the quiet period (that would break typing). Both apply at ENQUEUE.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic)
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic, loading)
 
     // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
     // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
     // event immediately, drop the rest until the window elapses. debounce and
     // throttle are mutually exclusive (the Ruby on() raises on both).
     const throttleMs = Number(throttle) || 0
-    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic)
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic, loading)
 
-    return this.#enqueue(action, params, optimistic, target)
+    return this.#enqueue(action, params, optimistic, target, loading)
   }
 
   // Apply the optimistic hint ONCE (recording its inverse) and chain the round
@@ -664,21 +678,30 @@ export default class extends Controller {
   // per-controller queue reverts the RIGHT request's hint on failure (issue
   // #98). Applying here — the single flush/enqueue point every path funnels
   // through — is what makes a hint apply once per enqueue, not per raw dispatch.
-  #enqueue(action, params, optimistic, target) {
+  //
+  // The loading state (issue #99) applies here too, for the same reason: enqueue
+  // is the moment the request is committed to the queue, so the always-on busy
+  // vocabulary (data-reactive-busy on the trigger + root, aria-busy via a pending
+  // counter, busy_on scoping) and the loading hint (disable + class + text swap)
+  // cover the WHOLE pending window — queue wait included — not just the fetch. It
+  // returns a `settle` closure that #perform runs in its finally (success OR
+  // failure), guarded so a morph-replaced trigger is never clobbered.
+  #enqueue(action, params, optimistic, target, loading) {
     const inverse = this.#applyOptimistic(optimistic, target)
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse))
+    const settle = this.#applyLoading(action, target, loading)
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse, settle))
     return this.queue
   }
 
   // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
   // Also flush immediately on blur so leaving the field never drops the last
   // edit (a long debounce shouldn't swallow a value the user tabbed away from).
-  #debounceDispatch(target, ms, action, params, optimistic) {
+  #debounceDispatch(target, ms, action, params, optimistic, loading) {
     this.#clearDebounce(target)
 
     const flush = () => {
       this.#clearDebounce(target)
-      this.#enqueue(action, params, optimistic, target)
+      this.#enqueue(action, params, optimistic, target, loading)
     }
     const timer = setTimeout(flush, ms)
     target?.addEventListener?.("blur", flush, { once: true })
@@ -706,7 +729,7 @@ export default class extends Controller {
   // are keyed on action + target, NOT target alone: window-bound scroll/resize
   // events all share event.target === document, so two window-bound triggers
   // on one component would otherwise collide on one timer.
-  #throttleDispatch(target, ms, action, params, optimistic) {
+  #throttleDispatch(target, ms, action, params, optimistic, loading) {
     const timers = this.#throttleTimers.get(target) ?? new Map()
     if (timers.has(action)) return // inside the window — suppress
 
@@ -716,7 +739,7 @@ export default class extends Controller {
     }, ms)
     timers.set(action, timer)
     this.#throttleTimers.set(target, timers)
-    return this.#enqueue(action, params, optimistic, target) // leading edge: fire NOW
+    return this.#enqueue(action, params, optimistic, target, loading) // leading edge: fire NOW
   }
 
   // Clear every throttle suppression timer (used on disconnect, alongside
@@ -761,7 +784,7 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
-  async #perform(action, params, inverse) {
+  async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
     // chosen file inputs in the SAME walk. Explicit params
@@ -780,7 +803,9 @@ export default class extends Controller {
       ? this.#buildFormData(token, action, allParams, files)
       : JSON.stringify({ token, act: action, params: allParams })
 
-    this.element.setAttribute("aria-busy", "true")
+    // aria-busy on the root is now driven by the loading pending counter
+    // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
+    // set here. #settleLoading in the finally clears it — see #enqueue.
 
     try {
       let response
@@ -869,7 +894,11 @@ export default class extends Controller {
       this.#revertOptimistic(inverse)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
-      this.element.removeAttribute("aria-busy")
+      // Settle the loading state (issue #99): decrement the pending counter,
+      // drop the trigger's/root's busy tokens, restore disabled/text/class —
+      // guarded so a morph-replaced trigger is never clobbered. Runs on EVERY
+      // exit (success, every failure branch, or an apply throw).
+      settle?.()
     }
   }
 
@@ -1163,6 +1192,165 @@ export default class extends Controller {
   #optimisticTargets(optimistic, trigger) {
     if (optimistic.to == null) return trigger ? [trigger] : []
     return this.#opTargets({ to: optimistic.to })
+  }
+
+  // Apply the loading state for THIS enqueue (issue #99) and return a `settle`
+  // closure that undoes exactly this enqueue's contribution when the round trip
+  // finishes (success OR any failure). Everything is refcounted so overlapping
+  // enqueues never clobber: A's settle can't clear busy while B is still pending.
+  //
+  // Two layers:
+  //   1. The ALWAYS-ON busy vocabulary (fires for every action, no hint needed):
+  //      data-reactive-busy="<action>" on the trigger and the root (a
+  //      space-separated, per-action refcounted set), aria-busy on the root (a
+  //      pending counter), and data-reactive-busy on any busy_on element scoped
+  //      to this action. Apps style a spinner with pure CSS and zero Ruby.
+  //   2. The loading HINT (only when loading:/disable_with: was declared):
+  //      disable the trigger, add a loading class (to the trigger or a `to:`
+  //      target), swap its text. These apply at ENQUEUE — never during a debounce
+  //      quiet period — so a debounced input is not disabled mid-typing.
+  #applyLoading(action, trigger, loading) {
+    this.#markBusy(action, trigger)
+    const restoreHint = this.#applyLoadingHint(action, trigger, loading)
+
+    let settled = false
+    return () => {
+      if (settled) return // one settle per enqueue, even if called twice
+      settled = true
+      this.#unmarkBusy(action, trigger)
+      restoreHint()
+    }
+  }
+
+  // Layer 1 — the always-on busy markers. Trigger + root carry the action token;
+  // the root's counter drives aria-busy; busy_on elements scoped to this action
+  // light up. Refcounts (#busyActions, #busyPending) so overlapping requests
+  // don't clear each other.
+  #markBusy(action, trigger) {
+    this.#setBusyToken(trigger, action, +1)
+    this.#setBusyToken(this.element, action, +1)
+
+    this.#busyActions.set(action, (this.#busyActions.get(action) ?? 0) + 1)
+    if (this.#busyPending++ === 0) this.element.setAttribute("aria-busy", "true")
+
+    for (const el of this.#busyOnTargets(action)) this.#setBusyToken(el, action, +1)
+  }
+
+  #unmarkBusy(action, trigger) {
+    this.#setBusyToken(trigger, action, -1)
+    this.#setBusyToken(this.element, action, -1)
+
+    const count = (this.#busyActions.get(action) ?? 1) - 1
+    if (count <= 0) this.#busyActions.delete(action)
+    else this.#busyActions.set(action, count)
+
+    if (--this.#busyPending <= 0) {
+      this.#busyPending = 0
+      this.element.removeAttribute("aria-busy")
+    }
+
+    for (const el of this.#busyOnTargets(action)) this.#setBusyToken(el, action, -1)
+  }
+
+  // Add (+1) or remove (-1) `action` from an element's space-separated
+  // data-reactive-busy token set, refcounted PER ELEMENT+ACTION so two queued
+  // requests of the same action on the same element don't drop the token early
+  // (and two DIFFERENT actions both keep their token — the set never clobbers).
+  // The attribute is removed only when the set empties. No-op on a nullish/
+  // detached element (a morph may have replaced the trigger before settle).
+  #setBusyToken(el, action, delta) {
+    if (!el || typeof el.getAttribute !== "function") return
+
+    const counts = (this.#busyTokenCounts.get(el) ?? new Map())
+    const next = (counts.get(action) ?? 0) + delta
+    if (next <= 0) counts.delete(action)
+    else counts.set(action, next)
+
+    if (counts.size === 0) {
+      this.#busyTokenCounts.delete(el)
+      el.removeAttribute("data-reactive-busy")
+      return
+    }
+    this.#busyTokenCounts.set(el, counts)
+    el.setAttribute("data-reactive-busy", [...counts.keys()].join(" "))
+  }
+
+  // busy_on elements scoped to THIS action, owned by this root (not a nested
+  // reactive root's, issue #15). data-reactive-busy-on="<action>" is the marker
+  // busy_on(:action) emits.
+  #busyOnTargets(action) {
+    const nodes = this.element.querySelectorAll?.("[data-reactive-busy-on]") ?? []
+    return [...nodes].filter(
+      (el) => el.getAttribute("data-reactive-busy-on") === action && this.#ownsField(el),
+    )
+  }
+
+  // Layer 2 — the loading HINT (disable + class + text). Snapshots the trigger's
+  // ORIGINAL disabled/text/classes on the FIRST enqueue for that trigger
+  // (refcounted so an overlapping enqueue never snapshots the already-swapped
+  // "Saving…" as the original), applies the swap, and returns a restore closure.
+  // With no hint, returns a no-op restore (the always-on busy markers still ran).
+  #applyLoadingHint(action, trigger, loading) {
+    if (!loading || !trigger) return () => {}
+
+    const classTargets = this.#loadingTargets(loading, trigger)
+    const classes = Array.isArray(loading.class) ? loading.class : []
+    const addedByTarget = []
+    for (const el of classTargets) {
+      const added = classes.filter((c) => !el.classList.contains(c))
+      el.classList.add(...added)
+      if (added.length) addedByTarget.push([el, added])
+    }
+
+    // Snapshot disabled/text ONCE per trigger (refcounted). A second overlapping
+    // enqueue increments the count but does NOT re-snapshot — so the recorded
+    // "original" is the true pre-loading state, never the swapped label.
+    const snap = this.#loadingSnapshots.get(trigger)
+    if (snap) {
+      snap.count++
+    } else if (loading.disable || loading.text != null) {
+      this.#loadingSnapshots.set(trigger, {
+        count: 1,
+        disabled: trigger.disabled,
+        text: trigger.textContent,
+        hadText: loading.text != null,
+      })
+    }
+
+    if (loading.disable) trigger.disabled = true
+    if (loading.text != null) trigger.textContent = loading.text
+
+    return () => {
+      for (const [el, added] of addedByTarget) if (el.isConnected) el.classList.remove(...added)
+      this.#restoreLoadingSnapshot(trigger, loading)
+    }
+  }
+
+  // Restore the trigger's disabled/text from its snapshot when the LAST enqueue
+  // for that trigger settles (refcount → 0). GUARDED: skip a disconnected
+  // trigger (a plain replace detached it — the node is gone), and do NOT restore
+  // the text if it no longer equals what we swapped IN (a morph rendered a new
+  // server label — clobbering it with the old text would fight server truth).
+  #restoreLoadingSnapshot(trigger, loading) {
+    const snap = this.#loadingSnapshots.get(trigger)
+    if (!snap) return
+    if (--snap.count > 0) return // another enqueue for this trigger is still pending
+    this.#loadingSnapshots.delete(trigger)
+
+    if (!trigger.isConnected) return // detached — nothing to restore
+
+    if (loading.disable) trigger.disabled = snap.disabled
+    // Only restore the label if the trigger still shows OUR swapped text; a
+    // changed textContent means the server morph relabeled it — leave it.
+    if (snap.hadText && trigger.textContent === loading.text) trigger.textContent = snap.text
+  }
+
+  // The elements a loading class applies to: the `to:` selector (resolved like
+  // an op target — "@root" is the root, a selector is scoped to this root's
+  // owned matches) or, with no `to:`, the trigger itself.
+  #loadingTargets(loading, trigger) {
+    if (loading.to == null) return trigger ? [trigger] : []
+    return this.#opTargets({ to: loading.to })
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -450,8 +450,30 @@ module Phlex
       #   input(type: "checkbox", checked: @todo.done,
       #     **mix(on(:toggle, event: "change", optimistic: { checked: :keep }), name: "done"))
       #   button(**on(:destroy, confirm: "Delete?", optimistic: { hide: true, to: :root })) { "Delete" }
+      # `loading:` / `disable_with:` (issue #99) — declarative per-trigger loading
+      # states, Livewire's wire:loading + phx-disable-with without a Stimulus
+      # controller. The moment the request is ENQUEUED (covering the queue wait,
+      # not just the fetch), the trigger gets `data-reactive-busy="<action>"`, an
+      # optional loading class, an optional disabled + text swap; all revert in a
+      # guarded finally. `loading:` is a hash:
+      #   * disable: true         — disable the trigger while pending
+      #   * class: "…" / [ … ]    — a loading class string/array on the trigger
+      #                             (or a `to:` selector scoped to the root)
+      #   * text: "Saving…"       — swap the trigger's textContent while pending
+      #   * to: :root / "sel"     — target the class/text at the root or a selector
+      # `disable_with: "Saving…"` is the shorthand for
+      # `{ disable: true, text: "Saving…" }` and merges over an explicit `loading:`
+      # (its text/disable win). Both become RESERVED on() kwargs (CHANGELOG note,
+      # like #80's four and #98's optimistic:) — no longer free action-param names.
+      # The trigger/root also always carry `data-reactive-busy` for the whole
+      # pending window regardless of these hints, so an app styles a spinner with
+      # `[data-reactive-busy] .spinner { display: block }` and zero Ruby; see
+      # busy_on for scoped indicators.
+      #   button(**on(:save, disable_with: "Saving…")) { "Save" }
+      #   button(**on(:destroy, confirm: "Sure?", loading: { class: "opacity-50" })) { "Delete" }
       def on(action_name, event: "click", debounce: nil, throttle: nil, confirm: nil, listnav: nil,
-             window: false, once: false, outside: false, optimistic: nil, **params)
+             window: false, once: false, outside: false, optimistic: nil, loading: nil, disable_with: nil,
+             **params)
         if debounce && throttle
           raise ArgumentError,
             "on(#{action_name.inspect}) got both debounce: and throttle: — they are mutually " \
@@ -473,6 +495,9 @@ module Phlex
         attrs[:data][:reactive_confirm_param] = confirm if confirm
         attrs[:data][:reactive_listnav_option_param] = listnav if listnav
         attrs[:data][:reactive_optimistic_param] = optimistic_hint_json(optimistic, action_name) if optimistic
+        if (loading_hint = loading_hint_json(loading, disable_with, action_name))
+          attrs[:data][:reactive_loading_param] = loading_hint
+        end
         # STRING "true", not boolean: Phlex renders a `true` attribute VALUELESS
         # (data-reactive-outside-param), which Stimulus's param reader sees as ""
         # — falsy in JS, so the guard silently never fires. The explicit ="true"
@@ -555,6 +580,16 @@ module Phlex
       #   reactive_input(:value, value: @record.name, type: "text")
       def reactive_input(param, **attrs)
         input(**reactive_field(param, **attrs))
+      end
+
+      # Scoped busy indicator (issue #99). Marks an element so the generic
+      # controller toggles `data-reactive-busy` on it ONLY while `action` is in
+      # flight — the scoped sibling of the always-on `data-reactive-busy` the
+      # trigger and root carry. Spread onto any element inside the reactive root;
+      # style it with `[data-reactive-busy] { … }` and zero Ruby:
+      #   span(**busy_on(:save), class: "spinner hidden")
+      def busy_on(action)
+        { data: { reactive_busy_on: action.to_s } }
       end
 
       # Data attributes declaring a client-side compute for the root element.
@@ -664,6 +699,53 @@ module Phlex
               "on(#{action_name.inspect}) got an unknown optimistic hint #{key.inspect} — " \
               "supported: toggle_class/add_class/remove_class, checked: :keep, hide: true, to:"
           end
+        end
+
+        hint.to_json
+      end
+
+      # Normalize + validate the loading hint (issue #99), returning its JSON wire
+      # form (data-reactive-loading-param) or nil when neither loading: nor
+      # disable_with: is given (the bare on() hot path stays untouched).
+      # disable_with: "Saving…" expands to { disable: true, text: … } and MERGES
+      # over an explicit loading: hash — its text/disable win. `to: :root` becomes
+      # the "@root" sentinel the js op builder uses so the client resolves targets
+      # uniformly. An unknown key or a non-hash loading: raises — a dead hint must
+      # fail loudly at render, not silently in the browser (default-deny).
+      def loading_hint_json(loading, disable_with, action_name)
+        return nil if loading.nil? && disable_with.nil?
+
+        source = loading || {}
+        unless source.is_a?(Hash)
+          raise ArgumentError,
+            "on(#{action_name.inspect}) loading: must be a Hash of loading hints " \
+            "(e.g. { disable: true, class: \"opacity-50\", text: \"Saving…\" }), got #{loading.class}"
+        end
+
+        hint = {}
+        source.each do |key, value|
+          case key.to_s
+          when "class"
+            hint["class"] = Array(value).map(&:to_s)
+          when "disable"
+            hint["disable"] = value ? true : false
+          when "text"
+            hint["text"] = value.to_s
+          when "to"
+            hint["to"] = value == :root ? Phlex::Reactive::JS::ROOT_SENTINEL : value.to_s
+          else
+            raise ArgumentError,
+              "on(#{action_name.inspect}) got an unknown loading hint #{key.inspect} — " \
+              "supported: disable:, class:, text:, to:"
+          end
+        end
+
+        # disable_with: "Saving…" ≡ { disable: true, text: … }, applied AFTER the
+        # explicit loading: hash so it wins on both keys (the shorthand is the
+        # more specific intent when a caller passes both).
+        if disable_with
+          hint["disable"] = true
+          hint["text"] = disable_with.to_s
         end
 
         hint.to_json

--- a/spec/dummy/app/components/loading_button_component.rb
+++ b/spec/dummy/app/components/loading_button_component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Exercises declarative loading states (issue #99) end-to-end:
+#
+#   * on(:save, disable_with: "Saving…") — the button DISABLES and swaps its
+#     text to "Saving…" the instant the request is enqueued, and reverts when the
+#     round trip settles. Because a disabled button fires no further clicks, a
+#     rapid double-click enqueues exactly ONE POST — so @count bumps by one, not
+#     two (the disable IS the dedup; the queue only serializes, it doesn't dedupe).
+#   * busy_on(:save) — a spinner element that carries data-reactive-busy only
+#     while `save` is in flight, styled with pure CSS (no Ruby).
+#
+# The save action sleeps briefly so the browser spec can observe the disabled +
+# "Saving…" + spinner state DISTINCTLY before the morph reconciles — and so a
+# second click lands inside the pending window (proving the dedup).
+class LoadingButtonComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+
+  action :save
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = "loading-button"
+
+  def save
+    # Deliberate delay so the disabled + "Saving…" + spinner state is observable
+    # BEFORE the morph lands, and so a rapid second click falls inside the pending
+    # window (where the disabled button swallows it) — proving the dedup-to-one.
+    sleep 0.4
+    @count += 1
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      button(**mix(on(:save, disable_with: "Saving…"), data: { testid: "save" })) { "Save" }
+      # A scoped busy indicator: data-reactive-busy toggles ONLY while save is in
+      # flight, so `[data-reactive-busy] { … }` reveals it with zero Ruby.
+      span(**mix(busy_on(:save), data: { testid: "spinner" })) { "…" }
+      span(data: { testid: "count" }) { @count.to_s }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -110,6 +110,13 @@ class DemosController < ActionController::Base
     render html: %(<ul>#{component}</ul>).html_safe, layout: true
   end
 
+  # Declarative loading states (issue #99): a disable_with button that disables +
+  # swaps its text while a slow save runs, so a rapid double-click enqueues only
+  # ONE POST (the disabled button swallows the second), plus a busy_on spinner.
+  def loading_button
+    render_component LoadingButtonComponent.new(count: 0)
+  end
+
   def morph_grid
     render_component MorphGridComponent.new(account: Account.find(params[:id]))
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "client_tabs" => "demos#client_tabs"
   get "confirm" => "demos#confirm"
   get "optimistic" => "demos#optimistic"
+  get "loading_button" => "demos#loading_button"
   get "morph_grid/:id" => "demos#morph_grid"
   get "js_focus/:id" => "demos#js_focus"
   get "partial_grid/:id" => "demos#partial_grid"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -339,6 +339,12 @@ export default class extends Controller {
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
+  // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
+  // refcount correctly and never clobber each other:
+  #busyPending = 0 // root aria-busy pending counter (remove only at zero)
+  #busyActions = new Map() // action -> in-flight count (root's space-separated busy set + busy_on)
+  #busyTokenCounts = new WeakMap() // element -> Map(action -> count): its data-reactive-busy token set
+  #loadingSnapshots = new Map() // trigger element -> { count, disabled, text } refcounted snapshot
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -385,7 +391,8 @@ export default class extends Controller {
     // modifier params (issue #80). The client decides preventDefault behavior
     // from event.params — set by the Ruby on() — never by sniffing the
     // Stimulus descriptor.
-    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic } = event.params
+    const { action, params, debounce, throttle, confirm, outside, window: windowBound, optimistic, loading } =
+      event.params
     if (!action) return
 
     // Outside guard FIRST (issue #80): an outside: trigger only fires for
@@ -396,9 +403,14 @@ export default class extends Controller {
     // lifecycle event (nothing to announce, nothing to veto).
     if (outside && this.element.contains(event.target)) return
 
-    // Capture the trigger element now; #proceed runs in a later microtask (after
-    // the confirm resolver settles), by which point event.target may be reset.
-    const target = event.target
+    // The trigger is event.currentTarget — the element on(...) was spread onto —
+    // NOT event.target (issue #99). A `<button><span>Save</span></button>` click
+    // has target === the span, which carries no params and is the wrong element
+    // to disable / swap text on. currentTarget is the bound element; fall back to
+    // target for a directly-invoked/synthetic event. Captured now because
+    // #proceed runs in a later microtask (after the confirm resolver), by which
+    // point currentTarget is reset to null.
+    const target = event.currentTarget ?? event.target
 
     // Stop native behavior (button submit / FORM NAVIGATION) HERE, synchronously
     // within the event dispatch — BEFORE the (possibly async) confirm gate below.
@@ -424,7 +436,7 @@ export default class extends Controller {
     if (!windowBound && !this.#keepsNativeToggle(optimistic, target)) event.preventDefault()
 
     // No confirm message → proceed straight away (unchanged fast path).
-    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic)
+    if (!confirm) return this.#proceed(target, action, params, debounce, throttle, optimistic, loading)
 
     // Confirmation gate (issue #52, made overridable + async in #55). A reactive
     // trigger can't use Hotwire's data-turbo-confirm — this controller preempts
@@ -441,7 +453,7 @@ export default class extends Controller {
       .then(() => confirmResolver(confirm))
       .catch(() => false)
       .then((ok) => {
-        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic)
+        if (ok) this.#proceed(target, action, params, debounce, throttle, optimistic, loading)
       })
   }
 
@@ -626,7 +638,7 @@ export default class extends Controller {
   // Split out of dispatch so both the no-confirm fast path and the post-confirm
   // microtask share one place (issue #55). `target` is captured up front because
   // this can run in a later microtask, after event.target has been reset.
-  #proceed(target, action, params, debounce, throttle, optimistic) {
+  #proceed(target, action, params, debounce, throttle, optimistic, loading) {
     // Lifecycle veto point (issue #79): one cancelable reactive:before-dispatch
     // per user gesture — post-preventDefault, post-confirm, PRE-debounce (and
     // PRE-throttle, the same timing). event.preventDefault() skips the
@@ -644,19 +656,21 @@ export default class extends Controller {
     // Debounced trigger (e.g. on(:update, event: "input", debounce: 300)):
     // coalesce rapid events into ONE round trip after a quiet period, instead of
     // one POST per keystroke (issue #17). A blur flushes a pending dispatch.
-    // The optimistic hint (issue #98) rides to the flush too, so it applies ONCE
-    // per enqueue — a debounced trigger must not flap toggle_class per keystroke.
+    // The optimistic hint (issue #98) and the loading state (issue #99) ride to
+    // the flush too, so they apply ONCE per enqueue — a debounced input must not
+    // flap toggle_class per keystroke, and its element must NOT be disabled
+    // during the quiet period (that would break typing). Both apply at ENQUEUE.
     const ms = Number(debounce) || 0
-    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic)
+    if (ms > 0) return this.#debounceDispatch(target, ms, action, params, optimistic, loading)
 
     // Throttled trigger (e.g. on(:track, event: "scroll", window: true,
     // throttle: 250), issue #80): LEADING-EDGE rate limit — fire the first
     // event immediately, drop the rest until the window elapses. debounce and
     // throttle are mutually exclusive (the Ruby on() raises on both).
     const throttleMs = Number(throttle) || 0
-    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic)
+    if (throttleMs > 0) return this.#throttleDispatch(target, throttleMs, action, params, optimistic, loading)
 
-    return this.#enqueue(action, params, optimistic, target)
+    return this.#enqueue(action, params, optimistic, target, loading)
   }
 
   // Apply the optimistic hint ONCE (recording its inverse) and chain the round
@@ -664,21 +678,30 @@ export default class extends Controller {
   // per-controller queue reverts the RIGHT request's hint on failure (issue
   // #98). Applying here — the single flush/enqueue point every path funnels
   // through — is what makes a hint apply once per enqueue, not per raw dispatch.
-  #enqueue(action, params, optimistic, target) {
+  //
+  // The loading state (issue #99) applies here too, for the same reason: enqueue
+  // is the moment the request is committed to the queue, so the always-on busy
+  // vocabulary (data-reactive-busy on the trigger + root, aria-busy via a pending
+  // counter, busy_on scoping) and the loading hint (disable + class + text swap)
+  // cover the WHOLE pending window — queue wait included — not just the fetch. It
+  // returns a `settle` closure that #perform runs in its finally (success OR
+  // failure), guarded so a morph-replaced trigger is never clobbered.
+  #enqueue(action, params, optimistic, target, loading) {
     const inverse = this.#applyOptimistic(optimistic, target)
-    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse))
+    const settle = this.#applyLoading(action, target, loading)
+    this.queue = (this.queue ?? Promise.resolve()).then(() => this.#perform(action, params, inverse, settle))
     return this.queue
   }
 
   // Reset a per-element timer; only enqueue the round trip after `ms` of quiet.
   // Also flush immediately on blur so leaving the field never drops the last
   // edit (a long debounce shouldn't swallow a value the user tabbed away from).
-  #debounceDispatch(target, ms, action, params, optimistic) {
+  #debounceDispatch(target, ms, action, params, optimistic, loading) {
     this.#clearDebounce(target)
 
     const flush = () => {
       this.#clearDebounce(target)
-      this.#enqueue(action, params, optimistic, target)
+      this.#enqueue(action, params, optimistic, target, loading)
     }
     const timer = setTimeout(flush, ms)
     target?.addEventListener?.("blur", flush, { once: true })
@@ -706,7 +729,7 @@ export default class extends Controller {
   // are keyed on action + target, NOT target alone: window-bound scroll/resize
   // events all share event.target === document, so two window-bound triggers
   // on one component would otherwise collide on one timer.
-  #throttleDispatch(target, ms, action, params, optimistic) {
+  #throttleDispatch(target, ms, action, params, optimistic, loading) {
     const timers = this.#throttleTimers.get(target) ?? new Map()
     if (timers.has(action)) return // inside the window — suppress
 
@@ -716,7 +739,7 @@ export default class extends Controller {
     }, ms)
     timers.set(action, timer)
     this.#throttleTimers.set(target, timers)
-    return this.#enqueue(action, params, optimistic, target) // leading edge: fire NOW
+    return this.#enqueue(action, params, optimistic, target, loading) // leading edge: fire NOW
   }
 
   // Clear every throttle suppression timer (used on disconnect, alongside
@@ -761,7 +784,7 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
-  async #perform(action, params, inverse) {
+  async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
     // chosen file inputs in the SAME walk. Explicit params
@@ -780,7 +803,9 @@ export default class extends Controller {
       ? this.#buildFormData(token, action, allParams, files)
       : JSON.stringify({ token, act: action, params: allParams })
 
-    this.element.setAttribute("aria-busy", "true")
+    // aria-busy on the root is now driven by the loading pending counter
+    // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
+    // set here. #settleLoading in the finally clears it — see #enqueue.
 
     try {
       let response
@@ -869,7 +894,11 @@ export default class extends Controller {
       this.#revertOptimistic(inverse)
       this.#emit("reactive:error", { action, params: allParams, kind: "apply" })
     } finally {
-      this.element.removeAttribute("aria-busy")
+      // Settle the loading state (issue #99): decrement the pending counter,
+      // drop the trigger's/root's busy tokens, restore disabled/text/class —
+      // guarded so a morph-replaced trigger is never clobbered. Runs on EVERY
+      // exit (success, every failure branch, or an apply throw).
+      settle?.()
     }
   }
 
@@ -1163,6 +1192,165 @@ export default class extends Controller {
   #optimisticTargets(optimistic, trigger) {
     if (optimistic.to == null) return trigger ? [trigger] : []
     return this.#opTargets({ to: optimistic.to })
+  }
+
+  // Apply the loading state for THIS enqueue (issue #99) and return a `settle`
+  // closure that undoes exactly this enqueue's contribution when the round trip
+  // finishes (success OR any failure). Everything is refcounted so overlapping
+  // enqueues never clobber: A's settle can't clear busy while B is still pending.
+  //
+  // Two layers:
+  //   1. The ALWAYS-ON busy vocabulary (fires for every action, no hint needed):
+  //      data-reactive-busy="<action>" on the trigger and the root (a
+  //      space-separated, per-action refcounted set), aria-busy on the root (a
+  //      pending counter), and data-reactive-busy on any busy_on element scoped
+  //      to this action. Apps style a spinner with pure CSS and zero Ruby.
+  //   2. The loading HINT (only when loading:/disable_with: was declared):
+  //      disable the trigger, add a loading class (to the trigger or a `to:`
+  //      target), swap its text. These apply at ENQUEUE — never during a debounce
+  //      quiet period — so a debounced input is not disabled mid-typing.
+  #applyLoading(action, trigger, loading) {
+    this.#markBusy(action, trigger)
+    const restoreHint = this.#applyLoadingHint(action, trigger, loading)
+
+    let settled = false
+    return () => {
+      if (settled) return // one settle per enqueue, even if called twice
+      settled = true
+      this.#unmarkBusy(action, trigger)
+      restoreHint()
+    }
+  }
+
+  // Layer 1 — the always-on busy markers. Trigger + root carry the action token;
+  // the root's counter drives aria-busy; busy_on elements scoped to this action
+  // light up. Refcounts (#busyActions, #busyPending) so overlapping requests
+  // don't clear each other.
+  #markBusy(action, trigger) {
+    this.#setBusyToken(trigger, action, +1)
+    this.#setBusyToken(this.element, action, +1)
+
+    this.#busyActions.set(action, (this.#busyActions.get(action) ?? 0) + 1)
+    if (this.#busyPending++ === 0) this.element.setAttribute("aria-busy", "true")
+
+    for (const el of this.#busyOnTargets(action)) this.#setBusyToken(el, action, +1)
+  }
+
+  #unmarkBusy(action, trigger) {
+    this.#setBusyToken(trigger, action, -1)
+    this.#setBusyToken(this.element, action, -1)
+
+    const count = (this.#busyActions.get(action) ?? 1) - 1
+    if (count <= 0) this.#busyActions.delete(action)
+    else this.#busyActions.set(action, count)
+
+    if (--this.#busyPending <= 0) {
+      this.#busyPending = 0
+      this.element.removeAttribute("aria-busy")
+    }
+
+    for (const el of this.#busyOnTargets(action)) this.#setBusyToken(el, action, -1)
+  }
+
+  // Add (+1) or remove (-1) `action` from an element's space-separated
+  // data-reactive-busy token set, refcounted PER ELEMENT+ACTION so two queued
+  // requests of the same action on the same element don't drop the token early
+  // (and two DIFFERENT actions both keep their token — the set never clobbers).
+  // The attribute is removed only when the set empties. No-op on a nullish/
+  // detached element (a morph may have replaced the trigger before settle).
+  #setBusyToken(el, action, delta) {
+    if (!el || typeof el.getAttribute !== "function") return
+
+    const counts = (this.#busyTokenCounts.get(el) ?? new Map())
+    const next = (counts.get(action) ?? 0) + delta
+    if (next <= 0) counts.delete(action)
+    else counts.set(action, next)
+
+    if (counts.size === 0) {
+      this.#busyTokenCounts.delete(el)
+      el.removeAttribute("data-reactive-busy")
+      return
+    }
+    this.#busyTokenCounts.set(el, counts)
+    el.setAttribute("data-reactive-busy", [...counts.keys()].join(" "))
+  }
+
+  // busy_on elements scoped to THIS action, owned by this root (not a nested
+  // reactive root's, issue #15). data-reactive-busy-on="<action>" is the marker
+  // busy_on(:action) emits.
+  #busyOnTargets(action) {
+    const nodes = this.element.querySelectorAll?.("[data-reactive-busy-on]") ?? []
+    return [...nodes].filter(
+      (el) => el.getAttribute("data-reactive-busy-on") === action && this.#ownsField(el),
+    )
+  }
+
+  // Layer 2 — the loading HINT (disable + class + text). Snapshots the trigger's
+  // ORIGINAL disabled/text/classes on the FIRST enqueue for that trigger
+  // (refcounted so an overlapping enqueue never snapshots the already-swapped
+  // "Saving…" as the original), applies the swap, and returns a restore closure.
+  // With no hint, returns a no-op restore (the always-on busy markers still ran).
+  #applyLoadingHint(action, trigger, loading) {
+    if (!loading || !trigger) return () => {}
+
+    const classTargets = this.#loadingTargets(loading, trigger)
+    const classes = Array.isArray(loading.class) ? loading.class : []
+    const addedByTarget = []
+    for (const el of classTargets) {
+      const added = classes.filter((c) => !el.classList.contains(c))
+      el.classList.add(...added)
+      if (added.length) addedByTarget.push([el, added])
+    }
+
+    // Snapshot disabled/text ONCE per trigger (refcounted). A second overlapping
+    // enqueue increments the count but does NOT re-snapshot — so the recorded
+    // "original" is the true pre-loading state, never the swapped label.
+    const snap = this.#loadingSnapshots.get(trigger)
+    if (snap) {
+      snap.count++
+    } else if (loading.disable || loading.text != null) {
+      this.#loadingSnapshots.set(trigger, {
+        count: 1,
+        disabled: trigger.disabled,
+        text: trigger.textContent,
+        hadText: loading.text != null,
+      })
+    }
+
+    if (loading.disable) trigger.disabled = true
+    if (loading.text != null) trigger.textContent = loading.text
+
+    return () => {
+      for (const [el, added] of addedByTarget) if (el.isConnected) el.classList.remove(...added)
+      this.#restoreLoadingSnapshot(trigger, loading)
+    }
+  }
+
+  // Restore the trigger's disabled/text from its snapshot when the LAST enqueue
+  // for that trigger settles (refcount → 0). GUARDED: skip a disconnected
+  // trigger (a plain replace detached it — the node is gone), and do NOT restore
+  // the text if it no longer equals what we swapped IN (a morph rendered a new
+  // server label — clobbering it with the old text would fight server truth).
+  #restoreLoadingSnapshot(trigger, loading) {
+    const snap = this.#loadingSnapshots.get(trigger)
+    if (!snap) return
+    if (--snap.count > 0) return // another enqueue for this trigger is still pending
+    this.#loadingSnapshots.delete(trigger)
+
+    if (!trigger.isConnected) return // detached — nothing to restore
+
+    if (loading.disable) trigger.disabled = snap.disabled
+    // Only restore the label if the trigger still shows OUR swapped text; a
+    // changed textContent means the server morph relabeled it — leave it.
+    if (snap.hadText && trigger.textContent === loading.text) trigger.textContent = snap.text
+  }
+
+  // The elements a loading class applies to: the `to:` selector (resolved like
+  // an op target — "@root" is the root, a selector is scoped to this root's
+  // owned matches) or, with no `to:`, the trigger itself.
+  #loadingTargets(loading, trigger) {
+    if (loading.to == null) return trigger ? [trigger] : []
+    return this.#opTargets({ to: loading.to })
   }
 
   // The action path comes from a <meta> tag that is fixed for the page's life,

--- a/spec/javascript/reactive_loading.test.js
+++ b/spec/javascript/reactive_loading.test.js
@@ -1,0 +1,463 @@
+// Unit tests for declarative loading states on reactive triggers (issue #99).
+//
+// `on(:x, loading: { … })` / `on(:x, disable_with: "…")` emit
+// data-reactive-loading-param (JSON) that Stimulus surfaces as
+// event.params.loading. The controller, when a request is ENQUEUED (covering the
+// queue wait, not just the fetch):
+//
+//   * marks the TRIGGER with data-reactive-busy="<action>" and the root with the
+//     SAME action token in a SPACE-SEPARATED set (two queued actions never
+//     clobber), plus aria-busy via a PENDING COUNTER (removed only at zero),
+//   * applies the loading class, disables the trigger, swaps its text — but the
+//     disable + text swap happen at ENQUEUE, never during a debounce quiet
+//     period (a debounced input's element must not be disabled mid-typing),
+//   * scopes busy_on elements: data-reactive-busy-on="save" gets
+//     data-reactive-busy toggled only while `save` is in flight,
+//   * on settle (success OR failure) restores the trigger, GUARDED — skipped if
+//     the trigger disconnected, and the text is not clobbered if a morph rendered
+//     a new server label (textContent no longer equals the disable_with text).
+//
+// The trigger is event.currentTarget (a <button><span> click's target is the
+// span, which carries no params) — captured in dispatch and threaded through.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// A fake element with a classList over a Set, a token-store for attributes, a
+// `disabled` flag, and `textContent`. `isConnected` defaults true. Records
+// blur/input listeners so a debounce flush can be driven.
+function makeEl({ owner = null } = {}) {
+  const listeners = {}
+  const attrs = {}
+  const el = {
+    isConnected: true,
+    disabled: false,
+    textContent: "",
+    classes: new Set(),
+    closest: () => owner,
+    getAttribute: (n) => (n in attrs ? attrs[n] : null),
+    setAttribute: (n, v) => {
+      attrs[n] = String(v)
+    },
+    removeAttribute: (n) => {
+      delete attrs[n]
+    },
+    hasAttribute: (n) => n in attrs,
+    addEventListener: (t, fn) => {
+      (listeners[t] ||= []).push(fn)
+    },
+    removeEventListener: (t, fn) => {
+      listeners[t] = (listeners[t] || []).filter((f) => f !== fn)
+    },
+    fire: (t) => (listeners[t] || []).slice().forEach((fn) => fn()),
+  }
+  el.classList = {
+    add: (...cs) => cs.forEach((c) => el.classes.add(c)),
+    remove: (...cs) => cs.forEach((c) => el.classes.delete(c)),
+    toggle: (c) => (el.classes.has(c) ? el.classes.delete(c) : el.classes.add(c)),
+    contains: (c) => el.classes.has(c),
+  }
+  return el
+}
+
+let root
+
+// A reactive root that resolves `to:`/busy_on selectors from a `matches` map,
+// tracks its own attributes (aria-busy, data-reactive-busy set), and owns the
+// trigger. querySelectorAll returns whatever the map holds for a selector.
+function makeRoot(matches = {}) {
+  const attrs = {}
+  return {
+    isConnected: true,
+    id: "counter",
+    hidden: false,
+    getAttribute: (n) => (n in attrs ? attrs[n] : null),
+    setAttribute: (n, v) => {
+      attrs[n] = String(v)
+    },
+    removeAttribute: (n) => {
+      delete attrs[n]
+    },
+    hasAttribute: (n) => n in attrs,
+    dispatchEvent: () => {},
+    contains: () => false,
+    querySelectorAll: (sel) => matches[sel] ?? [],
+  }
+}
+
+// Build a controller with a scripted fetch. `responses` is consumed in order;
+// the last repeats. Each is {...response fields} or { reject: Error }. A
+// `hold` promise lets a test keep the fetch pending to inspect mid-flight state.
+function buildController(responses, { rootMatches = {}, hold = null } = {}) {
+  root = makeRoot(rootMatches)
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = async () => {
+    const script = responses[Math.min(calls, responses.length - 1)]
+    calls++
+    if (hold) await hold
+    if (script.reject) return Promise.reject(script.reject)
+    return {
+      redirected: script.redirected ?? false,
+      ok: script.ok ?? true,
+      status: script.status ?? 200,
+      headers: { get: () => script.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(script.body ?? ""),
+    }
+  }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls }
+}
+
+// Fire a dispatch with a loading hint. `trigger` is event.currentTarget.
+function fireDispatch(controller, trigger, loading, extra = {}) {
+  const event = {
+    target: trigger,
+    currentTarget: trigger,
+    params: { action: "save", params: "{}", loading, ...extra },
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+  return { promise: controller.dispatch(event), event }
+}
+
+// --- currentTarget capture --------------------------------------------------
+
+test("the trigger is event.currentTarget, not event.target (a nested span click)", async () => {
+  const { controller } = buildController([{}])
+  const button = makeEl()
+  const span = makeEl() // the inner <span> the click actually landed on
+  const event = {
+    target: span, // the span carries no loading/params
+    currentTarget: button, // on() is spread onto the button
+    params: { action: "save", params: "{}", loading: { class: ["busy"] } },
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true
+    },
+  }
+  controller.dispatch(event)
+  // The class must land on the BUTTON (currentTarget), never the span.
+  expect(button.classes.has("busy")).toBe(true)
+  expect(span.classes.has("busy")).toBe(false)
+  await controller.queue
+})
+
+// --- busy vocabulary at enqueue ---------------------------------------------
+
+test("marks the trigger with data-reactive-busy=<action> on enqueue", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true })
+  expect(trigger.getAttribute("data-reactive-busy")).toBe("save")
+  await promise
+})
+
+test("adds the action token to the root's SPACE-SEPARATED busy set", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true })
+  expect(root.getAttribute("data-reactive-busy")).toBe("save")
+  await promise
+})
+
+test("sets aria-busy on the root during the pending window", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}], { hold })
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true })
+  expect(root.getAttribute("aria-busy")).toBe("true")
+  release()
+  await promise
+  expect(root.hasAttribute("aria-busy")).toBe(false)
+})
+
+test("applies the loading class + disable + text swap on enqueue", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}], { hold })
+  const trigger = makeEl()
+  trigger.textContent = "Save"
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true, class: ["opacity-50"], text: "Saving…" })
+  expect(trigger.disabled).toBe(true)
+  expect(trigger.classes.has("opacity-50")).toBe(true)
+  expect(trigger.textContent).toBe("Saving…")
+  release()
+  await promise
+})
+
+test("a to: selector applies the loading class to owned matches, not the trigger", async () => {
+  const spinner = makeEl()
+  spinner.closest = () => root
+  const { controller } = buildController([{}], { rootMatches: { ".spinner": [spinner] } })
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { class: ["on"], to: ".spinner" })
+  expect(spinner.classes.has("on")).toBe(true)
+  expect(trigger.classes.has("on")).toBe(false)
+  await promise
+})
+
+// --- busy_on scoping --------------------------------------------------------
+
+test("busy_on element gets data-reactive-busy while its action is in flight, cleared after", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const spinner = makeEl()
+  spinner.closest = () => root
+  spinner.setAttribute("data-reactive-busy-on", "save")
+  const { controller } = buildController([{}], {
+    hold,
+    rootMatches: { "[data-reactive-busy-on]": [spinner] },
+  })
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true })
+  expect(spinner.getAttribute("data-reactive-busy")).toBe("save")
+  release()
+  await promise
+  expect(spinner.hasAttribute("data-reactive-busy")).toBe(false)
+})
+
+test("busy_on element for a DIFFERENT action is not marked", async () => {
+  const spinner = makeEl()
+  spinner.closest = () => root
+  spinner.setAttribute("data-reactive-busy-on", "destroy") // different action
+  const { controller } = buildController([{}], {
+    rootMatches: { "[data-reactive-busy-on]": [spinner] },
+  })
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true })
+  expect(spinner.hasAttribute("data-reactive-busy")).toBe(false)
+  await promise
+})
+
+// --- restore on settle (success) --------------------------------------------
+
+test("restores disabled + text on success settle", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+  trigger.textContent = "Save"
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true, text: "Saving…" })
+  await promise
+  expect(trigger.disabled).toBe(false)
+  expect(trigger.textContent).toBe("Save")
+  expect(trigger.hasAttribute("data-reactive-busy")).toBe(false)
+})
+
+test("restores disabled + text on failure settle", async () => {
+  const { controller } = buildController([{ ok: false, status: 500 }])
+  const trigger = makeEl()
+  trigger.textContent = "Save"
+  const originalError = console.error
+  console.error = () => {}
+  try {
+    const { promise } = fireDispatch(controller, trigger, { disable: true, text: "Saving…" })
+    await promise
+  } finally {
+    console.error = originalError
+  }
+  expect(trigger.disabled).toBe(false)
+  expect(trigger.textContent).toBe("Save")
+})
+
+test("removes the loading class on settle", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+
+  const { promise } = fireDispatch(controller, trigger, { class: ["opacity-50"] })
+  await promise
+  expect(trigger.classes.has("opacity-50")).toBe(false)
+})
+
+// --- guarded restore --------------------------------------------------------
+
+test("restore is SKIPPED when the trigger left the DOM (guarded by isConnected)", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+  trigger.textContent = "Save"
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true, text: "Saving…" })
+  trigger.isConnected = false // a plain replace detached the trigger
+  await promise
+  // No restore against a detached node — text stays as swapped (the node is gone).
+  expect(trigger.textContent).toBe("Saving…")
+})
+
+test("does NOT clobber a server-rendered new label (textContent changed by the morph)", async () => {
+  const { controller } = buildController([{}])
+  const trigger = makeEl()
+  trigger.textContent = "Save"
+
+  const { promise } = fireDispatch(controller, trigger, { disable: true, text: "Saving…" })
+  // A morph re-rendered the trigger with a fresh label before the settle lands.
+  trigger.textContent = "Saved ✓"
+  await promise
+  // The restore must NOT overwrite the server's new label with the old "Save".
+  expect(trigger.textContent).toBe("Saved ✓")
+  // The disabled flag is still restored (it's the client's, not the server's).
+  expect(trigger.disabled).toBe(false)
+})
+
+// --- pending counter across overlapping enqueues ----------------------------
+
+test("aria-busy survives A's settle while B is still queued (pending counter)", async () => {
+  // A per-call gate so we can release A's fetch while B's stays pending. The
+  // queue serializes #perform, so only A is in flight when we release its gate;
+  // B's #perform then starts and blocks on gate #2.
+  const gates = []
+  const nextGate = () => {
+    let release
+    const p = new Promise((r) => (release = r))
+    gates.push(release)
+    return p
+  }
+  root = makeRoot()
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.tokenValue = "tok"
+  globalThis.fetch = async () => {
+    await nextGate()
+    return {
+      redirected: false,
+      ok: true,
+      status: 200,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    }
+  }
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+
+  const triggerA = makeEl()
+  const triggerB = makeEl()
+
+  // Enqueue A then B — both pending; counter = 2.
+  fireDispatch(controller, triggerA, { disable: true }, { action: "a" })
+  fireDispatch(controller, triggerB, { disable: true }, { action: "b" })
+  await wait(5) // let A's #perform reach its fetch/gate
+  expect(root.getAttribute("aria-busy")).toBe("true")
+
+  // Release A's gate: A settles, but B is next in the serialized queue.
+  gates[0]()
+  await wait(5)
+  // With A settled and B still in flight (or newly started), aria-busy must NOT
+  // have been cleared — the pending counter is still > 0.
+  expect(root.getAttribute("aria-busy")).toBe("true")
+
+  await wait(5)
+  gates[1]?.() // release B
+  await controller.queue
+  // Both settled → counter 0 → attribute removed.
+  expect(root.hasAttribute("aria-busy")).toBe(false)
+})
+
+test("the root busy set keeps a token until ALL its requests settle (per-action refcount)", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}, {}], { hold })
+  const t1 = makeEl()
+  const t2 = makeEl()
+
+  // Two "save" requests overlapping.
+  fireDispatch(controller, t1, { disable: true })
+  fireDispatch(controller, t2, { disable: true })
+  expect(root.getAttribute("data-reactive-busy")).toBe("save")
+
+  release()
+  await controller.queue
+  // Both settled → the token is gone.
+  expect(root.hasAttribute("data-reactive-busy")).toBe(false)
+})
+
+test("two different queued actions keep both tokens in the space-separated set", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}, {}], { hold })
+  const t1 = makeEl()
+  const t2 = makeEl()
+
+  fireDispatch(controller, t1, { disable: true }, { action: "save" })
+  fireDispatch(controller, t2, { disable: true }, { action: "publish" })
+
+  const set = root.getAttribute("data-reactive-busy").split(" ").sort()
+  expect(set).toEqual(["publish", "save"])
+  release()
+  await controller.queue
+})
+
+// --- debounce: disable only at flush, not during the quiet period -----------
+
+test("a debounced trigger is NOT disabled during the quiet period, only at flush", async () => {
+  // Hold the fetch so the request stays pending after the flush — otherwise the
+  // whole round trip completes within the wait and the busy state settles before
+  // we can observe it.
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}], { hold })
+  const input = makeEl()
+  input.textContent = ""
+
+  // Fire a debounced dispatch; the disable must NOT apply yet (still typing) —
+  // the debounced input's element must not be disabled during the quiet period.
+  fireDispatch(controller, input, { disable: true }, { debounce: 50 })
+  expect(input.disabled).toBe(false)
+  expect(input.hasAttribute("data-reactive-busy")).toBe(false)
+
+  // Cross the quiet period → flush → enqueue → NOW the busy state applies.
+  await wait(80)
+  expect(input.disabled).toBe(true)
+  expect(input.getAttribute("data-reactive-busy")).toBe("save")
+  release()
+  await controller.queue
+})
+
+// --- always-on busy vocabulary (no loading hint needed) ---------------------
+
+test("the busy vocabulary is ALWAYS-ON — a bare on() (no loading hint) still marks busy", async () => {
+  let release
+  const hold = new Promise((r) => (release = r))
+  const { controller } = buildController([{}], { hold })
+  const trigger = makeEl()
+
+  // No loading hint at all — the always-on data-reactive-busy/aria-busy vocab
+  // still fires so an app styles a spinner with pure CSS and zero Ruby.
+  const { promise } = fireDispatch(controller, trigger, undefined)
+  expect(trigger.getAttribute("data-reactive-busy")).toBe("save")
+  expect(root.getAttribute("data-reactive-busy")).toBe("save")
+  expect(root.getAttribute("aria-busy")).toBe("true")
+  // …but with no hint there is NO disable, NO class, NO text swap.
+  expect(trigger.disabled).toBe(false)
+  expect(trigger.classes.size).toBe(0)
+  release()
+  await promise
+  // All busy markers clear on settle.
+  expect(trigger.hasAttribute("data-reactive-busy")).toBe(false)
+  expect(root.hasAttribute("data-reactive-busy")).toBe(false)
+  expect(root.hasAttribute("aria-busy")).toBe(false)
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -644,6 +644,102 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#on loading states (issue #99 — loading:/disable_with:)" do
+    subject(:instance) { state_klass.new }
+
+    it "omits the loading param by default (bare on() hot path untouched)" do
+      attrs = instance.send(:on, :increment)
+      expect(attrs[:data]).not_to have_key(:reactive_loading_param)
+    end
+
+    it "expands disable_with: shorthand to { disable: true, text: … }" do
+      attrs = instance.send(:on, :save, disable_with: "Saving…")
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "disable" => true, "text" => "Saving…" })
+    end
+
+    it "emits a full loading: hash (disable + class + text)" do
+      attrs = instance.send(:on, :save, loading: { disable: true, class: "opacity-50", text: "Saving…" })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "disable" => true, "class" => ["opacity-50"], "text" => "Saving…" })
+    end
+
+    it "serializes a loading class array" do
+      attrs = instance.send(:on, :save, loading: { class: %w[opacity-50 pointer-events-none] })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "class" => %w[opacity-50 pointer-events-none] })
+    end
+
+    it "normalizes loading disable: to a real boolean" do
+      attrs = instance.send(:on, :save, loading: { disable: true })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param])).to eq({ "disable" => true })
+    end
+
+    it "normalizes to: :root to the @root sentinel" do
+      attrs = instance.send(:on, :save, loading: { class: "busy", to: :root })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "class" => ["busy"], "to" => "@root" })
+    end
+
+    it "passes a to: CSS selector string through verbatim" do
+      attrs = instance.send(:on, :save, loading: { class: "busy", to: ".spinner" })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "class" => ["busy"], "to" => ".spinner" })
+    end
+
+    it "merges disable_with: over loading: (disable_with wins on text + implies disable)" do
+      attrs = instance.send(:on, :save, loading: { class: "busy" }, disable_with: "Saving…")
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "class" => ["busy"], "disable" => true, "text" => "Saving…" })
+    end
+
+    it "keeps the loading hint out of the explicit params payload" do
+      attrs = instance.send(:on, :save, disable_with: "Saving…", reason: "click")
+      expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "reason" => "click" })
+    end
+
+    it "threads loading alongside confirm, debounce and optimistic without collision" do
+      attrs = instance.send(:on, :save, confirm: "Sure?", debounce: 200,
+        optimistic: { add_class: "pending" }, disable_with: "Saving…")
+      expect(attrs[:data][:reactive_confirm_param]).to eq("Sure?")
+      expect(attrs[:data][:reactive_debounce_param]).to eq(200)
+      expect(JSON.parse(attrs[:data][:reactive_optimistic_param])).to eq({ "add_class" => ["pending"] })
+      expect(JSON.parse(attrs[:data][:reactive_loading_param]))
+        .to eq({ "disable" => true, "text" => "Saving…" })
+    end
+
+    it "rejects an unknown loading key (default-deny — a dead hint fails at build)" do
+      expect { instance.send(:on, :save, loading: { spin: true }) }
+        .to raise_error(ArgumentError, /spin/)
+    end
+
+    it "rejects a non-hash loading:" do
+      expect { instance.send(:on, :save, loading: "Saving…") }
+        .to raise_error(ArgumentError, /loading/)
+    end
+
+    it "still forces type=button for a click trigger with a loading hint" do
+      attrs = instance.send(:on, :save, disable_with: "Saving…")
+      expect(attrs[:type]).to eq("button")
+    end
+  end
+
+  describe "#busy_on (issue #99 — scoped busy indicators)" do
+    subject(:instance) { state_klass.new }
+
+    it "emits data-reactive-busy-on for the named action" do
+      expect(instance.send(:busy_on, :save)).to eq({ data: { reactive_busy_on: "save" } })
+    end
+
+    it "stringifies a symbol action name" do
+      expect(instance.send(:busy_on, :destroy)[:data][:reactive_busy_on]).to eq("destroy")
+    end
+
+    it "accepts a string action name" do
+      expect(instance.send(:busy_on, "save")[:data][:reactive_busy_on]).to eq("save")
+    end
+  end
+
   describe "#on_client (issue #95 — client-only DOM ops, zero round trip)" do
     subject(:instance) { state_klass.new }
 

--- a/spec/system/loading_button_spec.rb
+++ b/spec/system/loading_button_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Declarative loading states (issue #99): on(:save, disable_with: "Saving…")
+# disables the trigger and swaps its text the instant the request is enqueued,
+# and busy_on(:save) toggles data-reactive-busy on a spinner only while `save` is
+# in flight. The save action sleeps 0.4s server-side so the loading state is
+# observable BEFORE the morph reconciles — and so a rapid second click lands
+# inside the pending window, where the disabled button swallows it (the disable
+# IS the dedup; the queue only serializes tokens, it does not dedupe).
+#
+# Runs under Puma (sync) AND Falcon (async) in CI's server matrix.
+RSpec.describe "Declarative loading states (issue #99)", type: :system do
+  it "swaps text, disables the button, and shows the busy spinner while pending" do
+    visit "/loading_button"
+    page.execute_script("window.__noReload = 'alive'")
+
+    expect(page).to have_css("[data-testid='count']", text: "0")
+    expect(page).to have_button("Save")
+    # The spinner has no busy attribute at rest (styled hidden with pure CSS).
+    expect(page).to have_no_css("[data-testid='spinner'][data-reactive-busy]")
+
+    find("[data-testid='save']").click
+
+    # Loading state paints IMMEDIATELY (at enqueue), BEFORE the 0.4s morph lands:
+    #   * the button text swaps to "Saving…" and the button is disabled,
+    #   * the busy_on spinner carries data-reactive-busy="save",
+    #   * the root carries aria-busy + data-reactive-busy for the pending window.
+    # A hint that never fired can't pass these no-wait assertions' waiting form.
+    expect(page).to have_button("Saving…", disabled: true)
+    expect(page).to have_css("[data-testid='spinner'][data-reactive-busy='save']")
+    expect(page).to have_css("#loading-button[aria-busy='true']")
+    expect(page).to have_css("#loading-button[data-reactive-busy~='save']")
+    # The morph has NOT landed yet — the count is still 0.
+    expect(page).to have_css("[data-testid='count']", text: "0")
+
+    # …then the round trip settles: count becomes 1, the button restores to
+    # "Save" and re-enables, and every busy marker clears.
+    expect(page).to have_css("[data-testid='count']", text: "1")
+    expect(page).to have_button("Save", disabled: false)
+    expect(page).to have_no_css("[data-testid='spinner'][data-reactive-busy]")
+    expect(page).to have_no_css("#loading-button[aria-busy]")
+    expect(page).to have_no_css("#loading-button[data-reactive-busy]")
+
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "dedupes a rapid double-click to exactly ONE server-side increment" do
+    visit "/loading_button"
+    expect(page).to have_css("[data-testid='count']", text: "0")
+
+    # Two clicks as fast as possible. The first enqueues the POST and DISABLES the
+    # button (disable_with) before the second click can register — a disabled
+    # button fires no click event — so the second click is swallowed and only one
+    # save runs.
+    page.execute_script(<<~JS)
+      const btn = document.querySelector("[data-testid='save']")
+      btn.click()
+      btn.click()
+    JS
+
+    # Exactly one increment landed. If the disable-at-enqueue dedup had failed,
+    # two POSTs would serialize and the count would reach 2.
+    expect(page).to have_css("[data-testid='count']", text: "1")
+    expect(page).to have_button("Save", disabled: false)
+
+    # A THIRD click after the settle still works (the button re-enabled) — the
+    # dedup is per pending-window, not a permanent lock.
+    find("[data-testid='save']").click
+    expect(page).to have_css("[data-testid='count']", text: "2")
+  end
+end


### PR DESCRIPTION
Closes #99

## Problem

Between the click and the morph the UI was fully live and unchanged: no per-trigger loading feedback, buttons stayed enabled, and a rapid double-click enqueued a full duplicate POST (the queue serializes tokens, it does **not** dedupe). Livewire has `wire:loading`/`phx-disable-with`; phlex-reactive had nothing per-trigger.

## What this adds

Declarative loading states — Livewire's `wire:loading` + `phx-disable-with` and LiveView's `phx-click-loading`, without a Stimulus controller.

- **`on(:save, disable_with: "Saving…")`** — disable the trigger + swap its text while pending. A disabled button fires no further clicks, so a rapid double-click enqueues exactly **one** POST (the disable is the dedup). Shorthand for `loading: { disable: true, text: "Saving…" }`.
- **`on(:save, loading: { disable:, class:, text:, to: })`** — full form: a loading `class:` on the trigger or a `to:` target (`to: :root` = the root), plus `disable:` and a `text:` swap.
- **Always-on busy vocabulary (zero Ruby)** — independent of any hint, every round trip marks the DOM for the whole enqueue→settle window: `data-reactive-busy="<action>"` on the trigger and root (a **space-separated set** on the root so concurrent actions don't clobber), `aria-busy` on the root (a **pending counter**, cleared only when the last request settles), and **`busy_on(:action)`** to scope `data-reactive-busy` onto a spinner only while that action is in flight. Style with pure CSS (`[data-reactive-busy] .spinner { … }`).

## Verifier-corrected details honored

- The trigger is **`event.currentTarget`**, not `event.target` — a `<button><span>Save</span></button>` click disables/relabels the button, not the inner span.
- The disable + text swap apply **at enqueue** (covering the queue wait), and **never during a `debounce:` quiet period** — a debounced `input` (whose element *is* the field) is not disabled mid-typing.
- Root `aria-busy` uses a **pending counter** — with click A in flight and B queued, A's settle does not clear the busy state.
- Restore is **guarded**: skipped for a disconnected (replace-detached) trigger, and the text is not restored if `textContent` no longer equals the swapped-in label (a morph rendered a new server label — leave it). A per-trigger **refcounted snapshot** means overlapping enqueues never snapshot the loading text as the "original".
- Root `data-reactive-busy` is a **space-separated action set** with per-element+action refcounting — two queued actions coexist.
- `loading:` / `disable_with:` are now **reserved keyword names** on `on(...)` (CHANGELOG note, like #80's four and #98's `optimistic:`). Emitted as `data-reactive-loading-param` via the guarded-append pattern, so the bare-`on()` hot path stays byte-identical.

## Known trap (not "fixed")

Field auto-collection deliberately ignores `disabled` (#66) and params are captured at dispatch, so `disable: true` does not break param collection — `#collectFields` still walks named controls regardless of `disabled`.

## Test plan

| Layer | Coverage |
|---|---|
| Ruby (`component_spec.rb`) | emission for `loading:`/`disable_with:` + shorthand + merge, `to: :root` sentinel, out-of-params, unknown-key raise, non-hash raise, `busy_on` emission; **bare-`on()` byte-identical pin still green** |
| bun (`reactive_loading.test.js`, 18) | `currentTarget` capture (nested span); busy vocab at enqueue; `busy_on` scoping (matching + non-matching action); guarded restore (disconnected + server-relabel); **pending counter across overlapping enqueues**; space-separated root set; **debounce disable-only-at-flush**; always-on vocabulary with no hint |
| System (`loading_button_spec.rb`) | `disable_with` visibly swaps text + disables + spinner shows while pending, then restores; **a double-click yields exactly ONE server-side increment**; runs under **Puma AND Falcon** |

## Verification

- `bundle exec rubocop` — 133 files clean
- `bundle exec rspec spec/phlex spec/requests` — 416 passed
- `bun test spec/javascript` — 175 passed
- full `spec/system` — 44 passed under **Puma** AND **Falcon**
- vendored client re-synced to `spec/dummy/public/vendor/reactive_controller.js` (drift guard green)

## Invariants preserved

No client state (request-lifecycle attrs only) · default-deny · ONE generic controller · pgbus optional (untouched) · self-targeting `#id` · backwards compatible (bare `on()` byte-identical, existing components unchanged).
