### PR TITLE
feat(component): on(:typo) raises under verbose_errors — undeclared action fails at render, not click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **`on(:typo)` fails at render, not click (#105).** A misspelled or forgotten
+  action used to render fine and only surface as an unexplained **403 on click**
+  (the endpoint's default-deny). Now, when **`Phlex::Reactive.verbose_errors`** is
+  on (the default in development and test via `Rails.env.local?`), **`on(:name)`
+  raises `Phlex::Reactive::Error`** at **render** time if `:name` isn't declared
+  on that component — the message lists the declared actions, the same loud-
+  failure courtesy `reactive_compute_attrs` already gives an undeclared compute.
+  You catch the typo the moment you load the page instead of hunting a mystery
+  403.
+  - **Production is unchanged.** With `verbose_errors` off (the production
+    default) `on()` keeps today's permissive emit, so a stale page after a deploy
+    that removed an action **never 500s on render**.
+  - **Cross-component dispatch still works.** A component that declares **no
+    actions of its own** — a child row rendering a trigger for its container's
+    action and sending the container's token (e.g. a notification row → the list's
+    `:dismiss`) — is skipped: it can't self-validate against a registry it doesn't
+    own. `on_client` triggers are never checked (they aren't declared actions).
+  - **Not the security boundary.** This is a dev-time aid; the server's
+    default-deny stays the enforcement. The check is one flag-gated hash lookup
+    with **zero added allocations** on the `on()`/render/token hot paths (measured:
+    `on(:increment)` and `to_stream_replace` allocate byte-identically before and
+    after; the prod path short-circuits on the flag before the lookup).
+
 ### Added
 
 - **`reactive_text` mirrors + typed compute inputs (#104).** Mirror a form field

--- a/README.md
+++ b/README.md
@@ -1532,6 +1532,17 @@ hint when a flat name looks like the bracketed twin of a declared nested key
 
 The flag never changes a status — only the body and the coercion log.
 
+The same flag also makes `on(:typo)` fail loudly at **render** time: when
+`verbose_errors` is on, `on(:name)` raises `Phlex::Reactive::Error` (listing the
+declared actions) if `:name` isn't declared on that component — so a misspelled
+or forgotten `action` surfaces the moment you load the page in dev/test, instead
+of as an unexplained 403 on click. Production (flag off) keeps the permissive
+emit, so a stale page after a deploy that removed an action never 500s on render.
+A component that declares no actions of its own (a cross-component dispatch
+helper — a child row rendering a trigger for its container's action) is skipped;
+`on_client` triggers are never checked (they aren't declared actions). The
+server's default-deny stays the security boundary — this is a dev-time courtesy.
+
 See [docs/security.md](https://phlex-reactive.zoolutions.llc/docs/security) for the threat model and a checklist.
 
 ---

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -525,6 +525,34 @@ module Phlex
       def on(action_name, event: "click", debounce: nil, throttle: nil, confirm: nil, listnav: nil,
              window: false, once: false, outside: false, optimistic: nil, loading: nil, disable_with: nil,
              **params)
+        # A typo'd or forgotten action renders fine and only surfaces as an
+        # opaque 403 at CLICK time (the endpoint's default-deny). Under
+        # verbose_errors (dev + test), fail loudly at RENDER time instead —
+        # listing the declared actions — the same courtesy reactive_compute_attrs
+        # gives an undeclared compute (issue #105). Placed FIRST, before any attr
+        # building. Production (flag off) keeps the permissive emit: a stale page
+        # after a deploy that removed an action must not 500 on render. This is a
+        # dev-time aid, NOT the security boundary — default-deny stays the
+        # SERVER's enforcement. on_client triggers are not declared actions (no
+        # registry), so they are never checked here.
+        #
+        # The check applies ONLY to a component that declares actions of its own.
+        # A component with an EMPTY registry is a cross-component dispatch helper
+        # — a child row that renders a trigger for its CONTAINER's action and
+        # sends the container's token (e.g. NotificationRowComponent → the list's
+        # :dismiss). It can't self-validate against a registry it doesn't own, so
+        # the guard would false-positive; skipping the empty case keeps the
+        # pattern working while still catching a typo in a component that DOES
+        # declare actions (the issue's target — on(:togle) where :toggle exists).
+        # verbose_errors is checked FIRST so production (flag off) short-circuits
+        # before touching the registry — zero added cost on the hot path.
+        if Phlex::Reactive.verbose_errors &&
+           (actions = self.class.reactive_actions).any? && !actions.key?(action_name.to_sym)
+          raise Phlex::Reactive::Error,
+            "#{self.class} has no declared action #{action_name.to_sym.inspect} " \
+            "(declared: #{actions.keys.inspect})"
+        end
+
         if debounce && throttle
           raise ArgumentError,
             "on(#{action_name.inspect}) got both debounce: and throttle: — they are mutually " \

--- a/spec/dummy/app/components/counter_component.rb
+++ b/spec/dummy/app/components/counter_component.rb
@@ -6,6 +6,13 @@ class CounterComponent < ApplicationComponent
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
+  # A registered authorization error (see config/initializers/phlex_reactive.rb),
+  # so `boom` denies inside the action and the endpoint maps it to a 403 — the
+  # SAME observable outcome (status 403, client kind=http) the lifecycle-events
+  # system spec watches, while keeping `boom` a DECLARED action so the render-time
+  # undeclared-action guard (issue #105) doesn't reject the page on render.
+  class Denied < StandardError; end
+
   reactive_state :count
   action :increment
   action :decrement
@@ -18,6 +25,7 @@ class CounterComponent < ApplicationComponent
   action :bump_with_sibling
   action :bump_with_self_stream
   action :bump_with_js
+  action :boom
 
   def initialize(count: 0)
     @count = count
@@ -97,6 +105,12 @@ class CounterComponent < ApplicationComponent
     reply.morph.js(js.focus("@root").dispatch("app:bumped", detail: { count: @count }))
   end
 
+  # A denied action: raises a registered authorization error so the endpoint
+  # returns 403 (client kind=http). Declared (unlike a raw undeclared action) so
+  # the page renders under the issue #105 render-time guard; the 403 the browser
+  # observes is unchanged.
+  def boom = raise(Denied, "boom")
+
   def view_template
     div(id:, **reactive_attrs) do
       button(**mix(on(:decrement), data: { testid: "dec" })) { "−" }
@@ -105,9 +119,10 @@ class CounterComponent < ApplicationComponent
       button(**mix(on(:bump_via_update), data: { testid: "bump-update" })) { "+1 (update)" }
       button(**mix(on(:reset_with_flash), data: { testid: "reset" })) { "reset" }
       button(**mix(on(:go_home), data: { testid: "go-home" })) { "go home" }
-      # DELIBERATELY undeclared action (no `action :boom`): the endpoint
-      # default-denies it with a 403, which the lifecycle-events system spec
-      # uses to observe a real reactive:error (kind=http) in the browser (#79).
+      # `boom` denies inside the action (a registered authorization error) → the
+      # endpoint returns 403, which the lifecycle-events system spec uses to
+      # observe a real reactive:error (kind=http) in the browser (#79). Declared
+      # so the page renders under the #105 render-time undeclared-action guard.
       button(**mix(on(:boom), data: { testid: "boom" })) { "boom" }
     end
   end

--- a/spec/dummy/app/components/failure_surface_component.rb
+++ b/spec/dummy/app/components/failure_surface_component.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 # Drives the user-visible failure surface system spec (issue #100):
-#   * `boom` is DELIBERATELY undeclared → the endpoint default-denies it (403).
-#     With Phlex::Reactive.error_flash configured, the rescue renders a
-#     turbo-stream flash the browser SHOWS, and the client sets
-#     data-reactive-error="http" on this root.
+#   * `boom` denies inside a DECLARED action (a registered authorization error)
+#     → the endpoint returns 403. With Phlex::Reactive.error_flash configured,
+#     the rescue renders a turbo-stream flash the browser SHOWS, and the client
+#     sets data-reactive-error="http" on this root. It is DECLARED (not a raw
+#     undeclared action) so the page renders under the render-time
+#     undeclared-action guard (issue #105); the 403 the browser sees is unchanged.
 #   * `succeed` is a normal action whose re-render CLEARS data-reactive-error.
 #   * `flash_now` emits a self-dismissing flash (dismiss_after:) that the
 #     document-level handler removes after the timeout.
@@ -12,9 +14,14 @@ class FailureSurfaceComponent < ApplicationComponent
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
+  # Registered in config/initializers/phlex_reactive.rb so `boom`'s denial maps
+  # to a 403 (client kind=http) instead of a 500.
+  class Denied < StandardError; end
+
   reactive_state :count
   action :succeed
   action :flash_now
+  action :boom
 
   def initialize(count: 0)
     @count = count
@@ -23,6 +30,10 @@ class FailureSurfaceComponent < ApplicationComponent
   def id = "failure-surface"
 
   def succeed = @count += 1
+
+  # Denies inside the action → 403 (client kind=http), the failure the system
+  # spec drives. Declared so the page renders under the issue #105 guard.
+  def boom = raise(Denied, "boom")
 
   # A short-lived flash so the system spec can watch it appear then disappear.
   # 800ms is long enough that Capybara reliably observes it PRESENT before the
@@ -34,7 +45,8 @@ class FailureSurfaceComponent < ApplicationComponent
   def view_template
     div(id:, **reactive_attrs) do
       span(data: { testid: "count" }) { @count.to_s }
-      # Undeclared action → default-deny 403 → error_flash renders a flash.
+      # Denied action → 403 → error_flash renders a flash. Declared (see class
+      # header) so the page renders under the issue #105 render-time guard.
       button(**mix(on(:boom), data: { testid: "boom" })) { "boom" }
       button(**mix(on(:succeed), data: { testid: "succeed" })) { "succeed" }
       button(**mix(on(:flash_now), data: { testid: "flash-now" })) { "flash" }

--- a/spec/dummy/config/initializers/phlex_reactive.rb
+++ b/spec/dummy/config/initializers/phlex_reactive.rb
@@ -11,4 +11,12 @@ Rails.application.config.after_initialize do
   # applied hint before the (deliberately delayed) failure reverts it, instead of
   # racing a fast default-deny 403.
   Phlex::Reactive.authorization_errors << OptimisticRowComponent::Denied
+
+  # The `boom` fixtures (CounterComponent, FailureSurfaceComponent) deny inside a
+  # DECLARED action so their pages still render under the render-time
+  # undeclared-action guard (issue #105) while the endpoint still returns 403 —
+  # the kind=http failure the lifecycle-events and failure-surface system specs
+  # observe. Registering the errors maps them to that 403.
+  Phlex::Reactive.authorization_errors << CounterComponent::Denied
+  Phlex::Reactive.authorization_errors << FailureSurfaceComponent::Denied
 end

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -5,6 +5,11 @@ require "phlex" # for the render-context-free `mix` helper used by reactive_root
 
 RSpec.describe Phlex::Reactive::Component do
   # A minimal state-backed component (no Rails/Phlex render needed for these).
+  # It declares every action the #on specs exercise: on() now consults the
+  # actions registry under verbose_errors (issue #105 — undeclared names raise at
+  # render), which is ON whenever Rails is loaded (the combined fast suite), so a
+  # trigger for an undeclared name would raise here. Declaring them keeps every
+  # #on wire-format example green regardless of the flag's default.
   let(:state_klass) do
     Class.new do
       include Phlex::Reactive::Component
@@ -14,6 +19,10 @@ RSpec.describe Phlex::Reactive::Component do
       reactive_state :count
       action :increment
       action :set, params: { count: :integer }
+      # Action names the #on option specs (debounce/listnav/confirm/keyboard/
+      # modifiers/optimistic/loading) build triggers for — declared so the
+      # render-time undeclared-action guard (issue #105) passes them through.
+      %i[search destroy add cancel switch toggle track dismiss close_menu save].each { action(it) }
 
       def initialize(count: 0) = @count = count
       attr_reader :count
@@ -494,6 +503,77 @@ RSpec.describe Phlex::Reactive::Component do
     it "still serializes explicit params" do
       attrs = instance.send(:on, :set, count: 9)
       expect(JSON.parse(attrs[:data][:reactive_params_param])).to eq({ "count" => 9 })
+    end
+  end
+
+  # Issue #105: on(:typo) — an undeclared action name (a typo, or an action you
+  # forgot to declare) renders fine today and only surfaces as an unexplained
+  # 403 at CLICK time (the endpoint's default-deny). With verbose_errors on
+  # (dev + test), on() consults the actions registry and raises at RENDER time,
+  # listing the declared actions — the same loud-failure precedent as
+  # reactive_compute_attrs. Production (flag off) keeps today's permissive emit
+  # so a stale page after a deploy that removed an action doesn't 500 on render.
+  describe "#on undeclared-action guard (issue #105)" do
+    subject(:instance) { state_klass.new }
+
+    # This unit spec runs WITHOUT Rails (spec_helper), so verbose_errors defaults
+    # to false — the raising path is flag-gated, so force it ON here (in a Rails
+    # app it defaults ON in dev + test via Rails.env.local?). Restore the lazy
+    # default after each example — remove the ivar entirely so the explicit value
+    # never leaks into the next one.
+    around do
+      Phlex::Reactive.verbose_errors = true
+      it.run
+    ensure
+      if Phlex::Reactive.instance_variable_defined?(:@verbose_errors)
+        Phlex::Reactive.remove_instance_variable(:@verbose_errors)
+      end
+    end
+
+    it "passes through for a declared action" do
+      expect { instance.send(:on, :increment) }.not_to raise_error
+      expect(instance.send(:on, :increment)[:data][:reactive_action_param]).to eq("increment")
+    end
+
+    it "raises for an undeclared action (a typo), naming it and listing the declared ones" do
+      # (An anonymous test class stringifies as #<Class:0x…>, not its .name, so
+      # we assert on the typo + the declared list — the parts a real component's
+      # class name is embedded alongside.)
+      expect { instance.send(:on, :incremnt) }
+        .to raise_error(Phlex::Reactive::Error) {
+          expect(it.message).to include("has no declared action :incremnt")
+          expect(it.message).to include("declared: [").and include(":increment").and include(":set")
+        }
+    end
+
+    it "does not raise when verbose_errors is off (production keeps the permissive emit)" do
+      Phlex::Reactive.verbose_errors = false
+      expect { instance.send(:on, :incremnt) }.not_to raise_error
+      expect(instance.send(:on, :incremnt)[:data][:reactive_action_param]).to eq("incremnt")
+    end
+
+    it "runs the check BEFORE the debounce/throttle guard (a typo raises the action error first)" do
+      # Both a typo AND the mutually-exclusive debounce+throttle are wrong; the
+      # undeclared-action check is placed first, so it wins.
+      expect { instance.send(:on, :incremnt, debounce: 100, throttle: 100) }
+        .to raise_error(Phlex::Reactive::Error, /no declared action :incremnt/)
+    end
+
+    # A component that declares NO actions of its own is a cross-component
+    # dispatch helper — a child row rendering a trigger for its CONTAINER's
+    # action, sending the container's token (e.g. a notification row → the list's
+    # :dismiss). It can't self-validate against a registry it doesn't own, so the
+    # guard skips the empty case entirely rather than false-positive.
+    it "skips the check for a component that declares no actions (cross-component dispatch)" do
+      dispatch_helper = Class.new do
+        include Phlex::Reactive::Component
+
+        def self.name = "DispatchHelper"
+      end
+      instance = dispatch_helper.new
+
+      expect { instance.send(:on, :dismiss, id: 7) }.not_to raise_error
+      expect(instance.send(:on, :dismiss, id: 7)[:data][:reactive_action_param]).to eq("dismiss")
     end
   end
 


### PR DESCRIPTION
## Summary

`on(:togle)` with a typo — or an action you forgot to declare — used to render fine and only surface as an unexplained **403 at click time** (the endpoint's default-deny). Now, when `Phlex::Reactive.verbose_errors` is on (the default in dev + test via `Rails.env.local?`), `on(:name)` raises `Phlex::Reactive::Error` at **render** time if `:name` isn't declared on that component — listing the declared actions, the same loud-failure courtesy `reactive_compute_attrs` already gives an undeclared compute. You catch the typo the moment you load the page.

The check is placed **first** in `on()`, before any attr building. `verbose_errors` is evaluated first, so **production (flag off) short-circuits before touching the registry** — zero added cost, and a stale page after a deploy that removed an action never 500s on render.

Closes #105

## Behavior

| Case | Result |
|------|--------|
| Declared action | passes through (unchanged) |
| Undeclared name, `verbose_errors` on | raises `Phlex::Reactive::Error` listing declared actions |
| Undeclared name, `verbose_errors` off (production) | permissive emit (unchanged) |
| Component declaring **no** actions of its own | **skipped** — cross-component dispatch helper (a child row rendering a trigger for its container's action, sending the container's token). It can't self-validate against a registry it doesn't own. |
| `on_client` triggers | never checked (not declared actions) |

**This is a dev-time courtesy, not the security boundary** — the server's default-deny stays the enforcement.

## Dummy fixtures

Two dummy components (`CounterComponent`, `FailureSurfaceComponent`) previously rendered a **deliberately undeclared** `on(:boom)` to drive default-deny system specs. Under the new render-time guard their pages would raise on render. They now **declare `:boom`** and deny inside the action via a **registered authorization error** — the endpoint still returns **403 (client `kind=http`)**, so the browser-observable behavior is byte-identical, while the page renders cleanly.

The undeclared-action → 403 default-deny path loses no coverage: `verbose_errors_spec.rb` posts `act: "togle"` directly to the endpoint (no render), so the security boundary is still fully exercised at the request layer.

## Test Coverage

- **Unit** (`component_spec.rb`): declared name passes; a typo raises with the declared-actions list; flag off → no raise; the check runs **before** the debounce/throttle guard; a zero-action component (cross-component dispatch) is **skipped**.
- **Fast suite**: 462 examples, 0 failures.
- **System**: `lifecycle_events` (`:boom` → real `reactive:error` kind=http), `failure_surface` (error flash on failure), and `notifications` (cross-component `:dismiss` dispatch) all green.

## Performance

`rake bench` before/after — the check is one flag-gated hash lookup, **zero added allocations**:

| Bench | Before | After |
|-------|--------|-------|
| `on(:increment)` allocations | 6 objects / 856 bytes | 6 objects / 856 bytes |
| `to_stream_replace` allocations | 205 objects / 27608 bytes | 205 objects / 27608 bytes |

Allocation counts are byte-identical; throughput differences between runs are shared-machine noise (the allocation count is the noise-free signal). The prod path short-circuits on the `verbose_errors` flag before the registry is read.

## Verification

- [x] `bundle exec rubocop` — 145 files, no offenses
- [x] `bundle exec rspec spec/phlex spec/requests` — 462 examples, 0 failures
- [x] Affected system specs green
- [x] README (verbose_errors section) + CHANGELOG (Unreleased) updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter error reporting in development and test environments when an action is triggered that hasn’t been declared.
  * Improved documentation to explain the new behavior and when it applies.

* **Bug Fixes**
  * Helps catch mistyped or missing action names earlier, instead of failing later during interaction.
  * Preserves existing production behavior and cross-component action dispatch for components without declared actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->