### PR TITLE
feat(engine): ActiveSupport::Notifications on the hot paths + opt-in LogSubscriber

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -197,6 +197,9 @@ RSpec/DescribeClass:
     - spec/phlex/reactive/streamable_morph_spec.rb
     - spec/phlex/reactive/streamable_token_spec.rb
     - spec/phlex/reactive/streamable_view_context_spec.rb
+    # render.phlex_reactive + broadcast.phlex_reactive are cross-cutting events
+    # emitted from several class methods, not one class under test (issue #107).
+    - spec/phlex/reactive/instrumentation_spec.rb
 
 # The `describe Klass, "label"` form uses the second arg as a context label
 # (e.g. `describe Component, "reactive_collection"`), not a method name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`ActiveSupport::Notifications` on the hot paths + an opt-in `LogSubscriber`
+  (#107).** The gem now emits three events under the `phlex_reactive` namespace,
+  so an APM (AppSignal, Datadog, Skylight) sees reactive traffic at the
+  **component level** — which component/action a slow request was, render time,
+  and broadcast fan-out — where before it saw nothing:
+  - `action.phlex_reactive` — one per request; payload `component`, `action`,
+    `outcome` (`ok`/`denied_undeclared`/`invalid_token`/`not_found`/`unauthorized`).
+  - `render.phlex_reactive` — per render; payload `component`, `bytesize`.
+  - `broadcast.phlex_reactive` — per `broadcast_*_to` (fires on Action Cable
+    **and** pgbus); payload `component`, `stream_action`, `streamables` count.
+
+  Payloads carry **names, the outcome, and sizes only** — never the token,
+  params, or state, so an event can't leak a secret; an `invalid_token` event has
+  no trusted component name (the token didn't verify) and omits it. Statuses and
+  the endpoint flow are unchanged — the instrument only wraps the existing paths.
+  An unsubscribed `instrument` is cheap (a few objects per call, **zero
+  retained** — measured on the render micro bench) so the hot paths carry it
+  unconditionally. Flip on `Phlex::Reactive.log_events = true` (default off) to
+  get one compact debug line per event: `[reactive] Counter#increment ok (3.1ms)`.
+  See the Observability section of the README and the performance docs page.
+
 - **`bin/rails phlex_reactive:doctor` — validate the whole install (#106).** Five
   closed issues (#3 boot/eager-load, #26 route shadowing, #42 lost request, #48
   unregistered controller, #57 importmap 404) were pure integration papercuts

--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,47 @@ See [docs/broadcasting.md](https://phlex-reactive.zoolutions.llc/docs/broadcasti
 
 ---
 
+## Observability
+
+The hot paths emit `ActiveSupport::Notifications` events, so an APM (AppSignal,
+Datadog, Skylight) sees reactive traffic at the **component level** — which
+component/action a slow request was, render time, and broadcast fan-out. Three
+events, all under the `phlex_reactive` namespace:
+
+| Event | Fires | Payload |
+|-------|-------|---------|
+| `action.phlex_reactive` | once per request | `component`, `action`, `outcome` (`ok`/`denied_undeclared`/`invalid_token`/`not_found`/`unauthorized`) |
+| `render.phlex_reactive` | per component render | `component`, `bytesize` |
+| `broadcast.phlex_reactive` | per `broadcast_*_to` (Action Cable **and** pgbus) | `component`, `stream_action`, `streamables` |
+
+Payloads carry **names, the outcome, and sizes only** — never the token, params,
+or state, so an event can't leak a secret. Subscribe from an initializer:
+
+```ruby
+ActiveSupport::Notifications.subscribe("action.phlex_reactive") do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  MyAPM.record("reactive.#{event.payload[:outcome]}", event.duration,
+    component: event.payload[:component], action: event.payload[:action])
+end
+```
+
+To watch reactive traffic in your own log without an APM, flip on the bundled
+`LogSubscriber` (default off) — one compact line per event at DEBUG:
+
+```ruby
+# config/initializers/phlex_reactive.rb
+Phlex::Reactive.log_events = true
+# [reactive] Counter#increment ok (3.1ms)
+# [reactive] render Counter 512B (0.9ms)
+# [reactive] broadcast replace Counter →2 (1.4ms)
+```
+
+The events fire whether or not you enable the LogSubscriber; the flag only
+controls the gem's own log lines. See
+[docs/performance.md](https://phlex-reactive.zoolutions.llc/docs/performance).
+
+---
+
 ## Documentation
 
 - [Installation & bundler setups](https://phlex-reactive.zoolutions.llc/docs/installation)

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -27,28 +27,55 @@ module Phlex
       wrap_parameters false if respond_to?(:wrap_parameters)
 
       def create
+        # ONE action.phlex_reactive event per request (issue #107). The event
+        # payload carries the component/action NAMES + outcome ONLY (never the
+        # token, params, or state); we fill it as those become known and set
+        # :outcome on every exit path — the success tail and each rescue. The
+        # rescue bodies are unchanged (verbose diagnostics + reactive_error per
+        # #82/#87); we only ADD the outcome finalizer. `action` is safe to read
+        # up front (it comes from the request, not the verified token).
+        event = { component: nil, action: reactive_action_name.to_s, outcome: nil }
+        Phlex::Reactive.instrument("action", event) do
+          create_action(event)
+        end
+      end
+
+      private
+
+      # The action body, run inside the instrument block so its payload (`event`)
+      # can be finalized on every exit path. Kept separate so `create` stays a
+      # thin instrument wrapper.
+      def create_action(event)
         payload = verified_payload
         component_class = resolve_component(payload["c"])
+        event[:component] = component_class.name
         action_def = component_class.reactive_action(reactive_action_name)
 
         # default-deny
-        return reactive_error(:forbidden, undeclared_action_message(component_class), kind: :forbidden) unless action_def
+        unless action_def
+          event[:outcome] = :denied_undeclared
+          return reactive_error(:forbidden, undeclared_action_message(component_class), kind: :forbidden)
+        end
 
         component = component_class.from_identity(payload)
         coerced = coerce_params(action_def.params, component_class:, action_name: action_def.name)
 
         result = run_action(component, action_def, coerced)
 
+        event[:outcome] = :ok
         render turbo_stream: response_streams(result, component)
       rescue Phlex::Reactive::InvalidToken => e
+        # The component name here came from an UNVERIFIED token — do NOT report it
+        # as trusted. Leave event[:component] nil.
+        event[:outcome] = :invalid_token
         reactive_error(:bad_request, e.message, kind: e.diagnostic || :tampered)
       rescue ActiveRecord::RecordNotFound
+        event[:outcome] = :not_found
         reactive_error(:not_found, record_not_found_message(payload), kind: :not_found)
       rescue *authorization_errors => e
+        event[:outcome] = :unauthorized
         reactive_error(:forbidden, authorization_error_message(e, component_class, action_def), kind: :forbidden)
       end
-
-      private
 
       # Reply to an endpoint failure. The status NEVER changes with any flag —
       # only the body. Precedence for the body (issue #100):

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -15,6 +15,7 @@ module Views
         def content
           overview
           hot_paths
+          observability
           measuring
           before_change
           numbers
@@ -111,6 +112,101 @@ module Views
                   plain 'per controller; CSRF + pgbus connection id stay live (they can rotate).'
                 end
               end
+            end
+          end
+        end
+
+        def observability
+          DocsUI::Section('Observability (ActiveSupport::Notifications)') do
+            DocsUI::Prose() do
+              p do
+                plain 'The hot paths emit '
+                code { 'ActiveSupport::Notifications' }
+                plain ' events so an APM (AppSignal, Datadog, Skylight) sees reactive traffic at the '
+                strong { 'component level' }
+                plain ' — which component/action a slow request was, how long a render took, and broadcast '
+                plain 'fan-out. Three events, all in the '
+                code { 'phlex_reactive' }
+                plain ' namespace:'
+              end
+              ul do
+                li do
+                  code { 'action.phlex_reactive' }
+                  plain ' — one per request. Payload: '
+                  code { 'component' }
+                  plain ', '
+                  code { 'action' }
+                  plain ', '
+                  code { 'outcome' }
+                  plain ' ('
+                  code { 'ok' }
+                  plain '/'
+                  code { 'denied_undeclared' }
+                  plain '/'
+                  code { 'invalid_token' }
+                  plain '/'
+                  code { 'not_found' }
+                  plain '/'
+                  code { 'unauthorized' }
+                  plain ').'
+                end
+                li do
+                  code { 'render.phlex_reactive' }
+                  plain ' — around each component render. Payload: '
+                  code { 'component' }
+                  plain ', '
+                  code { 'bytesize' }
+                  plain '.'
+                end
+                li do
+                  code { 'broadcast.phlex_reactive' }
+                  plain ' — around each '
+                  code { 'broadcast_*_to' }
+                  plain ' (fires on Action Cable AND pgbus). Payload: '
+                  code { 'component' }
+                  plain ', '
+                  code { 'stream_action' }
+                  plain ', '
+                  code { 'streamables' }
+                  plain ' (the key count).'
+                end
+              end
+              p do
+                strong { 'Payloads carry names, the outcome, and sizes only' }
+                plain ' — never the token, the params, or component state, so an event can never leak a '
+                plain 'secret. An '
+                code { 'invalid_token' }
+                plain ' event has no trusted component name (the token did not verify), so it is omitted.'
+              end
+              p { plain 'Subscribe from an initializer exactly as you would for any Rails event:' }
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'config/initializers/phlex_reactive_apm.rb')
+              ActiveSupport::Notifications.subscribe('action.phlex_reactive') do |*args|
+                event = ActiveSupport::Notifications::Event.new(*args)
+                # event.payload => { component:, action:, outcome: }
+                # event.duration => ms
+                MyAPM.record("reactive.\#{event.payload[:outcome]}", event.duration,
+                  component: event.payload[:component], action: event.payload[:action])
+              end
+            RUBY
+            DocsUI::Prose() do
+              p do
+                plain 'To watch reactive traffic in your own log without an APM, flip on the bundled '
+                code { 'LogSubscriber' }
+                plain ' (default off). It logs one compact line per event at DEBUG:'
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'config/initializers/phlex_reactive.rb')
+              Phlex::Reactive.log_events = true
+              # [reactive] Counter#increment ok (3.1ms)
+              # [reactive] Counter#drop_table denied_undeclared (0.2ms)
+              # [reactive] render Counter 512B (0.9ms)
+              # [reactive] broadcast replace Counter →2 (1.4ms)
+            RUBY
+            DocsUI::Callout(:tip) do
+              plain 'The events fire whether or not you enable the LogSubscriber — the flag only controls the '
+              plain "gem's own log lines. An unsubscribed instrument is cheap (a few objects per call, zero "
+              plain 'retained), so the hot paths carry it unconditionally.'
             end
           end
         end

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -19,6 +19,12 @@
 # change). Defaults to Rails.env.local? — on in development AND test, off in production.
 # Phlex::Reactive.verbose_errors = true
 
+# Log one compact line per reactive event (action/render/broadcast) at DEBUG —
+# `[reactive] Counter#increment ok (3.1ms)`. Default off. The events fire for
+# your APM regardless (ActiveSupport::Notifications, `*.phlex_reactive`); this
+# flag only controls the gem's own log lines. See the README Observability section.
+# Phlex::Reactive.log_events = true
+
 # Sign identity tokens with a dedicated key instead of secret_key_base.
 # Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
 

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -46,6 +46,13 @@ module Phlex
     # minted for phlex-reactive can't be replayed against another verifier use.
     IDENTITY_PURPOSE = "phlex-reactive/identity"
 
+    # The ActiveSupport::Notifications namespace for the gem's hot-path events
+    # (issue #107): action.phlex_reactive, render.phlex_reactive,
+    # broadcast.phlex_reactive. APM tools (AppSignal, Datadog, Skylight)
+    # auto-subscribe to `*.phlex_reactive` and get component-level visibility.
+    # Payloads carry NAMES/outcome/sizes ONLY — never the token, params, or state.
+    INSTRUMENTATION_NAMESPACE = "phlex_reactive"
+
     class << self
       # The message verifier used to sign/verify component identity tokens.
       # Defaults to a purpose-scoped verifier derived from secret_key_base.
@@ -95,6 +102,29 @@ module Phlex
         return @verbose_errors if defined?(@verbose_errors)
 
         defined?(::Rails.env) && ::Rails.env.local?
+      end
+
+      # Attach the opt-in LogSubscriber (issue #107) so each hot-path event is
+      # debug-logged as one compact line (`[reactive] Counter#increment ok
+      # (3.1ms)`). Default OFF — the events still fire for APMs regardless; this
+      # only controls the gem's own log lines. The engine reads it at boot and
+      # attaches exactly once. Set true in an initializer to see the lines.
+      attr_writer :log_events
+
+      def log_events
+        return @log_events if defined?(@log_events)
+
+        false
+      end
+
+      # Emit an `<event>.phlex_reactive` ActiveSupport::Notifications event around
+      # a block, yielding the mutable payload so a rescue can finalize the outcome
+      # (issue #107). ASN.instrument is cheap when nothing is subscribed (the hot
+      # paths depend on this — proven by the render bench), so this wraps the
+      # render/broadcast/action paths unconditionally. The payload must carry
+      # NAMES/outcome/sizes ONLY — never token/params/state.
+      def instrument(event, payload = {}, &)
+        ::ActiveSupport::Notifications.instrument("#{event}.#{INSTRUMENTATION_NAMESPACE}", payload, &)
       end
 
       def verifier

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -84,6 +84,11 @@ module Phlex
       # a one-line log pointing at the cause. No-op when the route is fine.
       config.after_initialize do
         Phlex::Reactive.warn_unless_action_route_mounted!
+
+        # Attach the opt-in LogSubscriber (issue #107) exactly once, only when
+        # the app enabled it. attach_to is idempotent-safe here because this runs
+        # once per boot; the events fire for APMs regardless of this flag.
+        Phlex::Reactive::LogSubscriber.attach_to(:phlex_reactive) if Phlex::Reactive.log_events
       end
     end
   end

--- a/lib/phlex/reactive/log_subscriber.rb
+++ b/lib/phlex/reactive/log_subscriber.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "active_support/log_subscriber"
+
+module Phlex
+  module Reactive
+    # Opt-in LogSubscriber (issue #107): turns each hot-path event into ONE
+    # compact debug line, so a developer can watch reactive traffic in the log
+    # without an APM:
+    #
+    #   [reactive] Counter#increment ok (3.1ms)
+    #   [reactive] Counter#drop_table denied_undeclared (0.2ms)
+    #   [reactive] render Counter 512B (0.9ms)
+    #   [reactive] broadcast replace Counter →2 (1.4ms)
+    #
+    # Default OFF — the events fire for APMs regardless of this; attaching the
+    # subscriber only adds the gem's own log lines. The engine attaches it once
+    # at boot when Phlex::Reactive.log_events is true. Lines are logged at DEBUG,
+    # so they're invisible unless the app's log level allows it.
+    #
+    # Payloads carry NAMES/outcome/sizes ONLY (never token/params/state), so
+    # these lines can never leak a secret. A :invalid_token event has no trusted
+    # component name (the token didn't verify), so the line omits the `Class#`
+    # prefix rather than echo an unverified class.
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      def action(event)
+        return unless logger.debug?
+
+        payload = event.payload
+        subject =
+          if payload[:component]
+            "#{payload[:component]}##{payload[:action]}"
+          else
+            # No trusted component (invalid token) — name the action alone.
+            payload[:action]
+          end
+        debug { "[reactive] #{subject} #{payload[:outcome]} (#{round(event.duration)}ms)" }
+      end
+
+      def render(event)
+        return unless logger.debug?
+
+        payload = event.payload
+        debug { "[reactive] render #{payload[:component]} #{payload[:bytesize]}B (#{round(event.duration)}ms)" }
+      end
+
+      def broadcast(event)
+        return unless logger.debug?
+
+        payload = event.payload
+        debug do
+          "[reactive] broadcast #{payload[:stream_action]} #{payload[:component]} " \
+            "→#{payload[:streamables]} (#{round(event.duration)}ms)"
+        end
+      end
+
+      private
+
+      def round(duration_ms)
+        duration_ms.round(1)
+      end
+    end
+  end
+end

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -151,7 +151,16 @@ module Phlex
         # view context still carries the full Rails helper set, so
         # dom_id/url_for/t()/csrf keep working during a re-render or broadcast.
         def render_component(component)
-          component.render_in(turbo_view_context)
+          # render.phlex_reactive (issue #107): the pure render cost — the unit
+          # an APM most wants (broadcast fan-out renders once per stream key).
+          # Payload carries the component NAME + html bytesize ONLY. bytesize is
+          # known only after rendering, so we mutate the payload inside the block.
+          event = { component: name, bytesize: 0 }
+          Phlex::Reactive.instrument("render", event) do
+            html = component.render_in(turbo_view_context)
+            event[:bytesize] = html.bytesize
+            html
+          end
         end
 
         # `morph: true` emits `<turbo-stream action="replace" method="morph">` so
@@ -201,44 +210,59 @@ module Phlex
         # so a peer tab keeps its focus/caret on the morphed row. The broadcast
         # path takes EXTRA <turbo-stream> attributes via `attributes:` (not the
         # TagBuilder's `method:` kwarg), so the morph flag rides there.
+        # Each broadcast_*_to wraps its body in a broadcast.phlex_reactive event
+        # (issue #107) via instrument_broadcast — the stream action + streamables
+        # COUNT + component name, never the model/state. The event fires on BOTH
+        # transports (Action Cable AND pgbus): it wraps this class-method body,
+        # which is the same on either, so pgbus optionality is preserved.
         def broadcast_replace_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          component = build(model, options)
-          ::Turbo::StreamsChannel.broadcast_replace_to(
-            *streamables, target: component.id, html: render_component(component),
-            **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("replace", streamables) do
+            component = build(model, options)
+            ::Turbo::StreamsChannel.broadcast_replace_to(
+              *streamables, target: component.id, html: render_component(component),
+              **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         def broadcast_update_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
-          component = build(model, options)
-          ::Turbo::StreamsChannel.broadcast_update_to(
-            *streamables, target: component.id, html: render_component(component),
-            **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("update", streamables) do
+            component = build(model, options)
+            ::Turbo::StreamsChannel.broadcast_update_to(
+              *streamables, target: component.id, html: render_component(component),
+              **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         def broadcast_append_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          component = build(model, options)
-          ::Turbo::StreamsChannel.broadcast_append_to(
-            *streamables, target:, html: render_component(component),
-            **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("append", streamables) do
+            component = build(model, options)
+            ::Turbo::StreamsChannel.broadcast_append_to(
+              *streamables, target:, html: render_component(component),
+              **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         def broadcast_prepend_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          component = build(model, options)
-          ::Turbo::StreamsChannel.broadcast_prepend_to(
-            *streamables, target:, html: render_component(component),
-            **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("prepend", streamables) do
+            component = build(model, options)
+            ::Turbo::StreamsChannel.broadcast_prepend_to(
+              *streamables, target:, html: render_component(component),
+              **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         def broadcast_remove_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
-          component = build(model, options)
-          ::Turbo::StreamsChannel.broadcast_remove_to(
-            *streamables, target: component.id,
-            **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("remove", streamables) do
+            component = build(model, options)
+            ::Turbo::StreamsChannel.broadcast_remove_to(
+              *streamables, target: component.id,
+              **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         # Push server-side client DOM ops to EVERY subscriber of a stream (issue
@@ -261,18 +285,33 @@ module Phlex
         # actor-reply concern only (Response#js), so it raises ArgumentError here
         # rather than silently shipping a hostile-feeling broadcast.
         def broadcast_js_to(*streamables, ops, exclude: nil, visible_to: nil, target: nil)
-          json = broadcast_js_ops_json(ops)
-          ::Turbo::StreamsChannel.broadcast_action_to(
-            *streamables,
-            action: "reactive:js",
-            target: target,
-            attributes: { data: { reactive_ops: json } },
-            render: false,
-            **broadcast_transport_opts(exclude:, visible_to:)
-          )
+          instrument_broadcast("reactive:js", streamables) do
+            json = broadcast_js_ops_json(ops)
+            ::Turbo::StreamsChannel.broadcast_action_to(
+              *streamables,
+              action: "reactive:js",
+              target: target,
+              attributes: { data: { reactive_ops: json } },
+              render: false,
+              **broadcast_transport_opts(exclude:, visible_to:)
+            )
+          end
         end
 
         private
+
+        # Wrap a broadcast_*_to body in a broadcast.phlex_reactive event (issue
+        # #107). Payload: the component NAME, the Turbo stream action, and the
+        # streamables COUNT — never the model/state. Fires on both transports
+        # because it wraps the shared class-method body. Returns the block's value
+        # (the broadcast result) so callers are unaffected.
+        def instrument_broadcast(stream_action, streamables, &)
+          Phlex::Reactive.instrument(
+            "broadcast",
+            { component: name, stream_action: stream_action, streamables: streamables.size },
+            &
+          )
+        end
 
         # Validate + serialize broadcast ops: reject focus-class ops (they steal
         # focus in every tab) and an empty chain (a dead broadcast), then return

--- a/spec/phlex/reactive/instrumentation_spec.rb
+++ b/spec/phlex/reactive/instrumentation_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "turbo/broadcastable/test_helper"
+
+# The render and broadcast hot paths emit ActiveSupport::Notifications events
+# (issue #107) carrying only NAMES/sizes — never token/params/state — so an APM
+# sees render time and broadcast fan-out at the component level.
+RSpec.describe "render + broadcast instrumentation" do
+  def capture(name)
+    events = []
+    sub = ActiveSupport::Notifications.subscribe(name) do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  describe "render.phlex_reactive" do
+    it "fires around render_component with the component name and html bytesize" do
+      events = capture("render.phlex_reactive") do
+        CounterComponent.render_component(CounterComponent.new(count: 1))
+      end
+      expect(events.size).to eq(1)
+      payload = events.first.payload
+      expect(payload[:component]).to eq("CounterComponent")
+      expect(payload[:bytesize]).to be > 0
+      expect(payload.keys).to contain_exactly(:component, :bytesize)
+    end
+  end
+
+  describe "broadcast.phlex_reactive" do
+    include Turbo::Broadcastable::TestHelper
+
+    it "fires around a broadcast with the component name, stream action and streamables count" do
+      events = capture("broadcast.phlex_reactive") do
+        CounterComponent.broadcast_replace_to("room", :counters, model: nil, count: 3)
+      end
+      expect(events.size).to eq(1)
+      payload = events.first.payload
+      expect(payload[:component]).to eq("CounterComponent")
+      expect(payload[:stream_action]).to eq("replace")
+      expect(payload[:streamables]).to eq(2) # "room", :counters
+      expect(payload).not_to have_key(:model)
+    end
+
+    it "fires for remove too (no rendered body)" do
+      events = capture("broadcast.phlex_reactive") do
+        CounterComponent.broadcast_remove_to("room", model: nil, count: 3)
+      end
+      expect(events.first.payload[:stream_action]).to eq("remove")
+    end
+  end
+end

--- a/spec/phlex/reactive/log_subscriber_spec.rb
+++ b/spec/phlex/reactive/log_subscriber_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The opt-in LogSubscriber turns each hot-path event into one compact debug line
+# (issue #107). Default off; attached by the engine when Phlex::Reactive.log_events
+# is set. Driven here directly with synthesized events so we assert the exact
+# formatted line without touching the live notification bus.
+RSpec.describe Phlex::Reactive::LogSubscriber do
+  def line_for(event_name, payload)
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.level = Logger::DEBUG
+    subscriber = described_class.new
+    allow(subscriber).to receive(:logger).and_return(logger)
+    event = ActiveSupport::Notifications::Event.new(event_name, Time.now, Time.now, "id", payload)
+    subscriber.public_send(event_name.split(".").first, event)
+    io.string
+  end
+
+  it "formats a successful action line" do
+    line = line_for("action.phlex_reactive", component: "Counter", action: "increment", outcome: :ok)
+    expect(line).to match(/\[reactive\] Counter#increment ok \(\d/)
+  end
+
+  it "formats a denied action line" do
+    line = line_for("action.phlex_reactive", component: "Counter", action: "drop_table", outcome: :denied_undeclared)
+    expect(line).to include("[reactive] Counter#drop_table denied_undeclared")
+  end
+
+  it "formats an invalid-token line without a trusted component name" do
+    line = line_for("action.phlex_reactive", component: nil, action: "increment", outcome: :invalid_token)
+    expect(line).to include("invalid_token")
+    expect(line).not_to include("#increment") # no trusted component to prefix
+  end
+
+  it "formats a render line" do
+    line = line_for("render.phlex_reactive", component: "Counter", bytesize: 512)
+    expect(line).to match(/\[reactive\] render Counter 512B \(\d/)
+  end
+
+  it "formats a broadcast line" do
+    line = line_for("broadcast.phlex_reactive", component: "Counter", stream_action: "replace", streamables: 2)
+    expect(line).to match(/\[reactive\] broadcast replace Counter →2 \(\d/)
+  end
+
+  it "logs nothing when the level is above DEBUG" do
+    io = StringIO.new
+    logger = Logger.new(io)
+    logger.level = Logger::INFO
+    subscriber = described_class.new
+    allow(subscriber).to receive(:logger).and_return(logger)
+    event = ActiveSupport::Notifications::Event.new(
+      "action.phlex_reactive", Time.now, Time.now, "id", { component: "Counter", action: "increment", outcome: :ok }
+    )
+    subscriber.action(event)
+    expect(io.string).to be_empty
+  end
+end

--- a/spec/requests/instrumentation_spec.rb
+++ b/spec/requests/instrumentation_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The action endpoint emits ONE `action.phlex_reactive` ActiveSupport::Notifications
+# event per request (issue #107), carrying the component/action NAMES, the
+# outcome, and duration — never the token, params, or state. APM tools
+# (AppSignal, Datadog, Skylight) auto-subscribe to `*.phlex_reactive` and get
+# component-level visibility they had none of before.
+RSpec.describe "action.phlex_reactive instrumentation", type: :request do
+  # Collect every action event fired during the block.
+  def capture_action_events
+    events = []
+    sub = ActiveSupport::Notifications.subscribe("action.phlex_reactive") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  let(:todo) { Todo.create!(title: "x") }
+
+  it "emits :ok with the component + action names on a successful action" do
+    events = capture_action_events do
+      post_action(CounterComponent, act: "increment", payload: { "s" => { "count" => 1 } })
+    end
+    expect(response).to have_http_status(:ok)
+    expect(events.size).to eq(1)
+    payload = events.first.payload
+    expect(payload[:component]).to eq("CounterComponent")
+    expect(payload[:action]).to eq("increment")
+    expect(payload[:outcome]).to eq(:ok)
+    expect(events.first.duration).to be >= 0
+  end
+
+  it "emits :denied_undeclared for an undeclared action (default-deny)" do
+    events = capture_action_events do
+      post_action(CounterComponent, act: "drop_table", payload: { "s" => { "count" => 1 } })
+    end
+    expect(response).to have_http_status(:forbidden)
+    expect(events.first.payload[:outcome]).to eq(:denied_undeclared)
+    expect(events.first.payload[:action]).to eq("drop_table")
+  end
+
+  it "emits :invalid_token WITHOUT trusting the unverified component name" do
+    events = capture_action_events do
+      post "/reactive/actions",
+        params: { token: "garbage.token.value", act: "increment", params: {} }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+    end
+    expect(response).to have_http_status(:bad_request)
+    payload = events.first.payload
+    expect(payload[:outcome]).to eq(:invalid_token)
+    # The component name comes from an UNVERIFIED token — it must NOT be reported
+    # as if trusted. nil is acceptable; a truthy trusted class name is not.
+    expect(payload[:component]).to be_nil
+  end
+
+  it "emits :not_found when the record vanished" do
+    gid = todo.to_gid.to_s
+    todo.destroy!
+    events = capture_action_events do
+      post_action(TodoItemComponent, act: "toggle", payload: { "gid" => gid })
+    end
+    expect(response).to have_http_status(:not_found)
+    expect(events.first.payload[:outcome]).to eq(:not_found)
+  end
+
+  it "emits :unauthorized when the action raises a registered authorization error" do
+    events = capture_action_events do
+      post_action(CounterComponent, act: "boom", payload: { "s" => { "count" => 1 } })
+    end
+    expect(response).to have_http_status(:forbidden)
+    expect(events.first.payload[:outcome]).to eq(:unauthorized)
+  end
+
+  describe "the payload never carries secrets" do
+    it "has no token, params, or state key on any outcome" do
+      events = capture_action_events do
+        post_action(CounterComponent, act: "set",
+          payload: { "s" => { "count" => 1 } }, params: { count: 99, secret: "leak" })
+      end
+      payload = events.first.payload
+      expect(payload.keys).to contain_exactly(:component, :action, :outcome)
+      # Belt-and-suspenders: no value anywhere mentions the posted secret.
+      expect(payload.values.join).not_to include("leak")
+      expect(payload.values.join).not_to include("99")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Emits three `ActiveSupport::Notifications` events on the hot paths so an APM (AppSignal, Datadog, Skylight) sees reactive traffic at the **component level** — which component/action a slow request was, render time, and broadcast fan-out. Before this, there was not a single `ASN.instrument` call in the gem and APMs saw nothing component-level.

| Event | Fires | Payload |
|-------|-------|---------|
| `action.phlex_reactive` | once per request | `component`, `action`, `outcome` (`ok`/`denied_undeclared`/`invalid_token`/`not_found`/`unauthorized`) |
| `render.phlex_reactive` | per component render | `component`, `bytesize` |
| `broadcast.phlex_reactive` | per `broadcast_*_to` (Action Cable **and** pgbus) | `component`, `stream_action`, `streamables` |

Plus an opt-in `Phlex::Reactive::LogSubscriber` (default off) that logs one compact debug line per event:

```
[reactive] Counter#increment ok (3.1ms)
[reactive] Counter#drop_table denied_undeclared (0.2ms)
[reactive] render Counter 512B (0.9ms)
[reactive] broadcast replace Counter →2 (1.4ms)
```

## Design

- **One `action.phlex_reactive` per request.** `create` is now a thin instrument wrapper around `create_action(event)`; the outcome is set on every exit path — the success tail and each rescue. The rescue bodies are otherwise **unchanged** (the #82/#87 verbose diagnostics + `reactive_error` flow are untouched); I only ADD the `event[:outcome]` finalizer.
- **`:invalid_token` never trusts the component name.** When the token fails to verify, `event[:component]` stays `nil` — the name would come from an unverified/garbage token. The LogSubscriber line omits the `Class#` prefix accordingly.
- **Broadcasts fire on both transports.** Each `broadcast_*_to` wraps its body in `instrument_broadcast(action, streamables) { … }`, which wraps the shared class-method body that's identical on Action Cable and pgbus — so the event fires regardless of transport. pgbus optionality is preserved.
- **Payloads carry names, outcome, and sizes ONLY** — never the token, params, or state. An explicit spec asserts the action payload keys are exactly `component`/`action`/`outcome` and that a posted secret never appears in any value.
- **Statuses and the endpoint flow are unchanged** — the instrument only wraps existing paths.

## Benchmark (mandatory — render + action are declared hot paths)

Same machine (Darwin arm64, Ruby 3.4.2), render micro bench. An unsubscribed `ASN.instrument` is cheap but non-zero; the honest signal is allocations (deterministic), since throughput is noisy run-to-run.

**Allocations (deterministic):**

| | before | after | delta |
|---|---|---|---|
| `render_component` objects | 113 | 115 | +2 |
| `to_stream_replace` objects | 205 | 207 | +2 |
| `render_component` bytes | 17081 | 17321 | +240 |
| retained per render | 0 | 0 | 0 |

**Isolated per-call cost** (`GC.stat(:total_allocated_objects)`):
- bare unsubscribed `instrument`: ~4 objects/call
- `render_component` instrumented (184) vs raw `render_in` (177) = **+7 objects** for the wrap
- **retained: 0** (no leak)

**Throughput (i/s):** moves within run-to-run noise (±6–16% bands overlap) — `render_component` reads 10.1k–11.6k across repeated runs vs a 12.9k baseline in the same noise band. No request-throughput impact (the Rails stack + DB dominate a full request; this is the intended, negligible price of component-level observability).

## Test Coverage

- **`spec/requests/instrumentation_spec.rb`** — each of the 5 outcomes emits `action.phlex_reactive` with the right payload; `:invalid_token` reports no trusted component; an explicit **no-secrets** spec (keys are exactly `component`/`action`/`outcome`; the posted secret/param value never appears).
- **`spec/phlex/reactive/instrumentation_spec.rb`** — `render.phlex_reactive` (component + bytesize) and `broadcast.phlex_reactive` (component + stream action + streamables count, incl. `remove` with no body), asserted on the Action Cable path.
- **`spec/phlex/reactive/log_subscriber_spec.rb`** — every line format, the untrusted invalid-token line, and silence when the log level is above DEBUG.

## Docs

- README **Observability** section (event table + APM subscribe snippet + `log_events`).
- Performance docs page **Observability** section.
- CHANGELOG entry; the install-generator initializer template documents `log_events`.

## Verification

- `bundle exec rubocop` — 153 files, no offenses; docs RuboCop clean.
- `bundle exec rspec spec/phlex spec/requests spec/generators` — 508 examples, 0 failures.

## Invariants

No state/token in payloads · statuses/flow unchanged · pgbus optional (the broadcast event fires on both transports).

Closes #107
