### PR TITLE
feat(component): reactive_text mirrors + typed compute inputs (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`reactive_text` mirrors + typed compute inputs (#104).** Mirror a form field
+  into a **text node** — a live preview heading, a character counter,
+  `"Hello, {name}"` — with **no round trip and no bespoke Stimulus controller**.
+  Datastar's `data-text` / Alpine's `x-text`, but declared on the component.
+  - **`reactive_text(:name, initial)`** renders `span(data: { reactive_text:
+    name }) { initial }` — the **text sibling of `reactive_field`**. The client
+    writes it via **`textContent`** (XSS-safe by construction, never `innerHTML`).
+    It carries **no `name`**, so `#collectFields` never sweeps it into the POSTed
+    params.
+  - **Typed compute inputs.** `reactive_compute :x, inputs: { title: :string,
+    qty: :number }, outputs:` types each input: a `:number` is coerced through
+    `Number` (blank/NaN → 0), a `:string` reaches the reducer **raw** — so a live
+    text preview reads real text, not `NaN`. The **array form** (`inputs: %i[a
+    b]`) stays all-numeric and **byte-identical on the wire** (a JSON array); the
+    hash form emits a JSON object of name→type.
+  - **Output resolution.** A compute output whose name matches an owned form
+    field writes that field's `.value` (the existing change-guarded `input`
+    dispatch). An output with **no** matching field writes every owned
+    `[data-reactive-text="<name>"]` node via `textContent` — change-guarded too,
+    but **no** input dispatch (a text node has no listener contract).
+  - **Reducer-less identity mirrors.** A separate always-run pass syncs each
+    declared **input**'s raw value into its own `reactive_text(:same_name)` node
+    on every keystroke — so `reactive_text(:title)` is a live field echo with **no
+    registered reducer at all**.
+  - **Seed the server render.** `view_template` must seed each mirror with the
+    same derived value the reducer would, or a later morph repaints stale text —
+    the same reconcile contract the new-vs-persisted split already documents.
+
 - **Dirty-field tracking + unsaved-changes guard (#103).** Show "unsaved
   changes", enable **Save** only when something changed, or warn before navigating
   away — Livewire's `wire:dirty` — **without shipping any client state**. The

--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `js` | The immutable op builder behind `on_client`: `show`/`hide`/`toggle` (the `hidden` attribute, with an optional `transition:`), `add_class`/`remove_class`/`toggle_class`, `set_attr`/`remove_attr`/`toggle_attr` (allowlisted names), `focus`/`focus_first`, and `dispatch` — chainable. |
 | `reactive_input(:param, **attrs)` / `reactive_select(:param, **attrs)` | Render a control already bound to an action param (no magic `name:`). |
 | `reactive_field(:param, **attrs)` | The attribute hash behind the above — spread onto any control. |
+| `reactive_text(:name, initial)` | Mirror a compute output (or a declared input) into a **text node** — a live preview heading, a character counter, `"Hello, {name}"` — via `textContent` (XSS-safe). The text sibling of `reactive_field`; carries no `name`, so it's never POSTed. See [Client-side computes](#client-side-computes-reactive_compute--reactive_text). |
+| `reactive_compute :name, inputs: { title: :string, qty: :number }, outputs:` | **Typed** inputs: a `:string` reaches the JS reducer raw, a `:number` is coerced through `Number`. The array form (`inputs: %i[a b]`) stays all-numeric. |
 | `reactive_root(track_dirty: true, warn_unsaved: true)` / `reactive_field(:param, dirty: true)` | **Dirty tracking** against the DOM's own `defaultValue`/`defaultChecked`/`defaultSelected` — no client state. Marks changed fields + the root `data-reactive-dirty`; `warn_unsaved:` arms a `beforeunload`/`turbo:before-visit` guard. Style with `[data-reactive-dirty]`. See [Dirty-field tracking](#dirty-field-tracking-dirty--track_dirty--warn_unsaved). |
 | `nested_update!(:assoc, attrs)` | Map a nested param onto `<assoc>_attributes` with id preservation; update the record. |
 | `reactive_collection :name, item:, container:, count:, empty:, size:` | Declare an add/remove-row list once; actions call `reply.append`/`prepend`/`remove`. See [Reactive collections](#reactive-collections-addremove-rows--count--empty-state). |
@@ -797,6 +799,53 @@ free as an ordinary action-param name (`on(:switch, key: "pgbus")` still passes
 > input — the second would overwrite the first's action name. Bind each key
 > trigger to its own element (the field saves on Enter; a Cancel button — or the
 > field's own blur — handles Escape), as above.
+
+### Client-side computes (`reactive_compute` + `reactive_text`)
+
+Some math should feel instant with **no round trip** — a NEW, unsaved record's
+running total, a live title preview, a character counter. `reactive_compute`
+declares a client-side reducer (a plain JS function registered once) that runs on
+`input` and writes derived values straight into the DOM. When the component also
+carries `on(...)`, the debounced POST still fires and the server reply reconciles
+— the compute just paints first.
+
+```ruby
+reactive_compute :preview,
+  inputs: { title: :string, qty: :number },  # typed: :string raw, :number → Number
+  outputs: %i[title_preview char_count]       # written with no round trip
+
+div(**mix(reactive_root, reactive_compute_attrs(:preview))) do
+  input(**mix(reactive_field(:title, value: @post.title),
+              data: { action: "input->reactive#recompute" }))
+  h2    { reactive_text(:title_preview, @post.title) }  # a text-node output
+  small { reactive_text(:char_count) }                  # another text-node output
+end
+```
+
+```js
+// Register the reducer once at boot. Its signature is (values, { changed }).
+import { setComputeReducer } from "phlex/reactive/compute"
+setComputeReducer("preview", ({ title }) => ({
+  title_preview: title, char_count: `${title.length}/80`,
+}))
+```
+
+- **Typed inputs.** `inputs:` takes a **hash** to type each input: a `:number` is
+  coerced through `Number` (blank/NaN → 0 — the array-form default), a `:string`
+  reaches the reducer **raw** so a live text preview reads real text. The **array
+  form** (`inputs: %i[a b]`) stays all-numeric and byte-identical on the wire.
+- **`reactive_text(:name, initial)`** mirrors a value into a **text node** via
+  `textContent` (XSS-safe by construction). An output whose name matches an owned
+  form field writes that field's `.value`; an output with **no** matching field
+  writes every owned `[data-reactive-text="<name>"]` node. It carries **no
+  `name`**, so it's never collected or POSTed as a param.
+- **Reducer-less mirrors.** A declared **input** also mirrors into its own
+  `reactive_text(:same_name)` node on every keystroke with **no reducer at all** —
+  so `reactive_text(:title)` is a live field echo out of the box.
+- **Seed the server render.** Your `view_template` must seed each mirror with the
+  same derived value the reducer would (`reactive_text(:char_count, "5/80")`), or
+  a later morph repaints stale text — the same reconcile contract the whole
+  new-vs-persisted split relies on.
 
 ### Combobox keyboard navigation (`listnav:`)
 

--- a/app/javascript/phlex/reactive/compute.js
+++ b/app/javascript/phlex/reactive/compute.js
@@ -22,10 +22,24 @@
 //
 // The reducer's signature is (values, meta):
 //
-//   values — a plain object of { inputName: Number } over the declared inputs
+//   values — a plain object of { inputName: value } over the declared inputs.
+//            Untyped inputs (the array form) AND :number-typed inputs arrive as
+//            Numbers (blank/NaN → 0); :string-typed inputs (the hash form,
+//            issue #104) arrive as the RAW string. `reactive_compute :x, inputs:
+//            { title: :string, qty: :number }` is what selects per-input types;
+//            `inputs: %i[a b]` stays all-numeric (backward compatible).
 //   meta   — { changed }: the name (string) of the declared input the
 //            triggering event edited, or null (a direct recompute() call, or a
 //            target this root doesn't own / didn't declare as an input).
+//
+// OUTPUTS may be a form FIELD or a TEXT NODE (issue #104). An output whose name
+// matches an owned control writes its .value (+ the change-guarded input
+// dispatch below). An output with NO matching field writes textContent to every
+// owned [data-reactive-text="<name>"] node (reactive_text(:name)) — XSS-safe by
+// construction, change-guarded, NO input dispatch (a text node has no listener
+// contract). A declared INPUT also mirrors into its own text node on every
+// input via an always-run pass — so reactive_text(:title) is a live field
+// preview with NO registered reducer at all.
 //
 // It returns a plain object of { outputName: value } — only the outputs it
 // names are written, so it can leave the edited field (and its caret)

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -710,33 +710,54 @@ export default class extends Controller {
   // changed = that output's name — the reducer must be convergent (see
   // compute.js) so the change guard settles the chain.
   recompute(event) {
+    // Inputs may be a JSON ARRAY of names (array form — every input coerced
+    // through Number, the shipped behavior) or a JSON OBJECT of name→type (hash
+    // form, issue #104 — :number coerced, :string read raw). #parseComputeInputs
+    // returns [name, type] pairs either way (array form defaults type "number").
+    const inputPairs = this.#parseComputeInputs()
+    const inputs = inputPairs.map(([name]) => name)
+
+    // Identity-mirror pass (issue #104), ALWAYS run — even with NO registered
+    // reducer, so reactive_text(:title) mirrors a field into its text node with
+    // zero reducer wiring. Each declared input's RAW string value is written to
+    // its owned [data-reactive-text="<name>"] node(s). It runs BEFORE the reducer
+    // early-return below so a reducer-less binding still mirrors.
+    for (const name of inputs) this.#mirrorText(name, this.#rawFieldValue(name))
+
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
     const reduce = computeReducer(key)
     if (!reduce) return
 
-    const inputs = this.#parseComputeList("data-reactive-compute-inputs-param")
     const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
 
     const values = {}
-    for (const name of inputs) values[name] = this.#numericFieldValue(name)
+    for (const [name, type] of inputPairs) values[name] = this.#computeInputValue(name, type)
 
     const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
-      if (!field) continue
-      // Real browsers do NOT fire `input` on a programmatic .value write (issue
-      // #76), so after writing we dispatch a bubbling `input` ourselves — that's
-      // what drives a chained repaint (a summary listener, a second compute),
-      // matching the server's set_value + dispatch("input") contract. The write
-      // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
-      // event). The guard is what lets a reducer with overlapping inputs/outputs
-      // (the shipped payment_split shape) settle — an unconditional dispatch
-      // would re-enter input->reactive#recompute forever.
-      if (String(result[name]) === field.value) continue
-      field.value = result[name]
-      field.dispatchEvent(new Event("input", { bubbles: true }))
+      // Output resolution (issue #104): write to the owned named FIELD if one
+      // exists, ELSE mirror to every owned [data-reactive-text="<name>"] node.
+      if (field) {
+        // Real browsers do NOT fire `input` on a programmatic .value write (issue
+        // #76), so after writing we dispatch a bubbling `input` ourselves — that's
+        // what drives a chained repaint (a summary listener, a second compute),
+        // matching the server's set_value + dispatch("input") contract. The write
+        // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
+        // event). The guard is what lets a reducer with overlapping inputs/outputs
+        // (the shipped payment_split shape) settle — an unconditional dispatch
+        // would re-enter input->reactive#recompute forever.
+        if (String(result[name]) === field.value) continue
+        field.value = result[name]
+        field.dispatchEvent(new Event("input", { bubbles: true }))
+      } else {
+        // A text-node output: textContent, XSS-safe by construction. Change-
+        // guarded too (compare before writing), but NO input dispatch — a text
+        // node has no listener contract, so nothing chains off it.
+        this.#mirrorText(name, result[name])
+      }
     }
   }
 
@@ -816,6 +837,38 @@ export default class extends Controller {
     }
   }
 
+  // Parse the inputs param into [name, type] pairs (issue #104). The wire is a
+  // JSON ARRAY of names (array form → every input typed "number", the shipped
+  // numeric coercion) OR a JSON OBJECT of name→type (hash form → ":string" read
+  // raw, ":number" coerced). Malformed/absent degrades to [] — a bad binding
+  // must never throw on input.
+  #parseComputeInputs() {
+    const raw = this.element.getAttribute("data-reactive-compute-inputs-param")
+    if (!raw) return []
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed.map((name) => [name, "number"])
+      if (parsed && typeof parsed === "object") return Object.entries(parsed)
+      return []
+    } catch {
+      return []
+    }
+  }
+
+  // Coerce a declared input's field value for the reducer per its type (issue
+  // #104): "string" → the raw string value (field.value ?? ""); anything else
+  // ("number", the array-form default) → the numeric coercion (blank/NaN → 0).
+  #computeInputValue(name, type) {
+    if (type === "string") return this.#rawFieldValue(name)
+    return this.#numericFieldValue(name)
+  }
+
+  // A declared input's RAW string value — the display string, used for :string
+  // inputs and for identity mirrors. "" for a blank/absent field (never NaN).
+  #rawFieldValue(name) {
+    return this.#ownedField(name)?.value ?? ""
+  }
+
   // The declared compute input the event just edited — the reducer's
   // meta.changed (issue #75). The triggering field counts only when it is a
   // named form control OWNED by this root (not a nested reactive root's, issue
