### PR TITLE
feat(component): user-visible failure surface — error bodies, error_flash, dismiss_after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **User-visible failure surface — render error bodies, `error_flash`,
+  `dismiss_after:` (#100).** A failing action used to show the user *nothing*:
+  the client read a non-OK body only for the console and discarded it, the
+  endpoint's rescue paths could log but not display anything, a network failure
+  had no server to render, and flashes never cleaned themselves up. Four pieces
+  close the gap, all opt-in and status-preserving:
+  - **Client renders non-OK turbo-stream bodies.** When `!response.ok` but the
+    Content-Type is a turbo-stream, the body is now applied (an `error_flash`, or
+    a plain controller's `status: :unprocessable_entity` validation reply, is
+    SHOWN). The root gets `data-reactive-error="<kind>"` (styleable in pure CSS),
+    cleared on the next success. Token safety is preserved: a 400 body never
+    refreshes the held identity token (`#extractToken` no-ops unless a stream
+    re-renders this element's id).
+  - **`Phlex::Reactive.error_flash`** (default `nil`) — a `->(kind) { "message" }`
+    lambda. When set, every rescue path (400/403/404) renders a turbo-stream flash
+    into `flash_target` at the **same status** it returns today. Composes with
+    `verbose_errors`: the flash wins the response body, the diagnostic still logs.
+    A lambda that raises degrades gracefully (falls back to the bare/diagnostic
+    body — never a 500).
+  - **Offline fallback** — a server-rendered `<template data-reactive-error-flash>`
+    the client clones into the flash region on a `network` failure (trusted
+    markup, cloned verbatim — no client templating).
+  - **`dismiss_after:` on `reply.flash`** — `reply.replace.flash(:error, msg,
+    dismiss_after: 4000)` self-removes the flash after the timeout via a
+    **document-level** handler (so it self-cleans broadcast-delivered flashes too).
+    Wraps string content; a verbatim Phlex component owns its own lifecycle.
 - **Declarative loading states — `loading:` / `disable_with:` on `on(...)` +
   `busy_on(:action)` (#99).** Between the click and the morph the UI was fully
   live and unchanged: no per-trigger feedback, buttons stayed enabled, and a

--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,75 @@ One honest caveat on timing: `reactive:applied` means the turbo-streams were
 DOM mutation may complete a tick later. If you need post-morph timing, listen
 to Turbo's own events (`turbo:before-stream-render` and friends).
 
+#### Showing the user a failure (not just the console)
+
+The events above are the *hook* — but a user who just wants to see "that
+didn't work" shouldn't have to write a toast controller. There are three
+built-in ways to surface a failure, cheapest first:
+
+**1. In-action validation replies (already works).** For a failure your action
+*knows about* — a validation error, a business rule — return a flash directly.
+It renders at **200** (a normal reply, not an error):
+
+```ruby
+def rename(title:)
+  return reply.replace.flash(:error, "Title can't be blank") if title.blank?
+  @todo.update!(title:)
+end
+```
+
+**2. `Phlex::Reactive.error_flash` — server-rendered flashes on endpoint
+failures.** For the failures the *endpoint* catches (bad token, default-deny,
+authorization, missing record — the 400/403/404 rescue paths), set a lambda and
+every one renders a turbo-stream flash the user sees, at the **same status** it
+already returns (statuses never change):
+
+```ruby
+# config/initializers/phlex_reactive.rb
+Phlex::Reactive.error_flash = ->(kind) { "Something went wrong (#{kind})." }
+```
+
+The client now **renders non-OK turbo-stream bodies** (previously it read the
+body only for the console and discarded it), so an `error_flash` — or a plain
+controller replying `status: :unprocessable_entity` with a turbo-stream flash —
+lands in your flash region. The failing component's root also gets
+`data-reactive-error="<kind>"`, so you can style it in **pure CSS** with zero JS,
+and the next successful action clears it:
+
+```css
+[data-reactive-error] { outline: 2px solid var(--danger); }
+```
+
+> **Note.** A 400 (invalid token) reply never refreshes the client's held token
+> — the identity token is not a nonce, it stays retry-valid. The client only
+> adopts a fresh token from a body that re-renders *this* element's id, so a
+> foreign/error body can't swap it out.
+
+**3. Offline fallback (no server to render anything).** A `network` failure
+reached no server, so there's nothing to render. Opt in with a server-rendered
+`<template>` in your layout — on a network failure the client clones it into the
+flash region (it's your trusted markup, cloned verbatim — no client templating):
+
+```erb
+<template data-reactive-error-flash>
+  <div class="reactive-flash reactive-flash--error">You appear to be offline.</div>
+</template>
+```
+
+#### Self-dismissing flashes (`dismiss_after:`)
+
+A flash that never cleans itself up piles up. Pass `dismiss_after:` (ms) and the
+flash removes itself after the timeout — driven by a **document-level** handler,
+so it self-cleans both reply-delivered and **broadcast-delivered** flashes (the
+flash container is a plain host-app div with no controller attached):
+
+```ruby
+reply.replace.flash(:error, "Couldn't save — try again", dismiss_after: 4000)
+```
+
+It wraps string content with `data-reactive-dismiss-after="4000"`; a verbatim
+Phlex component owns its own lifecycle and is left untouched.
+
 ### Reactive collections (add/remove rows + count + empty-state)
 
 An add/remove-row list — line items, attachments, tags, comments, a
@@ -1193,6 +1262,19 @@ Phlex::Reactive.action_path = "/_r/actions"
 # Diagnostic error bodies + dropped-param logging (default: Rails.env.local? —
 # on in development AND test, off in production):
 Phlex::Reactive.verbose_errors = true
+
+# User-visible flash on endpoint failures (default nil = off). When set, every
+# rescue path (400/403/404) ALSO renders a turbo-stream flash the user sees — at
+# the SAME status it returns today (statuses never change). The lambda receives
+# the failure kind (:tampered/:unknown_class/:not_reactive_class/:forbidden/
+# :not_found), so you can map it to a friendly message:
+Phlex::Reactive.error_flash = ->(kind) do
+  case kind
+  when :not_found  then "That item is no longer available."
+  when :forbidden  then "You don't have permission to do that."
+  else                  "Something went wrong — please try again."
+  end
+end
 ```
 
 If you set a custom `action_path`, expose it to the client:

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -32,7 +32,7 @@ module Phlex
         action_def = component_class.reactive_action(reactive_action_name)
 
         # default-deny
-        return reactive_error(:forbidden, undeclared_action_message(component_class)) unless action_def
+        return reactive_error(:forbidden, undeclared_action_message(component_class), kind: :forbidden) unless action_def
 
         component = component_class.from_identity(payload)
         coerced = coerce_params(action_def.params, component_class:, action_name: action_def.name)
@@ -41,28 +41,51 @@ module Phlex
 
         render turbo_stream: response_streams(result, component)
       rescue Phlex::Reactive::InvalidToken => e
-        reactive_error(:bad_request, e.message)
+        reactive_error(:bad_request, e.message, kind: e.diagnostic || :tampered)
       rescue ActiveRecord::RecordNotFound
-        reactive_error(:not_found, record_not_found_message(payload))
+        reactive_error(:not_found, record_not_found_message(payload), kind: :not_found)
       rescue *authorization_errors => e
-        reactive_error(:forbidden, authorization_error_message(e, component_class, action_def))
+        reactive_error(:forbidden, authorization_error_message(e, component_class, action_def), kind: :forbidden)
       end
 
       private
 
-      # Reply to an endpoint failure. The status NEVER changes with the flag —
-      # only the body: verbose_errors renders the diagnostic as plain text (the
-      # client console.errors non-OK bodies), otherwise a bare head. The warn
-      # log fires in EVERY environment so a misbehaving client is debuggable
-      # from the server log alone.
-      def reactive_error(status, message)
+      # Reply to an endpoint failure. The status NEVER changes with any flag —
+      # only the body. Precedence for the body (issue #100):
+      #   1. error_flash set → a turbo-stream flash the user actually SEES (the
+      #      client renders non-OK turbo-stream bodies). It wins over the verbose
+      #      diagnostic (both can't be the body); the diagnostic still logs below.
+      #   2. else verbose_errors → the plain-text diagnostic (client console.errors it).
+      #   3. else a bare head.
+      # The warn log fires in EVERY environment first, so a misbehaving client is
+      # debuggable from the server log alone regardless of which body path runs.
+      def reactive_error(status, message, kind: nil)
         ::Rails.logger&.warn("[phlex-reactive] #{message}") if defined?(::Rails) && ::Rails.respond_to?(:logger)
 
-        if Phlex::Reactive.verbose_errors
+        flash = error_flash_stream(kind)
+        if flash
+          render turbo_stream: flash, status: status
+        elsif Phlex::Reactive.verbose_errors
           render plain: message, status: status
         else
           head status
         end
+      end
+
+      # Build the error flash turbo-stream when Phlex::Reactive.error_flash is
+      # configured, else nil (the non-flash body paths run). Degrades gracefully:
+      # a lambda that raises returns nil so the endpoint falls back to the bare/
+      # diagnostic body and NEVER turns one failure into a 500.
+      def error_flash_stream(kind)
+        callable = Phlex::Reactive.error_flash
+        return unless callable
+
+        message = callable.call(kind)
+        Phlex::Reactive::Response.flash_stream(:error, message, target: Phlex::Reactive.flash_target)
+      rescue => e # rubocop:disable Style/RescueStandardError
+        ::Rails.logger&.warn("[phlex-reactive] error_flash raised: #{e.message}") if defined?(::Rails) &&
+                                                                                     ::Rails.respond_to?(:logger)
+        nil
       end
 
       def undeclared_action_message(component_class)

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -107,10 +107,76 @@ export function registerReactiveJs() {
   }
 }
 
+// Document-level self-dismissing flashes (issue #100). A flash rendered with
+// dismiss_after: carries data-reactive-dismiss-after="<ms>"; after the timeout
+// it removes itself. This is deliberately NOT a Stimulus controller — the flash
+// container is a plain host-app div (Response#flash appends into it) with no
+// controller attached, so nothing would honor the attr. A document-level scan
+// on turbo:before-stream-render (which fires for EVERY <turbo-stream> render —
+// a reply AND a broadcast) schedules removal for any newly-arrived dismissing
+// flash. Each is marked data-reactive-dismiss-scheduled so re-scans (a later
+// stream render) never double-schedule the same node. Registered once; the
+// guard flag makes a second call a no-op (bun imports the module once per run).
+let dismissRegistered = false
+export function registerReactiveDismiss() {
+  if (dismissRegistered) return
+  if (typeof document === "undefined" || !document.addEventListener) return
+  dismissRegistered = true
+  // turbo:before-stream-render fires BEFORE the stream is applied — and Turbo
+  // then does `await nextRepaint(); await event.detail.render(this)`, so a bare
+  // setTimeout(0) can run BEFORE the node is inserted (observed under Falcon).
+  // WRAP event.detail.render instead: run Turbo's own render, then scan once it
+  // has resolved — timing-independent and correct on every server. The event
+  // fires for EVERY <turbo-stream> (a reply AND a broadcast), so both delivery
+  // paths self-clean. detail.render may be absent on exotic streams — guard it.
+  document.addEventListener("turbo:before-stream-render", wrapStreamRenderForDismiss)
+}
+
+// Chain the dismissing-flash scan after Turbo's own stream render resolves, so
+// the scan sees the freshly-inserted node. Idempotent per event (marks
+// detail.render as already-wrapped) and defensive if detail/render is missing.
+function wrapStreamRenderForDismiss(event) {
+  const detail = event.detail
+  const original = detail?.render
+  if (typeof original !== "function" || original.__reactiveDismissWrapped) {
+    // No render to wrap (or already wrapped) — fall back to a post-repaint scan.
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(scheduleReactiveDismissals)
+    else setTimeout(scheduleReactiveDismissals, 0)
+    return
+  }
+  const wrapped = async (streamElement) => {
+    await original(streamElement)
+    scheduleReactiveDismissals()
+  }
+  wrapped.__reactiveDismissWrapped = true
+  detail.render = wrapped
+}
+
+// Scan for un-scheduled dismissing flashes and schedule each one's removal.
+// Kept a module function so the scan logic is testable and re-run on every
+// stream render.
+function scheduleReactiveDismissals() {
+  const flashes = document.querySelectorAll("[data-reactive-dismiss-after]")
+  for (const el of flashes) {
+    if (el.hasAttribute("data-reactive-dismiss-scheduled")) continue
+    const ms = Number(el.getAttribute("data-reactive-dismiss-after"))
+    if (!Number.isFinite(ms) || ms <= 0) continue
+    el.setAttribute("data-reactive-dismiss-scheduled", "")
+    setTimeout(() => el.remove(), ms)
+  }
+}
+
+// Test seam: reset the one-time registration guard so a fresh document stub in
+// the next test registers its own listener (bun runs all specs in one process).
+export function __resetReactiveDismissForTest() {
+  dismissRegistered = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
+  registerReactiveDismiss()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -784,6 +850,38 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
+  // Mark the reactive root as errored (issue #100) with the failure kind, so an
+  // app can style it purely in CSS ([data-reactive-error] { … }) with zero JS.
+  // Guarded — a plain replace may have detached the root before the failure lands.
+  #markError(kind) {
+    if (this.element?.isConnected === false) return
+    this.element?.setAttribute?.("data-reactive-error", kind)
+  }
+
+  // Clear the failure marker on the next successful apply (issue #100).
+  #clearError() {
+    this.element?.removeAttribute?.("data-reactive-error")
+  }
+
+  // Offline fallback (issue #100): a network failure reached no server, so there
+  // is no body to render. Clone the content of a server-rendered
+  // <template data-reactive-error-flash> into the flash region so the user still
+  // sees SOMETHING. The template is app-authored (trusted) — this is a pure
+  // deep clone, never client templating of untrusted data. No template, or no
+  // flash container, is a silent no-op (a page without the opt-in is unchanged).
+  #renderNetworkFallback() {
+    const template = document.querySelector("[data-reactive-error-flash]")
+    if (!template?.content) return
+    // The flash region is the host-app container Response#flash targets. Its id
+    // defaults to "flash" (Phlex::Reactive.flash_target); an app that customized
+    // it can point the fallback at the same node by putting the template's
+    // data-reactive-error-flash value there — but the common case is #flash.
+    const targetId = template.getAttribute("data-reactive-error-flash") || "flash"
+    const region = document.getElementById(targetId)
+    if (!region) return
+    region.appendChild(template.content.cloneNode(true))
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -843,6 +941,12 @@ export default class extends Controller {
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
         this.#revertOptimistic(inverse)
+        // No server reached — nothing to render (issue #100). Clone a
+        // server-rendered <template data-reactive-error-flash> into the flash
+        // region as an offline fallback. The template is rendered by the app
+        // (trusted), so this is a pure clone — no client templating of data.
+        this.#renderNetworkFallback()
+        this.#markError("network")
         this.#emitError(action, params, allParams, { kind: "network" })
         return
       }
@@ -850,6 +954,7 @@ export default class extends Controller {
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
         this.#revertOptimistic(inverse)
+        this.#markError("redirected")
         this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
@@ -857,6 +962,19 @@ export default class extends Controller {
         const errorBody = await response.text()
         console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
         this.#revertOptimistic(inverse)
+        // Render a non-OK turbo-stream body so a server-rendered error flash
+        // (an error_flash rescue, or a status: :unprocessable_entity validation
+        // reply from a plain controller) is actually SHOWN — instead of being
+        // read only for the console (issue #100). #extractToken is run as usual;
+        // it NO-OPS when no stream re-renders our id, so a 400 InvalidToken body
+        // never refreshes the held identity token (which is not a nonce and stays
+        // retry-valid — do not "fix" that). A non-turbo-stream body is left to the
+        // console.error above (an HTML error page must not be handed to Turbo).
+        if ((response.headers.get("Content-Type") || "").includes("turbo-stream")) {
+          this.#currentToken = this.#extractToken(errorBody) ?? this.#currentToken
+          window.Turbo.renderStreamMessage(errorBody)
+        }
+        this.#markError("http")
         this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
@@ -865,6 +983,7 @@ export default class extends Controller {
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
         this.#revertOptimistic(inverse)
+        this.#markError("content-type")
         this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
@@ -878,6 +997,9 @@ export default class extends Controller {
       // replace (Response.morph) or an update morphs in place, preserving the
       // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
+      // A successful apply CLEARS any prior failure marker (issue #100), so
+      // error-driven CSS on the root (a red border, a shake) resets on recovery.
+      this.#clearError()
       // Lifecycle hook (issue #79): the streams were HANDED TO Turbo — a
       // renderStreamMessage applies asynchronously, so the DOM mutation may
       // complete a tick later. Apps needing post-morph timing listen to Turbo's

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -21,6 +21,7 @@ module Views
           csrf_auth
           failure_modes
           failure_ux
+          error_flash_ux
           token_lifetime
           checklist
         end
@@ -340,6 +341,69 @@ module Views
             DocsUI::Callout(:note, title: 'The events are hooks, not the security boundary') do
               plain 'A 403 still denies the action server-side whether or not anything listens; the existing ' \
                     'console.error logging is unchanged. The events only make the failure visible to your UI.'
+            end
+          end
+        end
+
+        def error_flash_ux
+          DocsUI::Section('Showing the user a failure (error_flash, error bodies, dismiss_after)') do
+            DocsUI::Prose() do
+              p do
+                plain 'The lifecycle events are the hook; these three built-ins are the ready-made surface, ' \
+                      'all opt-in and '
+                strong { 'status-preserving' }
+                plain ' — no flag ever changes an HTTP status.'
+              end
+              ul do
+                li do
+                  strong { 'In-action validation replies' }
+                  plain ' — a failure the action knows about returns a flash at 200: '
+                  code { 'reply.replace.flash(:error, "Title can\'t be blank")' }
+                  plain '.'
+                end
+                li do
+                  code { 'Phlex::Reactive.error_flash' }
+                  plain ' — a '
+                  code { '->(kind) { "message" }' }
+                  plain ' lambda. When set, every endpoint rescue path (400/403/404) renders a turbo-stream ' \
+                        'flash the user sees, at the SAME status. It composes with '
+                  code { 'verbose_errors' }
+                  plain ' (the flash wins the body, the diagnostic still logs) and degrades gracefully if the ' \
+                        'lambda raises (falls back to the bare/diagnostic body — never a 500).'
+                end
+                li do
+                  strong { 'Non-OK turbo-stream bodies are rendered' }
+                  plain ' — the client applies a turbo-stream error body instead of discarding it, and marks ' \
+                        'the root '
+                  code { 'data-reactive-error="<kind>"' }
+                  plain ' (styleable in pure CSS), cleared on the next success.'
+                end
+                li do
+                  code { 'dismiss_after:' }
+                  plain ' on '
+                  code { 'reply.flash' }
+                  plain ' — a document-level handler removes the flash after the timeout, so it self-cleans ' \
+                        'reply AND broadcast flashes.'
+                end
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby)
+              # config/initializers/phlex_reactive.rb
+              Phlex::Reactive.error_flash = ->(kind) do
+                case kind
+                when :not_found then "That item is no longer available."
+                when :forbidden then "You don't have permission to do that."
+                else                 "Something went wrong — please try again."
+                end
+              end
+
+              # In an action, a self-dismissing validation flash:
+              reply.replace.flash(:error, "Couldn't save — try again", dismiss_after: 4000)
+            RUBY
+            DocsUI::Callout(:note, title: 'A 400 error body never refreshes the held token') do
+              plain 'The identity token is not a nonce — it stays retry-valid. The client only adopts a fresh ' \
+                    'token from a body that re-renders THIS element\'s id, so an error/foreign body can\'t swap ' \
+                    'the token out. This is intentional; do not "fix" it.'
             end
           end
         end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -137,6 +137,16 @@ module Phlex
 
       attr_writer :flash_target
 
+      # A user-visible flash rendered on every endpoint rescue path (issue #100).
+      # Default nil = today's behavior (a bare head, or the verbose_errors
+      # plain-text diagnostic). Set a lambda ->(kind) { "message" } (kind is
+      # :tampered/:unknown_class/:not_reactive_class/:forbidden/:not_found) and
+      # the ActionsController ALSO renders a turbo-stream flash into flash_target
+      # — at the SAME status it returns today (statuses never change). Composes
+      # with verbose_errors: the turbo-stream flash wins the response body, the
+      # diagnostic still goes to the log.
+      attr_accessor :error_flash
+
       # Component class used to render STRING flash content (issue #77).
       # Instantiated as flash_component.new(level:, content:) and rendered
       # through the existing render path, replacing the built-in

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -174,8 +174,8 @@ module Phlex
         # content gets a level-carrying wrapper (or the configured
         # Phlex::Reactive.flash_component); component content renders VERBATIM
         # — the caller owns the markup, no wrapper, no double-wrapping.
-        def flash_stream(level, content, target:)
-          Phlex::Reactive.flash_builder.append(target, html: flash_html(level, content))
+        def flash_stream(level, content, target:, dismiss_after: nil)
+          Phlex::Reactive.flash_builder.append(target, html: flash_html(level, content, dismiss_after))
         end
 
         # Resolve flash `content` to HTML, carrying the level (issue #77):
@@ -185,13 +185,18 @@ module Phlex
         #     app's component is instantiated new(level:, content:) and
         #     rendered through the existing render_html path.
         #   * a String otherwise — the default level-carrying wrapper below.
-        def flash_html(level, content)
+        def flash_html(level, content, dismiss_after = nil)
+          # Verbatim Phlex component content owns its own markup (and lifecycle),
+          # so dismiss_after has nowhere to hang — it wraps only string content.
           return render_html(content) if content.is_a?(::Phlex::SGML)
 
           component_class = Phlex::Reactive.flash_component
-          return render_html(component_class.new(level:, content:)) if component_class
+          if component_class
+            html = render_html(component_class.new(level:, content:))
+            return dismiss_after ? wrap_dismiss(html, dismiss_after) : html
+          end
 
-          default_flash_html(level, content)
+          default_flash_html(level, content, dismiss_after)
         end
 
         # The default string-flash wrapper:
@@ -206,13 +211,30 @@ module Phlex
         # (html_safe) still renders. The wrapper is html_safe by construction
         # (both interpolations are escaped above), so the TagBuilder emits it
         # as-is.
-        def default_flash_html(level, content)
+        def default_flash_html(level, content, dismiss_after = nil)
           level_attr = CGI.escapeHTML(level.to_s)
           body = ERB::Util.html_escape(content.to_s)
 
-          # html_safe is safe by construction: both interpolated pieces are escaped above.
+          # html_safe is safe by construction: every interpolated piece is escaped
+          # (dismiss_attr coerces to an integer, so it can't inject an attribute).
           %(<div class="reactive-flash reactive-flash--#{level_attr}" \
-data-reactive-flash-level="#{level_attr}">#{body}</div>).html_safe
+data-reactive-flash-level="#{level_attr}"#{dismiss_attr(dismiss_after)}>#{body}</div>).html_safe
+        end
+
+        # The self-dismiss attribute, or "" when off. The value is forced through
+        # to_i so a String/float (or an injection attempt) becomes a plain integer
+        # — the client's document-level handler reads it as a timeout in ms.
+        def dismiss_attr(dismiss_after)
+          return "" if dismiss_after.nil?
+
+          %( data-reactive-dismiss-after="#{dismiss_after.to_i}")
+        end
+
+        # Wrap already-rendered flash HTML (the flash_component path) in a
+        # dismiss-bearing div. SafeBuffer#to_s returns SELF, so concatenate the
+        # html_safe pieces (never .to_s + raw) to keep the buffer safe.
+        def wrap_dismiss(html, dismiss_after)
+          (%(<div#{dismiss_attr(dismiss_after)}>).html_safe + html.html_safe + "</div>".html_safe)
         end
 
         # Build a turbo-stream that updates an arbitrary target id with `content`
@@ -325,8 +347,12 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
 
       # Append a flash turbo-stream into a host-app container (default
       # <div id="flash">, configurable via Phlex::Reactive.flash_target).
-      def flash(level, content, target: Phlex::Reactive.flash_target)
-        stream(self.class.flash_stream(level, content, target:))
+      # `dismiss_after:` (ms) makes the flash self-remove after the timeout — a
+      # document-level client handler removes any [data-reactive-dismiss-after]
+      # container, so it works for reply AND broadcast flashes (issue #100). It
+      # wraps only STRING content; a verbatim Phlex component owns its lifecycle.
+      def flash(level, content, target: Phlex::Reactive.flash_target, dismiss_after: nil)
+        stream(self.class.flash_stream(level, content, target:, dismiss_after:))
       end
 
       # Also re-render a COMPANION element alongside self — a page heading, a

--- a/spec/dummy/app/components/failure_surface_component.rb
+++ b/spec/dummy/app/components/failure_surface_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Drives the user-visible failure surface system spec (issue #100):
+#   * `boom` is DELIBERATELY undeclared → the endpoint default-denies it (403).
+#     With Phlex::Reactive.error_flash configured, the rescue renders a
+#     turbo-stream flash the browser SHOWS, and the client sets
+#     data-reactive-error="http" on this root.
+#   * `succeed` is a normal action whose re-render CLEARS data-reactive-error.
+#   * `flash_now` emits a self-dismissing flash (dismiss_after:) that the
+#     document-level handler removes after the timeout.
+class FailureSurfaceComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+  action :succeed
+  action :flash_now
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = "failure-surface"
+
+  def succeed = @count += 1
+
+  # A short-lived flash so the system spec can watch it appear then disappear.
+  # 800ms is long enough that Capybara reliably observes it PRESENT before the
+  # dismiss fires, yet short enough that have_no_css waits it out quickly.
+  def flash_now
+    reply.replace.flash(:notice, "gone soon", dismiss_after: 800)
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      span(data: { testid: "count" }) { @count.to_s }
+      # Undeclared action → default-deny 403 → error_flash renders a flash.
+      button(**mix(on(:boom), data: { testid: "boom" })) { "boom" }
+      button(**mix(on(:succeed), data: { testid: "succeed" })) { "succeed" }
+      button(**mix(on(:flash_now), data: { testid: "flash-now" })) { "flash" }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -10,6 +10,21 @@ class DemosController < ActionController::Base
     render_component CounterComponent.new(count: 0)
   end
 
+  # User-visible failure surface (issue #100): a boom (undeclared → 403 with an
+  # error_flash), a success that clears data-reactive-error, and a self-dismissing
+  # flash. The page carries a server-rendered <template data-reactive-error-flash>
+  # so the offline fallback has something to clone (not exercised without a real
+  # network failure, but proves the opt-in renders).
+  def failure_surface
+    component = render_to_string(FailureSurfaceComponent.new(count: 0), layout: false)
+    template = <<~HTML
+      <template data-reactive-error-flash>
+        <div class="reactive-flash reactive-flash--error" data-testid="offline-flash">You are offline</div>
+      </template>
+    HTML
+    render html: component + template.html_safe, layout: true
+  end
+
   def todos
     render_component TodoListComponent.new
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   # Example pages exercised by system specs.
   get "counter" => "demos#counter"
+  get "failure_surface" => "demos#failure_surface"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
   get "combobox" => "demos#combobox"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -107,10 +107,76 @@ export function registerReactiveJs() {
   }
 }
 
+// Document-level self-dismissing flashes (issue #100). A flash rendered with
+// dismiss_after: carries data-reactive-dismiss-after="<ms>"; after the timeout
+// it removes itself. This is deliberately NOT a Stimulus controller — the flash
+// container is a plain host-app div (Response#flash appends into it) with no
+// controller attached, so nothing would honor the attr. A document-level scan
+// on turbo:before-stream-render (which fires for EVERY <turbo-stream> render —
+// a reply AND a broadcast) schedules removal for any newly-arrived dismissing
+// flash. Each is marked data-reactive-dismiss-scheduled so re-scans (a later
+// stream render) never double-schedule the same node. Registered once; the
+// guard flag makes a second call a no-op (bun imports the module once per run).
+let dismissRegistered = false
+export function registerReactiveDismiss() {
+  if (dismissRegistered) return
+  if (typeof document === "undefined" || !document.addEventListener) return
+  dismissRegistered = true
+  // turbo:before-stream-render fires BEFORE the stream is applied — and Turbo
+  // then does `await nextRepaint(); await event.detail.render(this)`, so a bare
+  // setTimeout(0) can run BEFORE the node is inserted (observed under Falcon).
+  // WRAP event.detail.render instead: run Turbo's own render, then scan once it
+  // has resolved — timing-independent and correct on every server. The event
+  // fires for EVERY <turbo-stream> (a reply AND a broadcast), so both delivery
+  // paths self-clean. detail.render may be absent on exotic streams — guard it.
+  document.addEventListener("turbo:before-stream-render", wrapStreamRenderForDismiss)
+}
+
+// Chain the dismissing-flash scan after Turbo's own stream render resolves, so
+// the scan sees the freshly-inserted node. Idempotent per event (marks
+// detail.render as already-wrapped) and defensive if detail/render is missing.
+function wrapStreamRenderForDismiss(event) {
+  const detail = event.detail
+  const original = detail?.render
+  if (typeof original !== "function" || original.__reactiveDismissWrapped) {
+    // No render to wrap (or already wrapped) — fall back to a post-repaint scan.
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(scheduleReactiveDismissals)
+    else setTimeout(scheduleReactiveDismissals, 0)
+    return
+  }
+  const wrapped = async (streamElement) => {
+    await original(streamElement)
+    scheduleReactiveDismissals()
+  }
+  wrapped.__reactiveDismissWrapped = true
+  detail.render = wrapped
+}
+
+// Scan for un-scheduled dismissing flashes and schedule each one's removal.
+// Kept a module function so the scan logic is testable and re-run on every
+// stream render.
+function scheduleReactiveDismissals() {
+  const flashes = document.querySelectorAll("[data-reactive-dismiss-after]")
+  for (const el of flashes) {
+    if (el.hasAttribute("data-reactive-dismiss-scheduled")) continue
+    const ms = Number(el.getAttribute("data-reactive-dismiss-after"))
+    if (!Number.isFinite(ms) || ms <= 0) continue
+    el.setAttribute("data-reactive-dismiss-scheduled", "")
+    setTimeout(() => el.remove(), ms)
+  }
+}
+
+// Test seam: reset the one-time registration guard so a fresh document stub in
+// the next test registers its own listener (bun runs all specs in one process).
+export function __resetReactiveDismissForTest() {
+  dismissRegistered = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
+  registerReactiveDismiss()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -784,6 +850,38 @@ export default class extends Controller {
     this.#emit("reactive:error", { action, params: sentParams, ...extra, retry })
   }
 
+  // Mark the reactive root as errored (issue #100) with the failure kind, so an
+  // app can style it purely in CSS ([data-reactive-error] { … }) with zero JS.
+  // Guarded — a plain replace may have detached the root before the failure lands.
+  #markError(kind) {
+    if (this.element?.isConnected === false) return
+    this.element?.setAttribute?.("data-reactive-error", kind)
+  }
+
+  // Clear the failure marker on the next successful apply (issue #100).
+  #clearError() {
+    this.element?.removeAttribute?.("data-reactive-error")
+  }
+
+  // Offline fallback (issue #100): a network failure reached no server, so there
+  // is no body to render. Clone the content of a server-rendered
+  // <template data-reactive-error-flash> into the flash region so the user still
+  // sees SOMETHING. The template is app-authored (trusted) — this is a pure
+  // deep clone, never client templating of untrusted data. No template, or no
+  // flash container, is a silent no-op (a page without the opt-in is unchanged).
+  #renderNetworkFallback() {
+    const template = document.querySelector("[data-reactive-error-flash]")
+    if (!template?.content) return
+    // The flash region is the host-app container Response#flash targets. Its id
+    // defaults to "flash" (Phlex::Reactive.flash_target); an app that customized
+    // it can point the fallback at the same node by putting the template's
+    // data-reactive-error-flash value there — but the common case is #flash.
+    const targetId = template.getAttribute("data-reactive-error-flash") || "flash"
+    const region = document.getElementById(targetId)
+    if (!region) return
+    region.appendChild(template.content.cloneNode(true))
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -843,6 +941,12 @@ export default class extends Controller {
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
         this.#revertOptimistic(inverse)
+        // No server reached — nothing to render (issue #100). Clone a
+        // server-rendered <template data-reactive-error-flash> into the flash
+        // region as an offline fallback. The template is rendered by the app
+        // (trusted), so this is a pure clone — no client templating of data.
+        this.#renderNetworkFallback()
+        this.#markError("network")
         this.#emitError(action, params, allParams, { kind: "network" })
         return
       }
@@ -850,6 +954,7 @@ export default class extends Controller {
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
         this.#revertOptimistic(inverse)
+        this.#markError("redirected")
         this.#emitError(action, params, allParams, { kind: "redirected", status: response.status })
         return
       }
@@ -857,6 +962,19 @@ export default class extends Controller {
         const errorBody = await response.text()
         console.error(`[phlex-reactive] action failed: HTTP ${response.status}`, errorBody)
         this.#revertOptimistic(inverse)
+        // Render a non-OK turbo-stream body so a server-rendered error flash
+        // (an error_flash rescue, or a status: :unprocessable_entity validation
+        // reply from a plain controller) is actually SHOWN — instead of being
+        // read only for the console (issue #100). #extractToken is run as usual;
+        // it NO-OPS when no stream re-renders our id, so a 400 InvalidToken body
+        // never refreshes the held identity token (which is not a nonce and stays
+        // retry-valid — do not "fix" that). A non-turbo-stream body is left to the
+        // console.error above (an HTML error page must not be handed to Turbo).
+        if ((response.headers.get("Content-Type") || "").includes("turbo-stream")) {
+          this.#currentToken = this.#extractToken(errorBody) ?? this.#currentToken
+          window.Turbo.renderStreamMessage(errorBody)
+        }
+        this.#markError("http")
         this.#emitError(action, params, allParams, { kind: "http", status: response.status, body: errorBody })
         return
       }
@@ -865,6 +983,7 @@ export default class extends Controller {
       if (!contentType.includes("turbo-stream")) {
         console.error(`[phlex-reactive] expected a turbo-stream, got "${contentType}" — no update applied`)
         this.#revertOptimistic(inverse)
+        this.#markError("content-type")
         this.#emitError(action, params, allParams, { kind: "content-type", status: response.status })
         return
       }
@@ -878,6 +997,9 @@ export default class extends Controller {
       // replace (Response.morph) or an update morphs in place, preserving the
       // focused input + caret on unchanged nodes — see issue #28.
       window.Turbo.renderStreamMessage(html)
+      // A successful apply CLEARS any prior failure marker (issue #100), so
+      // error-driven CSS on the root (a red border, a shake) resets on recovery.
+      this.#clearError()
       // Lifecycle hook (issue #79): the streams were HANDED TO Turbo — a
       // renderStreamMessage applies asynchronously, so the DOM mutation may
       // complete a tick later. Apps needing post-morph timing listen to Turbo's

--- a/spec/javascript/reactive_dismiss.test.js
+++ b/spec/javascript/reactive_dismiss.test.js
@@ -1,0 +1,172 @@
+// Unit tests for dismiss_after (issue #100): a flash carrying
+// data-reactive-dismiss-after="<ms>" self-removes after the timeout. The
+// removal is driven by a DOCUMENT-LEVEL handler (registered alongside
+// registerReactiveVisit/registerReactiveToken), NOT a Stimulus controller — the
+// flash container is a plain host-app div with no controller attached, so
+// "the controller honors the attr" can't work. Because it's document-level and
+// fires on turbo:before-stream-render, it self-cleans BOTH reply-delivered and
+// broadcast-delivered flashes.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeEach, afterEach } from "bun:test"
+
+let registerReactiveDismiss
+let __resetReactiveDismissForTest
+
+// A minimal element stub: records whether it was removed, and its own attrs.
+function makeFlash(ms, { scheduled = false } = {}) {
+  const attrs = { "data-reactive-dismiss-after": String(ms) }
+  if (scheduled) attrs["data-reactive-dismiss-scheduled"] = ""
+  const el = {
+    removed: false,
+    getAttribute: (name) => attrs[name] ?? null,
+    setAttribute: (name, value) => (attrs[name] = String(value)),
+    hasAttribute: (name) => name in attrs,
+    remove: () => (el.removed = true),
+  }
+  return el
+}
+
+// A document stub whose querySelectorAll returns the given dismissing flashes,
+// and whose addEventListener records document-level listeners so a test can fire
+// turbo:before-stream-render manually. The handler WRAPS event.detail.render (the
+// Turbo extension point): fire() builds an event with a stub render(), lets the
+// handler wrap it, then invokes the wrapped render — mirroring how Turbo calls
+// `await event.detail.render(this)` after the node is inserted. So the scan runs
+// exactly once the streamed node exists.
+function makeDocument(flashes) {
+  const listeners = {}
+  return {
+    flashes,
+    listeners,
+    addEventListener: (name, fn) => ((listeners[name] ??= []).push(fn)),
+    querySelectorAll: (sel) => (sel.includes("data-reactive-dismiss-after") ? flashes : []),
+    // Returns a promise that resolves once the wrapped render (and thus the
+    // scan) has run — a test awaits it before asserting.
+    fire: async (name) => {
+      const detail = { render: async () => {} } // Turbo's own stream render (stubbed)
+      const event = { type: name, detail }
+      ;(listeners[name] ?? []).forEach((fn) => fn(event))
+      await detail.render() // Turbo invokes the (now-wrapped) render post-insert
+    },
+  }
+}
+
+// Per-test fake timers: capture scheduled callbacks so a test advances virtual
+// time with drainTimers(ms) instead of a real wait. Restored in afterEach. The
+// handler defers its scan with setTimeout(scan, 0); dismiss removals use
+// setTimeout(remove, ms). dismissCount counts ONLY the ms>0 removal timers, so a
+// test can assert "scheduled exactly once" independent of the 0ms deferral.
+const realSetTimeout = globalThis.setTimeout
+let pending = []
+let dismissCount = 0
+function installFakeTimers() {
+  pending = []
+  dismissCount = 0
+  globalThis.setTimeout = (fn, ms) => {
+    if (ms > 0) dismissCount++
+    pending.push({ fn, ms })
+    return pending.length
+  }
+}
+// Run all due timers at <= uptoMs, repeatedly, so a 0ms deferral that itself
+// schedules an ms>0 removal is fully drained in one call.
+function drainTimers(uptoMs) {
+  let ran = 0
+  for (;;) {
+    const due = pending.filter((t) => t.ms <= uptoMs)
+    if (due.length === 0) break
+    pending = pending.filter((t) => t.ms > uptoMs)
+    due.forEach((t) => t.fn())
+    ran += due.length
+  }
+  return ran
+}
+
+beforeEach(async () => {
+  mock.module("@hotwired/stimulus", () => ({ Controller: class {} }))
+  ;({ registerReactiveDismiss, __resetReactiveDismissForTest } = await import(
+    "../../app/javascript/phlex/reactive/reactive_controller.js"
+  ))
+  __resetReactiveDismissForTest() // fresh registration per test (shared process)
+  installFakeTimers()
+})
+
+afterEach(() => {
+  globalThis.setTimeout = realSetTimeout
+})
+
+test("removes a dismissing flash after its timeout (fake timers)", async () => {
+  const flash = makeFlash(4000)
+  const doc = makeDocument([flash])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  await doc.fire("turbo:before-stream-render") // scan runs after Turbo's render resolves
+
+  // Scheduled but not removed immediately — only after the timeout elapses.
+  expect(flash.removed).toBe(false)
+
+  expect(drainTimers(4000)).toBeGreaterThan(0)
+  expect(flash.removed).toBe(true)
+})
+
+test("does NOT remove before the timeout elapses", async () => {
+  const flash = makeFlash(4000)
+  const doc = makeDocument([flash])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  await doc.fire("turbo:before-stream-render")
+
+  drainTimers(3999) // one ms short
+  expect(flash.removed).toBe(false)
+})
+
+test("schedules each dismissing flash exactly ONCE (idempotent across stream renders)", async () => {
+  const flash = makeFlash(1000)
+  const doc = makeDocument([flash])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  await doc.fire("turbo:before-stream-render")
+  await doc.fire("turbo:before-stream-render") // a second stream render must NOT re-schedule
+  await doc.fire("turbo:before-stream-render")
+
+  expect(dismissCount).toBe(1)
+  expect(flash.hasAttribute("data-reactive-dismiss-scheduled")).toBe(true)
+})
+
+test("skips a flash already marked scheduled (broadcast re-scan safety)", async () => {
+  const flash = makeFlash(1000, { scheduled: true })
+  const doc = makeDocument([flash])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  await doc.fire("turbo:before-stream-render")
+
+  expect(dismissCount).toBe(0)
+})
+
+test("a non-numeric / zero dismiss-after is ignored (no scheduling, no removal)", async () => {
+  const flash = makeFlash("nope")
+  const doc = makeDocument([flash])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  await doc.fire("turbo:before-stream-render")
+  drainTimers(100000)
+
+  expect(dismissCount).toBe(0)
+  expect(flash.removed).toBe(false)
+})
+
+test("registerReactiveDismiss is idempotent (a second call adds no second listener)", () => {
+  const doc = makeDocument([])
+  globalThis.document = doc
+
+  registerReactiveDismiss()
+  registerReactiveDismiss()
+
+  expect(doc.listeners["turbo:before-stream-render"].length).toBe(1)
+})

--- a/spec/javascript/reactive_error_surface.test.js
+++ b/spec/javascript/reactive_error_surface.test.js
@@ -1,0 +1,204 @@
+// Unit tests for the user-visible failure surface (issue #100):
+//
+//   1. Non-OK turbo-stream bodies are RENDERED (not just console.error'd): when
+//      !response.ok BUT the Content-Type is turbo-stream, the body is read, run
+//      through #extractToken (which no-ops when nothing re-renders our id — a 400
+//      InvalidToken body never refreshes the held token), handed to
+//      Turbo.renderStreamMessage, and data-reactive-error="<kind>" is set on the
+//      root. The existing reactive:error (kind http) STILL fires. The next
+//      successful apply clears data-reactive-error.
+//   2. A network failure (no server to render anything) clones the content of a
+//      server-rendered <template data-reactive-error-flash> into the flash region.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A reactive root stub that RECORDS attribute writes so a test can assert
+// data-reactive-error was set/cleared. Records dispatched events too.
+function makeRoot({ connected = true, id = "counter" } = {}) {
+  const attrs = {}
+  const events = []
+  return {
+    attrs,
+    events,
+    isConnected: connected,
+    id,
+    dispatchEvent: (event) => events.push(event),
+    querySelectorAll: () => [],
+    setAttribute: (name, value) => (attrs[name] = String(value)),
+    removeAttribute: (name) => delete attrs[name],
+    getAttribute: (name) => attrs[name] ?? null,
+    hasAttribute: (name) => name in attrs,
+  }
+}
+
+function buildController(responses, { root, template } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root ?? makeRoot()
+  controller.tokenValue = "tok"
+  let calls = 0
+  globalThis.fetch = () => {
+    const script = responses[Math.min(calls, responses.length - 1)]
+    calls++
+    if (script.reject) return Promise.reject(script.reject)
+    return Promise.resolve({
+      redirected: script.redirected ?? false,
+      ok: script.ok ?? true,
+      status: script.status ?? 200,
+      headers: { get: () => script.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(script.body ?? ""),
+    })
+  }
+
+  // A flash container the network fallback clones the template into.
+  const flash = { children: [], appendChild: (node) => flash.children.push(node) }
+  globalThis.document = {
+    querySelector: (sel) => {
+      if (sel === 'meta[name="phlex-reactive-action-path"]') return { content: "/reactive/actions" }
+      if (sel === 'meta[name="csrf-token"]') return { content: "csrf" }
+      if (sel === "[data-reactive-error-flash]") return template ?? null
+      return null
+    },
+    getElementById: (elId) => (elId === "flash" ? flash : null),
+    dispatchEvent: () => {},
+  }
+  const rendered = []
+  globalThis.window = {
+    Turbo: { renderStreamMessage: (html) => rendered.push(html) },
+  }
+  return { controller, calls: () => calls, rendered, flash }
+}
+
+function click(controller, extra = {}) {
+  return controller.dispatch({
+    params: { action: "save", params: '{"n":1}', ...extra },
+    preventDefault: () => {},
+  })
+}
+
+function eventsNamed(root, name) {
+  return root.events.filter((event) => event.type === name)
+}
+
+// --- 1. Non-OK turbo-stream bodies are rendered -----------------------------
+
+test("a non-OK turbo-stream body is rendered via Turbo.renderStreamMessage", async () => {
+  const body =
+    '<turbo-stream action="append" target="flash"><template>' +
+    '<div class="reactive-flash reactive-flash--error">nope</div></template></turbo-stream>'
+  const root = makeRoot()
+  const { controller, rendered } = buildController([{ ok: false, status: 422, body }], { root })
+
+  await click(controller)
+
+  // The error body was HANDED TO Turbo (not discarded).
+  expect(rendered).toContain(body)
+})
+
+test("a non-OK turbo-stream response STILL fires reactive:error kind=http with status+body", async () => {
+  const body = '<turbo-stream action="append" target="flash"><template>x</template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ ok: false, status: 422, body }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("http")
+  expect(event.detail.status).toBe(422)
+  expect(event.detail.body).toBe(body)
+})
+
+test("data-reactive-error is set to the kind on a non-OK turbo-stream failure", async () => {
+  const body = '<turbo-stream action="append" target="flash"><template>x</template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ ok: false, status: 422, body }], { root })
+
+  await click(controller)
+
+  expect(root.attrs["data-reactive-error"]).toBe("http")
+})
+
+test("a non-turbo-stream non-OK body is NOT rendered (only console.error'd, as before)", async () => {
+  const root = makeRoot()
+  const { controller, rendered } = buildController(
+    [{ ok: false, status: 500, contentType: "text/html", body: "<html>error</html>" }],
+    { root },
+  )
+
+  await click(controller)
+
+  expect(rendered.length).toBe(0)
+  // But the attribute + event still fire — the failure is still surfaced.
+  expect(root.attrs["data-reactive-error"]).toBe("http")
+  expect(eventsNamed(root, "reactive:error")[0].detail.kind).toBe("http")
+})
+
+test("a 400 error body does NOT refresh the held token (extractToken no-ops on a foreign body)", async () => {
+  // A 400 body that re-renders 'flash', not our 'counter' id: #extractToken must
+  // return undefined, so the retry-valid held token is unchanged (issue #100 note).
+  const body =
+    '<turbo-stream action="append" target="flash">' +
+    '<template><div data-reactive-token-value="ATTACKER-TOKEN">x</div></template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ ok: false, status: 400, body }], { root })
+
+  await click(controller)
+
+  // The next request must still carry the ORIGINAL token, not a token lifted
+  // from a body that never re-rendered our id.
+  expect(controller.tokenValue).toBe("tok")
+})
+
+test("the next successful apply CLEARS data-reactive-error", async () => {
+  const errBody = '<turbo-stream action="append" target="flash"><template>x</template></turbo-stream>'
+  const okBody = '<turbo-stream action="replace" target="counter"><template>' +
+    '<div id="counter" data-reactive-token-value="fresh"></div></template></turbo-stream>'
+  const root = makeRoot()
+  const { controller } = buildController([{ ok: false, status: 422, body: errBody }, { body: okBody }], { root })
+
+  await click(controller)
+  expect(root.attrs["data-reactive-error"]).toBe("http")
+
+  await click(controller)
+  expect(root.attrs["data-reactive-error"]).toBeUndefined()
+})
+
+// --- 2. Network fallback clones the error-flash template ---------------------
+
+test("a network failure clones <template data-reactive-error-flash> into the flash region", async () => {
+  const cloned = { tag: "cloned-node" }
+  const template = {
+    content: { cloneNode: (deep) => (deep ? cloned : null) },
+    getAttribute: () => null, // no explicit target → defaults to "flash"
+  }
+  const root = makeRoot()
+  const { controller, flash } = buildController([{ reject: new Error("offline") }], { root, template })
+
+  await click(controller)
+
+  // The template's content was deep-cloned into the flash container.
+  expect(flash.children).toContain(cloned)
+  // The network error still surfaces as usual.
+  expect(eventsNamed(root, "reactive:error")[0].detail.kind).toBe("network")
+})
+
+test("a network failure with NO template present degrades silently (no throw)", async () => {
+  const root = makeRoot()
+  const { controller, flash } = buildController([{ reject: new Error("offline") }], { root, template: null })
+
+  await click(controller)
+
+  expect(flash.children.length).toBe(0)
+  expect(eventsNamed(root, "reactive:error")[0].detail.kind).toBe("network")
+})

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -380,4 +380,72 @@ RSpec.describe Phlex::Reactive::Response do
       expect(response.streams.last).to include('action="reactive:js"')
     end
   end
+
+  # Issue #100: dismiss_after — a flash that self-removes after N ms. The wrapper
+  # carries data-reactive-dismiss-after="<ms>"; a document-level client handler
+  # removes the container after the timeout (works for reply AND broadcast
+  # flashes, since it isn't tied to any Stimulus controller). Off by default —
+  # no attribute unless the caller opts in.
+  describe "dismiss_after: (issue #100)" do
+    it "wraps a string flash with data-reactive-dismiss-after when set" do
+      stream = described_class.with.flash(:error, "boom", dismiss_after: 4000).streams.first
+
+      expect(stream).to include('data-reactive-dismiss-after="4000"')
+      expect(stream).to include('class="reactive-flash reactive-flash--error"')
+      expect(stream).to include("boom")
+    end
+
+    it "omits the attribute entirely when dismiss_after is not given (default)" do
+      stream = described_class.with.flash(:error, "boom").streams.first
+
+      expect(stream).not_to include("data-reactive-dismiss-after")
+    end
+
+    it "coerces the ms to an integer string (a float/String can't inject an attribute)" do
+      stream = described_class.with.flash(:notice, "hi", dismiss_after: "4000\"><script>").streams.first
+
+      expect(stream).to include('data-reactive-dismiss-after="4000"')
+      expect(stream).not_to include("<script>")
+    end
+
+    it "still HTML-escapes the content inside a dismissing wrapper (injection contract)" do
+      stream = described_class.with.flash(:notice, "<em>x</em> & y", dismiss_after: 3000).streams.first
+
+      expect(stream).to include("&lt;em&gt;x&lt;/em&gt; &amp; y")
+      expect(stream).not_to include("<em>x</em>")
+    end
+
+    it "applies dismiss_after to flash_component content too (wraps the rendered component)" do
+      klass = Class.new(Phlex::HTML) do
+        def self.name = "DismissFlashProbe"
+
+        def initialize(level:, content:)
+          @level = level
+          @content = content
+        end
+
+        def view_template = div(class: "toast") { @content }
+      end
+      allow(Phlex::Reactive).to receive(:flash_component).and_return(klass)
+
+      stream = described_class.with.flash(:error, "boom", dismiss_after: 2000).streams.first
+
+      expect(stream).to include('data-reactive-dismiss-after="2000"')
+      expect(stream).to include("toast")
+    end
+
+    it "does NOT wrap verbatim Phlex component content (the caller owns the markup)" do
+      klass = Class.new(Phlex::HTML) do
+        def self.name = "VerbatimDismissProbe"
+        def view_template = span { "flash" }
+      end
+
+      stream = described_class.with.flash(:error, klass.new, dismiss_after: 2000).streams.first
+
+      # Component content renders verbatim — no built-in wrapper, so no place for
+      # the gem to hang dismiss_after. Documented limitation: dismiss_after wraps
+      # only STRING content; a component owns its own lifecycle.
+      expect(stream).not_to include("data-reactive-dismiss-after")
+    end
+  end
 end

--- a/spec/requests/error_flash_spec.rb
+++ b/spec/requests/error_flash_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #100: Phlex::Reactive.error_flash — a server-rendered, user-visible flash
+# on every endpoint rescue path (400/403/404). The contract:
+#
+#   * Default nil = today's behavior (bare head / verbose plain-text diagnostic).
+#   * When set (a lambda ->(kind) { "message" }), the rescue path ALSO renders a
+#     turbo-stream flash into Phlex::Reactive.flash_target — WITH THE SAME STATUS
+#     it returns today. Statuses NEVER change with the flag.
+#   * The lambda receives the failure KIND (:tampered/:forbidden/:not_found/…).
+#   * Composes with verbose_errors: the turbo-stream flash wins the RESPONSE BODY
+#     (a plain-text diagnostic and a turbo-stream flash can't both be the body);
+#     the diagnostic still goes to the log.
+RSpec.describe "error_flash — user-visible endpoint failures (issue #100)", type: :request do
+  # Restore both flags after each example so a set lambda / explicit flag never
+  # leaks into the next spec.
+  around do
+    it.run
+  ensure
+    Phlex::Reactive.error_flash = nil
+    if Phlex::Reactive.instance_variable_defined?(:@verbose_errors)
+      Phlex::Reactive.remove_instance_variable(:@verbose_errors)
+    end
+  end
+
+  before { allow(Rails.logger).to receive(:warn).and_call_original }
+
+  let!(:todo) { Todo.create!(title: "x", done: false) }
+
+  def post_raw(token:, act: "toggle", params: {})
+    post "/reactive/actions",
+      params: { token:, act:, params: }.to_json,
+      headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  describe "the config default" do
+    it "defaults to nil (no flash)" do
+      expect(Phlex::Reactive.error_flash).to be_nil
+    end
+  end
+
+  describe "when error_flash is nil (default behavior unchanged)" do
+    it "a tampered token keeps the 400 with no flash stream" do
+      Phlex::Reactive.verbose_errors = false
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).to be_empty
+      expect(response.body).not_to include("reactive-flash")
+    end
+  end
+
+  describe "when error_flash is set" do
+    before { Phlex::Reactive.error_flash = -> { "Something went wrong (#{it})" } }
+
+    it "renders a turbo-stream flash at the SAME 400 for a tampered token" do
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('action="append"')
+      expect(response.body).to include('target="flash"')
+      expect(response.body).to include("reactive-flash--error")
+      expect(response.body).to include("Something went wrong (tampered)")
+    end
+
+    it "renders a turbo-stream flash at the SAME 403 for an undeclared action" do
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "togle")
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to include("reactive-flash--error")
+      expect(response.body).to include("(forbidden)")
+    end
+
+    it "renders a turbo-stream flash at the SAME 404 for a missing record" do
+      gid = todo.to_gid.to_s
+      todo.destroy!
+      post_action(TodoItemComponent, payload: { "gid" => gid }, act: "toggle")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("reactive-flash--error")
+      expect(response.body).to include("(not_found)")
+    end
+
+    it "passes the correct kind to the lambda per rescue path" do
+      kinds = []
+      Phlex::Reactive.error_flash = lambda {
+        kinds << it
+        "msg"
+      }
+
+      post_raw(token: "bad")
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "togle")
+
+      expect(kinds).to eq(%i[tampered forbidden])
+    end
+
+    it "the flash body HTML-escapes the lambda's message (injection contract)" do
+      Phlex::Reactive.error_flash = ->(_kind) { "<script>alert(1)</script>" }
+      post_raw(token: "bad")
+
+      expect(response.body).not_to include("<script>alert(1)</script>")
+      expect(response.body).to include("&lt;script&gt;")
+    end
+
+    it "still fires the endpoint warn log (server-side debuggability preserved)" do
+      post_raw(token: "not.a.real.token")
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "token signature invalid"))
+    end
+  end
+
+  describe "composing with verbose_errors" do
+    before do
+      Phlex::Reactive.verbose_errors = true
+      Phlex::Reactive.error_flash = -> { "flash for #{it}" }
+    end
+
+    it "the turbo-stream flash wins the response body over the plain-text diagnostic" do
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("reactive-flash--error")
+      expect(response.body).to include("flash for tampered")
+      # The diagnostic is NOT the body (a turbo-stream flash and a plain-text
+      # diagnostic can't both be the response) — it goes to the log instead.
+      expect(response.body).not_to include("secret_key_base mismatch")
+    end
+
+    it "still logs the verbose diagnostic even though the flash owns the body" do
+      post_raw(token: "not.a.real.token")
+
+      expect(Rails.logger).to have_received(:warn)
+        .with(a_string_including("[phlex-reactive]", "token signature invalid"))
+    end
+  end
+
+  # A flash lambda that itself raises must not blow up the endpoint or change the
+  # status — degrade gracefully to the non-flash body (the invariant: a failure
+  # surface should never turn one failure into a worse one).
+  describe "when the error_flash lambda raises" do
+    before do
+      Phlex::Reactive.verbose_errors = false
+      Phlex::Reactive.error_flash = ->(_kind) { raise "boom in flash" }
+    end
+
+    it "falls back to the status-only body and keeps the status" do
+      post_raw(token: "not.a.real.token")
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.body).not_to include("reactive-flash")
+    end
+  end
+end

--- a/spec/system/failure_surface_spec.rb
+++ b/spec/system/failure_surface_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# The user-visible failure surface end-to-end (issue #100). A failing action now
+# SHOWS the user a flash (instead of silently doing nothing): the endpoint
+# renders an error_flash turbo-stream at the same status, the client applies it
+# and marks the root data-reactive-error; the next success clears the mark; a
+# dismiss_after flash removes itself. Runs under Puma AND Falcon (the reactive
+# round trip must pass sync and async).
+RSpec.describe "User-visible failure surface (issue #100)", type: :system do
+  # error_flash is process-global config read at request time; the in-process
+  # Capybara server thread sees it. Set it for this file only and restore after,
+  # so no other suite is affected.
+  before { Phlex::Reactive.error_flash = -> { "Action failed (#{it})" } }
+  after { Phlex::Reactive.error_flash = nil }
+
+  it "shows an error flash on a failing action and clears data-reactive-error on the next success" do
+    visit "/failure_surface"
+    expect(page).to have_css("[data-testid='boom']")
+
+    page.execute_script('window.__noReload = "alive"')
+
+    # A failing (undeclared) action → 403 with an error_flash turbo-stream.
+    find("[data-testid='boom']").click
+
+    # The flash the endpoint rendered is now VISIBLE in the host-app flash region
+    # (the waiting matcher is the barrier for the async round trip), and the root
+    # carries the failure marker.
+    expect(page).to have_css("#flash", text: "Action failed (forbidden)")
+    expect(page).to have_css("[data-reactive-error='http']#failure-surface")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+
+    # A subsequent SUCCESSFUL action re-renders the root and clears the marker.
+    find("[data-testid='succeed']").click
+    expect(page).to have_css("[data-testid='count']", text: "1")
+    expect(page).to have_no_css("[data-reactive-error]#failure-surface")
+  end
+
+  it "self-dismisses a dismiss_after flash after its timeout" do
+    visit "/failure_surface"
+    expect(page).to have_css("[data-testid='flash-now']")
+
+    find("[data-testid='flash-now']").click
+
+    # The flash appears...
+    expect(page).to have_css("#flash", text: "gone soon")
+    # ...then removes itself once the 300ms timeout elapses (a waiting matcher,
+    # so no manual sleep — Capybara polls until the node is gone).
+    expect(page).to have_no_css("#flash [data-reactive-dismiss-after]")
+    expect(page).to have_no_text("gone soon")
+  end
+end


### PR DESCRIPTION
Closes #100

## Problem

A user who clicked a failing reactive action saw **nothing**. The four gaps (from the Wave B audit):

1. The client bailed on `!response.ok` after reading the body only for the console — a server that renders a turbo-stream error body (a `status: :unprocessable_entity` validation reply, a flash-bearing rescue) had its body **discarded**.
2. The rescue paths could log + explain (`verbose_errors`) but could not **show** the user anything.
3. A network failure had no server to render anything.
4. Flashes never cleaned themselves up.

## What this adds (four opt-in, status-preserving pieces)

### 1. Client renders non-OK turbo-stream bodies
When `!response.ok` **but** the Content-Type is a turbo-stream, the body is applied (not discarded), the root gets `data-reactive-error="<kind>"` (styleable in pure CSS), and the existing `reactive:error` (kind `http`) still fires. The next success clears the marker.

Token safety preserved: `#extractToken` runs as usual — it **no-ops** unless a stream re-renders *this* element's id, so a 400 InvalidToken body never refreshes the held identity token (it's not a nonce; it stays retry-valid).

### 2. `Phlex::Reactive.error_flash` (default `nil`)
A `->(kind) { "message" }` lambda. When set, every rescue path (400/403/404) renders a turbo-stream flash into `flash_target` **at the same status** it returns today. `kind` is `:tampered`/`:unknown_class`/`:not_reactive_class`/`:forbidden`/`:not_found`.

- Composes with `verbose_errors`: the turbo-stream flash **wins the body**; the plain-text diagnostic still goes to the log.
- A lambda that **raises** degrades gracefully (falls back to the bare/diagnostic body — never a 500).

### 3. Offline fallback (`<template data-reactive-error-flash>`)
On a `network` failure (no server to render), the client clones a server-rendered `<template>` into the flash region — trusted markup, cloned verbatim, no client templating of data. Opt-in; absent template is a silent no-op.

### 4. `dismiss_after:` on `reply.flash`
`reply.replace.flash(:error, msg, dismiss_after: 4000)` wraps the flash with `data-reactive-dismiss-after`. A **document-level** handler removes it after the timeout — so it self-cleans **both reply- and broadcast-delivered** flashes (the flash container is a plain host-app div with no controller attached). Wraps string content; a verbatim Phlex component owns its own lifecycle.

## A timing subtlety worth calling out

The dismiss scan **chains after `event.detail.render` resolves** rather than deferring on a bare `setTimeout(0)`. Turbo's `StreamElement#render` does `dispatchEvent(before-stream-render)` then `await nextRepaint(); await event.detail.render(this)` — so a `setTimeout(0)` scheduled inside the event runs **before** the node is inserted (this reproduced under Falcon, not Puma). Wrapping `detail.render` is timing-independent and verified under both servers.

## Test coverage

| Layer | File | What |
|-------|------|------|
| Unit | `spec/phlex/reactive/response_spec.rb` | `dismiss_after` wrapper, escaping, ms coercion, string vs component content (6) |
| Request | `spec/requests/error_flash_spec.rb` | each rescue path with `error_flash` nil/set, correct kind per path, `verbose_errors` interplay (flash wins body + diagnostic logs), injection escaping, graceful fallback on a raising lambda (11) |
| bun | `spec/javascript/reactive_error_surface.test.js` | non-OK turbo-stream rendered + `reactive:error` still fired + `data-reactive-error` set/cleared + 400 token safety + network template clone (8) |
| bun | `spec/javascript/reactive_dismiss.test.js` | schedule-once idempotence, timeout removal (fake timers), broadcast re-scan safety (6) |
| System | `spec/system/failure_surface_spec.rb` | failing action shows the flash + sets `data-reactive-error`, next success clears it, a `dismiss_after` flash disappears — **Puma AND Falcon** |

## Verification

- `bundle exec rubocop` — clean (136 files) + `cd docs && bundle exec rubocop` clean
- `bundle exec rspec spec/phlex spec/requests` — 433 green
- `bun test spec/javascript` — 189 green
- `bundle exec rspec spec/system` — 46 green under **Puma** and 46 under **Falcon**
- Vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`)

## Invariants held

No client state · statuses never change with any flag · default-deny · ONE generic controller · pgbus optional · self-targeting `#id`.

## Note on performance

No Ruby hot path changed (the `error_flash` path runs only on failure). The client's dismiss scan is a single `querySelectorAll` deferred behind Turbo's own render — not on the success round-trip's critical path. No `rake bench` delta claimed (nothing measurable moved).
