### PR TITLE
feat(engine): rails phlex_reactive:doctor validates the install + hardens the generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`bin/rails phlex_reactive:doctor` — validate the whole install (#106).** Five
+  closed issues (#3 boot/eager-load, #26 route shadowing, #42 lost request, #48
+  unregistered controller, #57 importmap 404) were pure integration papercuts
+  that only surfaced **after** something already broke. The doctor turns "nothing
+  happens, why?" into an actionable checklist you run before or after setup. It
+  prints `✓/✗/?` with a fix for each failure and checks: the action route
+  resolves (reuses the boot route-shadow guard), the `reactive` controller is
+  registered in a Stimulus entrypoint (importmap **or** esbuild/bun **or** a
+  layout), `csrf_meta_tags` is referenced (**advisory `?`** — never a hard fail,
+  so a Phlex-only layout isn't false-flagged), the identity verifier round-trips,
+  `base_controller_name` constantizes, every declared `action :name` has a public
+  method (mirrors the endpoint's `public_send`), and every component resolves a
+  stable `#id` (a state-backed class with no `#id` is flagged; a record-backed
+  class on the #81 default is fine). It is **read-only** — no client surface, no
+  component instantiation, default-deny untouched — and exits non-zero on a hard
+  failure so CI or a setup script can gate on it.
+- **Install generator hardening (#106).** The generator now also detects
+  `app/javascript/application.js` (esbuild/bun/webpack) as a Stimulus entrypoint,
+  not just the importmap-style `controllers/index.js`, and its post-install output
+  ends by telling you to run `bin/rails phlex_reactive:doctor` to verify.
+
 ### Changed
 
 - **`on(:typo)` fails at render, not click (#105).** A misspelled or forgotten

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ That's all for **importmap** apps: the engine mounts the action endpoint at
 `/reactive/actions` and auto-pins (and preloads) the client runtime, and the
 installer adds the eager registration below to your Stimulus entrypoint.
 
+Verify the whole install any time with the doctor — it checks the route, the
+Stimulus registration, CSRF, the identity verifier, and every component, printing
+`✓/✗/?` with a fix for each failure:
+
+```bash
+bin/rails phlex_reactive:doctor
+```
+
 <details>
 <summary>What the installer wires (or do it by hand)</summary>
 
@@ -140,7 +148,9 @@ for broadcasting.
 
 Two host-app setups make the first reactive component *silently do nothing* —
 components render, but no action ever fires, with no error pointing at the cause.
-The gem now logs a warning for each, but here are the fixes:
+Run `bin/rails phlex_reactive:doctor` first — it flags both of these (and more)
+with the fix inline. The gem also logs a warning for each at boot; here are the
+fixes:
 
 **A catch-all route shadows `POST /reactive/actions`.** The engine appends its
 route *after* everything in your `config/routes.rb`, so a bottom-of-file

--- a/docs/app/views/docs/pages/installation.rb
+++ b/docs/app/views/docs/pages/installation.rb
@@ -250,15 +250,30 @@ module Views
           DocsUI::Section('Verify it works') do
             DocsUI::Prose() do
               p do
-                plain 'Drop a counter on any page, click '
+                plain 'Run the doctor — it validates the whole install (route, Stimulus registration, ' \
+                      'CSRF, the identity verifier, and every component) and prints '
+                code { '✓/✗/?' }
+                plain ' with a fix for each failure:'
+              end
+            end
+            DocsUI::Code(<<~SHELL, lexer: :shell)
+              bin/rails phlex_reactive:doctor
+            SHELL
+            DocsUI::Prose() do
+              p do
+                plain 'Then drop a counter on any page, click '
                 code { '+' }
                 plain ', and watch it increment with no full-page reload. If it reloads or does ' \
                       'nothing, check the testing guide troubleshooting section.'
               end
             end
             DocsUI::Callout(:tip) do
-              plain 'No full-page reload is the signal everything is wired: the engine endpoint is ' \
-                    'mounted, the controller is registered eagerly, and Turbo morphs the component in place.'
+              plain 'The doctor is read-only and safe to run anywhere. A '
+              code { '✗' }
+              plain ' points at the exact fix; a '
+              code { '?' }
+              plain ' is advisory (e.g. it can’t confirm csrf_meta_tags in a Phlex-only layout). ' \
+                    'No full-page reload on the click is the runtime signal everything is wired.'
             end
           end
         end

--- a/lib/generators/phlex/reactive/install/install_generator.rb
+++ b/lib/generators/phlex/reactive/install/install_generator.rb
@@ -59,15 +59,22 @@ module Phlex
             end
 
             Scaffold one with:  rails g phlex:reactive:component Counter
+
+            Then verify the whole install:  bin/rails phlex_reactive:doctor
           MSG
         end
 
         private
 
+        # Stimulus entrypoint candidates, importmap-style AND esbuild/bun (issue
+        # #106): importmap apps register in controllers/index.js (or
+        # controllers/application.js); esbuild/bun/webpack apps register in
+        # app/javascript/application.js. Whichever exists first is the target.
         def stimulus_index_path
           %w[
             app/javascript/controllers/index.js
             app/javascript/controllers/application.js
+            app/javascript/application.js
           ].map { File.join(destination_root, it) }.find { File.exist?(it) }
         end
 

--- a/lib/phlex/reactive/doctor.rb
+++ b/lib/phlex/reactive/doctor.rb
@@ -1,0 +1,331 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # Validates a phlex-reactive install and reports ✓/✗/? per check with a fix
+    # for each failure (issue #106). Five closed issues (#3 boot/eager-load, #26
+    # route shadowing, #42 lost request, #48 unregistered controller, #57
+    # importmap 404) were pure integration papercuts that only surfaced AFTER
+    # something already broke. The doctor turns "nothing happens, why?" into an
+    # actionable checklist you run before/after setup:
+    #
+    #   bin/rails phlex_reactive:doctor
+    #
+    # Every check is a small object answering [status, message, fix]. It is
+    # READ-ONLY — it never mounts a component, mutates state, or touches the
+    # default-deny boundary; the worst it does is a throwaway sign→verify round
+    # trip and (for the component checks) iterate the loaded Streamable registry.
+    class Doctor
+      # The result of one check: a status (:ok/:fail/:unknown), a human message,
+      # and (on anything but :ok) a fix line telling the adopter what to do. A
+      # plain value object (not Data) so it takes positional status/message plus
+      # keyword name:/fix: — the shape the check builders and specs construct.
+      class Check
+        attr_reader :name, :status, :message, :fix
+
+        def initialize(status, message, name: nil, fix: nil)
+          @name = name
+          @status = status
+          @message = message
+          @fix = fix
+        end
+
+        def ok? = status == :ok
+        def fail? = status == :fail
+        def unknown? = status == :unknown
+      end
+
+      # Glyphs are plain ASCII-safe Unicode with NO ANSI color, so CI/log capture
+      # reads cleanly (issue #106 acceptance: stable plain-text output).
+      GLYPHS = { ok: "✓", fail: "✗", unknown: "?" }.freeze
+
+      # The entrypoint the rake task calls: eager-load so the component registry
+      # is populated, print the report, and return TRUE when nothing failed (an
+      # advisory `?` doesn't count) so a caller can gate its exit code on it.
+      # (Not a predicate name — this is the imperative "run + report" action that
+      # happens to return a success boolean; `io` is the conventional stream name.)
+      def self.run(io: $stdout) # rubocop:disable Naming/PredicateMethod,Naming/MethodParameterName
+        ::Rails.application.eager_load! if defined?(::Rails) && ::Rails.application
+        doctor = new
+        io.puts(doctor.report)
+        !doctor.failures?
+      end
+
+      # Run every check and return the ordered list of Check objects, memoized so
+      # report + failures? share one pass. The caller (or Doctor.run) is
+      # responsible for eager_load! so component classes are in the registry —
+      # the component checks are empty otherwise.
+      def checks
+        @checks ||= build_checks
+      end
+
+      # True when any check FAILED (a hard ✗). Advisory `?` lines are not
+      # failures — a Phlex-layout app legitimately can't verify csrf that way.
+      def failures?
+        checks.any?(&:fail?)
+      end
+
+      def build_checks
+        components = registered_components
+        [
+          route_check,
+          stimulus_check,
+          csrf_check,
+          verifier_check,
+          base_controller_check,
+          action_check(components),
+          id_check(components)
+        ]
+      end
+
+      # --- individual checks ------------------------------------------------
+
+      # Does POST <action_path> resolve to the gem's ActionsController? A host
+      # catch-all route shadows it otherwise (issue #26). Reuses the shipped
+      # guard verbatim — it already handles routes-not-yet-drawn.
+      def route_check
+        path = Phlex::Reactive.action_path
+        if Phlex::Reactive.action_route_ok?(path)
+          Check.new(:ok, "POST #{path} routes to #{Doctor.actions_controller}", name: :route)
+        else
+          Check.new(:fail, "POST #{path} does not resolve to #{Doctor.actions_controller}", name: :route,
+            fix: "A host catch-all route (match \"*path\", ...) likely shadows it. Exempt " \
+                 "#{path.delete_prefix("/")} from the catch-all, or set Phlex::Reactive.action_path " \
+                 "to an unshadowed path.")
+        end
+      end
+
+      # Is the generic `reactive` controller registered in a Stimulus entrypoint
+      # (issue #48)? Grep the candidate entrypoints for the register line; when
+      # importmap is present, additionally verify the pin resolves.
+      def stimulus_check
+        entrypoint = stimulus_registration_files.find { registers_reactive?(it) }
+        return stimulus_missing_check unless entrypoint
+
+        if importmap_pin_broken?
+          return Check.new(:fail, "reactive registered in #{relative(entrypoint)}, but the importmap " \
+                                  "pin for phlex/reactive/reactive_controller is missing", name: :stimulus,
+            fix: "The engine auto-pins it; if you overrode config/importmap.rb, add:\n  " \
+                 "pin \"phlex/reactive/reactive_controller\"")
+        end
+
+        Check.new(:ok, "reactive controller registered in #{relative(entrypoint)}", name: :stimulus)
+      end
+
+      # ADVISORY only (issue #106): grep ERB layouts AND Phlex layout files for a
+      # csrf_meta_tags reference. A hard fail would false-flag Phlex-layout apps
+      # (this gem's core audience), so a miss is :unknown, never :fail.
+      def csrf_check
+        if csrf_meta_referenced?
+          Check.new(:ok, "csrf_meta_tags found in a layout", name: :csrf)
+        else
+          Check.new(:unknown, "could not verify csrf_meta_tags in a layout", name: :csrf,
+            fix: "Confirm your layout renders csrf_meta_tags (ERB: <%= csrf_meta_tags %>; " \
+                 "Phlex: render Phlex::Rails::Helpers::CSRFMetaTags or emit the meta tags) — " \
+                 "the client reads the CSRF token from <meta name=\"csrf-token\">.")
+        end
+      end
+
+      # A throwaway sign→verify round trip proves the verifier is configured and
+      # the key round-trips (a bad secret_key_base or a purpose mismatch fails).
+      def verifier_check
+        payload = { "c" => "Phlex::Reactive::Doctor", "probe" => true }
+        roundtripped = Phlex::Reactive.verify(Phlex::Reactive.sign(payload))
+        if roundtripped == payload
+          Check.new(:ok, "identity verifier signs and verifies", name: :verifier)
+        else
+          Check.new(:fail, "identity verifier did not round-trip a probe payload", name: :verifier,
+            fix: "Check secret_key_base is set, or configure a dedicated " \
+                 "Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(key).")
+        end
+      rescue => e # rubocop:disable Style/RescueStandardError
+        Check.new(:fail, "identity verifier raised: #{e.message}", name: :verifier,
+          fix: "Set secret_key_base, or configure Phlex::Reactive.verifier explicitly.")
+      end
+
+      # Does Phlex::Reactive.base_controller_name constantize (issue #48-adjacent)?
+      def base_controller_check
+        name = Phlex::Reactive.base_controller_name
+        klass = Phlex::Reactive.base_controller
+        Check.new(:ok, "base_controller_name #{name} constantizes to #{klass}", name: :base_controller)
+      rescue => e # rubocop:disable Style/RescueStandardError
+        Check.new(:fail, "base_controller_name #{Phlex::Reactive.base_controller_name.inspect} " \
+                         "does not constantize (#{e.class})", name: :base_controller,
+          fix: "Set Phlex::Reactive.base_controller_name to a controller that exists " \
+               "(e.g. \"ApplicationController\").")
+      end
+
+      # Every declared `action :name` must have a public instance method (mirrors
+      # the endpoint's public_send dispatch — a missing one 500s at click).
+      def action_check(components)
+        missing = components.flat_map { missing_action_methods(it) }
+        return Check.new(:ok, "every declared action has a public method", name: :actions) if missing.empty?
+
+        Check.new(:fail, "declared actions with no matching public method: #{missing.join(", ")}", name: :actions,
+          fix: "Define a public method for each, or remove the `action :name` declaration.")
+      end
+
+      # Flag a class that would raise NotImplementedError in #id at render: it
+      # inherits Streamable's default #id AND is NOT record-backed. A record-backed
+      # class on the default is FINE — that default shipped in #81.
+      def id_check(components)
+        offenders = components.select { default_id_without_record?(it) }.map(&:name)
+        return Check.new(:ok, "every component resolves a stable #id", name: :ids) if offenders.empty?
+
+        Check.new(:fail, "state-backed components with no #id (render raises NotImplementedError): " \
+                         "#{offenders.join(", ")}", name: :ids,
+          fix: "Add `def id = \"my-thing\"` to each — a state-backed component has no record to " \
+               "derive a default id from.")
+      end
+
+      # --- rendering --------------------------------------------------------
+
+      # The full plain-text report: a line per check, plus an indented fix under
+      # each non-passing one. No ANSI color (clean CI/log capture).
+      def report
+        lines = ["phlex-reactive doctor", ""]
+        results = checks
+        results.each { lines << render_check(it) }
+        lines << ""
+        lines << summary_line(results)
+        lines.join("\n")
+      end
+
+      # One check as "✓/✗/? message" plus an indented "→ fix" when it isn't ok.
+      def render_check(check)
+        line = "#{GLYPHS.fetch(check.status)} #{check.message}"
+        line += "\n    → #{check.fix}" if check.fix && !check.ok?
+        line
+      end
+
+      def self.actions_controller
+        "phlex/reactive/actions"
+      end
+
+      private
+
+      # A one-line tally: how many passed, failed, and are advisory/unknown.
+      def summary_line(results)
+        passed = results.count(&:ok?)
+        failed = results.count(&:fail?)
+        advisory = results.count(&:unknown?)
+        parts = ["#{passed} passed"]
+        parts << "#{failed} failed" if failed.positive?
+        parts << "#{advisory} advisory" if advisory.positive?
+        parts.join(", ")
+      end
+
+      # The registry filtered to real, CONSTANT-RESOLVABLE reactive components.
+      # A class is only invokable by the endpoint if its own name round-trips
+      # through safe_constantize (that's exactly how ActionsController#resolve_component
+      # rebuilds it from the token). So we validate only classes where
+      # name.safe_constantize is the class itself — which also excludes anonymous
+      # classes (name nil) and test fixtures that fake `def self.name` without a
+      # matching constant, keeping the whole-app scan honest.
+      def registered_components
+        Phlex::Reactive::Streamable.registered_classes.select { constant_backed_component?(it) }
+      end
+
+      def constant_backed_component?(klass)
+        reactive_component?(klass) && klass.name && klass.name.safe_constantize.equal?(klass)
+      rescue StandardError
+        false
+      end
+
+      def reactive_component?(klass)
+        klass.respond_to?(:reactive_actions) && klass.include?(Phlex::Reactive::Component)
+      rescue StandardError
+        false
+      end
+
+      # "Klass#action" for every declared action on `klass` that has no public
+      # method to dispatch to. Kept as its own method (not a nested block) so the
+      # class is a named method arg, not a shadowed `it`.
+      def missing_action_methods(klass)
+        klass.reactive_actions.keys
+          .reject { klass.public_method_defined?(it) }
+          .map { "#{klass}##{it}" }
+      end
+
+      # True when the class still uses Streamable's default #id AND has no record
+      # to back it (so the default raises). owner == Streamable means no override.
+      def default_id_without_record?(klass)
+        klass.instance_method(:id).owner == Phlex::Reactive::Streamable &&
+          !(klass.respond_to?(:reactive_record_key) && klass.reactive_record_key)
+      rescue StandardError
+        false
+      end
+
+      def stimulus_missing_check
+        Check.new(:fail, "the reactive controller is not registered in any Stimulus entrypoint", name: :stimulus,
+          fix: "Add to your entrypoint (e.g. app/javascript/controllers/index.js):\n  " \
+               "import ReactiveController from \"phlex/reactive/reactive_controller\"\n  " \
+               "application.register(\"reactive\", ReactiveController)\n" \
+               "or re-run: bin/rails generate phlex:reactive:install")
+      end
+
+      # Files that may hold the register line: the JS entrypoint candidates,
+      # importmap-style AND esbuild/bun (issue #106) — controllers/index.js,
+      # controllers/application.js, application.js — PLUS ERB layouts, since a
+      # small/importmap app often registers inline in <head> rather than in a
+      # dedicated entrypoint file. Only existing files are returned.
+      def stimulus_registration_files
+        candidates = %w[
+          app/javascript/controllers/index.js
+          app/javascript/controllers/application.js
+          app/javascript/application.js
+        ].map { app_path(it) }
+        candidates += ::Dir.glob(app_path("app/views/layouts/**/*.erb"))
+        candidates.select { File.exist?(it) }
+      end
+
+      def registers_reactive?(path)
+        File.read(path).include?('application.register("reactive", ReactiveController)')
+      rescue StandardError
+        false
+      end
+
+      # Only meaningful when importmap is in use. True when importmap is present
+      # but the reactive_controller pin is absent (the engine pins it, so this is
+      # really "someone overrode importmap.rb and dropped the pin").
+      def importmap_pin_broken?
+        return false unless defined?(::Importmap) && ::Rails.application.respond_to?(:importmap)
+
+        map = ::Rails.application.importmap
+        return false unless map
+
+        !map.packages.key?("phlex/reactive/reactive_controller")
+      rescue StandardError
+        false
+      end
+
+      # Grep ERB layouts AND Phlex layout files for a csrf_meta_tags reference.
+      def csrf_meta_referenced?
+        globs = %w[
+          app/views/**/*.erb
+          app/views/**/*.rb
+          app/components/**/*.rb
+          app/views/**/layout*.html*
+        ].map { app_path(it) }
+
+        ::Dir.glob(globs).any? do
+          File.read(it).include?("csrf_meta_tags")
+        rescue StandardError
+          false
+        end
+      rescue StandardError
+        false
+      end
+
+      def app_path(relative)
+        ::Rails.root.join(relative).to_s
+      end
+
+      def relative(path)
+        return path unless defined?(::Rails) && ::Rails.root
+
+        path.delete_prefix("#{::Rails.root}/")
+      end
+    end
+  end
+end

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -59,6 +59,20 @@ module Phlex
         def register(klass)
           @registry_mutex.synchronize { @registry[klass] = true }
         end
+
+        # A point-in-time snapshot of every registered streamable class, taken
+        # under the registry lock (the doctor iterates it — issue #106). Returns
+        # a plain Array so callers never hold the live WeakMap or the lock while
+        # working; a class GC'd later simply won't appear next time. Call
+        # Rails.application.eager_load! FIRST if you need every app class loaded —
+        # the WeakMap only holds classes that have actually been loaded.
+        def registered_classes
+          @registry_mutex.synchronize do
+            classes = []
+            @registry.each_key { classes << it }
+            classes
+          end
+        end
       end
 
       included do

--- a/lib/tasks/phlex_reactive.rake
+++ b/lib/tasks/phlex_reactive.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Rails engines auto-load rake tasks under lib/tasks — no engine.rb change is
+# needed for `bin/rails phlex_reactive:doctor` to appear in the host app.
+namespace :phlex_reactive do
+  desc "Validate the phlex-reactive install (route, Stimulus, verifier, components) — issue #106"
+  task doctor: :environment do
+    # Doctor.run eager-loads so the component registry is populated, prints the
+    # ✓/✗/? report (with a fix per failure), and returns false if any check
+    # FAILED (advisory `?` lines don't count) — abort so CI / a setup script can
+    # gate on `bin/rails phlex_reactive:doctor`.
+    abort unless Phlex::Reactive::Doctor.run
+  end
+end

--- a/phlex-reactive.gemspec
+++ b/phlex-reactive.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
       # three root docs), so a glob in a dirty working tree can't sweep in
       # machine-local artifacts (logs, .env, tmp, editor backups). This keeps
       # spec.files stable across build environments without a hand-written manifest.
-      patterns = %w[{app,config,lib}/**/*.{rb,js,erb} lib/**/USAGE]
+      patterns = %w[{app,config,lib}/**/*.{rb,js,erb,rake} lib/**/USAGE]
       patterns.flat_map { |p| Dir.glob(p, base: __dir__) }
         .select { |f| File.file?(File.join(__dir__, f)) } +
         %w[CHANGELOG.md LICENSE.txt README.md].select { |f| File.file?(File.join(__dir__, f)) }

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -45,10 +45,31 @@ RSpec.describe Phlex::Reactive::Generators::InstallGenerator do
     end
   end
 
+  context "with an esbuild/bun entrypoint (app/javascript/application.js)" do
+    before do
+      FileUtils.mkdir_p(tmp.join("app/javascript"))
+      File.write(tmp.join("app/javascript/application.js"), <<~JS)
+        import { application } from "./application"
+        // existing registrations
+      JS
+    end
+
+    it "registers the reactive controller in application.js (issue #106)" do
+      run!
+      entrypoint = File.read(tmp.join("app/javascript/application.js"))
+      expect(entrypoint).to include('import ReactiveController from "phlex/reactive/reactive_controller"')
+      expect(entrypoint).to include('application.register("reactive", ReactiveController)')
+    end
+  end
+
   context "without a Stimulus entrypoint" do
     it "still writes the initializer and does not crash" do
       expect { run! }.not_to raise_error
       expect(File).to exist(tmp.join("config/initializers/phlex_reactive.rb"))
     end
+  end
+
+  it "ends the output telling the user to run the doctor (issue #106)" do
+    expect { run! }.to output(/phlex_reactive:doctor/).to_stdout
   end
 end

--- a/spec/phlex/reactive/doctor_spec.rb
+++ b/spec/phlex/reactive/doctor_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The doctor validates the WHOLE install with ✓/✗/? checks (issue #106). It
+# boots against the dummy app — a correctly-wired install — so the happy path is
+# all-green, and inline fixtures exercise the two component findings that don't
+# need a second booted app (a declared-but-missing action, and a state-backed
+# class with no #id).
+RSpec.describe Phlex::Reactive::Doctor do
+  subject(:doctor) { described_class.new }
+
+  # A Check is the small object the issue specifies: it answers [status, message,
+  # fix]. status is one of :ok/:fail/:unknown; a passing check has no fix.
+  describe "a check" do
+    it "exposes status, message and fix" do
+      check = Phlex::Reactive::Doctor::Check.new(:ok, "all good", fix: nil)
+      expect(check.status).to eq(:ok)
+      expect(check.message).to eq("all good")
+      expect(check.fix).to be_nil
+      expect(check).to be_ok
+    end
+
+    it "carries a fix on failure" do
+      check = Phlex::Reactive::Doctor::Check.new(:fail, "broken", fix: "do this")
+      expect(check).not_to be_ok
+      expect(check.fix).to eq("do this")
+    end
+  end
+
+  describe "#checks (happy path against the dummy app)" do
+    before { Rails.application.eager_load! }
+
+    it "returns a check for every section" do
+      names = doctor.checks.map(&:name)
+      expect(names).to include(
+        :route, :stimulus, :csrf, :verifier, :base_controller, :actions, :ids
+      )
+    end
+
+    it "passes the route check (the endpoint resolves)" do
+      route = doctor.checks.find { it.name == :route }
+      expect(route).to be_ok
+    end
+
+    it "passes the verifier round-trip check" do
+      verifier = doctor.checks.find { it.name == :verifier }
+      expect(verifier).to be_ok
+    end
+
+    it "passes the base_controller_name constantize check" do
+      base = doctor.checks.find { it.name == :base_controller }
+      expect(base).to be_ok
+    end
+
+    it "passes the declared-action-has-a-method check (every dummy action maps)" do
+      actions = doctor.checks.find { it.name == :actions }
+      expect(actions).to be_ok
+    end
+
+    it "passes the #id check (dummy classes define #id or are record-backed)" do
+      ids = doctor.checks.find { it.name == :ids }
+      expect(ids).to be_ok
+    end
+
+    it "marks csrf ADVISORY (unknown, not fail) — Phlex-layout apps have no ERB layout" do
+      csrf = doctor.checks.find { it.name == :csrf }
+      # Never a hard fail — a Phlex-layout app (this gem's audience) would
+      # false-flag. It is :ok when a csrf_meta_tags reference is found, else :unknown.
+      expect(csrf.status).to be_in(%i[ok unknown])
+    end
+
+    it "has no failing checks on a correctly-wired install" do
+      expect(doctor.checks.reject(&:ok?).select { it.status == :fail }).to be_empty
+    end
+
+    # The whole-app checks scan the Streamable registry, which also holds every
+    # Class.new fixture the test suite defines — many deliberately state-backed
+    # without #id or with undeclared actions. The doctor validates ONLY
+    # constant-resolvable components (a class the endpoint could actually rebuild
+    # via safe_constantize), so a faked-`def self.name` fixture never leaks in and
+    # red-flags a correctly-wired app.
+    it "ignores registry classes whose name does not resolve to the class itself" do
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        # "Phantom::StateWidget" is not a real constant, so the doctor skips it.
+        def self.name = "Phantom::StateWidget"
+
+        reactive_state :n
+        # :ghost has no method and the class has no #id — it would fail BOTH
+        # component checks if the doctor scanned it.
+        action :ghost
+        def initialize(n: 0) = (@n = n)
+      end
+
+      expect(doctor.checks.select { it.status == :fail }).to be_empty
+    end
+  end
+
+  describe "the declared-action-has-a-method check (broken fixture)" do
+    # A component that declares an action with NO matching public method — the
+    # endpoint would 500 on public_send. Defined inline so no second app is booted.
+    let(:broken) do
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_state :n
+        action :ghost # no `def ghost`
+        def initialize(n: 0) = (@n = n)
+        def id = "broken-action"
+      end
+    end
+
+    it "flags the missing method" do
+      check = doctor.action_check([broken])
+      expect(check).not_to be_ok
+      expect(check.status).to eq(:fail)
+      expect(check.message).to include("ghost")
+    end
+
+    it "passes when every declared action has a method" do
+      ok = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_state :n
+        action :bump
+        def initialize(n: 0) = (@n = n)
+        def id = "ok-action"
+        def bump = @n += 1
+      end
+      expect(doctor.action_check([ok])).to be_ok
+    end
+  end
+
+  describe "the #id override check (broken fixture)" do
+    # A state-backed class on the DEFAULT #id still raises NotImplementedError at
+    # render — the finding. A record-backed class on the default is FINE (#81).
+    let(:state_without_id) do
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_state :n
+        action :bump
+        def initialize(n: 0) = (@n = n)
+        def bump = @n += 1
+        # NO `def id` — inherits Streamable's default, which raises for state-backed.
+      end
+    end
+
+    let(:state_with_id) do
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_state :n
+        def initialize(n: 0) = (@n = n)
+        def id = "has-id"
+      end
+    end
+
+    it "flags a state-backed class that never overrides #id" do
+      check = doctor.id_check([state_without_id])
+      expect(check).not_to be_ok
+      expect(check.status).to eq(:fail)
+    end
+
+    it "passes a state-backed class that defines #id" do
+      expect(doctor.id_check([state_with_id])).to be_ok
+    end
+
+    it "does NOT flag a record-backed class on the default #id (issue #81)" do
+      record_backed = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_record :todo
+        def initialize(todo:) = (@todo = todo)
+        # no `def id` — record-backed default is FINE, not a finding.
+      end
+      expect(doctor.id_check([record_backed])).to be_ok
+    end
+  end
+
+  describe "output rendering" do
+    before { Rails.application.eager_load! }
+
+    it "renders stable plain text (no ANSI color codes) with ✓/✗/? glyphs" do
+      output = doctor.report
+      expect(output).not_to match(/\e\[[0-9;]*m/) # no ANSI escapes
+      expect(output).to match(/[✓✗?]/)
+    end
+
+    it "prints the fix line for each failing check" do
+      broken = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        reactive_state :n
+        action :ghost
+        def initialize(n: 0) = (@n = n)
+        def id = "x"
+      end
+      check = doctor.action_check([broken])
+      output = doctor.render_check(check)
+      expect(output).to include("✗")
+      expect(output).to include(check.fix)
+    end
+  end
+end

--- a/spec/requests/doctor_task_spec.rb
+++ b/spec/requests/doctor_task_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# The `phlex_reactive:doctor` rake task ships in lib/tasks and is auto-loaded by
+# the Rails engine in a host app (issue #106). Here we load the .rake file
+# directly against the booted dummy app and drive the task, asserting it prints
+# the report and runs cleanly on a correctly-wired install.
+RSpec.describe "phlex_reactive:doctor rake task" do
+  let(:rake) do
+    app = Rake::Application.new
+    Rake.application = app
+    Rake::Task.define_task(:environment) # already booted; the task just depends on it
+    load File.expand_path("../../lib/tasks/phlex_reactive.rake", __dir__)
+    app
+  end
+
+  after { Rake.application = Rake::Application.new }
+
+  it "defines the doctor task" do
+    rake # trigger the load
+    expect(Rake::Task.task_defined?("phlex_reactive:doctor")).to be(true)
+  end
+
+  it "prints the ✓ report and does not abort on the correctly-wired dummy app" do
+    Rails.application.eager_load!
+    expect { rake["phlex_reactive:doctor"].invoke }
+      .to output(/phlex-reactive doctor.*✓.*passed/m).to_stdout
+  end
+end


### PR DESCRIPTION
## Summary

Adds `bin/rails phlex_reactive:doctor` — a read-only diagnostic that validates the whole phlex-reactive install and prints `✓/✗/?` per check with a fix for each failure. It turns the five closed integration papercuts (#3 boot/eager-load, #26 route shadowing, #42 lost request, #48 unregistered controller, #57 importmap 404) from "nothing happens, why?" into an actionable checklist you run before or after setup.

```
phlex-reactive doctor

✓ POST /reactive/actions routes to phlex/reactive/actions
✓ reactive controller registered in app/views/layouts/application.html.erb
✓ csrf_meta_tags found in a layout
✓ identity verifier signs and verifies
✓ base_controller_name ActionController::Base constantizes to ActionController::Base
✓ every declared action has a public method
✓ every component resolves a stable #id

7 passed
```

Rails engines auto-load `lib/tasks/*.rake`, so no `engine.rb` change is needed.

## The checks (each a small object returning `[status, message, fix]`)

| Check | What it does |
|-------|--------------|
| **route** | Reuses `Phlex::Reactive.action_route_ok?` verbatim (the boot catch-all-shadow guard — it already handles routes-not-yet-drawn). |
| **stimulus** | Greps the entrypoint candidates — importmap `controllers/index.js`, esbuild/bun `application.js`, **and** ERB layouts — for the register line; verifies the importmap pin resolves when `defined?(Importmap)`. |
| **csrf** | **Advisory `?` only.** Greps ERB **and** Phlex layouts; a miss prints `?`, never `✗` — a hard fail would false-flag Phlex-layout apps, this gem's core audience. |
| **verifier** | A throwaway sign→verify round trip on a probe payload. |
| **base_controller** | `base_controller_name` constantizes. |
| **actions** | Every declared `action :name` has a public instance method (mirrors the endpoint's `public_send` dispatch). |
| **ids** | Flags a state-backed class still on Streamable's default `#id` (it raises `NotImplementedError` at render). A **record-backed** class on the #81 default is fine, not a finding. |

## Design notes

- **Read-only.** It eager-loads (so the registry is populated), iterates a **snapshot** of the Streamable registry (no strong refs held past the call), and never instantiates a component. Nothing ships to the client; default-deny is untouched.
- **Constant-resolvable filter.** The whole-app checks validate only components whose own name round-trips through `safe_constantize` (exactly how `ActionsController#resolve_component` rebuilds one from the token). A class that can't round-trip can never actually be invoked — so anonymous/faked-name test fixtures are correctly excluded, keeping the scan honest.
- **Exit code.** The rake task aborts (non-zero) on a hard `✗` so CI or a setup script can gate on it; advisory `?` lines don't count.

## Generator hardening

- Detects `app/javascript/application.js` (esbuild/bun/webpack) as a Stimulus entrypoint, not just importmap's `controllers/index.js`.
- The install output now ends with "run `bin/rails phlex_reactive:doctor` to verify".

## Test Coverage

- **`spec/phlex/reactive/doctor_spec.rb`** — happy path (all `✓` against the dummy app), broken-state fixtures (declared-but-missing action; state-backed with/without `def id`; record-backed default is fine), stable plain-text output (no ANSI), and a regression that a faked-`def self.name` fixture never leaks into the whole-app checks.
- **`spec/requests/doctor_task_spec.rb`** — the `phlex_reactive:doctor` rake task loads from `lib/tasks` and runs cleanly against the booted dummy app.
- **`spec/generators/install_generator_spec.rb`** — esbuild/bun `application.js` detection + the doctor mention in the output.

## Verification

- `bundle exec rubocop` — 149 files, no offenses; docs RuboCop clean on the changed page.
- `bundle exec rspec spec/phlex spec/requests spec/generators` — 493 examples, 0 failures.

## Invariants

Read-only checks; nothing ships to the client; default-deny untouched.

Closes #106