@@ -843,6 +896,27 @@ export default class extends Controller {
     const field = this.#ownedField(name)
     const n = Number(field?.value)
     return Number.isFinite(n) ? n : 0
+  }
+
+  // Write `value` into every owned [data-reactive-text="<name>"] node via
+  // textContent (issue #104) — XSS-safe by construction (never innerHTML). Drives
+  // both the identity mirror (an input's raw value) and a text-node output (a
+  // reducer result with no matching field). Change-guarded (skip an unchanged
+  // node) and NO input dispatch — a text node has no listener contract. String()
+  // so a numeric result renders like the DOM would.
+  #mirrorText(name, value) {
+    const text = String(value)
+    for (const node of this.#ownedTextNodes(name)) {
+      if (node.textContent === text) continue
+      node.textContent = text
+    }
+  }
+
+  // Every [data-reactive-text="<name>"] mirror OWNED by this root (skips nested
+  // reactive roots, issue #15). Empty when none — reactive_text is optional.
+  #ownedTextNodes(name) {
+    const nodes = this.element.querySelectorAll(`[data-reactive-text="${name}"]`)
+    return Array.from(nodes).filter((el) => this.#ownsField(el))
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -68,7 +68,13 @@ module Phlex
       # is the key a JS function is registered under (Reactive.compute(key, fn)).
       # The generic controller runs the reducer on `input` — writing outputs with
       # NO round trip — then the debounced POST reconciles from the server reply.
-      ComputeDefinition = Data.define(:name, :inputs, :outputs, :reducer)
+      #
+      # `input_types` (issue #104) is nil for the ARRAY input form (untyped ⇒ the
+      # client coerces every input through Number, the shipped behavior) and a
+      # { name => type } hash for the typed HASH form (:string reads the field
+      # value raw, :number coerces). `inputs` stays the ordered name list either
+      # way, so iteration order is preserved and the array-form wire is unchanged.
+      ComputeDefinition = Data.define(:name, :inputs, :outputs, :reducer, :input_types)
 
       # A declared add/remove-row collection (issue #35): the list contract tied
       # into one unit — the per-row item component, the container DOM id rows
@@ -193,6 +199,18 @@ module Phlex
         #     inputs: %i[allowance cash leasing total],  # fields the JS reducer reads
         #     outputs: %i[allowance cash leasing]        # fields it writes (no round trip)
         #
+        # `inputs:` also takes a HASH to TYPE each input (issue #104): a :number is
+        # coerced through Number on the client (the array-form default), a :string
+        # is read raw — so a live text preview reads real text, not NaN→0:
+        #
+        #   reactive_compute :preview,
+        #     inputs: { title: :string, qty: :number },
+        #     outputs: %i[title_preview char_count]
+        #
+        # An output with no matching form field writes to its reactive_text(:name)
+        # node (textContent); a declared input also mirrors into its own text node
+        # with no reducer. The array form's wire stays byte-identical.
+        #
         # Register the matching JS once at boot. The reducer's signature is
         # (values, meta) — values is { inputName: Number } over the declared
         # inputs; meta is { changed }, the name of the declared input the
@@ -210,8 +228,9 @@ module Phlex
         def reactive_compute(name, inputs: nil, outputs: nil, reducer: nil)
           return reactive_computes[name.to_sym] if inputs.nil? && outputs.nil?
 
+          input_names, input_types = normalize_compute_inputs(inputs)
           reactive_computes[name.to_sym] = ComputeDefinition.new(
-            name: name.to_sym, inputs: Array(inputs).map(&:to_sym),
+            name: name.to_sym, inputs: input_names, input_types:,
             outputs: Array(outputs).map(&:to_sym), reducer: (reducer || name).to_s
           )
         end
@@ -222,6 +241,22 @@ module Phlex
 
         def reactive_compute?(name)
           reactive_computes.key?(name.to_sym)
+        end
+
+        # Split the `inputs:` argument into [ordered names, types-or-nil] (issue
+        # #104). A HASH ({ title: :string, qty: :number }) yields typed inputs —
+        # the ordered keys plus a symbolized name→type map. Anything else (an
+        # array, a bare symbol) is the UNTYPED form — ordered names and nil types,
+        # so the array-form wire stays byte-identical and the client keeps its
+        # numeric coercion. Named after the shape it normalizes.
+        def normalize_compute_inputs(inputs)
+          if inputs.is_a?(Hash)
+            names = inputs.keys.map(&:to_sym)
+            types = inputs.transform_keys(&:to_sym).transform_values(&:to_sym)
+            [names, types]
+          else
+            [Array(inputs).map(&:to_sym), nil]
+          end
         end
 
         # The record's instance-variable symbol (e.g. :@todo), computed once.
@@ -611,6 +646,24 @@ module Phlex
         input(**reactive_field(param, **attrs))
       end
 
+      # Mirror a compute output (or a declared input) into a TEXT NODE — a live
+      # preview heading, a character counter, a "Hello, {name}" greeting (issue
+      # #104). The text sibling of reactive_field: reactive_field binds a FORM
+      # CONTROL; reactive_text binds a plain span the client writes via
+      # textContent (XSS-safe by construction — never innerHTML).
+      #
+      #   h2 { reactive_text(:title_preview, @post.title) }
+      #   small { reactive_text(:char_count) }
+      #
+      # The span carries data-reactive-text=<name> and NO `name` attribute, so
+      # #collectFields never sweeps it into the POSTed params. `initial` seeds the
+      # first paint — the SERVER render must seed the same derived value the
+      # reducer would, or a morph repaints stale text (same reconcile contract
+      # reactive_compute documents). Extra attrs merge over the binding.
+      def reactive_text(name, initial = nil, **attrs)
+        span(**mix({ data: { reactive_text: name.to_s } }, attrs)) { initial }
+      end
+
       # Scoped busy indicator (issue #99). Marks an element so the generic
       # controller toggles `data-reactive-busy` on it ONLY while `action` is in
       # flight — the scoped sibling of the always-on `data-reactive-busy` the
@@ -637,10 +690,22 @@ module Phlex
         {
           data: {
             reactive_compute_reducer_param: definition.reducer,
-            reactive_compute_inputs_param: definition.inputs.map(&:to_s).to_json,
+            reactive_compute_inputs_param: compute_inputs_param(definition),
             reactive_compute_outputs_param: definition.outputs.map(&:to_s).to_json
           }
         }
+      end
+
+      # The inputs param wire (issue #104). Untyped (array form) → a JSON ARRAY of
+      # names, byte-identical to the shipped wire so the client keeps its numeric
+      # coercion. Typed (hash form) → a JSON OBJECT of name→type
+      # ({"title":"string","qty":"number"}) so the client reads a :string raw and
+      # coerces a :number through Number.
+      def compute_inputs_param(definition)
+        types = definition.input_types
+        return definition.inputs.map(&:to_s).to_json if types.nil?
+
+        definition.inputs.to_h { [it.to_s, types[it].to_s] }.to_json
       end
 
       # Render a <select> bound to an action param (issue #23). The options block

--- a/spec/dummy/app/components/post_preview_component.rb
+++ b/spec/dummy/app/components/post_preview_component.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# The reactive_text + typed-compute example (issue #104) — a live title preview
+# and character counter that update IN-BROWSER as you type, with NO round trip,
+# then a save reconciles through the server.
+#
+# Two things mirror the `title` field client-side:
+#
+#   * The preview heading is an IDENTITY MIRROR — reactive_text(:title) with no
+#     reducer output. The declared input's raw string is synced to its text node
+#     on every `input`, so the heading tracks the field with zero reducer wiring.
+#   * The character counter is a reducer OUTPUT written to a text node — the
+#     "preview" reducer (inputs typed { title: :string }) returns
+#     { char_count: `${title.length}/80` }, which has no matching form field, so
+#     it lands on the [data-reactive-text="char_count"] node via textContent.
+#
+# A save fires the reactive `save` action; the server persists the title and
+# re-renders, SEEDING the same derived heading + counter so the morph repaints
+# them from the authoritative value (the reconcile contract reactive_compute
+# documents — the server render must seed what the reducer would).
+class PostPreviewComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+
+  # Typed inputs (hash form): `title` is read RAW (a :string), never coerced
+  # through Number. The lone output — char_count — has no form field, so it
+  # resolves to the [data-reactive-text="char_count"] node.
+  reactive_compute :preview,
+    inputs: { title: :string },
+    outputs: %i[char_count]
+
+  action :save, params: { title: :string }
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo)
+
+  # Persisted path: save the title, then re-render self. The re-render seeds the
+  # SAME derived preview + counter the JS reducer would, so the morph reconciles.
+  def save(title:)
+    @todo.update!(title:)
+    reply.replace
+  end
+
+  def view_template
+    div(**mix(reactive_root, reactive_compute_attrs(:preview))) do
+      # The live preview heading — an identity mirror of `title`. Seed it with the
+      # server's current value so the first paint (and any morph) is correct.
+      h2(data: { testid: "preview" }) { reactive_text(:title, @todo.title) }
+
+      # The character counter — a reducer output written to this text node. Seed
+      # it server-side too (same contract) so a morph doesn't repaint stale text.
+      small(data: { testid: "counter" }) { reactive_text(:char_count, char_count(@todo.title)) }
+
+      # A SERVER-ONLY echo of the PERSISTED title (a plain text node, NOT a
+      # reactive_text mirror) — the client never touches it, so the system spec
+      # uses it as the barrier that the save round trip actually reconciled.
+      span(data: { testid: "saved" }) { @todo.title }
+
+      # The title field drives BOTH: the client recompute/mirror on `input` (no
+      # round trip) AND, on the save button, the reactive save action. mix so the
+      # recompute action deep-merges with reactive_field's data: (Never-Do #8).
+      input(**mix(
+        reactive_field(:title, value: @todo.title, type: "text", data: { testid: "title" }),
+        { data: { action: "input->reactive#recompute" } }
+      ))
+      # mix so the extra data: (testid) deep-merges with on()'s data-action /
+      # -params instead of clobbering them (Never-Do #8).
+      button(**mix(on(:save), data: { testid: "save" })) { "Save" }
+    end
+  end
+
+  private
+
+  # The server twin of the JS reducer's counter — seeds the same derived string
+  # on render so the morph reconciles from the authoritative value.
+  def char_count(title) = "#{title.to_s.length}/80"
+end

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -78,6 +78,13 @@ class DemosController < ActionController::Base
     render_component OrderComponent.new(order: Order.find(params[:id]))
   end
 
