### PR TITLE
feat(client): latency simulator dev aid — PhlexReactive.enableLatencySim(ms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Latency simulator dev aid — `PhlexReactive.enableLatencySim(ms)` /
+  `disableLatencySim()` (#102).** On localhost the click→morph round trip is
+  ~5 ms, so the pending/loading/optimistic affordances added in #98/#99/#100
+  (`aria-busy`, `disable_with:`, `busy_on`, optimistic hints) flash by too fast to
+  see while developing or demoing them — the reason LiveView ships
+  `liveSocket.enableLatencySim(ms)`. Two named exports from the client controller
+  (the `setConfirmResolver` precedent) persist a per-action delay to
+  `sessionStorage` under `"phlex-reactive:latency"`; `#perform` reads it live
+  right before the `fetch` — after the busy window has already opened at enqueue —
+  and awaits it, so the affordances become observable. The delay is session-scoped
+  (clears when the tab closes, so you can't leave it on across sessions), read
+  fresh per request (toggling takes effect on the next action with no reload), and
+  a one-time console banner reminds you while it's active.
+  - **Console handle, dev-gated.** importmap module exports are unreachable from
+    the DevTools console, so the bootstrap attaches
+    `window.PhlexReactive = { enableLatencySim, disableLatencySim }` — but **only**
+    when the app authored `<meta name="phlex-reactive-env" content="development">`.
+    The meta is app-authored (the engine can't inject into the host layout); the
+    install generator's initializer ships the commented snippet, and the README
+    documents it. Without the meta there is **no global handle** and `#perform`
+    short-circuits on the `null` `sessionStorage` read — **zero production
+    surface**. This finally lets a system spec observe `aria-busy` in a real
+    browser (previously impossible on a ~5 ms trip), under both Puma and Falcon.
+
 - **Request timeout + offline handling — `reactive:error` kinds `timeout` and
   `offline` (#101).** A server that never responded used to wedge a component's
   request queue *forever* — each action chains on the previous one, so one hung

--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,40 @@ document.addEventListener("reactive:error", (e) => {
 })
 ```
 
+#### Latency simulator (development aid)
+
+On localhost the click→morph round trip is **~5 ms**, so the pending affordances
+you just wired — `aria-busy`, `disable_with:`, `busy_on`, optimistic hints —
+flash by too fast to actually *see* while developing or demoing them. That's the
+same problem LiveView solves with `liveSocket.enableLatencySim(ms)`.
+
+`phlex-reactive` ships the equivalent. Because importmap module exports aren't
+reachable from the DevTools console, the two functions are exposed on a
+`window.PhlexReactive` handle — but **only** when your layout opts in with a
+development-gated meta:
+
+```erb
+<%# app/views/layouts/application.html.erb, inside <head> — DEVELOPMENT ONLY %>
+<%= tag.meta(name: "phlex-reactive-env", content: "development") if Rails.env.development? %>
+```
+
+Then, from the browser console:
+
+```js
+PhlexReactive.enableLatencySim(400)   // delay EVERY action by 400ms
+// …click around; aria-busy, spinners, disable_with, optimistic hints are now visible…
+PhlexReactive.disableLatencySim()     // back to full speed
+```
+
+The delay is read live before each fetch (so toggling takes effect on the very
+next action, no reload) and persists to `sessionStorage` — it clears when the tab
+closes, so you can't accidentally leave it on across sessions. A one-time console
+banner reminds you while it's active.
+
+Without the meta there is **no global handle at all** and the per-request read
+short-circuits on a `null` — **zero production surface**. It's purely a
+development convenience, gated by markup you author.
+
 The events bubble from the component's root element (or from `document` when
 the root was detached by the failing round trip), so they compose with plain
 Stimulus listening — a global toaster is one attribute on an ancestor:

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -207,12 +207,62 @@ export function __resetReactiveOfflineForTest() {
   offlineRegistered = false
 }
 
+// Latency simulator dev aid (issue #102). On localhost the click→morph round
+// trip is ~5ms, so the pending/loading/optimistic affordances (aria-busy,
+// disable_with, busy_on, optimistic hints) flash by too fast to see while
+// developing or demoing them — the reason LiveView ships enableLatencySim(ms).
+//
+// enableLatencySim(ms) persists the delay to sessionStorage (session-scoped, so
+// it clears when the tab closes — never a config you forget you left on);
+// #perform reads it right before the fetch and awaits setTimeout(ms), stretching
+// the already-set busy window to something visible. disableLatencySim() clears
+// it. NAMED exports (the setConfirmResolver precedent) — but importmap module
+// exports are unreachable from the browser console, so registerReactiveActions
+// ALSO attaches these to window.PhlexReactive, and ONLY when the app opts in with
+// <meta name="phlex-reactive-env" content="development"> (see #attachLatencyHandle).
+export const LATENCY_KEY = "phlex-reactive:latency"
+
+// One-time "sim active" banner guard (module-level, mirroring offlineRegistered):
+// #maybeSimulateLatency warns ONCE while the sim is on, not once per request.
+let latencyBannerShown = false
+
+export function enableLatencySim(ms) {
+  if (typeof sessionStorage === "undefined") return
+  sessionStorage.setItem(LATENCY_KEY, String(ms))
+}
+
+export function disableLatencySim() {
+  if (typeof sessionStorage === "undefined") return
+  sessionStorage.removeItem(LATENCY_KEY)
+}
+
+// The dev gate. importmap module exports aren't reachable from the DevTools
+// console, so we expose the two functions on a window handle — but ONLY when the
+// app authored <meta name="phlex-reactive-env" content="development">. There is
+// NO engine-emitted meta (the engine can't inject into the host layout); the
+// install generator ships the snippet commented. Without the meta: no global
+// handle at all, and #perform short-circuits on the null sessionStorage read —
+// zero production surface. The `?.content` chain is fully defensive (a stubbed
+// document with no querySelector, a missing meta) so bootstrap never throws.
+function attachLatencyHandle() {
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  const env = document.querySelector?.('meta[name="phlex-reactive-env"]')?.content
+  if (env !== "development") return
+  window.PhlexReactive = { enableLatencySim, disableLatencySim }
+}
+
+// Test seam: forget the one-time active-sim banner so the next test re-warns.
+export function __resetReactiveLatencyForTest() {
+  latencyBannerShown = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
   registerReactiveDismiss()
   registerReactiveOffline()
+  attachLatencyHandle()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -919,6 +969,28 @@ export default class extends Controller {
     region.appendChild(template.content.cloneNode(true))
   }
 
+  // Latency simulator (issue #102): if enableLatencySim(ms) stored a delay in
+  // sessionStorage, await it before the fetch so the busy window (already open
+  // since enqueue) is actually visible on localhost. Reads the key LIVE per
+  // request — like the CSRF token — so toggling the sim mid-session takes effect
+  // on the very next action without a reload. A missing sessionStorage, an absent
+  // key, or a non-positive/NaN value resolves immediately (no timer, no delay) —
+  // the whole feature is inert for any app that never opts in. Warns ONCE while
+  // active (module-level guard), not once per request.
+  #maybeSimulateLatency() {
+    if (typeof sessionStorage === "undefined") return Promise.resolve()
+    const ms = Number(sessionStorage.getItem(LATENCY_KEY))
+    if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve()
+    if (!latencyBannerShown) {
+      latencyBannerShown = true
+      console.warn(
+        `[phlex-reactive] latency simulator ACTIVE — every action is delayed by ${ms}ms. ` +
+          "Call PhlexReactive.disableLatencySim() (or clear sessionStorage) to turn it off.",
+      )
+    }
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -941,6 +1013,13 @@ export default class extends Controller {
     // aria-busy on the root is now driven by the loading pending counter
     // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
     // set here. #settleLoading in the finally clears it — see #enqueue.
+
+    // Latency simulator (issue #102): the busy window (aria-busy + loading state)
+    // is already applied at enqueue, so awaiting the configured delay HERE — after
+    // that window opened and before the fetch — is what makes it visible on
+    // localhost. A null/absent/non-positive sessionStorage key is a no-op (zero
+    // production surface), so this line vanishes for any app that never opts in.
+    await this.#maybeSimulateLatency()
 
     try {
       // Offline gate (issue #101), authoritative at the NETWORK BOUNDARY (send

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -234,6 +234,11 @@ export function enableLatencySim(ms) {
 export function disableLatencySim() {
   if (typeof sessionStorage === "undefined") return
   sessionStorage.removeItem(LATENCY_KEY)
+  // Re-arm the one-time "sim active" banner: turning the sim OFF is the lifecycle
+  // boundary, so a later enableLatencySim() in the same session re-announces that
+  // the sim is on (otherwise the guard would stay set across an off→on cycle and
+  // swallow the banner). Matches the __resetReactiveLatencyForTest seam.
+  latencyBannerShown = false
 }
 
 // The dev gate. importmap module exports aren't reachable from the DevTools

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -33,3 +33,15 @@
 #   <meta name="phlex-reactive-timeout" content="15000"> <%# 15s, in ms %>
 # A timed-out POST may have SUCCEEDED server-side — phlex-reactive never
 # auto-replays; make retryable actions idempotent.
+
+# Latency simulator (development only). On localhost the click→morph round trip is
+# ~5ms, so pending/loading/optimistic affordances (aria-busy, disable_with, busy_on,
+# optimistic hints) flash by too fast to see. Add this meta to your layout head IN
+# DEVELOPMENT ONLY to expose window.PhlexReactive.enableLatencySim(ms) /
+# disableLatencySim() in the browser console (importmap module exports aren't
+# reachable from the console, so this handle is how you toggle it):
+#   <% # in app/views/layouts/application.html.erb, inside <head>: %>
+#   <%%= tag.meta(name: "phlex-reactive-env", content: "development") if Rails.env.development? %>
+# Then in the console: PhlexReactive.enableLatencySim(400)  // delay every action 400ms
+# It persists to sessionStorage (clears when the tab closes). WITHOUT this meta
+# there is no global handle and zero production surface.

--- a/spec/dummy/app/components/latency_component.rb
+++ b/spec/dummy/app/components/latency_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Drives the latency-simulator system spec (issue #102). The `bump` action is
+# FAST server-side (no sleep) — exactly the localhost case where the ~5ms round
+# trip makes aria-busy flash by unobservably. The spec enables the simulator
+# (PhlexReactive.enableLatencySim(ms)) and then asserts aria-busy IS visible
+# during the injected client-side delay — proving the sim opens a real,
+# observable busy window without any server-side stall.
+class LatencyComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+
+  action :bump
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = "latency"
+
+  # No sleep: the busy window is created purely by the client latency simulator,
+  # not by a slow server action.
+  def bump = @count += 1
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      button(**mix(on(:bump), data: { testid: "bump" })) { "Bump" }
+      span(data: { testid: "count" }) { @count.to_s }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -43,6 +43,19 @@ class DemosController < ActionController::Base
     render html: component + extras.html_safe, layout: true
   end
 
+  # Latency simulator dev aid (issue #102). Carries the APP-AUTHORED
+  # <meta name="phlex-reactive-env" content="development"> so the client attaches
+  # window.PhlexReactive (the dev gate). The spec enables the sim and asserts
+  # aria-busy is visible during the injected client-side delay — finally covering
+  # aria-busy in a real browser (the fast `bump` action has no server-side sleep).
+  def latency
+    component = render_to_string(LatencyComponent.new(count: 0), layout: false)
+    extras = <<~HTML
+      <meta name="phlex-reactive-env" content="development">
+    HTML
+    render html: component + extras.html_safe, layout: true
+  end
+
   def todos
     render_component TodoListComponent.new
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "counter" => "demos#counter"
   get "failure_surface" => "demos#failure_surface"
   get "network_status" => "demos#network_status"
+  get "latency" => "demos#latency"
   get "chat" => "demos#chat"
   get "todos" => "demos#todos"
   get "combobox" => "demos#combobox"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -207,12 +207,62 @@ export function __resetReactiveOfflineForTest() {
   offlineRegistered = false
 }
 
+// Latency simulator dev aid (issue #102). On localhost the click→morph round
+// trip is ~5ms, so the pending/loading/optimistic affordances (aria-busy,
+// disable_with, busy_on, optimistic hints) flash by too fast to see while
+// developing or demoing them — the reason LiveView ships enableLatencySim(ms).
+//
+// enableLatencySim(ms) persists the delay to sessionStorage (session-scoped, so
+// it clears when the tab closes — never a config you forget you left on);
+// #perform reads it right before the fetch and awaits setTimeout(ms), stretching
+// the already-set busy window to something visible. disableLatencySim() clears
+// it. NAMED exports (the setConfirmResolver precedent) — but importmap module
+// exports are unreachable from the browser console, so registerReactiveActions
+// ALSO attaches these to window.PhlexReactive, and ONLY when the app opts in with
+// <meta name="phlex-reactive-env" content="development"> (see #attachLatencyHandle).
+export const LATENCY_KEY = "phlex-reactive:latency"
+
+// One-time "sim active" banner guard (module-level, mirroring offlineRegistered):
+// #maybeSimulateLatency warns ONCE while the sim is on, not once per request.
+let latencyBannerShown = false
+
+export function enableLatencySim(ms) {
+  if (typeof sessionStorage === "undefined") return
+  sessionStorage.setItem(LATENCY_KEY, String(ms))
+}
+
+export function disableLatencySim() {
+  if (typeof sessionStorage === "undefined") return
+  sessionStorage.removeItem(LATENCY_KEY)
+}
+
+// The dev gate. importmap module exports aren't reachable from the DevTools
+// console, so we expose the two functions on a window handle — but ONLY when the
+// app authored <meta name="phlex-reactive-env" content="development">. There is
+// NO engine-emitted meta (the engine can't inject into the host layout); the
+// install generator ships the snippet commented. Without the meta: no global
+// handle at all, and #perform short-circuits on the null sessionStorage read —
+// zero production surface. The `?.content` chain is fully defensive (a stubbed
+// document with no querySelector, a missing meta) so bootstrap never throws.
+function attachLatencyHandle() {
+  if (typeof window === "undefined" || typeof document === "undefined") return
+  const env = document.querySelector?.('meta[name="phlex-reactive-env"]')?.content
+  if (env !== "development") return
+  window.PhlexReactive = { enableLatencySim, disableLatencySim }
+}
+
+// Test seam: forget the one-time active-sim banner so the next test re-warns.
+export function __resetReactiveLatencyForTest() {
+  latencyBannerShown = false
+}
+
 export function registerReactiveActions() {
   registerReactiveVisit()
   registerReactiveToken()
   registerReactiveJs()
   registerReactiveDismiss()
   registerReactiveOffline()
+  attachLatencyHandle()
 }
 
 // Escape a DOM id for safe interpolation into a RegExp (an id can legally contain
@@ -919,6 +969,28 @@ export default class extends Controller {
     region.appendChild(template.content.cloneNode(true))
   }
 
+  // Latency simulator (issue #102): if enableLatencySim(ms) stored a delay in
+  // sessionStorage, await it before the fetch so the busy window (already open
+  // since enqueue) is actually visible on localhost. Reads the key LIVE per
+  // request — like the CSRF token — so toggling the sim mid-session takes effect
+  // on the very next action without a reload. A missing sessionStorage, an absent
+  // key, or a non-positive/NaN value resolves immediately (no timer, no delay) —
+  // the whole feature is inert for any app that never opts in. Warns ONCE while
+  // active (module-level guard), not once per request.
+  #maybeSimulateLatency() {
+    if (typeof sessionStorage === "undefined") return Promise.resolve()
+    const ms = Number(sessionStorage.getItem(LATENCY_KEY))
+    if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve()
+    if (!latencyBannerShown) {
+      latencyBannerShown = true
+      console.warn(
+        `[phlex-reactive] latency simulator ACTIVE — every action is delayed by ${ms}ms. ` +
+          "Call PhlexReactive.disableLatencySim() (or clear sessionStorage) to turn it off.",
+      )
+    }
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -941,6 +1013,13 @@ export default class extends Controller {
     // aria-busy on the root is now driven by the loading pending counter
     // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
     // set here. #settleLoading in the finally clears it — see #enqueue.
+
+    // Latency simulator (issue #102): the busy window (aria-busy + loading state)
+    // is already applied at enqueue, so awaiting the configured delay HERE — after
+    // that window opened and before the fetch — is what makes it visible on
+    // localhost. A null/absent/non-positive sessionStorage key is a no-op (zero
+    // production surface), so this line vanishes for any app that never opts in.
+    await this.#maybeSimulateLatency()
 
     try {
       // Offline gate (issue #101), authoritative at the NETWORK BOUNDARY (send

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -234,6 +234,11 @@ export function enableLatencySim(ms) {
 export function disableLatencySim() {
   if (typeof sessionStorage === "undefined") return
   sessionStorage.removeItem(LATENCY_KEY)
+  // Re-arm the one-time "sim active" banner: turning the sim OFF is the lifecycle
+  // boundary, so a later enableLatencySim() in the same session re-announces that
+  // the sim is on (otherwise the guard would stay set across an off→on cycle and
+  // swallow the banner). Matches the __resetReactiveLatencyForTest seam.
+  latencyBannerShown = false
 }
 
 // The dev gate. importmap module exports aren't reachable from the DevTools

--- a/spec/javascript/reactive_latency_sim.test.js
+++ b/spec/javascript/reactive_latency_sim.test.js
@@ -265,3 +265,20 @@ test("the active-sim console.warn banner fires once, not per request", async () 
   const banners = warnings.filter((w) => w.toLowerCase().includes("latency"))
   expect(banners.length).toBe(1)
 })
+
+test("disableLatencySim resets the warn-once guard so a later enable re-announces", async () => {
+  // enable → warn once → disable → enable again → the banner MUST fire again.
+  // disableLatencySim() is the lifecycle boundary that re-arms the one-time warn,
+  // so each fresh activation re-announces the sim is on (the banner text points
+  // the user AT disableLatencySim() to turn it off).
+  const { controller } = buildController({ latency: 20 })
+
+  await click(controller) // first activation → banner #1
+  expect(warnings.filter((w) => w.toLowerCase().includes("latency")).length).toBe(1)
+
+  disableLatencySim() // clears the key AND re-arms the guard
+  enableLatencySim(20) // re-set the key (same globalThis.sessionStorage stub)
+
+  await click(controller) // second activation → banner #2
+  expect(warnings.filter((w) => w.toLowerCase().includes("latency")).length).toBe(2)
+})

--- a/spec/javascript/reactive_latency_sim.test.js
+++ b/spec/javascript/reactive_latency_sim.test.js
@@ -1,0 +1,267 @@
+// Unit tests for the latency simulator dev aid (issue #102):
+//
+//   ENABLE/DISABLE — named exports enableLatencySim(ms) / disableLatencySim()
+//   persist to sessionStorage under "phlex-reactive:latency". enable writes the
+//   ms; disable removes the key.
+//
+//   SLEEP — in #perform, AFTER aria-busy is set (at enqueue) and right BEFORE the
+//   fetch, the controller reads the key and awaits setTimeout(ms) so the busy
+//   window is actually visible. A null/absent key is a no-op (zero prod surface);
+//   a NaN/non-positive value does not delay. A one-time console.warn banner fires
+//   while the sim is active, not once per request.
+//
+//   DEV GATE — registerReactiveActions attaches window.PhlexReactive =
+//   { enableLatencySim, disableLatencySim } ONLY when
+//   <meta name="phlex-reactive-env" content="development"> is present. Without the
+//   meta there is no global handle at all.
+//
+// Sleeps are asserted by ORDER (fetch happens after the awaited timer), never by
+// wall-clock timing — a fake setTimeout resolves synchronously via a captured
+// callback so the tests stay deterministic.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+
+let mod
+let ReactiveController
+let enableLatencySim
+let disableLatencySim
+let registerReactiveActions
+let __resetReactiveLatencyForTest
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  mod = await import("../../app/javascript/phlex/reactive/reactive_controller.js")
+  ReactiveController = mod.default
+  enableLatencySim = mod.enableLatencySim
+  disableLatencySim = mod.disableLatencySim
+  registerReactiveActions = mod.registerReactiveActions
+  __resetReactiveLatencyForTest = mod.__resetReactiveLatencyForTest
+})
+
+// A minimal sessionStorage stub (a Map behind the Storage API surface).
+function makeSessionStorage() {
+  const map = new Map()
+  return {
+    map,
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+  }
+}
+
+// bun runs EVERY spec in one process on a shared globalThis, so a test that
+// mutates a global must RESTORE it — not delete it. In particular bun provides a
+// native `navigator` (whose `.onLine` is undefined, so the offline gate passes);
+// deleting it would leave sibling suites' #perform throwing on `navigator.onLine`.
+// Snapshot the originals once and restore them in afterEach. `realSetTimeout` is
+// the untouched real timer used by this file's `wait()` helper (we never stub the
+// global timer — clobbering it would corrupt bun's own scheduling).
+const realSetTimeout = globalThis.setTimeout
+const ORIGINALS = {
+  window: globalThis.window,
+  document: globalThis.document,
+  sessionStorage: globalThis.sessionStorage,
+  navigator: globalThis.navigator,
+  fetch: globalThis.fetch,
+  console: globalThis.console,
+}
+
+let warnings
+beforeEach(() => {
+  warnings = []
+  globalThis.console = { warn: (...a) => warnings.push(a.join(" ")), error: () => {} }
+  __resetReactiveLatencyForTest?.()
+})
+
+afterEach(() => {
+  // Restore every global this file may have stubbed to its pre-file value.
+  for (const [key, value] of Object.entries(ORIGINALS)) {
+    if (value === undefined) delete globalThis[key]
+    else globalThis[key] = value
+  }
+})
+
+// --- ENABLE / DISABLE -------------------------------------------------------
+
+test("enableLatencySim writes the ms to sessionStorage under phlex-reactive:latency", () => {
+  const storage = makeSessionStorage()
+  globalThis.sessionStorage = storage
+
+  enableLatencySim(400)
+
+  expect(storage.getItem("phlex-reactive:latency")).toBe("400")
+})
+
+test("disableLatencySim removes the key", () => {
+  const storage = makeSessionStorage()
+  globalThis.sessionStorage = storage
+  storage.setItem("phlex-reactive:latency", "400")
+
+  disableLatencySim()
+
+  expect(storage.getItem("phlex-reactive:latency")).toBeNull()
+})
+
+// --- DEV GATE ---------------------------------------------------------------
+
+// A document stub whose phlex-reactive-env meta content is configurable, and
+// which records addEventListener so the Turbo-absent branch doesn't throw.
+function docWithEnv(env) {
+  return {
+    querySelector: (sel) => {
+      if (sel === 'meta[name="phlex-reactive-env"]') return env ? { content: env } : null
+      return null
+    },
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+    documentElement: { toggleAttribute: () => {} },
+  }
+}
+
+test("registerReactiveActions attaches window.PhlexReactive when env meta is development", () => {
+  const win = { addEventListener: () => {} }
+  globalThis.window = win
+  globalThis.document = docWithEnv("development")
+  globalThis.navigator = { onLine: true }
+
+  registerReactiveActions()
+
+  expect(typeof win.PhlexReactive).toBe("object")
+  expect(typeof win.PhlexReactive.enableLatencySim).toBe("function")
+  expect(typeof win.PhlexReactive.disableLatencySim).toBe("function")
+})
+
+test("registerReactiveActions does NOT attach window.PhlexReactive without the env meta", () => {
+  const win = { addEventListener: () => {} }
+  globalThis.window = win
+  globalThis.document = docWithEnv(null)
+  globalThis.navigator = { onLine: true }
+
+  registerReactiveActions()
+
+  expect(win.PhlexReactive).toBeUndefined()
+})
+
+test("registerReactiveActions does NOT attach window.PhlexReactive for a non-development env", () => {
+  const win = { addEventListener: () => {} }
+  globalThis.window = win
+  globalThis.document = docWithEnv("production")
+  globalThis.navigator = { onLine: true }
+
+  registerReactiveActions()
+
+  expect(win.PhlexReactive).toBeUndefined()
+})
+
+// --- SLEEP (in #perform) ----------------------------------------------------
+
+// A reactive root stub recording attribute writes + dispatched events.
+function makeRoot() {
+  const attrs = {}
+  return {
+    attrs,
+    isConnected: true,
+    id: "counter",
+    dispatchEvent: () => {},
+    querySelectorAll: () => [],
+    setAttribute: (name, value) => (attrs[name] = String(value)),
+    removeAttribute: (name) => delete attrs[name],
+    getAttribute: (name) => attrs[name] ?? null,
+    hasAttribute: (name) => name in attrs,
+  }
+}
+
+// Build a controller with a fetch that records whether (and when) it fired.
+// `latency` seeds the sessionStorage key. IMPORTANT: this NEVER stubs the global
+// setTimeout — bun runs every spec in one process and its own scheduling relies
+// on a working global timer, so clobbering it corrupts unrelated suites. Instead
+// the sleep uses a REAL (short) timer and the tests assert ordering with small
+// real waits — deterministic vs. microtasks, and zero cross-file leakage.
+function buildController({ latency } = {}) {
+  const controller = new ReactiveController()
+  controller.element = makeRoot()
+  controller.tokenValue = "tok"
+  globalThis.navigator = { onLine: true }
+
+  const storage = makeSessionStorage()
+  if (latency != null) storage.setItem("phlex-reactive:latency", String(latency))
+  globalThis.sessionStorage = storage
+
+  let fetched = false
+  globalThis.fetch = () => {
+    fetched = true
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      status: 200,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(""),
+    })
+  }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  globalThis.document = {
+    querySelector: () => null,
+    dispatchEvent: () => {},
+  }
+  return { controller, fetched: () => fetched, storage }
+}
+
+function click(controller) {
+  return controller.dispatch({
+    params: { action: "save", params: '{"n":1}' },
+    preventDefault: () => {},
+  })
+}
+
+// A real short wait, using the (untouched) real setTimeout via realSetTimeout.
+const wait = (ms) => new Promise((resolve) => realSetTimeout(resolve, ms))
+
+test("with the latency key set, the fetch is delayed until the sleep elapses", async () => {
+  // A generous 60ms delay: long enough that a microtask flush can't reach the
+  // fetch, short enough to keep the test fast.
+  const { controller, fetched } = buildController({ latency: 60 })
+
+  const done = click(controller)
+  // Drain microtasks + a short real wait WELL under the latency window.
+  await Promise.resolve()
+  await wait(10)
+
+  // The fetch has NOT fired yet — it is blocked behind the awaited sleep.
+  expect(fetched()).toBe(false)
+
+  // Once the sleep window elapses, the round trip completes and the fetch fires.
+  await done
+  expect(fetched()).toBe(true)
+})
+
+test("with NO latency key, the fetch is not delayed (round trip completes on the microtask queue)", async () => {
+  const { controller, fetched } = buildController({ latency: null })
+
+  await click(controller)
+
+  // No sleep for the null key — the round trip resolved without any real timer.
+  expect(fetched()).toBe(true)
+})
+
+test("a non-positive / NaN latency value does not delay the fetch", async () => {
+  const { controller, fetched } = buildController({ latency: "0" })
+
+  await click(controller)
+
+  expect(fetched()).toBe(true)
+})
+
+test("the active-sim console.warn banner fires once, not per request", async () => {
+  const { controller } = buildController({ latency: 20 })
+
+  await click(controller)
+  await click(controller)
+
+  const banners = warnings.filter((w) => w.toLowerCase().includes("latency"))
+  expect(banners.length).toBe(1)
+})

--- a/spec/system/latency_sim_spec.rb
+++ b/spec/system/latency_sim_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Latency simulator dev aid end-to-end (issue #102). On localhost the click→morph
+# round trip is ~5ms, so aria-busy (and the loading/optimistic affordances) flash
+# by unobservably — the reason LiveView ships enableLatencySim(ms). This spec
+# enables the simulator from the page (the dev-gated window.PhlexReactive handle),
+# then observes aria-busy DURING the injected delay — finally covering aria-busy in
+# a real browser. Runs under Puma AND Falcon (the round trip must behave the same
+# sync and async).
+RSpec.describe "Latency simulator (issue #102)", type: :system do
+  it "makes aria-busy visible during the injected delay, then clears on the morph" do
+    visit "/latency"
+    expect(page).to have_css("[data-testid='bump']")
+
+    # The dev gate: the page carries <meta name="phlex-reactive-env" content=
+    # "development">, so the client attached the global handle.
+    expect(page.evaluate_script("typeof window.PhlexReactive")).to eq("object")
+
+    # Enable a generous delay so the busy window is reliably observable under both
+    # servers (Capybara's waiting matcher polls within the window).
+    page.execute_script("window.PhlexReactive.enableLatencySim(1500)")
+
+    page.execute_script('window.__noReload = "alive"')
+    find("[data-testid='bump']").click
+
+    # DURING the injected delay the root carries aria-busy="true" — the whole point
+    # of the aid: an affordance that would be invisible on a ~5ms localhost trip is
+    # now observable. (aria-busy is applied at enqueue; the sim awaits before the
+    # fetch, so the window is stretched to 1.5s.)
+    expect(page).to have_css("#latency[aria-busy='true']")
+
+    # After the delay elapses and the morph lands, the action applied (count → 1)
+    # and aria-busy cleared — no full-page reload.
+    expect(page).to have_css("[data-testid='count']", text: "1", wait: 8)
+    expect(page).to have_no_css("#latency[aria-busy='true']")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "disableLatencySim removes the delay (aria-busy no longer lingers)" do
+    visit "/latency"
+    expect(page).to have_css("[data-testid='bump']")
+
+    page.execute_script("window.PhlexReactive.enableLatencySim(1500)")
+    page.execute_script("window.PhlexReactive.disableLatencySim()")
+
+    # With the sim disabled the fast action round-trips immediately: the count
+    # updates and aria-busy is never stuck on (it clears on the near-instant morph).
+    find("[data-testid='bump']").click
+    expect(page).to have_css("[data-testid='count']", text: "1", wait: 8)
+    expect(page).to have_no_css("#latency[aria-busy='true']")
+  end
+end


### PR DESCRIPTION
Closes #102

## What

Adds a development-only latency simulator so the pending/loading/optimistic affordances (#98/#99/#100 — `aria-busy`, `disable_with:`, `busy_on`, optimistic hints) are actually visible on localhost, where the click→morph round trip is ~5 ms. Same idea as LiveView's `liveSocket.enableLatencySim(ms)`.

```js
// browser console (dev only):
PhlexReactive.enableLatencySim(400)   // delay every action by 400ms
PhlexReactive.disableLatencySim()     // back to full speed
```

## How

- **Named exports** `enableLatencySim(ms)` / `disableLatencySim()` from the client controller (the `setConfirmResolver` precedent), persisting to `sessionStorage` under `"phlex-reactive:latency"`.
- **The sleep** lives in `#perform`, read **live** right before the `fetch` — after the busy window has already opened at enqueue — so awaiting it stretches `aria-busy` / the loading state into something observable. Read per request, so toggling takes effect on the next action with no reload. A one-time console banner reminds you while active.
- **Dev gate.** importmap module exports aren't reachable from the DevTools console, so the bootstrap attaches `window.PhlexReactive = { enableLatencySim, disableLatencySim }` — but **only** when the app authored `<meta name="phlex-reactive-env" content="development">`. The meta is app-authored (the engine can't inject into the host layout); the install generator ships the commented snippet.
- **Zero production surface.** Without the meta there is no global handle, and `#perform` short-circuits on the `null` `sessionStorage` read. A non-positive/NaN value is a no-op.

## Invariants

No client state (the delay is a dev sessionStorage value, never component state) · default-deny untouched · ONE generic controller · pgbus optional · self-targeting `#id` — all preserved. Nothing on the hot path changes when the sim is off (a single `typeof`/`getItem` guard that returns immediately).

## Test plan

- **bun (RED first)** — `spec/javascript/reactive_latency_sim.test.js`: enable/disable write & clear sessionStorage; the fetch is delayed until the sleep elapses when the key is set; null-key and `0`/NaN are no-ops; the console banner fires once (not per request); the dev gate attaches `window.PhlexReactive` only for the `development` env meta and nothing otherwise.
  - Note: the test carefully restores bun's native globals (`navigator` especially) in `afterEach` — deleting them would break sibling suites' `#perform`.
- **System (Puma AND Falcon)** — `spec/system/latency_sim_spec.rb`: enables the sim via `page.execute_script` and asserts `[aria-busy='true']` **is** visible during the injected window (finally covering `aria-busy` in a real browser), then clears on the morph; `disableLatencySim()` removes the delay.

## Verification

- [x] `bundle exec rubocop` (140 files)
- [x] `bundle exec rspec spec/phlex spec/requests` (433)
- [x] `bun test spec/javascript` (212)
- [x] `bundle exec rspec spec/system` under Puma **and** `CAPYBARA_SERVER=falcon` (50 each)
- [x] vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`)
- [x] README + install generator snippet + CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only latency simulator to make busy/loading states and optimistic UI changes easier to see locally.
  * Exposed browser console controls to enable or disable the delay during development.
  * Added a demo page for trying the feature end to end.

* **Documentation**
  * Updated the changelog, README, and setup notes with usage details and development-only behavior.

* **Tests**
  * Added coverage for the simulator settings, developer-only access, and delayed action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->