### PR TITLE
feat(client): debug mode — console.group every dispatch (devtools-lite) (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Client debug mode (devtools-lite) — `console.group` every dispatch (#108).**
+  The `LogSubscriber` (#107) is the *server* lens; this is the *client* one. Set
+  `Phlex::Reactive.debug = true` (default off; the initializer template suggests
+  `Rails.env.development?`) and `reactive_attrs`/`reactive_root` stamp
+  `data-reactive-debug="true"` on the root — the string `"true"`, not a
+  boolean-true attr, which Phlex renders valueless and the client would read as
+  falsy. The generic controller then `console.group`s **every dispatch** with the
+  action, the explicit param **names** + collected sibling-field **names** (never
+  their values — they may be sensitive), the request encoding (`json`/`multipart`),
+  the HTTP status, the response's stream actions + targets (parsed from the body
+  the controller **already read** — no re-fetch), whether a token refresh arrived
+  (a boolean — **never the token value**), and the round-trip ms:
+  `▼ reactive #todo_42 rename → 200 (48ms)`. This finally surfaces the
+  *successful-but-wrong* path (the #30/#44/#46/#50 token-threading series: which
+  streams arrived? did a refresh come?), which `console.error` + the #79 lifecycle
+  events never covered. **Zero cost when off** — one attribute check per dispatch,
+  no string building — measured on the render/token micro benches: **0 extra
+  allocations** per render and no throughput change. See the Client debug mode
+  section of the README.
+
 - **`ActiveSupport::Notifications` on the hot paths + an opt-in `LogSubscriber`
   (#107).** The gem now emits three events under the `phlex_reactive` namespace,
   so an APM (AppSignal, Datadog, Skylight) sees reactive traffic at the

--- a/README.md
+++ b/README.md
@@ -1699,6 +1699,37 @@ The events fire whether or not you enable the LogSubscriber; the flag only
 controls the gem's own log lines. See
 [docs/performance.md](https://phlex-reactive.zoolutions.llc/docs/performance).
 
+### Client debug mode (devtools-lite)
+
+The `LogSubscriber` above is the **server** lens. The client lens is
+`console.error` on a failure plus the [lifecycle events](#failure-ux--lifecycle-events)
+— but on the *successful-but-wrong* path (which streams arrived? did a token
+refresh come?) there was nothing to see. `Phlex::Reactive.debug` fills that gap:
+
+```ruby
+# config/initializers/phlex_reactive.rb
+Phlex::Reactive.debug = Rails.env.development?
+```
+
+With it on, every reactive root carries `data-reactive-debug="true"` and the
+generic controller `console.group`s **every dispatch** in the browser:
+
+```
+▼ reactive #todo_42 rename → 200 (48ms)
+    params: [title] + collected: [title]
+    encoding: json
+    streams: replace → #todo_42
+    token: refreshed ✓
+```
+
+The trace carries **names and outcomes only** — the explicit param names and the
+collected sibling-field names (never their **values**, which may be sensitive),
+the request encoding (`json`/`multipart`), the HTTP status, the response's stream
+actions + targets, whether a token refresh arrived (**never the token value**),
+and the round-trip time. Off (the default) it does nothing — a single attribute
+check per dispatch, no string building — so it is safe to leave gated on
+`Rails.env.development?`.
+
 ---
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1714,7 +1714,7 @@ Phlex::Reactive.debug = Rails.env.development?
 With it on, every reactive root carries `data-reactive-debug="true"` and the
 generic controller `console.group`s **every dispatch** in the browser:
 
-```
+```text
 ▼ reactive #todo_42 rename → 200 (48ms)
     params: [title] + collected: [title]
     encoding: json

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -1123,6 +1123,68 @@ export default class extends Controller {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
+  // Client debug mode (issue #108) — the "devtools-lite" lens. On when the Ruby
+  // reactive_attrs stamped data-reactive-debug="true" (Phlex::Reactive.debug).
+  // Read live (a single getAttribute) so the whole feature is inert for any app
+  // that never opts in: OFF → this returns false and #perform builds no debug
+  // object, parses no response, and logs nothing (the "zero cost when off"
+  // invariant — one nil-check per dispatch). Guarded for a stub root with no
+  // getAttribute (unit harnesses) so it degrades to off, never throwing.
+  #debugEnabled() {
+    return this.element?.getAttribute?.("data-reactive-debug") === "true"
+  }
+
+  // A monotonic timestamp for the round-trip duration (ms). performance.now is
+  // monotonic (immune to a wall-clock adjustment mid-request); Date.now is the
+  // fallback for an exotic environment without it. ONLY called on the debug path,
+  // so it costs nothing when debug is off.
+  #debugNow() {
+    return typeof performance !== "undefined" && typeof performance.now === "function"
+      ? performance.now()
+      : Date.now()
+  }
+
+  // Parse a turbo-stream response's action + target pairs for the debug trace,
+  // from the body text #perform ALREADY read (never a re-fetch). NAMES only — the
+  // <template> contents (rendered HTML, the fresh token) are deliberately not
+  // touched. A non-turbo-stream / empty body yields [] (nothing to report).
+  #debugStreams(body) {
+    if (!body) return []
+    const streams = []
+    const re = /<turbo-stream\b([^>]*)>/g
+    let match
+    while ((match = re.exec(body)) !== null) {
+      const attrs = match[1]
+      const action = attrs.match(/\baction="([^"]*)"/)?.[1] ?? "?"
+      const target = attrs.match(/\btarget="([^"]*)"/)?.[1]
+      streams.push(target ? `${action} → #${target}` : action)
+    }
+    return streams
+  }
+
+  // console.group ONE dispatch (issue #108). Carries NAMES + outcomes ONLY — the
+  // signed token VALUE and every field/param VALUE are deliberately absent (they
+  // may be sensitive; the whole point is observability without leaking data). The
+  // caller passes the info it already holds so nothing is recomputed or re-fetched:
+  //   { action, paramNames, fieldNames, encoding, status, streams, tokenRefreshed, ms }
+  // `console.groupCollapsed` keeps the console tidy (one collapsed line per action).
+  #logDispatch(info) {
+    const { action, status, ms } = info
+    // The client can't name the component CLASS (it's inside the signed, opaque
+    // token — never decoded here), but the root's id is the stable client-side
+    // handle (e.g. #todo_42), so the header reads `reactive #todo_42 rename → …`.
+    const who = this.element?.id ? `#${this.element.id} ` : ""
+    const header = `reactive ${who}${action} → ${status ?? "—"} (${Math.round(ms)}ms)`
+    /* eslint-disable no-console */
+    console.groupCollapsed(header)
+    console.log(`params: [${info.paramNames.join(", ")}] + collected: [${info.fieldNames.join(", ")}]`)
+    console.log(`encoding: ${info.encoding}`)
+    if (info.streams.length) console.log(`streams: ${info.streams.join("   ")}`)
+    console.log(`token: ${info.tokenRefreshed ? "refreshed ✓" : "unchanged"}`)
+    console.groupEnd()
+    /* eslint-enable no-console */
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -1141,6 +1203,25 @@ export default class extends Controller {
     const body = multipart
       ? this.#buildFormData(token, action, allParams, files)
       : JSON.stringify({ token, act: action, params: allParams })
+
+    // Client debug mode (issue #108): build the trace object ONLY when debug is on
+    // (one nil-check otherwise — zero cost off). It carries NAMES only: the
+    // explicit trigger param names and the collected sibling field names, split so
+    // the group shows `params: [...] + collected: [...]`. status/streams/
+    // tokenRefreshed are filled in at the branch that knows them; the group is
+    // emitted once in the finally so EVERY exit (success or any failure) logs.
+    const debug = this.#debugEnabled()
+      ? {
+          action,
+          paramNames: Object.keys(this.#parseParams(params)),
+          fieldNames: Object.keys(fields),
+          encoding: multipart ? "multipart" : "json",
+          status: null,
+          streams: [],
+          tokenRefreshed: false,
+          started: this.#debugNow(),
+        }
+      : null
 
     // aria-busy on the root is now driven by the loading pending counter
     // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
@@ -1232,6 +1313,12 @@ export default class extends Controller {
         return
       }
 
+      // Debug (issue #108): the server answered — record the status for the trace
+      // now, so every response branch below (redirected/http/content-type/ok) logs
+      // it. The transport-failure branches above return before here (they have no
+      // status); their group still fires from the finally with status null → "—".
+      if (debug) debug.status = response.status
+
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
         this.#revertOptimistic(inverse)
@@ -1252,7 +1339,9 @@ export default class extends Controller {
         // retry-valid — do not "fix" that). A non-turbo-stream body is left to the
         // console.error above (an HTML error page must not be handed to Turbo).
         if ((response.headers.get("Content-Type") || "").includes("turbo-stream")) {
-          this.#currentToken = this.#extractToken(errorBody) ?? this.#currentToken
+          const fresh = this.#extractToken(errorBody)
+          this.#currentToken = fresh ?? this.#currentToken
+          if (debug) this.#debugRecordBody(debug, errorBody, fresh)
           window.Turbo.renderStreamMessage(errorBody)
         }
         this.#markError("http")
@@ -1272,7 +1361,12 @@ export default class extends Controller {
       const html = await response.text()
       // Capture the new token from the response synchronously, so the next
       // queued request uses it without waiting for the async DOM morph.
-      this.#currentToken = this.#extractToken(html) ?? this.#currentToken
+      const fresh = this.#extractToken(html)
+      this.#currentToken = fresh ?? this.#currentToken
+      // Debug (issue #108): record the stream actions/targets + whether a refresh
+      // arrived, from the body we JUST read (reuse — no second text() read). Never
+      // the token or template contents.
+      if (debug) this.#debugRecordBody(debug, html, fresh)
       // Turbo applies the <turbo-stream> ops by id. A plain replace is an
       // outerHTML swap (focus on the replaced subtree is lost); a method="morph"
       // replace (Response.morph) or an update morphs in place, preserving the
@@ -1302,7 +1396,21 @@ export default class extends Controller {
       // guarded so a morph-replaced trigger is never clobbered. Runs on EVERY
       // exit (success, every failure branch, or an apply throw).
       settle?.()
+      // Debug (issue #108): emit the group here so EVERY exit path logs exactly
+      // once — success, any transport/response failure, or an apply throw. Null
+      // when debug is off (zero cost). The round-trip ms is measured now, at the
+      // finally, so it spans the whole #perform (fetch + apply) regardless of exit.
+      if (debug) this.#logDispatch({ ...debug, ms: this.#debugNow() - debug.started })
     }
+  }
+
+  // Debug (issue #108): fold the response body #perform already read into the
+  // trace — the stream action/target pairs and whether a token refresh arrived
+  // (a boolean; the token VALUE is intentionally not stored). Shared by the
+  // success and the non-OK-turbo-stream branches so both log the same shape.
+  #debugRecordBody(debug, body, freshToken) {
+    debug.streams = this.#debugStreams(body)
+    debug.tokenRefreshed = freshToken != null
   }
 
   get #currentToken() {

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -1191,7 +1191,14 @@ export default class extends Controller {
     // chosen file inputs in the SAME walk. Explicit params
     // (data-reactive-params-param) win over collected fields.
     const { fields, files } = this.#collectFields()
-    const allParams = { ...fields, ...this.#parseParams(params) }
+    // Parse the explicit trigger params ONCE — reused below for allParams and, on
+    // the debug path, for the params-only name list (so the trace can show
+    // `params: [...]` distinct from the collected `+ collected: [...]`). #parseParams
+    // is pure (a fresh object from a JSON string, or the same object by reference
+    // when already parsed); allParams spreads a COPY and nothing mutates parsedParams
+    // downstream (JSON.stringify / #buildFormData read allParams, a new object).
+    const parsedParams = this.#parseParams(params)
+    const allParams = { ...fields, ...parsedParams }
     const token = this.#currentToken
 
     // File/multipart path (issue #34): if THIS root has a populated
@@ -1213,7 +1220,7 @@ export default class extends Controller {
     const debug = this.#debugEnabled()
       ? {
           action,
-          paramNames: Object.keys(this.#parseParams(params)),
+          paramNames: Object.keys(parsedParams),
           fieldNames: Object.keys(fields),
           encoding: multipart ? "multipart" : "json",
           status: null,

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -208,6 +208,50 @@ module Views
               plain "gem's own log lines. An unsubscribed instrument is cheap (a few objects per call, zero "
               plain 'retained), so the hot paths carry it unconditionally.'
             end
+            DocsUI::Prose() do
+              h3 { 'Client debug mode (devtools-lite)' }
+              p do
+                plain 'The '
+                code { 'LogSubscriber' }
+                plain ' above is the '
+                strong { 'server' }
+                plain ' lens. The '
+                strong { 'client' }
+                plain ' lens is '
+                code { 'console.error' }
+                plain ' on a failure plus the lifecycle events — but on the '
+                em { 'successful-but-wrong' }
+                plain ' path (which streams arrived? did a token refresh come?) there was nothing to see. '
+                code { 'Phlex::Reactive.debug' }
+                plain ' fills that gap: turn it on and every reactive root carries '
+                code { 'data-reactive-debug="true"' }
+                plain ', so the generic controller '
+                code { 'console.group' }
+                plain 's every dispatch in the browser.'
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'config/initializers/phlex_reactive.rb')
+              Phlex::Reactive.debug = Rails.env.development?
+            RUBY
+            DocsUI::Code(<<~TEXT, lexer: :text, filename: 'browser console')
+              ▼ reactive #todo_42 rename → 200 (48ms)
+                  params: [title] + collected: [title]
+                  encoding: json
+                  streams: replace → #todo_42
+                  token: refreshed ✓
+            TEXT
+            DocsUI::Callout(:tip) do
+              strong { 'Names and outcomes only.' }
+              plain ' The trace shows the param and collected-field '
+              strong { 'names' }
+              plain ' (never their values — they may be sensitive), the encoding, the status, the response '
+              plain 'stream actions + targets, whether a token refresh arrived ('
+              strong { 'never the token value' }
+              plain '), and the round-trip ms. Off (the default) it does nothing — one attribute check per '
+              plain 'dispatch, no string building — so leave it gated on '
+              code { 'Rails.env.development?' }
+              plain '.'
+            end
           end
         end
 

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -25,6 +25,14 @@
 # flag only controls the gem's own log lines. See the README Observability section.
 # Phlex::Reactive.log_events = true
 
+# Client debug mode (devtools-lite). When on, every reactive root carries
+# data-reactive-debug="true" and the browser console.groups EVERY dispatch —
+# action, param/collected field NAMES (never values), request encoding, HTTP
+# status, the response's stream actions + targets, whether a token refresh
+# arrived (never the token value), and the round-trip ms. Off by default; safe to
+# gate on development (off → one attribute check per dispatch, zero string building).
+# Phlex::Reactive.debug = Rails.env.development?
+
 # Sign identity tokens with a dedicated key instead of secret_key_base.
 # Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
 

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -117,6 +117,24 @@ module Phlex
         false
       end
 
+      # Client debug mode (issue #108): the "devtools-lite" lens on the reactive
+      # round trip. When true, reactive_attrs (and so reactive_root) stamps
+      # data-reactive-debug="true" on the root, and the generic controller
+      # console.groups every dispatch — action, param/collected NAMES (never
+      # values), request encoding, HTTP status, the response's stream actions +
+      # targets, whether a token refresh arrived (never the token VALUE), and the
+      # round-trip ms. Default OFF (the initializer template suggests
+      # Rails.env.development?); zero cost when off (one nil-check per dispatch, no
+      # attr, no string building). The `defined?` guard (not `||=`) makes an
+      # explicit `= false` stick even where a truthy default might otherwise apply.
+      attr_writer :debug
+
+      def debug
+        return @debug if defined?(@debug)
+
+        false
+      end
+
       # Emit an `<event>.phlex_reactive` ActiveSupport::Notifications event around
       # a block, yielding the mutable payload so a rescue can finalize the outcome
       # (issue #107). ASN.instrument is cheap when nothing is subscribed (the hot

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -354,12 +354,17 @@ module Phlex
       # signed identity token. Spread onto the root:
       #   div(id:, **reactive_attrs) { ... }
       def reactive_attrs
-        {
-          data: {
-            controller: "reactive",
-            reactive_token_value: reactive_token
-          }
+        data = {
+          controller: "reactive",
+          reactive_token_value: reactive_token
         }
+        # Client debug mode (issue #108): stamp the flag so the generic controller
+        # console.groups every dispatch. STRING "true", not boolean — Phlex renders
+        # a boolean-true attr VALUELESS, which getAttribute reads as "" (falsy in
+        # JS), so the client's attr check would never fire (the on()/warn_unsaved
+        # precedent). Off by default → no key, no string, zero client surface.
+        data[:reactive_debug] = "true" if Phlex::Reactive.debug
+        { data: }
       end
 
       # The WHOLE reactive root in one spread (issue #48). reactive_attrs alone

--- a/spec/dummy/app/controllers/demos_controller.rb
+++ b/spec/dummy/app/controllers/demos_controller.rb
@@ -10,6 +10,19 @@ class DemosController < ActionController::Base
     render_component CounterComponent.new(count: 0)
   end
 
+  # Client debug mode (issue #108). Force Phlex::Reactive.debug ON around THIS
+  # render so the root carries data-reactive-debug="true"; the generic controller
+  # then console.groups every dispatch. The spec overrides console.group to write
+  # into a probe node and asserts the trace was emitted (with NAMES, never the
+  # token/values). Restore the flag after — a global toggled for one page only.
+  def debug
+    was = Phlex::Reactive.debug
+    Phlex::Reactive.debug = true
+    render_component CounterComponent.new(count: 0)
+  ensure
+    Phlex::Reactive.debug = was
+  end
+
   # User-visible failure surface (issue #100): a boom (undeclared → 403 with an
   # error_flash), a success that clears data-reactive-error, and a self-dismissing
   # flash. The page carries a server-rendered <template data-reactive-error-flash>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   # Example pages exercised by system specs.
   get "counter" => "demos#counter"
+  get "debug" => "demos#debug"
   get "failure_surface" => "demos#failure_surface"
   get "network_status" => "demos#network_status"
   get "latency" => "demos#latency"

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -1123,6 +1123,68 @@ export default class extends Controller {
     return new Promise((resolve) => setTimeout(resolve, ms))
   }
 
+  // Client debug mode (issue #108) — the "devtools-lite" lens. On when the Ruby
+  // reactive_attrs stamped data-reactive-debug="true" (Phlex::Reactive.debug).
+  // Read live (a single getAttribute) so the whole feature is inert for any app
+  // that never opts in: OFF → this returns false and #perform builds no debug
+  // object, parses no response, and logs nothing (the "zero cost when off"
+  // invariant — one nil-check per dispatch). Guarded for a stub root with no
+  // getAttribute (unit harnesses) so it degrades to off, never throwing.
+  #debugEnabled() {
+    return this.element?.getAttribute?.("data-reactive-debug") === "true"
+  }
+
+  // A monotonic timestamp for the round-trip duration (ms). performance.now is
+  // monotonic (immune to a wall-clock adjustment mid-request); Date.now is the
+  // fallback for an exotic environment without it. ONLY called on the debug path,
+  // so it costs nothing when debug is off.
+  #debugNow() {
+    return typeof performance !== "undefined" && typeof performance.now === "function"
+      ? performance.now()
+      : Date.now()
+  }
+
+  // Parse a turbo-stream response's action + target pairs for the debug trace,
+  // from the body text #perform ALREADY read (never a re-fetch). NAMES only — the
+  // <template> contents (rendered HTML, the fresh token) are deliberately not
+  // touched. A non-turbo-stream / empty body yields [] (nothing to report).
+  #debugStreams(body) {
+    if (!body) return []
+    const streams = []
+    const re = /<turbo-stream\b([^>]*)>/g
+    let match
+    while ((match = re.exec(body)) !== null) {
+      const attrs = match[1]
+      const action = attrs.match(/\baction="([^"]*)"/)?.[1] ?? "?"
+      const target = attrs.match(/\btarget="([^"]*)"/)?.[1]
+      streams.push(target ? `${action} → #${target}` : action)
+    }
+    return streams
+  }
+
+  // console.group ONE dispatch (issue #108). Carries NAMES + outcomes ONLY — the
+  // signed token VALUE and every field/param VALUE are deliberately absent (they
+  // may be sensitive; the whole point is observability without leaking data). The
+  // caller passes the info it already holds so nothing is recomputed or re-fetched:
+  //   { action, paramNames, fieldNames, encoding, status, streams, tokenRefreshed, ms }
+  // `console.groupCollapsed` keeps the console tidy (one collapsed line per action).
+  #logDispatch(info) {
+    const { action, status, ms } = info
+    // The client can't name the component CLASS (it's inside the signed, opaque
+    // token — never decoded here), but the root's id is the stable client-side
+    // handle (e.g. #todo_42), so the header reads `reactive #todo_42 rename → …`.
+    const who = this.element?.id ? `#${this.element.id} ` : ""
+    const header = `reactive ${who}${action} → ${status ?? "—"} (${Math.round(ms)}ms)`
+    /* eslint-disable no-console */
+    console.groupCollapsed(header)
+    console.log(`params: [${info.paramNames.join(", ")}] + collected: [${info.fieldNames.join(", ")}]`)
+    console.log(`encoding: ${info.encoding}`)
+    if (info.streams.length) console.log(`streams: ${info.streams.join("   ")}`)
+    console.log(`token: ${info.tokenRefreshed ? "refreshed ✓" : "unchanged"}`)
+    console.groupEnd()
+    /* eslint-enable no-console */
+  }
+
   async #perform(action, params, inverse, settle) {
     // Auto-collect named field values inside this component so a button-
     // triggered action still receives sibling inputs (Livewire-style), plus any
@@ -1141,6 +1203,25 @@ export default class extends Controller {
     const body = multipart
       ? this.#buildFormData(token, action, allParams, files)
       : JSON.stringify({ token, act: action, params: allParams })
+
+    // Client debug mode (issue #108): build the trace object ONLY when debug is on
+    // (one nil-check otherwise — zero cost off). It carries NAMES only: the
+    // explicit trigger param names and the collected sibling field names, split so
+    // the group shows `params: [...] + collected: [...]`. status/streams/
+    // tokenRefreshed are filled in at the branch that knows them; the group is
+    // emitted once in the finally so EVERY exit (success or any failure) logs.
+    const debug = this.#debugEnabled()
+      ? {
+          action,
+          paramNames: Object.keys(this.#parseParams(params)),
+          fieldNames: Object.keys(fields),
+          encoding: multipart ? "multipart" : "json",
+          status: null,
+          streams: [],
+          tokenRefreshed: false,
+          started: this.#debugNow(),
+        }
+      : null
 
     // aria-busy on the root is now driven by the loading pending counter
     // (#applyLoading, applied at ENQUEUE so it covers the queue wait too), not
@@ -1232,6 +1313,12 @@ export default class extends Controller {
         return
       }
 
+      // Debug (issue #108): the server answered — record the status for the trace
+      // now, so every response branch below (redirected/http/content-type/ok) logs
+      // it. The transport-failure branches above return before here (they have no
+      // status); their group still fires from the finally with status null → "—".
+      if (debug) debug.status = response.status
+
       if (response.redirected) {
         console.error("[phlex-reactive] action was redirected (auth/CSRF?) — no update applied")
         this.#revertOptimistic(inverse)
@@ -1252,7 +1339,9 @@ export default class extends Controller {
         // retry-valid — do not "fix" that). A non-turbo-stream body is left to the
         // console.error above (an HTML error page must not be handed to Turbo).
         if ((response.headers.get("Content-Type") || "").includes("turbo-stream")) {
-          this.#currentToken = this.#extractToken(errorBody) ?? this.#currentToken
+          const fresh = this.#extractToken(errorBody)
+          this.#currentToken = fresh ?? this.#currentToken
+          if (debug) this.#debugRecordBody(debug, errorBody, fresh)
           window.Turbo.renderStreamMessage(errorBody)
         }
         this.#markError("http")
@@ -1272,7 +1361,12 @@ export default class extends Controller {
       const html = await response.text()
       // Capture the new token from the response synchronously, so the next
       // queued request uses it without waiting for the async DOM morph.
-      this.#currentToken = this.#extractToken(html) ?? this.#currentToken
+      const fresh = this.#extractToken(html)
+      this.#currentToken = fresh ?? this.#currentToken
+      // Debug (issue #108): record the stream actions/targets + whether a refresh
+      // arrived, from the body we JUST read (reuse — no second text() read). Never
+      // the token or template contents.
+      if (debug) this.#debugRecordBody(debug, html, fresh)
       // Turbo applies the <turbo-stream> ops by id. A plain replace is an
       // outerHTML swap (focus on the replaced subtree is lost); a method="morph"
       // replace (Response.morph) or an update morphs in place, preserving the
@@ -1302,7 +1396,21 @@ export default class extends Controller {
       // guarded so a morph-replaced trigger is never clobbered. Runs on EVERY
       // exit (success, every failure branch, or an apply throw).
       settle?.()
+      // Debug (issue #108): emit the group here so EVERY exit path logs exactly
+      // once — success, any transport/response failure, or an apply throw. Null
+      // when debug is off (zero cost). The round-trip ms is measured now, at the
+      // finally, so it spans the whole #perform (fetch + apply) regardless of exit.
+      if (debug) this.#logDispatch({ ...debug, ms: this.#debugNow() - debug.started })
     }
+  }
+
+  // Debug (issue #108): fold the response body #perform already read into the
+  // trace — the stream action/target pairs and whether a token refresh arrived
+  // (a boolean; the token VALUE is intentionally not stored). Shared by the
+  // success and the non-OK-turbo-stream branches so both log the same shape.
+  #debugRecordBody(debug, body, freshToken) {
+    debug.streams = this.#debugStreams(body)
+    debug.tokenRefreshed = freshToken != null
   }
 
   get #currentToken() {

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -1191,7 +1191,14 @@ export default class extends Controller {
     // chosen file inputs in the SAME walk. Explicit params
     // (data-reactive-params-param) win over collected fields.
     const { fields, files } = this.#collectFields()
-    const allParams = { ...fields, ...this.#parseParams(params) }
+    // Parse the explicit trigger params ONCE — reused below for allParams and, on
+    // the debug path, for the params-only name list (so the trace can show
+    // `params: [...]` distinct from the collected `+ collected: [...]`). #parseParams
+    // is pure (a fresh object from a JSON string, or the same object by reference
+    // when already parsed); allParams spreads a COPY and nothing mutates parsedParams
+    // downstream (JSON.stringify / #buildFormData read allParams, a new object).
+    const parsedParams = this.#parseParams(params)
+    const allParams = { ...fields, ...parsedParams }
     const token = this.#currentToken
 
     // File/multipart path (issue #34): if THIS root has a populated
@@ -1213,7 +1220,7 @@ export default class extends Controller {
     const debug = this.#debugEnabled()
       ? {
           action,
-          paramNames: Object.keys(this.#parseParams(params)),
+          paramNames: Object.keys(parsedParams),
           fieldNames: Object.keys(fields),
           encoding: multipart ? "multipart" : "json",
           status: null,

--- a/spec/javascript/reactive_debug_mode.test.js
+++ b/spec/javascript/reactive_debug_mode.test.js
@@ -1,0 +1,226 @@
+// Unit tests for client debug mode (issue #108) — "devtools-lite".
+//
+// When the reactive root carries data-reactive-debug="true" (stamped by the Ruby
+// reactive_attrs only when Phlex::Reactive.debug is on), the generic controller
+// console.groups EVERY dispatch with an observability trace of the round trip:
+//
+//   ▼ reactive TodoItemComponent#rename → 200 (48ms)
+//       params: [title] + collected: [title]
+//       streams: replace → #todo_42   token: refreshed ✓
+//
+// The trace carries NAMES + outcomes ONLY — never the signed token VALUE, never
+// field VALUES (they may be sensitive). Off (no attr) it must do NOTHING and, in
+// particular, no response parsing (the "zero cost when off" invariant).
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll } from "bun:test"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+})
+
+// A reactive root stub. `debug` toggles the data-reactive-debug attribute the
+// controller reads to decide whether to log. `fields` are named controls the
+// field walk collects (so we can assert collected NAMES appear but not values).
+function makeRoot({ debug = false, id = "todo_42", fields = [] } = {}) {
+  const attrs = {}
+  if (debug) attrs["data-reactive-debug"] = "true"
+  const root = {
+    isConnected: true,
+    id,
+    ownerRoot: null,
+    dispatchEvent: () => {},
+    getAttribute: (name) => attrs[name] ?? null,
+    setAttribute: (name, value) => (attrs[name] = value),
+    removeAttribute: (name) => delete attrs[name],
+    querySelectorAll: (selector) => {
+      // The field walk queries named controls; return our stub fields ONLY for the
+      // standard input/select/textarea query and [] for everything else (the
+      // rich-text/contenteditable walk, busy_on, dirty scan, etc.).
+      if (selector === "input[name], select[name], textarea[name]") return fields
+      return []
+    },
+    contains: () => true,
+  }
+  // Each field's nearest reactive root is this element (ownership check).
+  for (const f of fields) f.closest = () => root
+  return root
+}
+
+// Build a controller with a scripted single fetch response.
+function buildController(response, { root } = {}) {
+  const controller = new ReactiveController()
+  controller.element = root ?? makeRoot()
+  controller.tokenValue = "tok-INITIAL-secret"
+  let bodyReads = 0
+  globalThis.fetch = () =>
+    Promise.resolve({
+      redirected: response.redirected ?? false,
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      headers: { get: () => response.contentType ?? "text/vnd.turbo-stream.html" },
+      text: () => {
+        bodyReads++
+        return Promise.resolve(response.body ?? "")
+      },
+    })
+  globalThis.document = { querySelector: () => null, dispatchEvent: () => {} }
+  globalThis.window = { Turbo: { renderStreamMessage: () => {} } }
+  return { controller, bodyReads: () => bodyReads }
+}
+
+// Spy on the whole console-group family for one call, restoring after.
+function captureConsole(fn) {
+  const calls = { group: [], groupCollapsed: [], groupEnd: [], log: [], info: [] }
+  const originals = {}
+  for (const key of Object.keys(calls)) {
+    originals[key] = console[key]
+    console[key] = (...args) => calls[key].push(args)
+  }
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      for (const key of Object.keys(calls)) console[key] = originals[key]
+    })
+    .then(() => calls)
+}
+
+// Every argument passed to any console method in this capture, flattened to one
+// string — the surface a token/value leak would show up in.
+function allConsoleText(calls) {
+  return Object.values(calls)
+    .flat()
+    .flat()
+    .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+    .join("\n")
+}
+
+function click(controller, extra = {}) {
+  return controller.dispatch({
+    params: { action: "rename", params: '{"title":"x"}', ...extra },
+    currentTarget: null,
+    preventDefault: () => {},
+  })
+}
+
+const REPLACE_BODY =
+  '<turbo-stream action="replace" target="todo_42"><template>' +
+  '<div data-reactive-token-value="tok-FRESH-secret"></div></template></turbo-stream>'
+
+// --- ON: the group is emitted with the right fields ------------------------
+
+test("debug on: groups the dispatch with action, status, encoding and param/collected NAMES", async () => {
+  const root = makeRoot({ debug: true, fields: [{ name: "title", value: "x", type: "text" }] })
+  const { controller } = buildController({ body: REPLACE_BODY }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+  const text = allConsoleText(calls)
+
+  // A group was opened (group or groupCollapsed) and closed.
+  const groupOpens = calls.group.length + calls.groupCollapsed.length
+  expect(groupOpens).toBe(1)
+  expect(calls.groupEnd.length).toBe(1)
+
+  // Action + status appear in the group header/body.
+  expect(text).toContain("rename")
+  expect(text).toContain("200")
+  // Param NAMES + collected field NAMES (names only).
+  expect(text).toContain("title")
+  // JSON encoding (no files chosen).
+  expect(text.toLowerCase()).toContain("json")
+})
+
+test("debug on: reports the response stream actions + targets it parses from the held body", async () => {
+  const root = makeRoot({ debug: true })
+  const { controller, bodyReads } = buildController({ body: REPLACE_BODY }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+  const text = allConsoleText(calls)
+
+  expect(text).toContain("replace")
+  expect(text).toContain("todo_42")
+  // The debug branch REUSES the body #perform already read — it does not re-fetch
+  // or read the stream a second time (text() called once).
+  expect(bodyReads()).toBe(1)
+})
+
+test("debug on: reports a token refresh as present WITHOUT logging the token value", async () => {
+  const root = makeRoot({ debug: true })
+  const { controller } = buildController({ body: REPLACE_BODY }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+  const text = allConsoleText(calls)
+
+  // A refresh was detected (the response re-renders our id with a fresh token).
+  expect(text.toLowerCase()).toContain("refresh")
+  // …but NEITHER the old NOR the new token VALUE is ever in any console argument.
+  expect(text).not.toContain("tok-FRESH-secret")
+  expect(text).not.toContain("tok-INITIAL-secret")
+})
+
+test("debug on: reports NO token refresh when the response does not re-render our id", async () => {
+  const root = makeRoot({ debug: true, id: "todo_42" })
+  // A stream targeting a DIFFERENT id — #extractToken returns undefined for us.
+  const otherBody =
+    '<turbo-stream action="append" target="list_1"><template>' +
+    '<div data-reactive-token-value="tok-OTHER"></div></template></turbo-stream>'
+  const { controller } = buildController({ body: otherBody }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+  const text = allConsoleText(calls)
+
+  expect(text).toContain("append")
+  expect(text).toContain("list_1")
+  // No refresh for us — and definitely no foreign token value.
+  expect(text).not.toContain("tok-OTHER")
+})
+
+test("debug on: field VALUES are never logged, only names", async () => {
+  const root = makeRoot({
+    debug: true,
+    fields: [{ name: "title", value: "SENSITIVE-VALUE", type: "text" }],
+  })
+  const { controller } = buildController({ body: REPLACE_BODY }, { root })
+
+  const calls = await captureConsole(() => click(controller, { params: '{"title":"SENSITIVE-EXPLICIT"}' }))
+  const text = allConsoleText(calls)
+
+  expect(text).toContain("title") // the NAME is fine
+  expect(text).not.toContain("SENSITIVE-VALUE") // collected field value
+  expect(text).not.toContain("SENSITIVE-EXPLICIT") // explicit param value
+})
+
+// --- OFF: nothing is logged, and no response parsing happens ----------------
+
+test("debug off: nothing is grouped (no attr → no log surface)", async () => {
+  const root = makeRoot({ debug: false })
+  const { controller } = buildController({ body: REPLACE_BODY }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+
+  expect(calls.group.length).toBe(0)
+  expect(calls.groupCollapsed.length).toBe(0)
+  expect(calls.groupEnd.length).toBe(0)
+})
+
+// --- Failure paths still log a meaningful status ----------------------------
+
+test("debug on: a non-OK response is grouped with its status", async () => {
+  const root = makeRoot({ debug: true })
+  const { controller } = buildController({ ok: false, status: 403, body: "denied", contentType: "text/html" }, { root })
+
+  const calls = await captureConsole(() => click(controller))
+  const text = allConsoleText(calls)
+
+  const groupOpens = calls.group.length + calls.groupCollapsed.length
+  expect(groupOpens).toBe(1)
+  expect(calls.groupEnd.length).toBe(1)
+  expect(text).toContain("403")
+})

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -472,6 +472,46 @@ RSpec.describe Phlex::Reactive::Component do
     end
   end
 
+  describe "#reactive_attrs debug flag (issue #108)" do
+    subject(:instance) { state_klass.new }
+
+    # This unit spec runs WITHOUT Rails, so debug defaults to false. Each example
+    # sets it explicitly; restore the lazy default after each by removing the ivar
+    # entirely so an explicit value never leaks into the next (the verbose_errors
+    # precedent below).
+    around do
+      it.run
+    ensure
+      Phlex::Reactive.remove_instance_variable(:@debug) if Phlex::Reactive.instance_variable_defined?(:@debug)
+    end
+
+    it "omits data-reactive-debug when debug is off (the default)" do
+      Phlex::Reactive.debug = false
+      expect(instance.send(:reactive_attrs)[:data]).not_to have_key(:reactive_debug)
+    end
+
+    it "emits data-reactive-debug=\"true\" (STRING) when debug is on" do
+      Phlex::Reactive.debug = true
+      # STRING "true", not boolean: Phlex renders a boolean-true attr VALUELESS,
+      # which the client's getAttribute reads as "" → falsy (the on()/warn_unsaved
+      # precedent). The explicit ="true" is what the controller matches on.
+      expect(instance.send(:reactive_attrs)[:data][:reactive_debug]).to eq("true")
+    end
+
+    it "flows the flag through reactive_root too" do
+      Phlex::Reactive.debug = true
+      attrs = instance.send(:reactive_attrs)
+      expect(attrs[:data][:reactive_debug]).to eq("true")
+      # still a full reactive root's attrs
+      expect(attrs[:data][:controller]).to eq("reactive")
+    end
+
+    it "defaults debug to false with no Rails env" do
+      Phlex::Reactive.remove_instance_variable(:@debug) if Phlex::Reactive.instance_variable_defined?(:@debug)
+      expect(Phlex::Reactive.debug).to be(false)
+    end
+  end
+
   describe "#on trigger attributes (issue #17 debounce)" do
     subject(:instance) { state_klass.new }
 

--- a/spec/system/debug_mode_spec.rb
+++ b/spec/system/debug_mode_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Client debug mode end-to-end (issue #108). The /debug page renders the counter
+# with Phlex::Reactive.debug ON, so the root carries data-reactive-debug="true"
+# and the generic controller console.groups every dispatch. This spec overrides
+# the console-group family to capture the trace, clicks increment, and asserts:
+#   - a group WAS emitted, carrying the action, status, encoding, streams+target
+#     and a token-refresh marker;
+#   - the signed token VALUE never appears in any console argument.
+# Runs under Puma AND Falcon — the trace must be identical sync and async.
+RSpec.describe "Client debug mode (issue #108)", type: :system do
+  it "console.groups the dispatch with NAMES/status/streams and never the token value" do
+    visit "/debug"
+    expect(page).to have_css("[data-testid='inc']")
+
+    # The Ruby flag flowed to the DOM: the root is marked for the client to log.
+    expect(page).to have_css("#counter[data-reactive-debug='true']")
+
+    # Capture every console-group-family call into one string on window, and prove
+    # no full-page navigation happened (marker survives).
+    page.execute_script(<<~JS)
+      window.__noReload = "alive"
+      window.__debugLog = ""
+      const record = (...args) => {
+        window.__debugLog += args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ") + "\\n"
+      }
+      console.group = record
+      console.groupCollapsed = record
+      console.log = record
+    JS
+
+    find("[data-testid='inc']").click
+    expect(page).to have_css("[data-testid='count']", text: "1")
+
+    log = page.evaluate_script("window.__debugLog")
+
+    # The trace carries the action, the OK status, the JSON encoding, and the
+    # self-replace stream targeting the counter id.
+    expect(log).to include("increment")
+    expect(log).to include("200")
+    expect(log).to include("json")
+    expect(log).to include("replace")
+    expect(log).to include("counter")
+    # A full self re-render refreshes the token — reported as a boolean marker.
+    expect(log.downcase).to include("refresh")
+
+    # The signed identity token VALUE is NEVER logged. Read the live token from the
+    # DOM and assert it appears nowhere in the captured console output.
+    token = page.evaluate_script("document.getElementById('counter').getAttribute('data-reactive-token-value')")
+    expect(token).to be_a(String).and be_present
+    expect(log).not_to include(token)
+
+    expect(page.evaluate_script("window.__noReload")).to eq("alive")
+  end
+end


### PR DESCRIPTION
Closes #108

## What & why

Server-driven UIs hide the interesting state on another machine. Today's client lens is `console.error` on failures plus the #79 lifecycle events — but on the **successful-but-wrong** path (which streams arrived? did a token refresh come? the exact trail of the #30/#44/#46/#50 token-threading bug series) there was nothing to see.

This adds a devtools-lite client debug mode: the **client** counterpart to the #107 `LogSubscriber` (the **server** lens).

## Developer API

```ruby
# config/initializers/phlex_reactive.rb
Phlex::Reactive.debug = Rails.env.development?
```

With it on, every reactive root carries `data-reactive-debug="true"` and the ONE generic controller `console.group`s **every dispatch** in the browser:

```
▼ reactive #todo_42 rename → 200 (48ms)
    params: [title] + collected: [title]
    encoding: json
    streams: replace → #todo_42
    token: refreshed ✓
```

The trace carries **names and outcomes only**:
- action name
- explicit param **names** + collected sibling-field **names** (never their **values** — they may be sensitive)
- request encoding (`json` / `multipart`)
- HTTP status
- the response's stream actions + targets (parsed from the body the controller **already read** — no re-fetch)
- whether a token refresh arrived (a boolean — **never the token value**)
- round-trip ms

Off (the default) it does nothing — a single attribute check per dispatch, no debug object, no response parsing, no string building.

## Security & invariants

- **Signed token VALUE never logged** — only a `refreshed ✓` / `unchanged` boolean. Asserted directly on the console spy's arguments in both the bun and browser specs (the live DOM token is read and checked to be absent from all console output).
- **Field and param VALUES never logged** — names only.
- The debug attr is a boolean **flag, not state**; no client state; ONE generic controller; pgbus optionality untouched.
- The flag is the STRING `"true"`, not a boolean-true attr (Phlex renders those valueless → the client's `getAttribute` reads `""` → falsy). Follows the `on()` / `warn_unsaved` precedent.

## Test coverage

| Layer | File | Proves |
|-------|------|--------|
| Unit (Ruby) | `spec/phlex/reactive/component_spec.rb` | `reactive_attrs` emits the flag only when `debug` (STRING `"true"`); flows through `reactive_root`; defaults false with no Rails env |
| Unit (JS) | `spec/javascript/reactive_debug_mode.test.js` | group with the right fields when the attr is present; **nothing and no body re-read** when absent; token VALUE and field VALUES never in any console argument; failure-status path still logs |
| System | `spec/system/debug_mode_spec.rb` | end-to-end under **Puma AND Falcon**: the flag reaches the DOM, the dispatch is grouped with names/status/streams, and the live DOM token never appears in the captured console output |

RED verified before each implementation (6 JS + 4 Ruby examples failed first).

## Performance (`rake bench`, same machine, main vs branch)

The issue calls out that `reactive_attrs` is render-hot and the off-path must add at most one nil-check. It does — zero extra allocations:

| Bench | main | branch | allocs (main → branch) |
|-------|------|--------|------------------------|
| `to_stream_replace` | 13.29k i/s | 13.06k i/s | 207 → **207** (0) |
| `render_component` | 25.23k i/s | 25.00k i/s | 115 → **115** (0) |
| state-backed token | 184.97k i/s | 188.30k i/s | 11 → **11** (0) |

Throughput deltas are within run-to-run noise (±2%); the flag adds only a method call returning `false` and builds no key on the off-path.

## Verification

- [x] `bundle exec rubocop` (154 files) + `cd docs && bundle exec rubocop`
- [x] `bundle exec rspec spec/phlex spec/requests` (501)
- [x] `bun test spec/javascript` (251)
- [x] `spec/system` green under Puma AND Falcon (55 each)
- [x] vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`)
- [x] README + performance docs page + initializer template + CHANGELOG updated

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “client debug mode (devtools-lite)” for reactive updates. When enabled, reactive roots are marked and each dispatch is traced via collapsed browser console groups with action, parameter/field names, request encoding, HTTP status, turbo-stream actions/targets, token-refresh presence, and round-trip latency.
* **Bug Fixes**
  * Improved dispatch tracing across success and failure paths while avoiding exposure of any sensitive token or response/template contents; debug is off by default for zero overhead.
* **Documentation / Tests**
  * Added documentation and example output, plus unit/system coverage for the debug mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->