+  # reactive_text + typed compute (issue #104): a live title preview + character
+  # counter that update in-browser as you type (no round trip), then a save
+  # reconciles through the server (the morph re-seeds the derived heading/counter).
+  def post_preview
+    render_component PostPreviewComponent.new(todo: Todo.find(params[:id]))
+  end
+
   def notifications
     render_component NotificationsListComponent.new
   end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -21,7 +21,8 @@
           "reactive_controller": "/vendor/reactive_controller.js",
           "phlex/reactive/confirm": "/vendor/confirm.js",
           "phlex/reactive/compute": "/vendor/compute.js",
-          "payment_split_reducer": "/vendor/payment_split_reducer.js"
+          "payment_split_reducer": "/vendor/payment_split_reducer.js",
+          "post_preview_reducer": "/vendor/post_preview_reducer.js"
         }
       }
     </script>
@@ -31,15 +32,18 @@
       import { Application } from "@hotwired/stimulus"
       import ReactiveController from "reactive_controller"
       import { registerPaymentSplit } from "payment_split_reducer"
+      import { registerPostPreview } from "post_preview_reducer"
 
       const application = Application.start()
       // Register eagerly so a click right after load is never missed.
       application.register("reactive", ReactiveController)
       window.Stimulus = application
 
-      // Register the demo's client-side compute reducer (the JS twin of the Ruby
-      // PaymentSplit). The OrderComponent's new-draft path runs this on input.
+      // Register the demo's client-side compute reducers (the JS twins of the Ruby
+      // PaymentSplit and the issue #104 typed-preview counter). The OrderComponent's
+      // new-draft path runs payment_split; PostPreviewComponent runs preview.
       registerPaymentSplit()
