### PR TITLE
feat(client): request timeout + offline handling (reactive:error kinds "timeout" and "offline")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Request timeout + offline handling — `reactive:error` kinds `timeout` and
+  `offline` (#101).** A server that never responded used to wedge a component's
+  request queue *forever* — each action chains on the previous one, so one hung
+  `fetch` froze every future action and the `finally` that clears `aria-busy` /
+  the loading state never ran. Going offline just fail-fast-looped each click as
+  `kind: "network"`. Two mechanisms close this:
+  - **Timeout.** The fetch is bounded by `AbortSignal.timeout(ms)` — default
+    **30 s**, configurable via a page-authored `<meta name="phlex-reactive-timeout">`
+    (same pattern as the action-path meta; no server setting). On abort it fires
+    `reactive:error` `kind: "timeout"` (retriable) and the queue advances, so the
+    component recovers. `AbortSignal.timeout()` rejects with a `TimeoutError`
+    `DOMException` (NOT `AbortError`), correctly distinguished from a genuine
+    network `TypeError` in the fetch catch.
+  - **Offline.** A gate at the **network boundary** (`#perform`, send time — so a
+    request that enqueued while online but reaches the wire after a drop is still
+    caught) short-circuits when `navigator.onLine === false`: it fires
+    `reactive:error` `kind: "offline"` (retriable) and never sends, so the edit is
+    not half-sent. `data-reactive-offline` is mirrored onto `<html>` (kept in sync
+    by the `online`/`offline` events) as a pure-CSS hook, zero app JS.
+  - **Explicit non-goal:** no automatic replay. A timed-out POST may have
+    succeeded server-side, so even manual `retry()` can double-apply a
+    non-idempotent action — make retryable actions idempotent or gate retry UI.
 - **User-visible failure surface — render error bodies, `error_flash`,
   `dismiss_after:` (#100).** A failing action used to show the user *nothing*:
   the client read a non-OK body only for the console and discarded it, the

--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,9 @@ latency, veto a dispatch, or build retry UI **without forking the controller**:
 | `redirected` | the POST was redirected (an auth `before_action` / CSRF guard bounced it) | `status`, `retry` |
 | `http` | non-2xx response (403 default-deny/authorization, 400 bad token, 404 record gone, 500 …) | `status`, `body`, `retry` |
 | `content-type` | 200, but not a turbo-stream (an HTML error page, a misconfigured route) | `status`, `retry` |
-| `network` | `fetch` itself rejected (offline, DNS, connection reset) — the server never saw the request | `retry` |
+| `timeout` | the request took longer than the configured window (default 30s) and was aborted — the server may or may not have finished | `retry` |
+| `offline` | the browser was offline (`navigator.onLine === false`) when the action fired — the fetch was never sent | `retry` |
+| `network` | `fetch` itself rejected (DNS, connection reset, an interface drop mid-flight) — the server never saw the request | `retry` |
 | `apply` | the server processed the action successfully, but something AFTER the fetch threw (a malformed response, a Turbo render error) | no `retry` |
 
 `apply` covers a throw in the controller's own post-fetch code — not a
@@ -1069,8 +1071,53 @@ the events add hooks, they don't replace the log.
 
 **`kind: "apply"` carries no `retry()` at all** — by the time this fires the
 server has already completed the mutation, so retrying would re-POST an
-action that already succeeded (potentially a non-idempotent one). Only the
-four fetch/response-shaped kinds above are retriable.
+action that already succeeded (potentially a non-idempotent one). Every kind
+EXCEPT `apply` is retriable.
+
+#### Request timeout (`kind: "timeout"`)
+
+A server that never responds used to wedge a component's request queue forever
+(each action chains on the previous one) — the spinner never cleared and every
+later action froze. Now the fetch is bounded by `AbortSignal.timeout`: after the
+window (default **30 s**) it aborts, fires `reactive:error` `kind: "timeout"`,
+and the queue advances so the component keeps working. Configure the window with
+a page-stable meta (app-authored, following the same pattern as the action path):
+
+```erb
+<meta name="phlex-reactive-timeout" content="15000"> <%# 15s #%>
+```
+
+> **Non-goal — no automatic replay.** A timed-out POST **may have succeeded
+> server-side** (the server just answered too late). phlex-reactive never
+> auto-replays a request, and even a manual `retry()` can double-apply a
+> non-idempotent action. Make retryable actions idempotent, or gate your retry
+> UI accordingly.
+
+#### Offline (`kind: "offline"`)
+
+When the browser is offline (`navigator.onLine === false`) at send time, the
+action short-circuits **before the fetch** — the edit is never half-sent — and
+fires `reactive:error` `kind: "offline"` with a `retry()`. The check lives at the
+network boundary, so a request that enqueued while online but reaches the wire
+after a connection drop is reported as `offline`, not `network`.
+
+`phlex-reactive` also mirrors `data-reactive-offline` onto `<html>` whenever the
+browser goes offline (kept in sync by the `online`/`offline` events) — a **pure
+CSS hook**, zero app JS:
+
+```css
+[data-reactive-offline] .save-button { opacity: .5; pointer-events: none }
+[data-reactive-offline] .offline-banner { display: block }
+```
+
+```js
+// Auto-retry a specific action when the connection returns:
+document.addEventListener("reactive:error", (e) => {
+  if (e.detail.kind === "offline") {
+    addEventListener("online", () => e.detail.retry(), { once: true })
+  }
+})
+```
 
 The events bubble from the component's root element (or from `document` when
 the root was detached by the failing round trip), so they compose with plain
@@ -1281,6 +1328,14 @@ If you set a custom `action_path`, expose it to the client:
 
 ```erb
 <meta name="phlex-reactive-action-path" content="<%= Phlex::Reactive.action_path %>">
+```
+
+The client request timeout (default 30 s) is likewise an app-authored meta —
+there is no server-side setting, so drop it in your layout head if 30 s is wrong
+for your slowest action:
+
+```erb
+<meta name="phlex-reactive-timeout" content="15000"> <%# 15s, in ms #%>
 ```
 
 ---

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -172,11 +172,47 @@ export function __resetReactiveDismissForTest() {
   dismissRegistered = false
 }
 
+// Offline CSS hook (issue #101). Mirror data-reactive-offline on
+// document.documentElement from navigator.onLine, kept in sync by the window
+// online/offline events — so an app can dim a save button or show a banner with
+// PURE CSS and zero JS ([data-reactive-offline] .save { pointer-events: none }).
+// Guarded on window (needed for addEventListener AND navigator) so importing the
+// module in a non-browser (bun test) context is a no-op, and registered once
+// (the online/offline listeners are NOT {once}, so a second registerReactiveActions
+// call must not stack duplicates) — mirroring the dismiss guard + reset seam.
+let offlineRegistered = false
+export function registerReactiveOffline() {
+  if (offlineRegistered) return
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  if (typeof window.addEventListener !== "function") return
+  offlineRegistered = true
+  // toggleAttribute(name, force) writes data-reactive-offline="" (a bare boolean
+  // attr the [data-reactive-offline] selector matches) or removes it — never the
+  // "true" string. navigator.onLine === false is the reliable direction (a false
+  // "online" is spec-permitted but rare, and this is only a presentational hook —
+  // the authoritative offline signal is the #perform gate, not this attribute).
+  // Fully defensive: a missing documentElement/toggleAttribute/navigator degrades
+  // to a no-op — a presentational hook must NEVER throw during bootstrap.
+  const sync = () => {
+    const root = document.documentElement
+    if (typeof root?.toggleAttribute !== "function") return
+    root.toggleAttribute("data-reactive-offline", globalThis.navigator?.onLine === false)
+  }
+  sync() // seed synchronously so first paint is correct
+  window.addEventListener("online", sync)
+  window.addEventListener("offline", sync)
+}
+
+export function __resetReactiveOfflineForTest() {
+  offlineRegistered = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
   registerReactiveDismiss()
+  registerReactiveOffline()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -405,6 +441,7 @@ export default class extends Controller {
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
+  #timeoutMsCache // page-stable request timeout (ms), resolved once per controller (issue #101)
   // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
   // refcount correctly and never clobber each other:
   #busyPending = 0 // root aria-busy pending counter (remove only at zero)
@@ -906,6 +943,21 @@ export default class extends Controller {
     // set here. #settleLoading in the finally clears it — see #enqueue.
 
     try {
+      // Offline gate (issue #101), authoritative at the NETWORK BOUNDARY (send
+      // time), not at enqueue. A click can enqueue while online and reach here
+      // after going offline (a debounced/queued request, a rapid transition) —
+      // gating in #perform makes the kind consistently "offline" for that whole
+      // condition instead of leaking through as a "network" fetch throw. The
+      // fetch never fires, so the edit is not half-sent; the finally still runs
+      // (settle clears loading), the optimistic hint reverts, and retry() (which
+      // re-enters #perform) re-checks and sends once back online.
+      if (navigator.onLine === false) {
+        this.#revertOptimistic(inverse)
+        this.#markError("offline")
+        this.#emitError(action, params, allParams, { kind: "offline" })
+        return
+      }
+
       let response
       try {
         const headers = {
@@ -937,10 +989,28 @@ export default class extends Controller {
           headers,
           body,
           credentials: "same-origin",
+          // Bound the request (issue #101): a server that never answers used to
+          // wedge this.queue forever (the finally that clears aria-busy/loading
+          // never ran). AbortSignal.timeout(ms) aborts the fetch after the
+          // configured window; the abort surfaces in this catch as a
+          // DOMException named "TimeoutError" (see the branch below).
+          signal: AbortSignal.timeout(this.#timeoutMs()),
         })
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
         this.#revertOptimistic(inverse)
+        // AbortSignal.timeout() rejects with a DOMException named "TimeoutError"
+        // (a manual AbortController.abort() would be "AbortError" — we don't use
+        // one, but accept it too for robustness). A timeout is NOT "offline":
+        // the request left and the server didn't answer in time; connectivity is
+        // unknown. So do NOT clone the offline-fallback template or mark network
+        // — just fire kind:"timeout" (retriable). The queue still advances
+        // (#perform returns, never rejects), so the hung request un-wedges it.
+        if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+          this.#markError("timeout")
+          this.#emitError(action, params, allParams, { kind: "timeout" })
+          return
+        }
         // No server reached — nothing to render (issue #100). Clone a
         // server-rendered <template data-reactive-error-flash> into the flash
         // region as an offline fallback. The template is rendered by the app
@@ -1484,6 +1554,19 @@ export default class extends Controller {
     return (this.#actionPathCache ??=
       document.querySelector('meta[name="phlex-reactive-action-path"]')?.content ||
       "/reactive/actions")
+  }
+
+  // The per-request timeout in ms (issue #101), from a page-stable
+  // <meta name="phlex-reactive-timeout"> (default 30000). Cached per-controller
+  // like the action path. Parsed defensively: a missing/blank/non-positive/NaN
+  // value falls back to the default, so a typo'd meta can never disable the
+  // timeout (which would reintroduce the wedged-queue bug) or set a zero/negative
+  // window that aborts instantly.
+  #timeoutMs() {
+    if (this.#timeoutMsCache != null) return this.#timeoutMsCache
+    const raw = document.querySelector('meta[name="phlex-reactive-timeout"]')?.content
+    const ms = Number(raw)
+    return (this.#timeoutMsCache = Number.isFinite(ms) && ms > 0 ? ms : 30000)
   }
 
   // CSRF token and connection id are read LIVE (not cached) on purpose: Rails

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -308,7 +308,7 @@ module Views
                   plain '; '
                   code { 'kind' }
                   plain ' is one of '
-                  code { 'redirected | http | content-type | network' }
+                  code { 'redirected | http | content-type | timeout | offline | network' }
                   plain ' (all retriable) or '
                   code { 'apply' }
                   plain ' — the server already completed the mutation but something AFTER the fetch threw ' \
@@ -341,6 +341,30 @@ module Views
             DocsUI::Callout(:note, title: 'The events are hooks, not the security boundary') do
               plain 'A 403 still denies the action server-side whether or not anything listens; the existing ' \
                     'console.error logging is unchanged. The events only make the failure visible to your UI.'
+            end
+            DocsUI::Prose() do
+              p do
+                plain 'The '
+                code { 'timeout' }
+                plain ' and '
+                code { 'offline' }
+                plain ' kinds bound the request itself. '
+                code { 'AbortSignal.timeout' }
+                plain ' (default 30s, set '
+                code { '<meta name="phlex-reactive-timeout">' }
+                plain ') aborts a hung request so one dead connection can no longer wedge the component\'s ' \
+                      'request queue; an offline click short-circuits BEFORE the fetch (the edit is never ' \
+                      'half-sent) and mirrors '
+                code { 'data-reactive-offline' }
+                plain ' onto '
+                code { '<html>' }
+                plain ' as a pure CSS hook.'
+              end
+            end
+            DocsUI::Callout(:warning, title: 'A timed-out request may have SUCCEEDED — no auto-replay') do
+              plain 'A timeout means the server did not answer in time, NOT that it did nothing — the mutation ' \
+                    'may have committed. phlex-reactive never auto-replays, and even a manual retry() can ' \
+                    'double-apply a non-idempotent action. Make retryable actions idempotent, or gate retry UI.'
             end
           end
         end

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -26,3 +26,10 @@
 # it, expose it to the client with:
 #   <meta name="phlex-reactive-action-path" content="<%%= Phlex::Reactive.action_path %>">
 # Phlex::Reactive.action_path = "/_r/actions"
+
+# Client request timeout (default 30s). There is NO server-side setting — a hung
+# request aborts client-side after this window (reactive:error kind "timeout"),
+# so the per-component queue never wedges. Override in your layout head:
+#   <meta name="phlex-reactive-timeout" content="15000"> <%# 15s, in ms %>
+# A timed-out POST may have SUCCEEDED server-side — phlex-reactive never
+# auto-replays; make retryable actions idempotent.

--- a/spec/dummy/app/components/network_status_component.rb
+++ b/spec/dummy/app/components/network_status_component.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Drives the timeout + offline system spec (issue #101):
+#   * `slow` sleeps LONGER than the page's shortened phlex-reactive-timeout meta,
+#     so the client aborts the fetch (kind:"timeout") — proving the queue does
+#     NOT wedge: a subsequent `ping` still round-trips.
+#   * `ping` returns immediately (a normal re-render) and is what the spec fires
+#     AFTER the timeout to prove the per-component queue recovered.
+class NetworkStatusComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+  action :slow
+  action :ping
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = "network-status"
+
+  # Sleeps well past the spec's shortened timeout meta so the CLIENT aborts the
+  # fetch. The server keeps working (it eventually finishes), but the client has
+  # already moved on — the queue is not wedged.
+  def slow
+    sleep 2.5
+    @count += 1
+  end
+
+  def ping = @count += 1
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      span(data: { testid: "count" }) { @count.to_s }
+      button(**mix(on(:slow), data: { testid: "slow" })) { "slow" }
+      button(**mix(on(:ping), data: { testid: "ping" })) { "ping" }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -25,6 +25,24 @@ class DemosController < ActionController::Base
     render html: component + template.html_safe, layout: true
   end
 
+  # Timeout + offline surface (issue #101). A SHORT phlex-reactive-timeout meta
+  # (300ms) so the component's 1.5s `slow` action reliably aborts on the client,
+  # plus a document-level probe node the reactive:error listener writes the kind
+  # into — the spec reads it to prove kind=timeout / kind=offline without app JS.
+  def network_status
+    component = render_to_string(NetworkStatusComponent.new(count: 0), layout: false)
+    extras = <<~HTML
+      <meta name="phlex-reactive-timeout" content="1000">
+      <div data-testid="error-probe"></div>
+      <script>
+        document.addEventListener("reactive:error", (e) => {
+          document.querySelector("[data-testid='error-probe']").textContent = e.detail.kind
+        })
+      </script>
+    HTML
+    render html: component + extras.html_safe, layout: true
+  end
+
   def todos
     render_component TodoListComponent.new
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # Example pages exercised by system specs.
   get "counter" => "demos#counter"
   get "failure_surface" => "demos#failure_surface"
+  get "network_status" => "demos#network_status"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
   get "combobox" => "demos#combobox"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -172,11 +172,47 @@ export function __resetReactiveDismissForTest() {
   dismissRegistered = false
 }
 
+// Offline CSS hook (issue #101). Mirror data-reactive-offline on
+// document.documentElement from navigator.onLine, kept in sync by the window
+// online/offline events — so an app can dim a save button or show a banner with
+// PURE CSS and zero JS ([data-reactive-offline] .save { pointer-events: none }).
+// Guarded on window (needed for addEventListener AND navigator) so importing the
+// module in a non-browser (bun test) context is a no-op, and registered once
+// (the online/offline listeners are NOT {once}, so a second registerReactiveActions
+// call must not stack duplicates) — mirroring the dismiss guard + reset seam.
+let offlineRegistered = false
+export function registerReactiveOffline() {
+  if (offlineRegistered) return
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  if (typeof window.addEventListener !== "function") return
+  offlineRegistered = true
+  // toggleAttribute(name, force) writes data-reactive-offline="" (a bare boolean
+  // attr the [data-reactive-offline] selector matches) or removes it — never the
+  // "true" string. navigator.onLine === false is the reliable direction (a false
+  // "online" is spec-permitted but rare, and this is only a presentational hook —
+  // the authoritative offline signal is the #perform gate, not this attribute).
+  // Fully defensive: a missing documentElement/toggleAttribute/navigator degrades
+  // to a no-op — a presentational hook must NEVER throw during bootstrap.
+  const sync = () => {
+    const root = document.documentElement
+    if (typeof root?.toggleAttribute !== "function") return
+    root.toggleAttribute("data-reactive-offline", globalThis.navigator?.onLine === false)
+  }
+  sync() // seed synchronously so first paint is correct
+  window.addEventListener("online", sync)
+  window.addEventListener("offline", sync)
+}
+
+export function __resetReactiveOfflineForTest() {
+  offlineRegistered = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
   registerReactiveDismiss()
+  registerReactiveOffline()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -405,6 +441,7 @@ export default class extends Controller {
   #debounceTimers = new Map() // trigger element -> { timer, flush } pending dispatch
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
+  #timeoutMsCache // page-stable request timeout (ms), resolved once per controller (issue #101)
   // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
   // refcount correctly and never clobber each other:
   #busyPending = 0 // root aria-busy pending counter (remove only at zero)
@@ -906,6 +943,21 @@ export default class extends Controller {
     // set here. #settleLoading in the finally clears it — see #enqueue.
 
     try {
+      // Offline gate (issue #101), authoritative at the NETWORK BOUNDARY (send
+      // time), not at enqueue. A click can enqueue while online and reach here
+      // after going offline (a debounced/queued request, a rapid transition) —
+      // gating in #perform makes the kind consistently "offline" for that whole
+      // condition instead of leaking through as a "network" fetch throw. The
+      // fetch never fires, so the edit is not half-sent; the finally still runs
+      // (settle clears loading), the optimistic hint reverts, and retry() (which
+      // re-enters #perform) re-checks and sends once back online.
+      if (navigator.onLine === false) {
+        this.#revertOptimistic(inverse)
+        this.#markError("offline")
+        this.#emitError(action, params, allParams, { kind: "offline" })
+        return
+      }
+
       let response
       try {
         const headers = {
@@ -937,10 +989,28 @@ export default class extends Controller {
           headers,
           body,
           credentials: "same-origin",
+          // Bound the request (issue #101): a server that never answers used to
+          // wedge this.queue forever (the finally that clears aria-busy/loading
+          // never ran). AbortSignal.timeout(ms) aborts the fetch after the
+          // configured window; the abort surfaces in this catch as a
+          // DOMException named "TimeoutError" (see the branch below).
+          signal: AbortSignal.timeout(this.#timeoutMs()),
         })
       } catch (error) {
         console.error("[phlex-reactive] action error", error)
         this.#revertOptimistic(inverse)
+        // AbortSignal.timeout() rejects with a DOMException named "TimeoutError"
+        // (a manual AbortController.abort() would be "AbortError" — we don't use
+        // one, but accept it too for robustness). A timeout is NOT "offline":
+        // the request left and the server didn't answer in time; connectivity is
+        // unknown. So do NOT clone the offline-fallback template or mark network
+        // — just fire kind:"timeout" (retriable). The queue still advances
+        // (#perform returns, never rejects), so the hung request un-wedges it.
+        if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+          this.#markError("timeout")
+          this.#emitError(action, params, allParams, { kind: "timeout" })
+          return
+        }
         // No server reached — nothing to render (issue #100). Clone a
         // server-rendered <template data-reactive-error-flash> into the flash
         // region as an offline fallback. The template is rendered by the app
@@ -1484,6 +1554,19 @@ export default class extends Controller {
     return (this.#actionPathCache ??=
       document.querySelector('meta[name="phlex-reactive-action-path"]')?.content ||
       "/reactive/actions")
+  }
+
+  // The per-request timeout in ms (issue #101), from a page-stable
+  // <meta name="phlex-reactive-timeout"> (default 30000). Cached per-controller
+  // like the action path. Parsed defensively: a missing/blank/non-positive/NaN
+  // value falls back to the default, so a typo'd meta can never disable the
+  // timeout (which would reintroduce the wedged-queue bug) or set a zero/negative
+  // window that aborts instantly.
+  #timeoutMs() {
+    if (this.#timeoutMsCache != null) return this.#timeoutMsCache
+    const raw = document.querySelector('meta[name="phlex-reactive-timeout"]')?.content
+    const ms = Number(raw)
+    return (this.#timeoutMsCache = Number.isFinite(ms) && ms > 0 ? ms : 30000)
   }
 
   // CSRF token and connection id are read LIVE (not cached) on purpose: Rails

--- a/spec/javascript/reactive_timeout_offline.test.js
+++ b/spec/javascript/reactive_timeout_offline.test.js
@@ -1,0 +1,319 @@
+// Unit tests for request timeout + offline handling (issue #101):
+//
+//   TIMEOUT — the fetch is given AbortSignal.timeout(ms) (ms from
+//   <meta name="phlex-reactive-timeout">, default 30000). AbortSignal.timeout()
+//   rejects with a DOMException named "TimeoutError" (NOT "AbortError" — that's a
+//   manual AbortController.abort()). The fetch catch maps "TimeoutError" to
+//   reactive:error kind:"timeout" (retriable) WITHOUT the offline-fallback clone
+//   or the network marker; the queue continues (a second click still fetches).
+//
+//   OFFLINE — #perform gates on navigator.onLine === false right before fetch
+//   (authoritative at the network boundary — catches a click that enqueued while
+//   online but sends after going offline), firing reactive:error kind:"offline"
+//   (retriable) and skipping the fetch entirely — the edit is never half-sent.
+//
+//   FLAG — module-level online/offline listeners toggle data-reactive-offline on
+//   document.documentElement (a pure CSS hook), seeded from navigator.onLine.
+//
+// Scripted fetch stubs reject with a NAMED DOMException-like error — never a real
+// timer against real fetch (bun:test fails a test on any surfaced exception).
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, afterEach } from "bun:test"
+
+let ReactiveController
+let registerReactiveOffline
+let __resetReactiveOfflineForTest
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  const mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  ReactiveController = mod.default
+  registerReactiveOffline = mod.registerReactiveOffline
+  __resetReactiveOfflineForTest = mod.__resetReactiveOfflineForTest
+})
+
+afterEach(() => {
+  // Restore a sane global navigator between tests.
+  globalThis.navigator = { onLine: true }
+})
+
+// A named DOMException-like error, matching what AbortSignal.timeout() / abort()
+// reject with (name is what the controller branches on).
+function abortError(name) {
+  const e = new Error(name)
+  e.name = name
+  return e
+}
+
+// A reactive root stub recording dispatched events + attribute writes.
+function makeRoot({ connected = true } = {}) {
+  const attrs = {}
+  const events = []
+  return {
+    attrs,
+    events,
+    isConnected: connected,
+    id: "counter",
+    dispatchEvent: (event) => events.push(event),
+    querySelectorAll: () => [],
+    setAttribute: (name, value) => (attrs[name] = String(value)),
+    removeAttribute: (name) => delete attrs[name],
+    getAttribute: (name) => attrs[name] ?? null,
+    hasAttribute: (name) => name in attrs,
+  }
+}
+
+// Build a controller with a scripted fetch. `responses` entries: { reject: Error }
+// to reject (a timeout/network), or a response-shape object. Records the fetch
+// `signal` each call received so a test can assert AbortSignal.timeout was passed.
+function buildController(responses, { root, onLine = true, timeoutMeta } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root ?? makeRoot()
+  controller.tokenValue = "tok"
+  globalThis.navigator = { onLine }
+
+  const signals = []
+  let calls = 0
+  globalThis.fetch = (_url, opts) => {
+    signals.push(opts?.signal ?? null)
+    const script = responses[Math.min(calls, responses.length - 1)]
+    calls++
+    if (script?.reject) return Promise.reject(script.reject)
+    return Promise.resolve({
+      redirected: script?.redirected ?? false,
+      ok: script?.ok ?? true,
+      status: script?.status ?? 200,
+      headers: { get: () => script?.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(script?.body ?? ""),
+    })
+  }
+  globalThis.document = {
+    querySelector: (sel) => {
+      if (sel === 'meta[name="phlex-reactive-timeout"]') return timeoutMeta ? { content: timeoutMeta } : null
+      return null
+    },
+    dispatchEvent: () => {},
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, calls: () => calls, signals }
+}
+
+function click(controller, extra = {}) {
+  return controller.dispatch({
+    params: { action: "save", params: '{"n":1}', ...extra },
+    preventDefault: () => {},
+  })
+}
+
+function eventsNamed(root, name) {
+  return root.events.filter((event) => event.type === name)
+}
+
+// --- TIMEOUT ----------------------------------------------------------------
+
+test("the fetch is given an AbortSignal (timeout wired)", async () => {
+  const root = makeRoot()
+  const { controller, signals } = buildController([{}], { root })
+
+  await click(controller)
+
+  expect(signals[0]).toBeInstanceOf(AbortSignal)
+})
+
+test("a TimeoutError abort fires reactive:error kind=timeout with retry", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ reject: abortError("TimeoutError") }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("timeout")
+  expect(typeof event.detail.retry).toBe("function")
+})
+
+test("a TimeoutError does NOT mark the root data-reactive-error=network (it's a timeout)", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ reject: abortError("TimeoutError") }], { root })
+
+  await click(controller)
+
+  expect(root.attrs["data-reactive-error"]).toBe("timeout")
+})
+
+test("the queue CONTINUES after a timeout — a second click still fetches", async () => {
+  const root = makeRoot()
+  // First fetch times out, second succeeds.
+  const { controller, calls } = buildController(
+    [{ reject: abortError("TimeoutError") }, { body: "" }],
+    { root },
+  )
+
+  await click(controller)
+  expect(calls()).toBe(1)
+
+  await click(controller)
+  expect(calls()).toBe(2) // the hung request did NOT wedge the queue
+})
+
+test("retry() after a timeout re-enters the queue and fetches again", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController(
+    [{ reject: abortError("TimeoutError") }, { body: "" }],
+    { root },
+  )
+
+  await click(controller)
+  const [event] = eventsNamed(root, "reactive:error")
+  await event.detail.retry()
+
+  expect(calls()).toBe(2)
+})
+
+test("a genuine network TypeError is still kind=network (NOT timeout)", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{ reject: new TypeError("Failed to fetch") }], { root })
+
+  await click(controller)
+
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("network")
+})
+
+test("a custom timeout meta is honored (the signal reflects a short timeout)", async () => {
+  // We can't easily read the ms off an AbortSignal, but we CAN prove the meta is
+  // read without throwing and a signal is still produced.
+  const root = makeRoot()
+  const { controller, signals } = buildController([{}], { root, timeoutMeta: "5000" })
+
+  await click(controller)
+
+  expect(signals[0]).toBeInstanceOf(AbortSignal)
+})
+
+// --- OFFLINE ----------------------------------------------------------------
+
+test("offline short-circuits: navigator.onLine false fires kind=offline and skips fetch", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController([{}], { root, onLine: false })
+
+  await click(controller)
+
+  expect(calls()).toBe(0) // never sent — the edit is not half-sent
+  const [event] = eventsNamed(root, "reactive:error")
+  expect(event.detail.kind).toBe("offline")
+  expect(typeof event.detail.retry).toBe("function")
+})
+
+test("offline marks the root data-reactive-error=offline", async () => {
+  const root = makeRoot()
+  const { controller } = buildController([{}], { root, onLine: false })
+
+  await click(controller)
+
+  expect(root.attrs["data-reactive-error"]).toBe("offline")
+})
+
+test("retry() after offline, once back online, actually fetches", async () => {
+  const root = makeRoot()
+  const { controller, calls } = buildController([{}], { root, onLine: false })
+
+  await click(controller)
+  expect(calls()).toBe(0)
+
+  // Back online, then retry.
+  globalThis.navigator = { onLine: true }
+  const [event] = eventsNamed(root, "reactive:error")
+  await event.detail.retry()
+
+  expect(calls()).toBe(1)
+})
+
+test("a request that enqueues online but sends offline is kind=offline (authoritative gate)", async () => {
+  // Gate lives in #perform (send time), so a transition after the click but
+  // before send still yields kind=offline, not network. Simulate by flipping
+  // navigator between dispatch and the queued #perform: onLine at click, offline
+  // by the time fetch would run. We approximate by starting offline (the perform
+  // gate reads navigator live).
+  const root = makeRoot()
+  const { controller, calls } = buildController([{}], { root, onLine: false })
+
+  await click(controller)
+
+  expect(calls()).toBe(0)
+  expect(eventsNamed(root, "reactive:error")[0].detail.kind).toBe("offline")
+})
+
+// --- FLAG -------------------------------------------------------------------
+
+test("registerReactiveOffline toggles data-reactive-offline from navigator.onLine + events", () => {
+  const attrs = {}
+  const root = {
+    toggleAttribute: (name, force) => {
+      if (force) attrs[name] = ""
+      else delete attrs[name]
+    },
+    hasAttribute: (name) => name in attrs,
+  }
+  const listeners = {}
+  globalThis.navigator = { onLine: true }
+  globalThis.window = {
+    addEventListener: (name, fn) => ((listeners[name] ??= []).push(fn)),
+  }
+  globalThis.document = { documentElement: root }
+
+  __resetReactiveOfflineForTest()
+  registerReactiveOffline()
+
+  // Seeded online → no flag.
+  expect(root.hasAttribute("data-reactive-offline")).toBe(false)
+
+  // Go offline → flag set.
+  globalThis.navigator = { onLine: false }
+  listeners["offline"].forEach((fn) => fn())
+  expect(root.hasAttribute("data-reactive-offline")).toBe(true)
+
+  // Back online → flag cleared.
+  globalThis.navigator = { onLine: true }
+  listeners["online"].forEach((fn) => fn())
+  expect(root.hasAttribute("data-reactive-offline")).toBe(false)
+})
+
+test("registerReactiveOffline seeds the flag when starting offline", () => {
+  const attrs = {}
+  const root = {
+    toggleAttribute: (name, force) => {
+      if (force) attrs[name] = ""
+      else delete attrs[name]
+    },
+    hasAttribute: (name) => name in attrs,
+  }
+  globalThis.navigator = { onLine: false }
+  globalThis.window = { addEventListener: () => {} }
+  globalThis.document = { documentElement: root }
+
+  __resetReactiveOfflineForTest()
+  registerReactiveOffline()
+
+  expect(root.hasAttribute("data-reactive-offline")).toBe(true)
+})
+
+test("registerReactiveOffline is idempotent (a second call adds no duplicate listeners)", () => {
+  const listeners = {}
+  globalThis.navigator = { onLine: true }
+  globalThis.window = {
+    addEventListener: (name, fn) => ((listeners[name] ??= []).push(fn)),
+  }
+  globalThis.document = { documentElement: { toggleAttribute: () => {} } }
+
+  __resetReactiveOfflineForTest()
+  registerReactiveOffline()
+  registerReactiveOffline()
+
+  expect(listeners["online"].length).toBe(1)
+  expect(listeners["offline"].length).toBe(1)
+})

--- a/spec/system/timeout_offline_spec.rb
+++ b/spec/system/timeout_offline_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Request timeout + offline handling end-to-end (issue #101). A hung request no
+# longer wedges the per-component queue, and going offline surfaces a retriable
+# error + a CSS hook instead of silently half-sending. Runs under Puma AND Falcon
+# (the reactive round trip must behave the same sync and async).
+RSpec.describe "Timeout + offline (issue #101)", type: :system do
+  # Reach the Playwright browser context to toggle offline (the driver exposes
+  # the underlying page; its context has set_offline).
+  def toggle_offline(offline)
+    page.driver.with_playwright_page do
+      it.context.set_offline(offline)
+    end
+  end
+
+  describe "offline" do
+    after { toggle_offline(false) } # never leak offline into the next example
+
+    it "sets data-reactive-offline on <html> and fires reactive:error kind=offline, skipping the fetch" do
+      visit "/network_status"
+      expect(page).to have_css("[data-testid='ping']")
+
+      page.execute_script('window.__noReload = "alive"')
+      toggle_offline(true)
+
+      # The online/offline events toggle the CSS hook on <html>.
+      expect(page).to have_css("html[data-reactive-offline]")
+
+      # A click while offline short-circuits: the fetch never fires, the edit is
+      # not applied (count stays 0), and reactive:error kind=offline is dispatched.
+      find("[data-testid='ping']").click
+      expect(page).to have_css("[data-testid='error-probe']", text: "offline")
+      expect(page).to have_css("[data-testid='count']", text: "0") # never sent
+      expect(page.evaluate_script("window.__noReload")).to eq("alive")
+
+      # Back online clears the flag.
+      toggle_offline(false)
+      expect(page).to have_no_css("html[data-reactive-offline]")
+    end
+  end
+
+  describe "timeout" do
+    it "aborts a hung request (kind=timeout) and does NOT wedge the queue" do
+      visit "/network_status"
+      expect(page).to have_css("[data-testid='slow']")
+
+      # The slow action sleeps 2.5s; the page's phlex-reactive-timeout meta is
+      # 1000ms, so the client aborts the fetch → reactive:error kind=timeout.
+      find("[data-testid='slow']").click
+      expect(page).to have_css("[data-testid='error-probe']", text: "timeout")
+
+      # THE CRITICAL ASSERTION: the hung request did not wedge this.queue. A
+      # subsequent ping still round-trips and re-renders (count → 1). Before the
+      # timeout mechanism, the queue chained on a promise that never resolved, so
+      # every future action was frozen and this would never update.
+      #
+      # The slow action still occupies a server thread until its 2.5s sleep ends;
+      # let it drain so the ping isn't itself starved past its own client timeout
+      # (this test proves the CLIENT queue recovered, not server concurrency).
+      sleep 2.5
+
+      find("[data-testid='ping']").click
+      expect(page).to have_css("[data-testid='count']", text: "1", wait: 8)
+    end
+  end
+end


### PR DESCRIPTION
Closes #101

## Problem

The `fetch` in `#perform` had **no timeout**, and `#enqueue` chains every request on `this.queue`. One hung request (server never responds) wedged the per-component queue **forever** — every future action froze and the `finally` that clears `aria-busy` / the loading state never ran. Going offline just fail-fast-looped each click as `kind: "network"`. The `reactive:error` enum from #79/#89 deliberately **excluded** `timeout` because no timeout existed; this adds the mechanism and the kind together.

## What this adds

### Timeout (`kind: "timeout"`)

The fetch is bounded by `AbortSignal.timeout(ms)` — `ms` from a page-authored `<meta name="phlex-reactive-timeout">` (default **30 s**, parsed defensively). On abort → `reactive:error` `kind: "timeout"` (retriable), and the queue advances so the component recovers.

> **Spec correctness caught by the design pass:** `AbortSignal.timeout()` rejects with a **`TimeoutError`** `DOMException`, **not** `AbortError` (that's a manual `AbortController.abort()`). Verified empirically against bun and the WHATWG DOM spec. The naive `error.name === "AbortError"` check would have misclassified *every* timeout as `network`. The fetch catch branches on `"TimeoutError"` (accepting `"AbortError"` defensively) and does **not** treat a timeout as offline — no fallback-template clone, no network marker.

### Offline (`kind: "offline"`)

A gate at the **network boundary** (`#perform`, send time) short-circuits on `navigator.onLine === false`, firing `reactive:error` `kind: "offline"` (retriable) and never sending — the edit is not half-sent.

> **Placement over the issue's literal `#proceed`:** the design pass argued (and I agreed) that gating in `#perform` is strictly better — a request that enqueued while *online* but reaches the wire after a drop (a debounced/queued request, a rapid transition) is still reported as `offline`, not leaked through as a `network` fetch throw. The fetch still never fires (nothing half-sent), the outer `try`'s `finally` still settles loading, the optimistic hint reverts, and `retry()` (which re-enters `#perform`) re-checks and sends once back online.

`data-reactive-offline` is mirrored onto `<html>` via module-level `online`/`offline` listeners — `toggleAttribute` (boolean-correct, never a `"true"` string), seeded from `navigator.onLine`. A pure CSS hook, zero app JS:

```css
[data-reactive-offline] .save-button { opacity: .5; pointer-events: none }
```

### Explicit non-goal: no automatic replay

A timed-out POST **may have succeeded server-side**. phlex-reactive never auto-replays, and even manual `retry()` can double-apply a non-idempotent action. Documented in the README, the docs security page (a warning callout), and the install-generator initializer. Make retryable actions idempotent or gate retry UI.

## Why I'm confident (ultracode)

Two multi-agent passes:

1. **Design pass** (before writing code) — pressure-tested the 3 hardest decisions. It caught the `TimeoutError` vs `AbortError` bug and the `#perform` vs `#proceed` placement, both confirmed against the spec.
2. **Adversarial review** (of the actual diff) — 3 lenses (discrimination correctness, queue/state interaction, missed edge cases), each finding **verified**. Result: **NO DEFECTS**. Confirmed revert-is-called-exactly-once on every failure path, the `finally` always settles loading (queue always advances, never wedges), strict `=== false` fails safe on an `undefined` navigator, and `AbortSignal.timeout` degrades gracefully (throws synchronously inside the inner try → classified `network`, not a false timeout) if ever unavailable.

## Test coverage

| Layer | File | What |
|-------|------|------|
| bun | `spec/javascript/reactive_timeout_offline.test.js` (14) | `AbortSignal` wired; `TimeoutError` → kind `timeout` + marker + **queue continues** (second click fetches) + retry; a network `TypeError` is still kind `network`; offline short-circuit skips the fetch + kind `offline` + retry-when-online sends; `data-reactive-offline` toggles from `navigator.onLine` + `online`/`offline` events; idempotent registration; offline seeding |
| System | `spec/system/timeout_offline_spec.rb` | Playwright offline sim shows the `<html>` flag + kind `offline` + no fetch; a hung route (2.5 s action vs 1 s meta timeout) fires kind `timeout` and **proves the queue un-wedges** (a subsequent `ping` still round-trips) — **Puma AND Falcon** |

## Verification

- `bundle exec rubocop` — clean (138 files) + `cd docs && bundle exec rubocop` clean
- `bundle exec rspec spec/phlex spec/requests` — 433 green
- `bun test spec/javascript` — 203 green
- `bundle exec rspec spec/system` — **48 green under Puma and 48 under Falcon**
- Vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`)

## Invariants held

No client state · default-deny · ONE generic controller · pgbus optional · self-targeting `#id`.
