### PR TITLE
feat(component): dirty-field tracking via defaultValue diff + unsaved-changes guard (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Dirty-field tracking + unsaved-changes guard (#103).** Show "unsaved
+  changes", enable **Save** only when something changed, or warn before navigating
+  away — Livewire's `wire:dirty` — **without shipping any client state**. The
+  browser already holds the last server-rendered value with zero extra bytes:
+  `input.defaultValue` / `defaultChecked` / `option.defaultSelected` **are** the
+  attributes from the last render, so **dirty = current ≠ default**, read straight
+  from the DOM.
+  - **`reactive_root(track_dirty: true)`** wires every input under the root to a
+    full re-scan on change; **`reactive_field(:title, dirty: true)`** opts a single
+    field in. On each change the client re-scans **every owned field in one pass**
+    (the ownership guard excludes nested reactive roots) and marks each changed
+    field `data-reactive-dirty="true"` and the root `data-reactive-dirty="<count>"`
+    (**absent at zero**). The full pass — not a per-field toggle — is required for
+    radio groups: the deselected radio fires no event, so only re-scanning
+    everything keeps its flag honest. File inputs and `contenteditable` editors
+    (no `default*` baseline) are out of scope in v1.
+  - **CSS vocabulary, zero Ruby.** `[data-reactive-dirty] .unsaved-badge { … }`
+    reveals a badge; `[data-reactive-dirty]` on a field outlines just the changed
+    control — the same pure-CSS pattern as `[data-reactive-busy]`.
+  - **Baselines reset on the server re-render.** A plain replace re-connects and
+    re-scans in `connect()`; an in-place morph keeps the element connected and
+    fires no Stimulus lifecycle, so a `turbo:morph-element` listener re-scans after
+    the morph writes fresh `default*` attributes — a `reply.morph` save clears the
+    markers with no reload. (`reactive:applied` fires *before* the DOM mutation, so
+    it is **not** a valid reset hook and is deliberately not used.)
+  - **`warn_unsaved: true`** arms a navigate-away guard gated on the **live** dirty
+    count — `beforeunload` and `turbo:before-visit`; a clean form never blocks.
+    Documented caveats: browsers show their own generic `beforeunload` copy, and
+    `turbo:before-visit` does not fire on restoration (Back/Forward) visits.
+  - Both `reactive_root` kwargs are **consumed before the `mix`** (otherwise an
+    unconsumed kwarg would render as a literal HTML attribute); `track_dirty` and
+    `dirty:` **token-join** their `input->reactive#trackDirty` descriptor onto any
+    existing `data-action` (they don't clobber it), so combining with your own
+    `data:`/`on(...)` still needs `mix(...)`.
+
 - **Latency simulator dev aid — `PhlexReactive.enableLatencySim(ms)` /
   `disableLatencySim()` (#102).** On localhost the click→morph round trip is
   ~5 ms, so the pending/loading/optimistic affordances added in #98/#99/#100

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute, with an optional `transition:`), `add_class`/`remove_class`/`toggle_class`, `set_attr`/`remove_attr`/`toggle_attr` (allowlisted names), `focus`/`focus_first`, and `dispatch` — chainable. |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
+| `reactive_root(track_dirty: true, warn_unsaved: true)` / `reactive_field(:param, dirty: true)` | **Dirty tracking** against the DOM's own `defaultValue`/`defaultChecked`/`defaultSelected` — no client state. Marks changed fields + the root `data-reactive-dirty`; `warn_unsaved:` arms a `beforeunload`/`turbo:before-visit` guard. Style with `[data-reactive-dirty]`. See [Dirty-field tracking](#dirty-field-tracking-dirty--track_dirty--warn_unsaved). |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
 | `reactive_collection :name, item:, container:, count:, empty:, size:` | Declare an add/remove-row list once; actions call `reply.append`/`prepend`/`remove`. See [Reactive collections](#reactive-collections-addremove-rows--count--empty-state). |
 | `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` / `.js(ops)` | Return from an action to control the reply (flash, remove, redirect, multi-stream, server-pushed client ops). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
@@ -599,6 +600,71 @@ quiet period — so a debounced `input` trigger (whose element *is* the text fie
 is not disabled mid-typing. On settle the text is restored only if it still
 matches what was swapped in; a morph that rendered a **new** server label is left
 alone.
+
+### Dirty-field tracking (`dirty:` / `track_dirty:` + `warn_unsaved:`)
+
+Show "unsaved changes", enable **Save** only when something changed, or warn
+before navigating away — Livewire's `wire:dirty` — **without shipping any client
+state**. The trick: the browser already holds the last server-rendered value with
+zero extra bytes. `input.defaultValue` / `defaultChecked` / `option.defaultSelected`
+**are** the attributes from the last render. So **dirty = current ≠ default**, and
+phlex-reactive reads that baseline straight from the DOM — nothing to snapshot,
+nothing to sign.
+
+```ruby
+div(**reactive_root(track_dirty: true, warn_unsaved: true)) do
+  input(**reactive_field(:title, value: @todo.title, dirty: true))
+  span(class: "unsaved-badge") { "Unsaved" }   # shown via [data-reactive-dirty] CSS
+  button(**on(:save, disable_with: "Saving…")) { "Save" }
+end
+```
+
+- **`track_dirty: true`** on the root wires every input under it to a full
+  re-scan on change. **`dirty: true`** on a single `reactive_field` opts that one
+  field in (use it when only some fields should count).
+- On each change the client re-scans **every field the root owns** in one pass and
+  marks:
+  - each changed field with **`data-reactive-dirty="true"`**, and
+  - the root with **`data-reactive-dirty="<count>"`** (the attribute is **absent
+    at zero** — so `[data-reactive-dirty]` matches iff the form is dirty).
+- The re-scan is a **full pass**, not a per-field toggle — required for radio
+  groups: deselecting a radio fires no event on the *deselected* one, so only
+  re-scanning everything keeps its flag honest.
+
+**The CSS vocabulary (you own the styling — phlex-reactive ships none):**
+
+```css
+/* Reveal an "unsaved" badge only while the form has changes. */
+.unsaved-badge { display: none; }
+[data-reactive-dirty] .unsaved-badge { display: inline; }
+
+/* Outline just the fields that changed. */
+[data-reactive-dirty] { outline: 2px solid gold; }
+
+/* Enable Save only when dirty (pair with a :disabled default). */
+[data-reactive-dirty] button[data-testid="save"] { pointer-events: auto; opacity: 1; }
+```
+
+**Baselines reset on the server's re-render.** A plain replace re-connects the
+controller (re-scan on `connect`); an in-place **morph** keeps the element
+connected and fires no Stimulus lifecycle, so the client also re-scans on
+`turbo:morph-element` after the morph writes fresh `default*` attributes. So a
+`reply.morph` save renders the field with the new value as its **new default**,
+and the badge clears with no reload. (Turbo 8 morph preserves a focused field's
+in-progress value while writing the fresh defaults — the post-morph re-scan is
+what keeps the root count honest in that state.)
+
+**`warn_unsaved: true`** arms a navigate-away guard gated on the **live** dirty
+count: `beforeunload` (a real browser unload) and `turbo:before-visit` (a Turbo
+in-app navigation). A clean form never blocks. **Caveats:** browsers show their
+own generic `beforeunload` copy (your message string is legacy and ignored), and
+`turbo:before-visit` **does not fire on restoration visits** (Back/Forward) — a
+documented Turbo gap, not a phlex-reactive one.
+
+**Out of scope (v1):** rich-text / `contenteditable` editors have no `default*`
+baseline and are **not** tracked. Combining `reactive_field(dirty:)` with your own
+`data:`/`on(...)` still needs `mix(...)` (a bare merge clobbers the `data-action`
+the descriptor rides on — the same rule as everywhere else).
 
 ### Client-only ops (`on_client` + `js`) — zero round trips
 

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -503,6 +503,11 @@ export default class extends Controller {
   #busyActions = new Map() // action -> in-flight count (root's space-separated busy set + busy_on)
   #busyTokenCounts = new WeakMap() // element -> Map(action -> count): its data-reactive-busy token set
   #loadingSnapshots = new Map() // trigger element -> { count, disabled, text } refcounted snapshot
+  // Dirty tracking (issue #103): the bound re-scan (turbo:morph-element) and the
+  // navigate-away guard handlers, held so disconnect() can remove exactly them.
+  #boundScanDirty
+  #boundBeforeUnload
+  #boundBeforeVisit
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -524,6 +529,42 @@ export default class extends Controller {
           "or div(id:, **reactive_attrs). The id: must NOT be on a child. See the README."
       )
     }
+
+    // Dirty tracking (issue #103) — ONLY when this root opts in (track_dirty: or a
+    // reactive_field(dirty:)), so a component that never uses it pays nothing (no
+    // baseline scan, no morph listener on every broadcast). A plain (outerHTML)
+    // replace re-connects the controller, so seed the baseline scan here — the root
+    // reflects current-vs-default WITHOUT waiting for the first input. An in-place
+    // morph / broadcast morph keeps the element CONNECTED and fires no Stimulus
+    // lifecycle, so ALSO listen for turbo:morph-element on this.element to re-scan
+    // after the morph writes fresh default* attributes (reactive:applied is NOT a
+    // valid hook — it fires when streams are handed to Turbo, BEFORE the DOM
+    // mutation). Both listeners are torn down in disconnect().
+    if (this.#dirtyTrackingEnabled()) {
+      this.#boundScanDirty = () => this.#scanDirty()
+      this.element.addEventListener?.("turbo:morph-element", this.#boundScanDirty)
+      this.#scanDirty()
+
+      // warn_unsaved: arm a navigate-away guard gated on a LIVE dirty-count read
+      // (never a cached snapshot — the count is re-derived from the DOM each time).
+      // beforeunload covers a real browser unload; turbo:before-visit covers a
+      // Turbo in-app navigation (it does NOT fire on restoration visits — the
+      // documented gap). Registered on window only when the marker is present.
+      if (this.element.getAttribute?.("data-reactive-warn-unsaved") === "true") {
+        this.#armUnsavedGuard()
+      }
+    }
+  }
+
+  // Whether this root opts into dirty tracking (issue #103): track_dirty: puts the
+  // trackDirty descriptor on the ROOT's data-action; a per-field reactive_field(
+  // dirty:) puts it on a descendant field. Either turns tracking on. A quick
+  // attribute read + one scoped query, evaluated once per connect (a cold path).
+  #dirtyTrackingEnabled() {
+    if ((this.element.getAttribute?.("data-action") ?? "").includes("reactive#trackDirty")) return true
+    const nodes = this.element.querySelectorAll?.('[data-action*="reactive#trackDirty"]') ?? []
+    for (const el of nodes) if (this.#ownsField(el)) return true
+    return false
   }
 
   // Tear down any pending debounce timers when the controller leaves the DOM
@@ -536,6 +577,7 @@ export default class extends Controller {
   disconnect() {
     this.#clearAllDebounces()
     this.#clearAllThrottles()
+    this.#teardownDirtyTracking()
   }
 
   // Serialize requests per component. Each round trip rewrites the signed
@@ -636,6 +678,17 @@ export default class extends Controller {
     if (!windowBound) event.preventDefault()
 
     this.#applyOps(this.#parseOps(ops))
+  }
+
+  // Dirty tracking (issue #103). Wired by reactive_field(dirty: true) /
+  // reactive_root(track_dirty: true): an `input` on an owned field runs a FULL
+  // re-scan of every field this root owns. NO round trip, NO shipped state — the
+  // baseline is the DOM's own defaultValue/defaultChecked/defaultSelected (the
+  // last server render). A full pass (not a per-target toggle) is essential for
+  // radio groups: the deselected radio flips to checked=false and fires no input
+  // event, so only re-scanning everything keeps its flag honest.
+  trackDirty() {
+    this.#scanDirty()
   }
 
   // Client-side compute (data binding). Wired by reactive_compute: an `input`
@@ -1282,6 +1335,107 @@ export default class extends Controller {
         }
       })
     return { fields, files }
+  }
+
+  // Re-compute the dirty flag for EVERY field this root owns in one pass (issue
+  // #103), then reflect the total onto the root. Called on an owned field's input
+  // (trackDirty), on connect (baseline seed), and after a turbo:morph-element
+  // re-render (fresh default* attrs). dirty = current ≠ the DOM's own default:
+  //   checkbox/radio → checked  !== defaultChecked
+  //   select         → some option.selected !== option.defaultSelected
+  //   else           → value    !== defaultValue
+  // A full pass (not per-target) is REQUIRED: a radio group's previously-checked
+  // radio flips to checked=false with NO input event, so per-target toggling
+  // would leave its flag stale. File inputs are skipped — a file has no server
+  // default baseline. Per-dirty-field data-reactive-dirty="true" ("true" STRING,
+  // not a valueless boolean attr — mirrors the on() flag convention); the root
+  // carries data-reactive-dirty="<count>" and DROPS the attr at zero, so
+  // `[data-reactive-dirty]` styles the whole form and `[data-reactive-dirty]`
+  // on a field styles just the changed control — both pure CSS, zero JS.
+  #scanDirty() {
+    // Runs at bootstrap (the connect baseline seed) as well as on input/morph, so
+    // it must never throw — degrade to a no-op if the root can't be queried (a real
+    // reactive root always can; this guards minimal/test element stubs).
+    if (typeof this.element?.querySelectorAll !== "function") return
+
+    let count = 0
+    this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
+      if (!this.#ownsField(field)) return // skip a nested reactive root's fields (issue #15)
+      if (field.type === "file") return // no server default baseline to diff against
+
+      if (this.#fieldDirty(field)) {
+        field.setAttribute("data-reactive-dirty", "true")
+        count++
+      } else {
+        field.removeAttribute("data-reactive-dirty")
+      }
+    })
+
+    if (count > 0) this.element.setAttribute("data-reactive-dirty", String(count))
+    else this.element.removeAttribute("data-reactive-dirty")
+  }
+
+  // Whether a single owned control differs from its server-rendered default.
+  #fieldDirty(field) {
+    if (field.type === "checkbox" || field.type === "radio") {
+      return field.checked !== field.defaultChecked
+    }
+    if (field.tag === "select" || field.options) {
+      // Any option whose selected state diverges from its defaultSelected. Guard
+      // for a stub/absent options list (degrade to clean).
+      return Array.from(field.options ?? []).some((o) => o.selected !== o.defaultSelected)
+    }
+    return field.value !== field.defaultValue
+  }
+
+  // The live dirty-field count, re-derived from the DOM (never a cached snapshot)
+  // — the source of truth for the warn_unsaved guard's gate.
+  #dirtyCount() {
+    const raw = this.element.getAttribute?.("data-reactive-dirty")
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : 0
+  }
+
+  // Arm the navigate-away guard (warn_unsaved: true, issue #103). beforeunload
+  // blocks a real browser unload; turbo:before-visit blocks a Turbo in-app
+  // navigation (it does NOT fire on restoration visits — the documented gap).
+  // Both read the LIVE dirty count, so a clean form never blocks. Handlers are
+  // stored so disconnect() removes exactly them.
+  #armUnsavedGuard() {
+    if (typeof window === "undefined" || typeof window.addEventListener !== "function") return
+
+    this.#boundBeforeUnload = (event) => {
+      if (this.#dirtyCount() === 0) return undefined
+      // The spec dance: preventDefault + a truthy returnValue triggers the native
+      // "leave site?" prompt. The string is legacy (modern browsers show their own
+      // copy) but must be non-empty/truthy to arm the dialog.
+      event.preventDefault()
+      event.returnValue = "You have unsaved changes."
+      return event.returnValue
+    }
+    this.#boundBeforeVisit = (event) => {
+      if (this.#dirtyCount() === 0) return
+      const ok = typeof window.confirm === "function" ? window.confirm("You have unsaved changes. Leave anyway?") : true
+      if (!ok) event.preventDefault?.()
+    }
+
+    window.addEventListener("beforeunload", this.#boundBeforeUnload)
+    window.addEventListener("turbo:before-visit", this.#boundBeforeVisit)
+  }
+
+  // Remove the dirty-tracking listeners on disconnect (Turbo morph/navigation) so
+  // a morph re-scan or a navigate-away guard never runs against a detached root.
+  #teardownDirtyTracking() {
+    if (this.#boundScanDirty) {
+      this.element.removeEventListener?.("turbo:morph-element", this.#boundScanDirty)
+      this.#boundScanDirty = undefined
+    }
+    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
+      if (this.#boundBeforeUnload) window.removeEventListener("beforeunload", this.#boundBeforeUnload)
+      if (this.#boundBeforeVisit) window.removeEventListener("turbo:before-visit", this.#boundBeforeVisit)
+    }
+    this.#boundBeforeUnload = undefined
+    this.#boundBeforeVisit = undefined
   }
 
   // Build the multipart body (issue #34). `token`/`act` are flat fields the

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -342,9 +342,25 @@ module Phlex
       # controller/token data: (a bare data: would). The id is resolved separately
       # (an explicit override wins as a clean replace, not a `mix` string-concat —
       # mix would join two String ids into "default override").
+      #
+      # `track_dirty:`/`warn_unsaved:` (issue #103) are CONSUMED here — deleted
+      # from overrides BEFORE the mix — because reactive_root treats every leftover
+      # kwarg as a literal HTML attribute override (only :id is special-cased), so
+      # an unconsumed `track_dirty: true` would render a bogus `track-dirty="true"`
+      # attribute. track_dirty mixes the trackDirty descriptor onto the root's
+      # data-action (mix token-joins, so a caller's own data-action survives);
+      # warn_unsaved emits the marker the client reads to arm the navigate-away
+      # guard (STRING "true" — a boolean-true attr renders valueless, which the
+      # client's param reader sees as "" → falsy).
       def reactive_root(**overrides)
         root_id = overrides.delete(:id) || id
-        mix({ **reactive_attrs }, overrides, { id: root_id })
+        track_dirty = overrides.delete(:track_dirty)
+        warn_unsaved = overrides.delete(:warn_unsaved)
+
+        attrs = mix({ **reactive_attrs }, overrides, { id: root_id })
+        attrs = mix(attrs, { data: { action: "input->reactive#trackDirty" } }) if track_dirty
+        attrs = mix(attrs, { data: { reactive_warn_unsaved: "true" } }) if warn_unsaved
+        attrs
       end
 
       # Attributes for an element that triggers an action.
@@ -571,8 +587,21 @@ module Phlex
       # Extra attrs merge over the binding; an explicit name: still wins (escape
       # hatch). The trigger (on(:save)) stays on the button, not the field — so
       # focusing the input doesn't dispatch and collapse edit mode.
-      def reactive_field(param, **attrs)
-        { name: param.to_s, **attrs }
+      #
+      # `dirty: true` (issue #103) wires the field to the generic controller's
+      # trackDirty action, so a change re-scans this reactive root's owned fields
+      # and marks the changed ones `data-reactive-dirty` (and the root with a
+      # count). NO client state is shipped — the baseline is the DOM's own
+      # `defaultValue`/`defaultChecked`/`defaultSelected`, i.e. the attributes from
+      # the last server render; dirty = current ≠ default. It deep-merges the
+      # descriptor via mix, so a caller's own data-action is token-joined, not
+      # clobbered (CLAUDE.md Never-Do #8 — combining with other data:/on() still
+      # needs mix at the call site).
+      def reactive_field(param, dirty: false, **attrs)
+        binding_attrs = { name: param.to_s, **attrs }
+        return binding_attrs unless dirty
+
+        mix(binding_attrs, { data: { action: "input->reactive#trackDirty" } })
       end
 
       # Render an <input> already bound to an action param (issue #23). Sugar for

--- a/spec/dummy/app/components/dirty_form_component.rb
+++ b/spec/dummy/app/components/dirty_form_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Dirty-field tracking (issue #103) end-to-end. The browser already holds the
+# last server-rendered value with ZERO shipped state: input.defaultValue IS the
+# attribute from the last server render, so dirty = current ≠ default.
+#
+#   * reactive_root(track_dirty: true, warn_unsaved: true) — every input on this
+#     root re-scans the owned fields on change (track_dirty mixes
+#     input->reactive#trackDirty onto the root's data-action), and warn_unsaved
+#     arms a navigate-away guard gated on the LIVE dirty count.
+#   * reactive_field(:title, value:, dirty: true) — the field itself also carries
+#     the trackDirty descriptor (redundant with the root here, but demonstrates
+#     the per-field opt-in).
+#   * The "Unsaved" badge is revealed purely by CSS ([data-reactive-dirty]) —
+#     no Ruby, no per-field JS. It appears on the first keystroke and clears when
+#     the morph reply writes a fresh defaultValue that equals the input's value.
+#
+# save morphs (reply.morph) so the reply re-renders the field in place with the
+# NEW value as its fresh default — the post-morph re-scan then finds it clean and
+# the badge clears WITHOUT a full-page reload.
+class DirtyFormComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :save, params: { title: :string }
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, "dirtyform")
+
+  def save(title:)
+    @todo.update!(title:) if title.present?
+    reply.morph
+  end
+
+  def view_template
+    div(**reactive_root(track_dirty: true, warn_unsaved: true)) do
+      # The field's baseline is its own defaultValue (= @todo.title from this
+      # render). dirty: true also wires trackDirty onto the field itself.
+      input(**mix(reactive_field(:title, value: @todo.title, dirty: true), data: { testid: "title" }))
+      # Revealed purely by CSS while the root is dirty — no Ruby toggles it.
+      span(class: "unsaved-badge", data: { testid: "badge" }) { "Unsaved" }
+      button(**mix(on(:save), data: { testid: "save" })) { "Save" }
+      span(data: { testid: "current" }) { @todo.title }
+    end
+  end
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -99,6 +99,14 @@ class DemosController < ActionController::Base
     render_component FormSubmitComponent.new(todo: Todo.find(params[:id]))
   end
 
+  # Dirty-field tracking (issue #103): a record-backed form whose title field is
+  # dirty-tracked against its own defaultValue. Typing reveals the "Unsaved" badge
+  # (pure CSS on [data-reactive-dirty]); saving morphs the field with the new value
+  # as its fresh default, so the post-morph re-scan clears the badge — no reload.
+  def dirty_form
+    render_component DirtyFormComponent.new(todo: Todo.find(params[:id]))
+  end
+
   def nested_editor
     render_component NestedEditorComponent.new
   end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -5,6 +5,14 @@
     <meta name="csrf-token" content="<%= form_authenticity_token %>">
     <%= csrf_meta_tags %>
 
+    <style>
+      /* Dirty tracking (issue #103): the badge is hidden until the reactive root
+         carries data-reactive-dirty (the count from #scanDirty) — pure CSS, no
+         Ruby toggles it. Mirrors how apps style [data-reactive-busy] spinners. */
+      .unsaved-badge { display: none; }
+      [data-reactive-dirty] .unsaved-badge { display: inline; }
+    </style>
+
     <script type="importmap">
       {
         "imports": {

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "reactive_rows" => "demos#reactive_rows"
   get "rich_editor/:id" => "demos#rich_editor"
   get "form_submit/:id" => "demos#form_submit"
+  get "dirty_form/:id" => "demos#dirty_form"
   get "nested_editor" => "demos#nested_editor"
   get "nested_params" => "demos#nested_params"
   get "debounce" => "demos#debounce"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -503,6 +503,11 @@ export default class extends Controller {
   #busyActions = new Map() // action -> in-flight count (root's space-separated busy set + busy_on)
   #busyTokenCounts = new WeakMap() // element -> Map(action -> count): its data-reactive-busy token set
   #loadingSnapshots = new Map() // trigger element -> { count, disabled, text } refcounted snapshot
+  // Dirty tracking (issue #103): the bound re-scan (turbo:morph-element) and the
+  // navigate-away guard handlers, held so disconnect() can remove exactly them.
+  #boundScanDirty
+  #boundBeforeUnload
+  #boundBeforeVisit
 
   // Mark that a reactive controller actually connected, so the registration
   // guard above knows the controller was registered (issue #26 part 2).
@@ -524,6 +529,42 @@ export default class extends Controller {
           "or div(id:, **reactive_attrs). The id: must NOT be on a child. See the README."
       )
     }
+
+    // Dirty tracking (issue #103) — ONLY when this root opts in (track_dirty: or a
+    // reactive_field(dirty:)), so a component that never uses it pays nothing (no
+    // baseline scan, no morph listener on every broadcast). A plain (outerHTML)
+    // replace re-connects the controller, so seed the baseline scan here — the root
+    // reflects current-vs-default WITHOUT waiting for the first input. An in-place
+    // morph / broadcast morph keeps the element CONNECTED and fires no Stimulus
+    // lifecycle, so ALSO listen for turbo:morph-element on this.element to re-scan
+    // after the morph writes fresh default* attributes (reactive:applied is NOT a
+    // valid hook — it fires when streams are handed to Turbo, BEFORE the DOM
+    // mutation). Both listeners are torn down in disconnect().
+    if (this.#dirtyTrackingEnabled()) {
+      this.#boundScanDirty = () => this.#scanDirty()
+      this.element.addEventListener?.("turbo:morph-element", this.#boundScanDirty)
+      this.#scanDirty()
+
+      // warn_unsaved: arm a navigate-away guard gated on a LIVE dirty-count read
+      // (never a cached snapshot — the count is re-derived from the DOM each time).
+      // beforeunload covers a real browser unload; turbo:before-visit covers a
+      // Turbo in-app navigation (it does NOT fire on restoration visits — the
+      // documented gap). Registered on window only when the marker is present.
+      if (this.element.getAttribute?.("data-reactive-warn-unsaved") === "true") {
+        this.#armUnsavedGuard()
+      }
+    }
+  }
+
+  // Whether this root opts into dirty tracking (issue #103): track_dirty: puts the
+  // trackDirty descriptor on the ROOT's data-action; a per-field reactive_field(
+  // dirty:) puts it on a descendant field. Either turns tracking on. A quick
+  // attribute read + one scoped query, evaluated once per connect (a cold path).
+  #dirtyTrackingEnabled() {
+    if ((this.element.getAttribute?.("data-action") ?? "").includes("reactive#trackDirty")) return true
+    const nodes = this.element.querySelectorAll?.('[data-action*="reactive#trackDirty"]') ?? []
+    for (const el of nodes) if (this.#ownsField(el)) return true
+    return false
   }
 
   // Tear down any pending debounce timers when the controller leaves the DOM
@@ -536,6 +577,7 @@ export default class extends Controller {
   disconnect() {
     this.#clearAllDebounces()
     this.#clearAllThrottles()
+    this.#teardownDirtyTracking()
   }
 
   // Serialize requests per component. Each round trip rewrites the signed
@@ -636,6 +678,17 @@ export default class extends Controller {
     if (!windowBound) event.preventDefault()
 
     this.#applyOps(this.#parseOps(ops))
+  }
+
+  // Dirty tracking (issue #103). Wired by reactive_field(dirty: true) /
+  // reactive_root(track_dirty: true): an `input` on an owned field runs a FULL
+  // re-scan of every field this root owns. NO round trip, NO shipped state — the
+  // baseline is the DOM's own defaultValue/defaultChecked/defaultSelected (the
+  // last server render). A full pass (not a per-target toggle) is essential for
+  // radio groups: the deselected radio flips to checked=false and fires no input
+  // event, so only re-scanning everything keeps its flag honest.
+  trackDirty() {
+    this.#scanDirty()
   }
 
   // Client-side compute (data binding). Wired by reactive_compute: an `input`
@@ -1282,6 +1335,107 @@ export default class extends Controller {
         }
       })
     return { fields, files }
+  }
+
+  // Re-compute the dirty flag for EVERY field this root owns in one pass (issue
+  // #103), then reflect the total onto the root. Called on an owned field's input
+  // (trackDirty), on connect (baseline seed), and after a turbo:morph-element
+  // re-render (fresh default* attrs). dirty = current ≠ the DOM's own default:
+  //   checkbox/radio → checked  !== defaultChecked
+  //   select         → some option.selected !== option.defaultSelected
+  //   else           → value    !== defaultValue
+  // A full pass (not per-target) is REQUIRED: a radio group's previously-checked
+  // radio flips to checked=false with NO input event, so per-target toggling
+  // would leave its flag stale. File inputs are skipped — a file has no server
+  // default baseline. Per-dirty-field data-reactive-dirty="true" ("true" STRING,
+  // not a valueless boolean attr — mirrors the on() flag convention); the root
+  // carries data-reactive-dirty="<count>" and DROPS the attr at zero, so
+  // `[data-reactive-dirty]` styles the whole form and `[data-reactive-dirty]`
+  // on a field styles just the changed control — both pure CSS, zero JS.
+  #scanDirty() {
+    // Runs at bootstrap (the connect baseline seed) as well as on input/morph, so
+    // it must never throw — degrade to a no-op if the root can't be queried (a real
+    // reactive root always can; this guards minimal/test element stubs).
+    if (typeof this.element?.querySelectorAll !== "function") return
+
+    let count = 0
+    this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
+      if (!this.#ownsField(field)) return // skip a nested reactive root's fields (issue #15)
+      if (field.type === "file") return // no server default baseline to diff against
+
+      if (this.#fieldDirty(field)) {
+        field.setAttribute("data-reactive-dirty", "true")
+        count++
+      } else {
+        field.removeAttribute("data-reactive-dirty")
+      }
+    })
+
+    if (count > 0) this.element.setAttribute("data-reactive-dirty", String(count))
+    else this.element.removeAttribute("data-reactive-dirty")
+  }
+
+  // Whether a single owned control differs from its server-rendered default.
+  #fieldDirty(field) {
+    if (field.type === "checkbox" || field.type === "radio") {
+      return field.checked !== field.defaultChecked
+    }
+    if (field.tag === "select" || field.options) {
+      // Any option whose selected state diverges from its defaultSelected. Guard
+      // for a stub/absent options list (degrade to clean).
+      return Array.from(field.options ?? []).some((o) => o.selected !== o.defaultSelected)
+    }
+    return field.value !== field.defaultValue
+  }
+
+  // The live dirty-field count, re-derived from the DOM (never a cached snapshot)
+  // — the source of truth for the warn_unsaved guard's gate.
+  #dirtyCount() {
+    const raw = this.element.getAttribute?.("data-reactive-dirty")
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : 0
+  }
+
+  // Arm the navigate-away guard (warn_unsaved: true, issue #103). beforeunload
+  // blocks a real browser unload; turbo:before-visit blocks a Turbo in-app
+  // navigation (it does NOT fire on restoration visits — the documented gap).
+  // Both read the LIVE dirty count, so a clean form never blocks. Handlers are
+  // stored so disconnect() removes exactly them.
+  #armUnsavedGuard() {
+    if (typeof window === "undefined" || typeof window.addEventListener !== "function") return
+
+    this.#boundBeforeUnload = (event) => {
+      if (this.#dirtyCount() === 0) return undefined
+      // The spec dance: preventDefault + a truthy returnValue triggers the native
+      // "leave site?" prompt. The string is legacy (modern browsers show their own
+      // copy) but must be non-empty/truthy to arm the dialog.
+      event.preventDefault()
+      event.returnValue = "You have unsaved changes."
+      return event.returnValue
+    }
+    this.#boundBeforeVisit = (event) => {
+      if (this.#dirtyCount() === 0) return
+      const ok = typeof window.confirm === "function" ? window.confirm("You have unsaved changes. Leave anyway?") : true
+      if (!ok) event.preventDefault?.()
+    }
+
+    window.addEventListener("beforeunload", this.#boundBeforeUnload)
+    window.addEventListener("turbo:before-visit", this.#boundBeforeVisit)
+  }
+
+  // Remove the dirty-tracking listeners on disconnect (Turbo morph/navigation) so
+  // a morph re-scan or a navigate-away guard never runs against a detached root.
+  #teardownDirtyTracking() {
+    if (this.#boundScanDirty) {
+      this.element.removeEventListener?.("turbo:morph-element", this.#boundScanDirty)
+      this.#boundScanDirty = undefined
+    }
+    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
+      if (this.#boundBeforeUnload) window.removeEventListener("beforeunload", this.#boundBeforeUnload)
+      if (this.#boundBeforeVisit) window.removeEventListener("turbo:before-visit", this.#boundBeforeVisit)
+    }
+    this.#boundBeforeUnload = undefined
+    this.#boundBeforeVisit = undefined
   }
 
   // Build the multipart body (issue #34). `token`/`act` are flat fields the

--- a/spec/javascript/reactive_dirty.test.js
+++ b/spec/javascript/reactive_dirty.test.js
@@ -1,0 +1,483 @@
+// Unit tests for dirty-field tracking (issue #103).
+//
+// The browser already holds the last server-rendered value with ZERO shipped
+// state: input.defaultValue / defaultChecked / option.defaultSelected ARE the
+// attributes from the last server render. dirty = current ≠ default. trackDirty
+// runs #scanDirty(), a FULL PASS over every field this reactive root owns:
+//
+//   checkbox/radio → checked  !== defaultChecked
+//   select         → some option.selected !== option.defaultSelected
+//   else           → value    !== defaultValue
+//
+// A full pass (not a per-target toggle) is REQUIRED for radio groups: when a new
+// radio is selected the previously-checked one flips to checked=false and fires
+// NO input event — only re-scanning every owned field keeps its flag honest.
+//
+// Each dirty field gets data-reactive-dirty="true"; the root carries
+// data-reactive-dirty="<count>" (absent at zero). Baselines RESET on a server
+// re-render: connect() re-scans (a plain replace re-connects Stimulus), and a
+// turbo:morph-element listener re-scans after an in-place morph (which keeps the
+// element CONNECTED and fires no Stimulus lifecycle). warn_unsaved arms a
+// beforeunload / turbo:before-visit guard gated on a LIVE dirty-count read.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A minimal field/element stub faithful enough for #scanDirty():
+//   - type/value/defaultValue/checked/defaultChecked/options (per control kind)
+//   - data-controller for the reactive-root ownership predicate
+//   - dataset-backed setAttribute/getAttribute/removeAttribute + a listener log
+class FakeNode {
+  constructor(opts = {}) {
+    const {
+      tag = "div",
+      name = null,
+      type = null,
+      value = "",
+      defaultValue = "",
+      checked = false,
+      defaultChecked = false,
+      options = null,
+      controller = null,
+    } = opts
+    this.tag = tag.toLowerCase()
+    this.name = name
+    this.type = type
+    this.value = value
+    this.defaultValue = defaultValue
+    this.checked = checked
+    this.defaultChecked = defaultChecked
+    this.options = options // [{ selected, defaultSelected }, ...] for <select>
+    this.parentNode = null
+    this.children = []
+    this.attrs = {}
+    this.isConnected = true
+    this.listeners = {}
+    if (controller) this.attrs["data-controller"] = controller
+  }
+
+  append(...nodes) {
+    for (const n of nodes) {
+      n.parentNode = this
+      this.children.push(n)
+    }
+    return this
+  }
+
+  #descendants() {
+    const out = []
+    for (const child of this.children) out.push(child, ...child.#descendants())
+    return out
+  }
+
+  matches(selector) {
+    if (selector === '[data-controller~="reactive"]') {
+      const c = this.attrs["data-controller"]
+      return !!c && c.split(/\s+/).includes("reactive")
+    }
+    // The dirty-tracking opt-in probe (#dirtyTrackingEnabled): any element whose
+    // data-action carries the trackDirty descriptor.
+    if (selector === '[data-action*="reactive#trackDirty"]') {
+      return (this.attrs["data-action"] ?? "").includes("reactive#trackDirty")
+    }
+    // #scanDirty scans the same control set as #collectFields.
+    const wantsField = ["input", "select", "textarea"].some((t) => selector.includes(`${t}[name]`))
+    if (wantsField) return ["input", "select", "textarea"].includes(this.tag) && this.name != null
+    return false
+  }
+
+  closest(selector) {
+    let node = this
+    while (node) {
+      if (node.matches(selector)) return node
+      node = node.parentNode
+    }
+    return null
+  }
+
+  querySelectorAll(selector) {
+    return this.#descendants().filter((n) => n.matches(selector))
+  }
+
+  getAttribute(name) {
+    if (name === "name") return this.name
+    return this.attrs[name] ?? null
+  }
+  setAttribute(name, value) {
+    this.attrs[name] = String(value)
+  }
+  removeAttribute(name) {
+    delete this.attrs[name]
+  }
+  hasAttribute(name) {
+    return name in this.attrs
+  }
+  addEventListener(name, fn) {
+    ;(this.listeners[name] ??= []).push(fn)
+  }
+  removeEventListener(name, fn) {
+    this.listeners[name] = (this.listeners[name] ?? []).filter((f) => f !== fn)
+  }
+  emit(name, event = {}) {
+    for (const fn of this.listeners[name] ?? []) fn(event)
+  }
+}
+
+function buildController(rootEl) {
+  const controller = new ReactiveController()
+  controller.element = rootEl
+  controller.tokenValue = "tok"
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { addEventListener: () => {}, removeEventListener: () => {} }
+  return controller
+}
+
+function reactiveRoot(extra = {}) {
+  return new FakeNode({ tag: "div", controller: "reactive", ...extra })
+}
+
+// A reactive root that has opted into dirty tracking (track_dirty: → the
+// trackDirty descriptor rides its own data-action). connect() only wires the
+// baseline scan / morph listener / warn_unsaved guard for such a root.
+function dirtyRoot(extra = {}) {
+  const root = reactiveRoot(extra)
+  root.setAttribute("data-action", "input->reactive#trackDirty")
+  return root
+}
+
+test("a changed text input is marked dirty and the root carries the count", () => {
+  const root = reactiveRoot()
+  const title = new FakeNode({ tag: "input", type: "text", name: "title", value: "new", defaultValue: "old" })
+  root.append(title)
+
+  const controller = buildController(root)
+  controller.trackDirty({ target: title })
+
+  expect(title.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+})
+
+test("an unchanged text input is NOT dirty and the root has no count", () => {
+  const root = reactiveRoot()
+  const title = new FakeNode({ tag: "input", type: "text", name: "title", value: "same", defaultValue: "same" })
+  root.append(title)
+
+  const controller = buildController(root)
+  controller.trackDirty({ target: title })
+
+  expect(title.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("editing then reverting a field clears the dirty flag (full re-scan, not sticky)", () => {
+  const root = reactiveRoot()
+  const title = new FakeNode({ tag: "input", type: "text", name: "title", value: "new", defaultValue: "old" })
+  root.append(title)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: title })
+  expect(title.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+
+  // User types the original value back — now equal to the default.
+  title.value = "old"
+  controller.trackDirty({ target: title })
+  expect(title.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("a checkbox is dirty iff checked !== defaultChecked", () => {
+  const root = reactiveRoot()
+  const done = new FakeNode({ tag: "input", type: "checkbox", name: "done", checked: true, defaultChecked: false })
+  root.append(done)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: done })
+  expect(done.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+
+  // Toggle back to its default → clean.
+  done.checked = false
+  controller.trackDirty({ target: done })
+  expect(done.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("a select is dirty when any option's selected !== defaultSelected", () => {
+  const root = reactiveRoot()
+  // Default selection was option 0; the user picked option 1.
+  const status = new FakeNode({
+    tag: "select",
+    name: "status",
+    options: [
+      { selected: false, defaultSelected: true },
+      { selected: true, defaultSelected: false },
+    ],
+  })
+  root.append(status)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: status })
+  expect(status.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+})
+
+test("a select back at its default selection is NOT dirty", () => {
+  const root = reactiveRoot()
+  const status = new FakeNode({
+    tag: "select",
+    name: "status",
+    options: [
+      { selected: true, defaultSelected: true },
+      { selected: false, defaultSelected: false },
+    ],
+  })
+  root.append(status)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: status })
+  expect(status.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("radio group: selecting a new radio marks the deselected default radio dirty too (full pass)", () => {
+  // The decisive full-pass case. The default was radio A (defaultChecked). The
+  // user picks radio B. B fires the input event; A gets NO event but flipped to
+  // checked=false — so a per-target toggle would leave A stale. #scanDirty
+  // re-scans EVERY owned field, catching both.
+  const root = reactiveRoot()
+  const a = new FakeNode({ tag: "input", type: "radio", name: "size", value: "s", checked: false, defaultChecked: true })
+  const b = new FakeNode({ tag: "input", type: "radio", name: "size", value: "m", checked: true, defaultChecked: false })
+  root.append(a, b)
+  const controller = buildController(root)
+
+  // Only B fired the event, but the full pass evaluates both.
+  controller.trackDirty({ target: b })
+
+  expect(a.getAttribute("data-reactive-dirty")).toBe("true") // deselected default
+  expect(b.getAttribute("data-reactive-dirty")).toBe("true") // newly selected
+  expect(root.getAttribute("data-reactive-dirty")).toBe("2")
+})
+
+test("radio group: re-selecting the default clears both flags", () => {
+  const root = reactiveRoot()
+  const a = new FakeNode({ tag: "input", type: "radio", name: "size", value: "s", checked: true, defaultChecked: true })
+  const b = new FakeNode({ tag: "input", type: "radio", name: "size", value: "m", checked: false, defaultChecked: false })
+  root.append(a, b)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: a })
+  expect(a.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(b.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("nested reactive root: an outer scan ignores an inner root's fields (issue #15 ownership)", () => {
+  const outer = reactiveRoot()
+  const outerField = new FakeNode({ tag: "input", type: "text", name: "notes", value: "changed", defaultValue: "orig" })
+  const inner = reactiveRoot()
+  const innerField = new FakeNode({ tag: "input", type: "text", name: "q", value: "changed", defaultValue: "orig" })
+  inner.append(innerField)
+  outer.append(outerField, inner)
+
+  const controller = buildController(outer)
+  controller.trackDirty({ target: outerField })
+
+  // Only the outer field counts toward the outer root.
+  expect(outerField.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(innerField.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(outer.getAttribute("data-reactive-dirty")).toBe("1")
+})
+
+test("file inputs are skipped (no meaningful default baseline)", () => {
+  const root = reactiveRoot()
+  const upload = new FakeNode({ tag: "input", type: "file", name: "doc", value: "C:\\fakepath\\x.pdf", defaultValue: "" })
+  root.append(upload)
+  const controller = buildController(root)
+
+  controller.trackDirty({ target: upload })
+  expect(upload.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("connect() seeds the baseline scan (a plain replace re-connects → re-scan)", () => {
+  const root = dirtyRoot()
+  root.id = "form"
+  const dirtyField = new FakeNode({ tag: "input", type: "text", name: "title", value: "server-new", defaultValue: "server-old" })
+  root.append(dirtyField)
+  const controller = buildController(root)
+
+  controller.connect()
+
+  // On connect the root reflects the current-vs-default diff immediately, without
+  // waiting for an input event.
+  expect(dirtyField.getAttribute("data-reactive-dirty")).toBe("true")
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+})
+
+test("a turbo:morph-element on the root re-scans (morph keeps it connected, no Stimulus lifecycle)", () => {
+  const root = dirtyRoot()
+  root.id = "form"
+  const field = new FakeNode({ tag: "input", type: "text", name: "title", value: "x", defaultValue: "old" })
+  root.append(field)
+  const controller = buildController(root)
+
+  controller.connect() // registers the morph listener + seeds a scan
+  expect(field.getAttribute("data-reactive-dirty")).toBe("true") // x !== old
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+
+  // Server morph writes a fresh default that NOW equals the field value (Turbo 8
+  // preserves the focused value, writes fresh default attrs) → post-morph re-scan
+  // must find it clean.
+  field.defaultValue = "x"
+  root.emit("turbo:morph-element", { target: root })
+
+  expect(field.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("disconnect() removes the morph-element listener (no re-scan after teardown)", () => {
+  const root = dirtyRoot()
+  root.id = "form"
+  const field = new FakeNode({ tag: "input", type: "text", name: "title", value: "x", defaultValue: "x" })
+  root.append(field)
+  const controller = buildController(root)
+
+  controller.connect()
+  controller.disconnect()
+
+  // After disconnect, a stray morph event must not run a scan (the listener is gone).
+  field.value = "changed"
+  root.emit("turbo:morph-element", { target: root })
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+})
+
+test("warn_unsaved arms a beforeunload guard gated on the LIVE dirty count", () => {
+  const winListeners = {}
+  const win = {
+    addEventListener: (name, fn) => ((winListeners[name] ??= []).push(fn)),
+    removeEventListener: (name, fn) => (winListeners[name] = (winListeners[name] ?? []).filter((f) => f !== fn)),
+  }
+  const root = dirtyRoot()
+  root.id = "form"
+  root.setAttribute("data-reactive-warn-unsaved", "true")
+  const field = new FakeNode({ tag: "input", type: "text", name: "title", value: "same", defaultValue: "same" })
+  root.append(field)
+
+  const controller = buildController(root)
+  globalThis.window = win
+  controller.connect()
+
+  // Clean form → the beforeunload handler does NOT block navigation.
+  const cleanEvent = { preventDefault: () => {} }
+  const beforeunload = winListeners.beforeunload?.[0]
+  expect(typeof beforeunload).toBe("function")
+  expect(beforeunload(cleanEvent)).toBeUndefined()
+
+  // Dirty the form and re-scan; now the SAME handler blocks (returnValue set).
+  field.value = "changed"
+  controller.trackDirty({ target: field })
+  expect(root.getAttribute("data-reactive-dirty")).toBe("1")
+
+  const dirtyEvent = {}
+  let prevented = false
+  dirtyEvent.preventDefault = () => (prevented = true)
+  const result = beforeunload(dirtyEvent)
+  expect(prevented).toBe(true)
+  expect(dirtyEvent.returnValue).toBeTruthy()
+  expect(result).toBeTruthy()
+})
+
+test("warn_unsaved: turbo:before-visit is vetoed while dirty and allowed when clean", () => {
+  const winListeners = {}
+  const win = {
+    addEventListener: (name, fn) => ((winListeners[name] ??= []).push(fn)),
+    removeEventListener: () => {},
+  }
+  const root = dirtyRoot()
+  root.id = "form"
+  root.setAttribute("data-reactive-warn-unsaved", "true")
+  const field = new FakeNode({ tag: "input", type: "text", name: "title", value: "orig", defaultValue: "orig" })
+  root.append(field)
+
+  const controller = buildController(root)
+  globalThis.window = win
+  // confirm() decides the veto; stub it to decline (stay on page).
+  win.confirm = () => false
+  controller.connect()
+
+  const beforeVisit = winListeners["turbo:before-visit"]?.[0]
+  expect(typeof beforeVisit).toBe("function")
+
+  // Clean → visit proceeds (no preventDefault).
+  let cleanPrevented = false
+  beforeVisit({ preventDefault: () => (cleanPrevented = true) })
+  expect(cleanPrevented).toBe(false)
+
+  // Dirty + user declines the confirm → the visit is vetoed.
+  field.value = "changed"
+  controller.trackDirty({ target: field })
+  let dirtyPrevented = false
+  beforeVisit({ preventDefault: () => (dirtyPrevented = true) })
+  expect(dirtyPrevented).toBe(true)
+})
+
+test("no warn_unsaved marker → no navigate-away guard registered", () => {
+  const winListeners = {}
+  const win = {
+    addEventListener: (name, fn) => ((winListeners[name] ??= []).push(fn)),
+    removeEventListener: () => {},
+  }
+  // Dirty tracking IS on (so connect wires the scan/morph listener), but the
+  // warn-unsaved marker is absent — so no navigate-away guard is armed. This
+  // proves the MARKER gates the guard, not merely the absence of tracking.
+  const root = dirtyRoot() // no data-reactive-warn-unsaved
+  root.id = "form"
+  buildController(root)
+  globalThis.window = win
+
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.tokenValue = "tok"
+  controller.connect()
+
+  expect(winListeners.beforeunload).toBeUndefined()
+  expect(winListeners["turbo:before-visit"]).toBeUndefined()
+})
+
+test("connect() does NOT wire dirty tracking for a root that never opted in", () => {
+  const winListeners = {}
+  const win = {
+    addEventListener: (name, fn) => ((winListeners[name] ??= []).push(fn)),
+    removeEventListener: () => {},
+  }
+  // A plain reactive root (no track_dirty:, no dirty: field) — connect must not
+  // register the morph listener, run a baseline scan, or arm any guard.
+  const root = reactiveRoot()
+  root.id = "form"
+  root.setAttribute("data-reactive-warn-unsaved", "true") // present, but tracking is OFF
+  const field = new FakeNode({ tag: "input", type: "text", name: "title", value: "changed", defaultValue: "orig" })
+  root.append(field)
+
+  const controller = buildController(root)
+  globalThis.window = win
+  controller.connect()
+
+  // No baseline scan ran (the changed field is NOT marked, root has no count).
+  expect(field.getAttribute("data-reactive-dirty")).toBeNull()
+  expect(root.getAttribute("data-reactive-dirty")).toBeNull()
+  // No morph listener, no navigate-away guard.
+  expect((root.listeners["turbo:morph-element"] ?? []).length).toBe(0)
+  expect(winListeners.beforeunload).toBeUndefined()
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -277,6 +277,47 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#reactive_field dirty tracking (issue #103)" do
+    # A real Phlex component so `mix` (Phlex::Helpers) is present, exactly as in
+    # production — reactive_field(dirty:) deep-merges its trackDirty descriptor.
+    subject(:instance) { field_klass.new }
+
+    let(:field_klass) do
+      Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "DirtyFieldThing"
+
+        reactive_state :count
+        def initialize(count: 0) = @count = count
+      end
+    end
+
+    it "wires the trackDirty action on dirty: true" do
+      attrs = instance.send(:reactive_field, :title, dirty: true)
+      expect(attrs[:name]).to eq("title")
+      expect(attrs[:data][:action]).to eq("input->reactive#trackDirty")
+    end
+
+    it "does not consume dirty: as a literal HTML attribute" do
+      attrs = instance.send(:reactive_field, :title, dirty: true)
+      expect(attrs).not_to have_key(:dirty)
+    end
+
+    it "omits the trackDirty wiring when dirty is falsey (the default)" do
+      expect(instance.send(:reactive_field, :title)).not_to have_key(:data)
+      expect(instance.send(:reactive_field, :title, dirty: false)).not_to have_key(:data)
+    end
+
+    it "token-joins trackDirty onto a caller's own data-action instead of clobbering it" do
+      # A field that also carries its own descriptor (mix deep-merges data-action).
+      attrs = instance.send(:reactive_field, :title, dirty: true,
+        data: { action: "blur->reactive#dispatch" })
+      expect(attrs[:data][:action]).to eq("blur->reactive#dispatch input->reactive#trackDirty")
+    end
+  end
+
   describe "#reactive_root (issue #48 — id on the root, not a child)" do
     subject(:instance) { root_klass.new }
 
@@ -339,6 +380,86 @@ RSpec.describe Phlex::Reactive::Component do
       expect(open_tag).to include('id="root-thing"')
       expect(open_tag).to include('data-controller="reactive"')
       expect(open_tag).to include('class="card"')
+    end
+  end
+
+  describe "#reactive_root dirty tracking (issue #103)" do
+    subject(:instance) { root_klass.new }
+
+    let(:root_klass) do
+      Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "DirtyRootThing"
+
+        reactive_state :count
+        def initialize(count: 0) = @count = count
+
+        def id = "dirty-root"
+      end
+    end
+
+    it "mixes the trackDirty descriptor onto the root's data-action for track_dirty: true" do
+      attrs = instance.send(:reactive_root, track_dirty: true)
+      expect(attrs[:data][:action]).to eq("input->reactive#trackDirty")
+      # still a full reactive root
+      expect(attrs[:data][:controller]).to eq("reactive")
+      expect(attrs[:id]).to eq("dirty-root")
+    end
+
+    it "does NOT emit track_dirty as a literal HTML attribute (kwarg consumed pre-mix)" do
+      attrs = instance.send(:reactive_root, track_dirty: true)
+      expect(attrs).not_to have_key(:track_dirty)
+      expect(attrs.dig(:data, :track_dirty)).to be_nil
+    end
+
+    it "emits the warn-unsaved marker for warn_unsaved: true" do
+      attrs = instance.send(:reactive_root, warn_unsaved: true)
+      # STRING "true" (Phlex renders a boolean-true attr valueless → JS sees "" → falsy)
+      expect(attrs[:data][:reactive_warn_unsaved]).to eq("true")
+      expect(attrs).not_to have_key(:warn_unsaved)
+    end
+
+    it "does NOT emit warn_unsaved as a literal HTML attribute (kwarg consumed pre-mix)" do
+      attrs = instance.send(:reactive_root, warn_unsaved: false)
+      expect(attrs).not_to have_key(:warn_unsaved)
+      expect(attrs.dig(:data, :reactive_warn_unsaved)).to be_nil
+    end
+
+    it "composes track_dirty with a caller's own data-action (token-join, not clobber)" do
+      attrs = instance.send(:reactive_root, track_dirty: true,
+        data: { action: "scroll->reactive#dispatch" })
+      expect(attrs[:data][:action]).to eq("scroll->reactive#dispatch input->reactive#trackDirty")
+      expect(attrs[:data][:controller]).to eq("reactive")
+    end
+
+    it "supports both flags at once, preserving id + controller + token" do
+      attrs = instance.send(:reactive_root, track_dirty: true, warn_unsaved: true, class: "card")
+      expect(attrs[:data][:action]).to eq("input->reactive#trackDirty")
+      expect(attrs[:data][:reactive_warn_unsaved]).to eq("true")
+      expect(attrs[:data][:controller]).to eq("reactive")
+      expect(attrs[:data][:reactive_token_value]).to be_a(String)
+      expect(attrs[:id]).to eq("dirty-root")
+      expect(attrs[:class]).to eq("card")
+    end
+
+    it "renders no literal track-dirty/warn-unsaved attribute in the output" do
+      render_klass = Class.new(root_klass) do
+        def self.name = "RenderDirtyRoot"
+        def view_template = div(**reactive_root(track_dirty: true, warn_unsaved: true)) { "hi" }
+      end
+      # NB: the trackDirty descriptor value contains a literal `>` (input->…), so a
+      # /<div [^>]*>/ regex would truncate mid-attribute — assert on the whole tag.
+      html = render_klass.new.call
+
+      expect(html).to include('data-action="input->reactive#trackDirty"')
+      expect(html).to include('data-reactive-warn-unsaved="true"')
+      # the raw kwargs never leak through as attributes (no `track-dirty` /
+      # `warn-unsaved` attribute, no `track_dirty`/`warn_unsaved` token anywhere)
+      expect(html).not_to include("track-dirty")
+      expect(html).not_to match(/\btrack_dirty\b/)
+      expect(html).not_to match(/\bwarn_unsaved\b/)
     end
   end
 

--- a/spec/system/dirty_form_spec.rb
+++ b/spec/system/dirty_form_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Dirty-field tracking (issue #103): reactive_root(track_dirty: true) re-scans the
+# root's owned fields on every input, marking the root data-reactive-dirty="<count>"
+# when a field diverges from its server-rendered defaultValue — with ZERO shipped
+# state (the baseline is the DOM's own default attribute). An "Unsaved" badge is
+# revealed purely by CSS ([data-reactive-dirty] .unsaved-badge). save morphs the
+# field with the new value as its fresh default, so the post-morph re-scan clears
+# the badge WITHOUT a full-page reload.
+#
+# Runs under Puma (sync) AND Falcon (async) in CI's server matrix.
+RSpec.describe "Dirty-field tracking (issue #103)", type: :system do
+  it "shows the unsaved badge on edit and clears it after a morph save — no reload" do
+    todo = Todo.create!(title: "original")
+    visit "/dirty_form/#{todo.id}"
+    # Prove no full-page reload happens across the whole interaction.
+    page.execute_script("window.__noReload = 'alive'")
+
+    # At rest: clean form, no count on the root, badge hidden (CSS on the count).
+    expect(page).to have_field("title", with: "original")
+    expect(page).to have_no_css("[data-testid='badge']", visible: :visible)
+    expect(page).to have_no_css("[id^='dirtyform'][data-reactive-dirty]")
+
+    # Type a change → the field diverges from its defaultValue → the root gains a
+    # count of 1, the field is marked dirty, and the badge becomes visible (CSS).
+    find("[data-testid='title']").set("edited")
+    expect(page).to have_css("[id^='dirtyform'][data-reactive-dirty='1']")
+    expect(page).to have_css("[data-testid='title'][data-reactive-dirty='true']")
+    expect(page).to have_css("[data-testid='badge']", visible: :visible, text: "Unsaved")
+
+    # Save. reply.morph re-renders the field in place with "edited" as the NEW
+    # defaultValue, so the post-morph re-scan finds it clean: the count/dirty
+    # attrs drop and the badge hides again — all without navigating.
+    find("[data-testid='save']").click
+
+    expect(page).to have_css("[data-testid='current']", text: "edited") # morph landed
+    expect(page).to have_no_css("[id^='dirtyform'][data-reactive-dirty]")
+    expect(page).to have_no_css("[data-testid='title'][data-reactive-dirty]")
+    expect(page).to have_no_css("[data-testid='badge']", visible: :visible)
+
+    expect(todo.reload.title).to eq("edited")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+
+  it "clears the badge when the field is edited back to its original value (full re-scan)" do
+    todo = Todo.create!(title: "keepme")
+    visit "/dirty_form/#{todo.id}"
+
+    field = find("[data-testid='title']")
+    field.set("changed")
+    expect(page).to have_css("[id^='dirtyform'][data-reactive-dirty='1']")
+
+    # Type the original value back — now equal to the default → clean again, even
+    # without saving (the scan is a full re-compute, not a sticky flag).
+    field.set("keepme")
+    expect(page).to have_no_css("[id^='dirtyform'][data-reactive-dirty]")
+    expect(page).to have_no_css("[data-testid='badge']", visible: :visible)
+  end
+end


### PR DESCRIPTION
Closes #103

## Problem

There was no way to show "unsaved changes", enable **Save** only when something changed, or warn before navigating away. Livewire's `wire:dirty` needs a client state snapshot — which the signed-identity model forbids. But the browser already holds the last server-rendered value with **zero shipped state**: `input.defaultValue` / `defaultChecked` / `option.defaultSelected` **are** the attributes from the last server render, so **dirty = current ≠ default**, read straight from the DOM.

## The API

```ruby
div(**reactive_root(track_dirty: true, warn_unsaved: true)) do
  input(**reactive_field(:title, value: @todo.title, dirty: true))
  span(class: "unsaved-badge") { "Unsaved" }   # shown via [data-reactive-dirty] CSS
  button(**on(:save, disable_with: "Saving…")) { "Save" }
end
```

- **`track_dirty: true`** on the root wires every input under it to a full re-scan on change; **`dirty: true`** on a single `reactive_field` opts one field in.
- On change the client re-scans **every field the root owns** (nested-reactive-root ownership guard) and marks each changed field `data-reactive-dirty="true"` and the root `data-reactive-dirty="<count>"` (**absent at zero**, so `[data-reactive-dirty]` matches iff dirty).
- **`warn_unsaved: true`** arms a `beforeunload` / `turbo:before-visit` guard gated on the **live** dirty count.

Style it purely in CSS — phlex-reactive ships none:

```css
.unsaved-badge { display: none; }
[data-reactive-dirty] .unsaved-badge { display: inline; }
```

## Design notes (the merged + verifier-corrected spec)

- **`reactive_root` kwargs are consumed BEFORE the `mix`.** `reactive_root` treats every leftover kwarg as a literal HTML attribute override (only `:id` is special-cased), so an unconsumed `track_dirty: true` would render a bogus `track-dirty="true"` attribute. Both are `overrides.delete(...)`-ed first, then `track_dirty`/`dirty:` **token-join** their `input->reactive#trackDirty` descriptor onto any existing `data-action` via `mix` (so a caller's own descriptor survives).
- **Full pass, not per-target.** A radio group's previously-checked radio flips to `checked=false` with **no** input event when deselected — per-target toggling would leave its flag stale. `#scanDirty()` re-computes every owned field.
- **Baselines reset on the server re-render.** A plain replace re-connects the controller (`connect()` re-scans); an in-place **morph** / broadcast morph keeps the element **connected** and fires no Stimulus lifecycle, so the client also listens for `turbo:morph-element` on the root and re-scans after the morph writes fresh `default*` attributes. `reactive:applied` fires when streams are handed to Turbo — **before** the DOM mutation — so it is **not** a valid reset hook and is deliberately not used.
- **Opt-in gate.** All of the above is wired only when the root opts in (`track_dirty:` or a `dirty:` field), so a component that never uses dirty tracking pays nothing — no baseline scan, no `turbo:morph-element` listener on every broadcast.
- **`warn_unsaved` caveats (documented):** browsers show their own generic `beforeunload` copy (the message string is legacy), and `turbo:before-visit` does not fire on restoration (Back/Forward) visits.
- **Out of scope (v1):** rich-text / `contenteditable` editors have no `default*` baseline and are not tracked. File inputs are skipped (no server default to diff).

## Test coverage

| Layer | File | Covers |
|---|---|---|
| Ruby | `spec/phlex/reactive/component_spec.rb` | kwargs consumed (no literal `track-dirty`/`warn-unsaved` attribute in output), `data-action` token-joined, `reactive_field(dirty:)` emission, both flags at once |
| bun | `spec/javascript/reactive_dirty.test.js` | text/checkbox/radio-group/select scan; nested-root exclusion; full-pass fixes the deselected radio; per-field + root count; file inputs skipped; post-morph re-scan via a synthesized `turbo:morph-element`; `warn_unsaved` beforeunload/before-visit gated on the live count; opt-in gate (no wiring when a root never opts in) |
| System | `spec/system/dirty_form_spec.rb` | type → badge appears; morph save → badge clears **without reload**; edit-back-to-original clears it. **Puma AND Falcon.** |

## Verification

- [x] `bundle exec rubocop` clean (142 files)
- [x] `bundle exec rspec spec/phlex spec/requests` — 444 pass
- [x] `bun test spec/javascript` — 230 pass; vendored client re-synced (byte-identical guard passes)
- [x] `bundle exec rspec spec/system` — 52 pass under **Puma AND Falcon**

## Invariants preserved

No client state (the baseline is the DOM's own server-rendered `default*` attrs) · default-deny actions untouched · ONE generic controller · pgbus optional · self-targeting `#id`. Existing components render and behave verbatim.