+      registerPostPreview()
     </script>
   </head>
   <body>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get "combobox" => "demos#combobox"
   get "new_order" => "demos#new_order"
   get "order/:id" => "demos#order"
+  get "post_preview/:id" => "demos#post_preview"
   get "notifications" => "demos#notifications"
   get "reactive_rows" => "demos#reactive_rows"
   get "rich_editor/:id" => "demos#rich_editor"

--- a/spec/dummy/public/vendor/compute.js
+++ b/spec/dummy/public/vendor/compute.js
@@ -22,10 +22,24 @@
 //
 // The reducer's signature is (values, meta):
 //
-//   values — a plain object of { inputName: Number } over the declared inputs
+//   values — a plain object of { inputName: value } over the declared inputs.
+//            Untyped inputs (the array form) AND :number-typed inputs arrive as
+//            Numbers (blank/NaN → 0); :string-typed inputs (the hash form,
+//            issue #104) arrive as the RAW string. `reactive_compute :x, inputs:
+//            { title: :string, qty: :number }` is what selects per-input types;
+//            `inputs: %i[a b]` stays all-numeric (backward compatible).
 //   meta   — { changed }: the name (string) of the declared input the
 //            triggering event edited, or null (a direct recompute() call, or a
 //            target this root doesn't own / didn't declare as an input).
+//
+// OUTPUTS may be a form FIELD or a TEXT NODE (issue #104). An output whose name
+// matches an owned control writes its .value (+ the change-guarded input
+// dispatch below). An output with NO matching field writes textContent to every
+// owned [data-reactive-text="<name>"] node (reactive_text(:name)) — XSS-safe by
+// construction, change-guarded, NO input dispatch (a text node has no listener
+// contract). A declared INPUT also mirrors into its own text node on every
+// input via an always-run pass — so reactive_text(:title) is a live field
+// preview with NO registered reducer at all.
 //
 // It returns a plain object of { outputName: value } — only the outputs it
 // names are written, so it can leave the edited field (and its caret)

--- a/spec/dummy/public/vendor/post_preview_reducer.js
+++ b/spec/dummy/public/vendor/post_preview_reducer.js
@@ -1,0 +1,14 @@
+// The JS twin for the reactive_text + typed-compute example (issue #104).
+// Registered under the "preview" reducer key. The typed input `title` arrives as
+// a RAW string (inputs: { title: :string }), so `.length` is the character count
+// — NOT a Number coercion. The lone output, char_count, has no matching form
+// field, so the controller writes it to the [data-reactive-text="char_count"]
+// node via textContent. The live preview HEADING needs no reducer output — it's
+// an identity mirror of `title` (the always-run mirror pass handles it).
+import { setComputeReducer } from "phlex/reactive/compute"
+
+export function registerPostPreview() {
+  setComputeReducer("preview", ({ title }) => ({
+    char_count: `${title.length}/80`,
+  }))
+}

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -710,33 +710,54 @@ export default class extends Controller {
   // changed = that output's name — the reducer must be convergent (see
   // compute.js) so the change guard settles the chain.
   recompute(event) {
+    // Inputs may be a JSON ARRAY of names (array form — every input coerced
+    // through Number, the shipped behavior) or a JSON OBJECT of name→type (hash
+    // form, issue #104 — :number coerced, :string read raw). #parseComputeInputs
+    // returns [name, type] pairs either way (array form defaults type "number").
+    const inputPairs = this.#parseComputeInputs()
+    const inputs = inputPairs.map(([name]) => name)
+
+    // Identity-mirror pass (issue #104), ALWAYS run — even with NO registered
+    // reducer, so reactive_text(:title) mirrors a field into its text node with
+    // zero reducer wiring. Each declared input's RAW string value is written to
+    // its owned [data-reactive-text="<name>"] node(s). It runs BEFORE the reducer
+    // early-return below so a reducer-less binding still mirrors.
+    for (const name of inputs) this.#mirrorText(name, this.#rawFieldValue(name))
+
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
     const reduce = computeReducer(key)
     if (!reduce) return
 
-    const inputs = this.#parseComputeList("data-reactive-compute-inputs-param")
     const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
 
     const values = {}
-    for (const name of inputs) values[name] = this.#numericFieldValue(name)
+    for (const [name, type] of inputPairs) values[name] = this.#computeInputValue(name, type)
 
     const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
       const field = this.#ownedField(name)
-      if (!field) continue
-      // Real browsers do NOT fire `input` on a programmatic .value write (issue
-      // #76), so after writing we dispatch a bubbling `input` ourselves — that's
-      // what drives a chained repaint (a summary listener, a second compute),
-      // matching the server's set_value + dispatch("input") contract. The write
-      // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
-      // event). The guard is what lets a reducer with overlapping inputs/outputs
-      // (the shipped payment_split shape) settle — an unconditional dispatch
-      // would re-enter input->reactive#recompute forever.
-      if (String(result[name]) === field.value) continue
-      field.value = result[name]
-      field.dispatchEvent(new Event("input", { bubbles: true }))
+      // Output resolution (issue #104): write to the owned named FIELD if one
+      // exists, ELSE mirror to every owned [data-reactive-text="<name>"] node.
+      if (field) {
+        // Real browsers do NOT fire `input` on a programmatic .value write (issue
+        // #76), so after writing we dispatch a bubbling `input` ourselves — that's
+        // what drives a chained repaint (a summary listener, a second compute),
+        // matching the server's set_value + dispatch("input") contract. The write
+        // is CHANGE-GUARDED: an unchanged value is skipped entirely (no write, no
+        // event). The guard is what lets a reducer with overlapping inputs/outputs
+        // (the shipped payment_split shape) settle — an unconditional dispatch
+        // would re-enter input->reactive#recompute forever.
+        if (String(result[name]) === field.value) continue
+        field.value = result[name]
+        field.dispatchEvent(new Event("input", { bubbles: true }))
+      } else {
+        // A text-node output: textContent, XSS-safe by construction. Change-
+        // guarded too (compare before writing), but NO input dispatch — a text
+        // node has no listener contract, so nothing chains off it.
+        this.#mirrorText(name, result[name])
+      }
     }
   }
 
@@ -816,6 +837,38 @@ export default class extends Controller {
     }
   }
 
+  // Parse the inputs param into [name, type] pairs (issue #104). The wire is a
+  // JSON ARRAY of names (array form → every input typed "number", the shipped
+  // numeric coercion) OR a JSON OBJECT of name→type (hash form → ":string" read
+  // raw, ":number" coerced). Malformed/absent degrades to [] — a bad binding
+  // must never throw on input.
+  #parseComputeInputs() {
+    const raw = this.element.getAttribute("data-reactive-compute-inputs-param")
+    if (!raw) return []
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed.map((name) => [name, "number"])
+      if (parsed && typeof parsed === "object") return Object.entries(parsed)
+      return []
+    } catch {
+      return []
+    }
+  }
+
+  // Coerce a declared input's field value for the reducer per its type (issue
+  // #104): "string" → the raw string value (field.value ?? ""); anything else
+  // ("number", the array-form default) → the numeric coercion (blank/NaN → 0).
+  #computeInputValue(name, type) {
+    if (type === "string") return this.#rawFieldValue(name)
+    return this.#numericFieldValue(name)
+  }
+
+  // A declared input's RAW string value — the display string, used for :string
+  // inputs and for identity mirrors. "" for a blank/absent field (never NaN).
+  #rawFieldValue(name) {
+    return this.#ownedField(name)?.value ?? ""
+  }
+
   // The declared compute input the event just edited — the reducer's
   // meta.changed (issue #75). The triggering field counts only when it is a
   // named form control OWNED by this root (not a nested reactive root's, issue
@@ -843,6 +896,27 @@ export default class extends Controller {
     const field = this.#ownedField(name)
     const n = Number(field?.value)
     return Number.isFinite(n) ? n : 0
+  }
+
+  // Write `value` into every owned [data-reactive-text="<name>"] node via
+  // textContent (issue #104) — XSS-safe by construction (never innerHTML). Drives
+  // both the identity mirror (an input's raw value) and a text-node output (a
+  // reducer result with no matching field). Change-guarded (skip an unchanged
+  // node) and NO input dispatch — a text node has no listener contract. String()
+  // so a numeric result renders like the DOM would.
+  #mirrorText(name, value) {
+    const text = String(value)
+    for (const node of this.#ownedTextNodes(name)) {
+      if (node.textContent === text) continue
+      node.textContent = text
+    }
+  }
+
+  // Every [data-reactive-text="<name>"] mirror OWNED by this root (skips nested
+  // reactive roots, issue #15). Empty when none — reactive_text is optional.
+  #ownedTextNodes(name) {
+    const nodes = this.element.querySelectorAll(`[data-reactive-text="${name}"]`)
+    return Array.from(nodes).filter((el) => this.#ownsField(el))
   }
 
   // Enqueue the action — debounced if a debounce window is set, else immediately.

--- a/spec/javascript/reactive_text_compute.test.js
+++ b/spec/javascript/reactive_text_compute.test.js
@@ -1,0 +1,393 @@
+// Unit tests for issue #104: typed compute inputs + reactive_text mirrors.
+//
+// Two additions to the client-side compute (#recompute):
+//
+//   1. TYPED INPUTS. The inputs param can be a JSON OBJECT { name: type } (hash
+//      form) instead of a JSON ARRAY of names (array form). A :number input is
+//      coerced through Number (the shipped behavior — blank/NaN → 0); a :string
+//      input is read raw (field.value ?? ""). The array form stays numeric.
+//
+//   2. TEXT-NODE OUTPUTS + IDENTITY MIRRORS. An output whose name has no owned
+//      form field is written to every owned [data-reactive-text="<name>"] node
+//      via textContent (change-guarded, XSS-safe, no input dispatch — a text
+//      node has no listeners). A separate ALWAYS-RUN pass mirrors each declared
+//      INPUT's raw string value into its owned text nodes, so reactive_text(:x)
+//      works with NO registered reducer.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach } from "bun:test"
+
+let ReactiveController
+let computeModule
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+  computeModule = await import("../../app/javascript/phlex/reactive/compute.js")
+})
+
+// A named form control (REAL DOM semantics): a programmatic .value write coerces
+// to String and fires NOTHING; listeners run only via dispatchEvent. `closest`
+// resolves to the owning root so #ownsField (issue #15) treats it as owned.
+function makeField(name, value) {
+  const listeners = []
+  return {
+    name,
+    tagName: "INPUT",
+    _root: null,
+    _value: String(value),
+    get value() {
+      return this._value
+    },
+    set value(v) {
+      this._value = String(v)
+    },
+    closest() {
+      return this._root
+    },
+    getAttribute() {
+      return null
+    },
+    addEventListener: (type, fn) => type === "input" && listeners.push(fn),
+    dispatchEvent(event) {
+      Object.defineProperty(event, "target", { value: this, configurable: true })
+      if (event.type === "input") listeners.slice().forEach((fn) => fn(event))
+      return true
+    },
+  }
+}
+
+// A [data-reactive-text="<name>"] mirror node: only textContent (no `value`, no
+// `name`), `closest` resolves ownership. It carries NO listeners — writing a
+// text node never dispatches input (nothing would hear it).
+function makeTextNode(name, text = "") {
+  return {
+    _root: null,
+    _mirror: name,
+    textContent: text,
+    closest() {
+      return this._root
+    },
+    getAttribute(attr) {
+      return attr === "data-reactive-text" ? this._mirror : null
+    },
+  }
+}
+
+// A root that resolves BOTH named fields ([name="x"]) and text mirrors
+// ([data-reactive-text="x"]) from a flat registry, mirroring how the real DOM's
+// querySelectorAll would return each. `inputs` may be an array (array form) or
+// an object (hash form) — serialized verbatim to the inputs param.
+function makeRoot({ reducer, inputs, outputs, fields = {}, texts = {} }) {
+  const attrs = {
+    "data-reactive-compute-reducer-param": reducer,
+    "data-reactive-compute-inputs-param": JSON.stringify(inputs),
+    "data-reactive-compute-outputs-param": JSON.stringify(outputs),
+  }
+  const root = {
+    id: "preview",
+    getAttribute: (k) => attrs[k] ?? null,
+    querySelectorAll: (sel) => {
+      let m = sel.match(/\[name="(.+?)"\]/)
+      if (m) {
+        const f = fields[m[1]]
+        return f ? [f] : []
+      }
+      m = sel.match(/\[data-reactive-text="(.+?)"\]/)
+      if (m) {
+        const nodes = texts[m[1]]
+        return nodes ? (Array.isArray(nodes) ? nodes : [nodes]) : []
+      }
+      return []
+    },
+    closest: () => null,
+  }
+  for (const f of Object.values(fields)) f._root = root
+  for (const list of Object.values(texts)) {
+    for (const n of Array.isArray(list) ? list : [list]) n._root = root
+  }
+  return root
+}
+
+function buildController(root) {
+  const controller = new ReactiveController()
+  controller.element = root
+  globalThis.window ??= {}
+  return controller
+}
+
+beforeEach(() => {
+  computeModule.__resetComputeRegistryForTest()
+})
+
+// ---------------------------------------------------------------------------
+// Typed inputs: string vs number coercion matrix.
+// ---------------------------------------------------------------------------
+
+test("a :string input is passed to the reducer RAW (not coerced through Number)", () => {
+  const fields = { title: makeField("title", "Hi there") }
+  let seen
+  computeModule.setComputeReducer("preview", (values) => {
+    seen = values
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "preview", inputs: { title: "string" }, outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.title })
+
+  // Raw string — Number("Hi there") would have been NaN→0 under the old path.
+  expect(seen).toEqual({ title: "Hi there" })
+})
+
+test("a blank :string input is passed as '' (not 0)", () => {
+  const fields = { title: makeField("title", "") }
+  let seen
+  computeModule.setComputeReducer("preview", (values) => {
+    seen = values
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "preview", inputs: { title: "string" }, outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.title })
+  expect(seen).toEqual({ title: "" })
+})
+
+test("a :number input is coerced through Number (blank → 0), alongside a :string", () => {
+  const fields = { title: makeField("title", "Hello"), qty: makeField("qty", "") }
+  let seen
+  computeModule.setComputeReducer("preview", (values) => {
+    seen = values
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "preview", inputs: { title: "string", qty: "number" }, outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.qty })
+
+  expect(seen).toEqual({ title: "Hello", qty: 0 })
+})
+
+test("the ARRAY input form still coerces every input through Number (backward compatible)", () => {
+  const fields = { allowance: makeField("allowance", "100"), total: makeField("total", "500") }
+  let seen
+  computeModule.setComputeReducer("split", (values) => {
+    seen = values
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "split", inputs: ["allowance", "total"], outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.allowance })
+
+  expect(seen).toEqual({ allowance: 100, total: 500 })
+})
+
+test("meta.changed still reports the edited typed input by name", () => {
+  const fields = { title: makeField("title", "Hi"), qty: makeField("qty", "3") }
+  let meta
+  computeModule.setComputeReducer("preview", (_values, m) => {
+    meta = m
+    return {}
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "preview", inputs: { title: "string", qty: "number" }, outputs: [], fields }),
+  )
+  controller.recompute({ target: fields.title })
+  expect(meta).toEqual({ changed: "title" })
+})
+
+// ---------------------------------------------------------------------------
+// Text-node outputs + output→field precedence.
+// ---------------------------------------------------------------------------
+
+test("an output with no owned field writes to its [data-reactive-text] node via textContent", () => {
+  const fields = { title: makeField("title", "Hi") }
+  const preview = makeTextNode("title_preview", "")
+  computeModule.setComputeReducer("preview", ({ title }) => ({ title_preview: title }))
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { title: "string" },
+      outputs: ["title_preview"],
+      fields,
+      texts: { title_preview: preview },
+    }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(preview.textContent).toBe("Hi")
+})
+
+test("an output writes to a FIELD in preference to a same-named text node", () => {
+  const field = makeField("shared", "old")
+  const text = makeTextNode("shared", "old")
+  computeModule.setComputeReducer("preview", () => ({ shared: "new" }))
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { seed: "string" },
+      outputs: ["shared"],
+      fields: { seed: makeField("seed", "x"), shared: field },
+      texts: { shared: text },
+    }),
+  )
+  controller.recompute({ target: controller.element.querySelectorAll('[name="seed"]')[0] })
+
+  expect(field.value).toBe("new") // field won
+  expect(text.textContent).toBe("old") // the text node was NOT touched
+})
+
+test("an UNCHANGED text-node write is skipped (the change guard applies to textContent too)", () => {
+  const fields = { title: makeField("title", "Hi") }
+  const preview = makeTextNode("title_preview", "Hi")
+  let writes = 0
+  Object.defineProperty(preview, "textContent", {
+    get() {
+      return this._t ?? "Hi"
+    },
+    set(v) {
+      writes++
+      this._t = v
+    },
+  })
+  computeModule.setComputeReducer("preview", ({ title }) => ({ title_preview: title }))
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { title: "string" },
+      outputs: ["title_preview"],
+      fields,
+      texts: { title_preview: preview },
+    }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(writes).toBe(0) // value already "Hi" → no write
+})
+
+test("an output writes to EVERY owned text node of that name (char counter + heading)", () => {
+  const fields = { title: makeField("title", "abc") }
+  const a = makeTextNode("title_preview", "")
+  const b = makeTextNode("title_preview", "")
+  computeModule.setComputeReducer("preview", ({ title }) => ({ title_preview: title }))
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { title: "string" },
+      outputs: ["title_preview"],
+      fields,
+      texts: { title_preview: [a, b] },
+    }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(a.textContent).toBe("abc")
+  expect(b.textContent).toBe("abc")
+})
+
+test("a text node owned by a NESTED reactive root is NOT written", () => {
+  const fields = { title: makeField("title", "Hi") }
+  const nested = makeTextNode("title_preview", "keep")
+  computeModule.setComputeReducer("preview", ({ title }) => ({ title_preview: title }))
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { title: "string" },
+      outputs: ["title_preview"],
+      fields,
+      texts: { title_preview: nested },
+    }),
+  )
+  // Re-point the mirror at a DIFFERENT root — it belongs to a nested component.
+  nested._root = { id: "nested-root" }
+  controller.recompute({ target: fields.title })
+
+  expect(nested.textContent).toBe("keep") // untouched — not owned by this root
+})
+
+// ---------------------------------------------------------------------------
+// Identity mirrors: sync a declared INPUT into its text node with NO reducer.
+// ---------------------------------------------------------------------------
+
+test("a declared input mirrors into its text node with NO registered reducer", () => {
+  const fields = { title: makeField("title", "Live!") }
+  const mirror = makeTextNode("title", "")
+  // No setComputeReducer call — the identity-mirror pass must still run.
+
+  const controller = buildController(
+    makeRoot({
+      reducer: "preview",
+      inputs: { title: "string" },
+      outputs: [],
+      fields,
+      texts: { title: mirror },
+    }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(mirror.textContent).toBe("Live!")
+})
+
+test("the identity mirror uses the input's RAW string value (not a Number coercion)", () => {
+  const fields = { title: makeField("title", "007 James") }
+  const mirror = makeTextNode("title", "")
+
+  const controller = buildController(
+    makeRoot({ reducer: "none", inputs: { title: "string" }, outputs: [], fields, texts: { title: mirror } }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(mirror.textContent).toBe("007 James") // raw, not "7"
+})
+
+test("the identity-mirror write is change-guarded (unchanged value → no write)", () => {
+  const fields = { title: makeField("title", "same") }
+  const mirror = makeTextNode("title", "same")
+  let writes = 0
+  Object.defineProperty(mirror, "textContent", {
+    get() {
+      return this._t ?? "same"
+    },
+    set(v) {
+      writes++
+      this._t = v
+    },
+  })
+
+  const controller = buildController(
+    makeRoot({ reducer: "none", inputs: { title: "string" }, outputs: [], fields, texts: { title: mirror } }),
+  )
+  controller.recompute({ target: fields.title })
+
+  expect(writes).toBe(0)
+})
+
+test("an ARRAY-form declared input also mirrors into its text node (untyped identity mirror)", () => {
+  const fields = { total: makeField("total", "500") }
+  const mirror = makeTextNode("total", "")
+
+  const controller = buildController(
+    makeRoot({ reducer: "none", inputs: ["total"], outputs: [], fields, texts: { total: mirror } }),
+  )
+  controller.recompute({ target: fields.total })
+
+  // Raw field value mirrored (the display string), even though the array form
+  // coerces the reducer's VALUES to Number.
+  expect(mirror.textContent).toBe("500")
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -1049,6 +1049,102 @@ RSpec.describe Phlex::Reactive::Component do
           .to raise_error(Phlex::Reactive::Error, /reactive_compute/)
       end
     end
+
+    # Issue #104: typed inputs. The ARRAY form must stay byte-identical on the
+    # wire (a JSON ARRAY, numeric coercion on the client). The HASH form declares
+    # a per-input type and emits a JSON OBJECT ({"title":"string","qty":"number"})
+    # so the client reads a :string input raw and coerces a :number through Number.
+    describe "typed inputs (issue #104)" do
+      let(:typed_klass) do
+        Class.new do
+          include Phlex::Reactive::Component
+
+          def self.name = "TypedCompute"
+
+          reactive_compute :preview,
+            inputs: { title: :string, qty: :number },
+            outputs: %i[title_preview char_count]
+        end
+      end
+
+      it "keeps the ARRAY form's inputs param a byte-identical JSON array" do
+        # The exact serialized string the client parses — pinned so the typed-
+        # inputs change can never silently alter the shipped array-form wire.
+        attrs = compute_klass.new.send(:reactive_compute_attrs, :payment_split)
+        expect(attrs[:data][:reactive_compute_inputs_param])
+          .to eq('["allowance","cash","leasing","total"]')
+      end
+
+      it "captures the input names in declaration order" do
+        expect(typed_klass.reactive_compute(:preview).inputs).to eq(%i[title qty])
+      end
+
+      it "captures the per-input types keyed by name" do
+        expect(typed_klass.reactive_compute(:preview).input_types)
+          .to eq(title: :string, qty: :number)
+      end
+
+      it "reports nil input_types for the array form (untyped, numeric)" do
+        expect(compute_klass.reactive_compute(:payment_split).input_types).to be_nil
+      end
+
+      it "emits the HASH form's inputs param as a JSON object of name→type" do
+        attrs = typed_klass.new.send(:reactive_compute_attrs, :preview)
+        expect(JSON.parse(attrs[:data][:reactive_compute_inputs_param]))
+          .to eq("title" => "string", "qty" => "number")
+      end
+
+      it "still emits the outputs param as a JSON array for the hash form" do
+        attrs = typed_klass.new.send(:reactive_compute_attrs, :preview)
+        expect(JSON.parse(attrs[:data][:reactive_compute_outputs_param]))
+          .to eq(%w[title_preview char_count])
+      end
+    end
+  end
+
+  # Issue #104: reactive_text mirrors a field into a TEXT NODE (live preview,
+  # char counter, "Hello, {name}") — the text sibling of reactive_field. It
+  # carries NO `name` attribute, so #collectFields never sweeps it into params.
+  describe "#reactive_text (text-node mirror, issue #104)" do
+    let(:text_klass) do
+      Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Component
+
+        def self.name = "TextMirror"
+
+        def view_template
+          reactive_text(:title_preview, "Hello")
+        end
+      end
+    end
+
+    let(:empty_klass) do
+      Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Component
+
+        def self.name = "EmptyTextMirror"
+
+        def view_template
+          reactive_text(:char_count)
+        end
+      end
+    end
+
+    it "renders a span carrying data-reactive-text=<name> with the initial content" do
+      html = text_klass.new.call
+      expect(html).to include('data-reactive-text="title_preview"')
+      expect(html).to include(">Hello</span>")
+    end
+
+    it "renders an empty span when no initial value is given" do
+      html = empty_klass.new.call
+      expect(html).to include('data-reactive-text="char_count"')
+      expect(html).to match(%r{<span[^>]*data-reactive-text="char_count"[^>]*></span>})
+    end
+
+    it "carries NO name attribute (so it is never collected/POSTed as a param)" do
+      expect(text_klass.new.call).not_to include("name=")
+    end
   end
 
   # Performance: reactive_token runs on EVERY render. It must produce a byte-

--- a/spec/requests/post_preview_render_spec.rb
+++ b/spec/requests/post_preview_render_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Renders PostPreviewComponent through a real request (issue #104) and pins the
+# typed-compute wire + the reactive_text mirrors: the inputs param is a JSON
+# OBJECT of name→type, the preview heading and counter are data-reactive-text
+# nodes seeded with the server's derived value, and the mirrors carry NO `name`
+# attribute (so they're never collected/POSTed as params).
+RSpec.describe "PostPreviewComponent render (reactive_text + typed compute)", type: :request do
+  let(:todo) { Todo.create!(title: "Draft") }
+
+  before { get "/post_preview/#{todo.id}" }
+
+  it "renders the compute binding with a TYPED inputs object (name→type)" do
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('data-reactive-compute-reducer-param="preview"')
+    # The hash form emits a JSON object; HTML-escaped in the attribute.
+    inputs = response.body[/data-reactive-compute-inputs-param="([^"]*)"/, 1]
+    expect(JSON.parse(CGI.unescapeHTML(inputs))).to eq("title" => "string")
+  end
+
+  it "seeds the preview heading + counter from the server's derived value" do
+    expect(response.body).to include('data-reactive-text="title"')
+    expect(response.body).to include('data-reactive-text="char_count"')
+    # "Draft" = 5 chars — the server twin seeds the same string the reducer would.
+    expect(response.body).to match(%r{data-reactive-text="char_count"[^>]*>5/80<})
+  end
+
+  it "gives the reactive_text mirrors NO name attribute (never collected as params)" do
+    # reactive_text renders a <span data-reactive-text=…> — the mirror must carry
+    # no name= (only the real <input> does), or #collectFields would sweep it in.
+    title_span = response.body[/<span[^>]*data-reactive-text="title"[^>]*>/]
+    expect(title_span).to be_present
+    expect(title_span).not_to include("name=")
+    count_span = response.body[/<span[^>]*data-reactive-text="char_count"[^>]*>/]
+    expect(count_span).to be_present
+    expect(count_span).not_to include("name=")
+  end
+
+  it "wires the title field to the client recompute mirror (input), plus a save action" do
+    expect(response.body).to include("input-&gt;reactive#recompute").or include("input->reactive#recompute")
+    expect(response.body).to include("save")
+  end
+end

--- a/spec/system/post_preview_spec.rb
+++ b/spec/system/post_preview_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# End-to-end proof of reactive_text + typed compute inputs (issue #104):
+#
+#   * Typing in the title field updates a live PREVIEW HEADING (an identity
+#     mirror — reactive_text(:title), no reducer output) and a CHARACTER COUNTER
+#     (a reducer output written to a text node) IN-BROWSER, with NO round trip.
+#   * The typed :string input reaches the reducer RAW, so the counter reflects the
+#     character length — never a Number coercion of the text.
+#   * A save fires the reactive action; the server persists and re-renders,
+#     re-seeding the same derived heading + counter (the morph reconciles).
+#
+# One contract (reactive_text / typed compute), two execution sites — the client
+# reducer for the instant feel, the server for the authoritative reconcile.
+RSpec.describe "Post preview (reactive_text + typed compute, issue #104)", type: :system do
+  let(:todo) { Todo.create!(title: "Draft") }
+
+  it "mirrors the title into a heading + char counter in-browser with NO round trip" do
+    visit "/post_preview/#{todo.id}"
+    expect(page).to have_field("title", with: "Draft")
+    expect(page).to have_css("[data-testid='preview']", text: "Draft")
+    expect(page).to have_css("[data-testid='counter']", text: "5/80") # "Draft" = 5 chars
+
+    # Count reactive action POSTs: the client-side mirror/compute must fire ZERO.
+    page.execute_script(<<~JS)
+      window.__actionPosts = 0
+      const orig = window.fetch
+      window.fetch = (url, opts) => {
+        if (String(url).includes("/reactive/actions")) window.__actionPosts++
+        return orig(url, opts)
+      }
+      window.__noReload = "alive"
+    JS
+
+    # Type a new title. The identity mirror repaints the heading; the reducer
+    # repaints the counter — both on `input`, both client-side.
+    fill_in "title", with: "Hello world"
+
+    expect(page).to have_css("[data-testid='preview']", text: "Hello world") # live heading
+    expect(page).to have_css("[data-testid='counter']", text: "11/80")       # raw string length
+    expect(page.evaluate_script("window.__actionPosts")).to eq(0)            # NO round trip
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")         # no reload
+
+    # A digit-only title proves the :string input is read RAW, not through Number:
+    # a numeric coercion would still count chars, but "007" as a Number is 7 — the
+    # heading mirror is the tell (it shows the literal text, not a coerced value).
+    fill_in "title", with: "007"
+    expect(page).to have_css("[data-testid='preview']", text: "007") # literal, not "7"
+    expect(page).to have_css("[data-testid='counter']", text: "3/80")
+    expect(page.evaluate_script("window.__actionPosts")).to eq(0)
+  end
+
+  it "reconciles through the server on save (the morph re-seeds the derived text)" do
+    visit "/post_preview/#{todo.id}"
+    page.execute_script("window.__noReload = 'alive'")
+
+    fill_in "title", with: "Persisted title"
+    expect(page).to have_css("[data-testid='counter']", text: "15/80") # client-computed first
+    # The server-only echo still shows the OLD persisted value pre-save (the client
+    # never touches it) — proof the barrier below is genuinely server-gated.
+    expect(page).to have_css("[data-testid='saved']", text: "Draft")
+
+    click_on "Save"
+
+    # The barrier: the server-only echo flips to the persisted value ONLY after the
+    # save round trip re-renders — so this waits for the actual reconcile, not the
+    # client mirror. Then the seeded heading + counter reconcile without a reload.
+    expect(page).to have_css("[data-testid='saved']", text: "Persisted title")
+    expect(page).to have_css("[data-testid='preview']", text: "Persisted title")
+    expect(page).to have_css("[data-testid='counter']", text: "15/80")
+    expect(page).to have_field("title", with: "Persisted title")
+    expect(page.evaluate_script("window.__noReload")).to eq("alive") # no full reload
+
+    expect(todo.reload.title).to eq("Persisted title")
+  end
+end


### PR DESCRIPTION
Closes #104

## What & why

Mirroring a form field into a **text node** — a live preview heading, a character counter, `"Hello, {name}"` — still needed a bespoke Stimulus controller: `reactive_compute` was numeric-only (`Number(...)`, NaN→0) and only wrote form-field `.value`, never text content. Datastar's `data-text` and Alpine's `x-text` are the one-attribute competitors. This ships the declarative equivalent.

## The API delta

**Typed compute inputs (hash form).** `inputs:` now takes a hash to type each input:

```ruby
reactive_compute :preview,
  inputs: { title: :string, qty: :number },  # :string raw, :number → Number
  outputs: %i[title_preview char_count]
```

The **array form** (`inputs: %i[a b]`) stays all-numeric and **byte-identical on the wire** (pinned by a spec); the hash form emits a JSON object of `name→type`.

**`reactive_text(:name, initial)`** — the text sibling of `reactive_field`:

```ruby
div(**mix(reactive_root, reactive_compute_attrs(:preview))) do
  input(**mix(reactive_field(:title, value: @post.title),
              data: { action: "input->reactive#recompute" }))
  h2    { reactive_text(:title_preview, @post.title) }
  small { reactive_text(:char_count) }
end
```

- Writes via **`textContent`** (XSS-safe by construction), carries **no `name`** (never collected/POSTed).
- **Output resolution:** an output matching an owned field writes its `.value` (the existing change-guarded `input` dispatch); an output with **no** matching field writes every owned `[data-reactive-text]` node (guarded, no input dispatch — a text node has no listener contract).
- **Reducer-less identity mirrors:** an always-run pass syncs each declared **input**'s raw value into its own `reactive_text(:same_name)` node — so `reactive_text(:title)` is a live echo with **no reducer at all**.

## Invariants preserved

- **No client state** — the mirror reads the DOM's own field value; nothing new is shipped or trusted back.
- **Change-guarded writes** — every new write (field and text node) compares before writing, so the shipped `payment_split` overlapping-inputs/outputs reducer still settles instead of looping.
- **Array-form wire byte-identical** — a decoded-shape spec pins `["allowance","cash","leasing","total"]` so the typed change can't silently alter existing components.
- One generic controller · default-deny · pgbus optional · self-targeting `#id` — all untouched.

## Test coverage

| Layer | File | Proves |
|-------|------|--------|
| Unit (Ruby) | `spec/phlex/reactive/component_spec.rb` | array-form wire byte-identical; hash-form JSON object emission; `input_types` capture; `reactive_text` markup + no `name` |
| Unit (JS) | `spec/javascript/reactive_text_compute.test.js` | string vs number coercion matrix; output→field precedence over text node; text-node change guard; identity mirror without a reducer; nested-root scoping; composes with `{changed}` |
| Request | `spec/requests/post_preview_render_spec.rb` | typed inputs object wire; server-seeded mirrors; mirrors carry no `name` |
| System | `spec/system/post_preview_spec.rb` | typed preview + char counter live with NO round trip, then a save reconciles — **Puma AND Falcon** |

## Verification

- `bundle exec rubocop` — 145 files, clean
- `bundle exec rspec spec/phlex spec/requests` — 457 examples, 0 failures
- `bun test spec/javascript` — 244 pass
- `spec/system` under **Puma** and **Falcon** — 54 each, 0 failures
- Vendored `reactive_controller.js` + `compute.js` re-synced (drift guard green)

## Docs

- `compute.js` header + `reactive_compute` DSL comment document typed inputs, text-node outputs, and identity mirrors.
- README: helper table rows + a new "Client-side computes (`reactive_compute` + `reactive_text`)" section.
- CHANGELOG `[Unreleased] → Added` entry.
