### PR TITLE
feat(component): extract Phlex::Reactive::ParamSchema — declaration-time validation + app-registerable param types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`Phlex::Reactive::ParamSchema` — declaration-time validation + app-registerable
+  param types (#109).** The ~200 lines of param coercion moved out of
+  `ActionsController` into a standalone `Phlex::Reactive::ParamSchema`, **compiled
+  once** when you declare an action (`ParamSchema.compile(params)`) instead of
+  interpreted on every request. Two adopter-facing wins:
+  - **Typos fail loud, at boot.** A schema naming an unknown type symbol
+    (`params: { count: :interger }`) now raises
+    **`Phlex::Reactive::UnknownParamType`** (an `ArgumentError` subclass) at class
+    load — validated recursively through nested-hash and array-of-hash element
+    types — instead of silently coercing the value to a `String` at click time.
+  - **New built-in types + custom registration.** `:date`/`:datetime` (ISO8601,
+    dropped on a parse failure) and `:decimal` (`BigDecimal`, dropped on a
+    non-numeric value) join the built-ins, so a date/decimal param no longer needs
+    `:string` + hand-parsing. Register your own with
+    **`Phlex::Reactive.param_type(:money) { |v| … }`** in an initializer — return
+    `Phlex::Reactive::ParamSchema::DROP` to reject a value (the keyword default
+    then applies, keeping the drop-don't-fabricate contract). The registry is
+    frozen after boot, so registration is initializer-only.
+
+  Behavior is otherwise **byte-for-byte identical**: every existing built-in keeps
+  its exact semantics (`"abc".to_i → 0`, not a drop; the `:file` duck-type drop;
+  the array/hash drop rules; the `#16`/`#21`/`#24`/`#39` bracket-expansion and
+  deep-merge matrix), and the `verbose_errors` dropped-param collector (`#82`/`#87`)
+  threads through unchanged — a `nil` collector is still the zero-cost production
+  path. Coercion is now unit-tested directly (`spec/phlex/reactive/param_schema_spec.rb`)
+  in addition to the request-spec integration cover. Bench (`rake bench:one[coerce_params]`),
+  same machine: ~35.5k → ~36.0k i/s, 207 → 202 obj/call (the memoized `Boolean`
+  type replaces a per-call instantiation), 0 retained — unchanged within noise.
+
 - **Client debug mode (devtools-lite) — `console.group` every dispatch (#108).**
   The `LogSubscriber` (#107) is the *server* lens; this is the *client* one. Set
   `Phlex::Reactive.debug = true` (default off; the initializer template suggests
@@ -71,6 +100,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ends by telling you to run `bin/rails phlex_reactive:doctor` to verify.
 
 ### Changed
+
+- **BREAKING (declaration-time): an unknown param type symbol now raises (#109).**
+  Before, a schema naming a type the coercer didn't recognize (a typo like
+  `params: { count: :interger }`, or a type never registered) fell through to a
+  silent `String` coercion. Now `Component.action` compiles the schema through
+  `Phlex::Reactive::ParamSchema.compile` and raises
+  **`Phlex::Reactive::UnknownParamType`** (an `ArgumentError` subclass) at class
+  load. The fix is to correct the typo or register the type
+  (`Phlex::Reactive.param_type(:name) { |v| … }` in an initializer). This only
+  affects schemas that were *already* silently mis-coercing; a valid schema is
+  unchanged.
 
 - **`on(:typo)` fails at render, not click (#105).** A misspelled or forgotten
   action used to render fine and only surface as an unexplained **403 on click**

--- a/README.md
+++ b/README.md
@@ -352,8 +352,34 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reply.replace` / `.morph` / `.update` / `.remove` / `.redirect(url)` / `.with(*)` / `.js(ops)` | Return from an action to control the reply (flash, remove, redirect, multi-stream, server-pushed client ops). See [Controlling the action's reply](#reply--controlling-the-actions-reply). |
 | `reply.append(name, model)` / `.prepend(...)` / `.remove(name, model)` | Add/remove a row in a declared `reactive_collection` (row + count + empty-state in one reply). |
 
-Param types: `:string` (default), `:integer`, `:float`, `:boolean`, `:file`.
-Anything not in the schema is dropped before reaching your method.
+Param types: `:string` (default), `:integer`, `:float`, `:boolean`, `:file`,
+`:date`, `:datetime`, `:decimal`. Anything not in the schema is dropped before
+reaching your method. `:date`/`:datetime` parse ISO8601 (a value that won't
+parse is dropped — the keyword default applies); `:decimal` parses through
+`BigDecimal` (dropped on a non-numeric value). The schema is **compiled once at
+declaration**: a typo'd type symbol (`params: { count: :interger }`) raises
+`Phlex::Reactive::UnknownParamType` at class load, not silently coercing to a
+string at click time.
+
+**Custom param types (`Phlex::Reactive.param_type`).** Register your own type in
+an initializer — the block receives the raw client value and returns the coerced
+value, or `Phlex::Reactive::ParamSchema::DROP` to reject it (the keyword default
+then applies, keeping the drop-don't-fabricate contract):
+
+```ruby
+# config/initializers/phlex_reactive.rb
+Phlex::Reactive.param_type(:money) do |value|
+  /\A\d+(\.\d{1,2})?\z/.match?(value.to_s) ? BigDecimal(value) : Phlex::Reactive::ParamSchema::DROP
+end
+
+# then, in any component:
+action :charge, params: { amount: :money }
+def charge(amount:) = @invoice.charge!(amount) # amount is a BigDecimal or unset
+```
+
+Register during boot only: the registry is **frozen after initialization**, so a
+runtime `param_type` call raises. A schema referencing a registered type is
+validated at declaration like any built-in.
 
 **File uploads (`:file`).** Declare `:file` (or `[:file]` for multiple) to accept
 an uploaded file in a reactive action — attach a document/receipt/image to the

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -58,7 +58,7 @@ module Phlex
         end
 
         component = component_class.from_identity(payload)
-        coerced = coerce_params(action_def.params, component_class:, action_name: action_def.name)
+        coerced = coerce_params(action_def, component_class:, action_name: action_def.name)
 
         result = run_action(component, action_def, coerced)
 
@@ -268,162 +268,32 @@ module Phlex
         params.require(:act).to_sym
       end
 
-      # Coerce client params against the action's declared schema. Anything not
+      # Coerce client params against the action's compiled schema (issue #109 —
+      # the coerce family now lives in Phlex::Reactive::ParamSchema). Anything not
       # in the schema is dropped — no raw mass assignment reaches the component.
-      # The top-level params arrive as an ActionController::Parameters; coerce
-      # them against the action's hash schema (same recursion as nested hashes).
       #
-      # With verbose_errors on, every dropped key is collected (full bracketed
-      # path + reason) and warn-logged once per action. With the flag off the
-      # collector is nil and every diagnostic branch below early-returns —
-      # zero extra work on the production path.
-      def coerce_params(schema, component_class: nil, action_name: nil)
+      # With verbose_errors on, ParamSchema fills a collector with every dropped
+      # key (full bracketed path + reason) and we warn-log it once per action.
+      # With the flag off the collector is nil and every diagnostic branch is
+      # skipped — zero extra work on the production path.
+      def coerce_params(action_def, component_class: nil, action_name: nil)
         dropped = Phlex::Reactive.verbose_errors ? [] : nil
+        raw = params.fetch(:params, {})
 
-        # A schema-less action drops EVERYTHING the client posted. Still surface
-        # that in verbose mode — forgetting the `params:` declaration entirely is
-        # the loudest version of the silent drop.
-        if schema.blank?
-          log_schemaless_drops(dropped, component_class, action_name) if dropped
-          return {}
-        end
-
-        coerced = coerce_hash(params.fetch(:params, {}), schema, dropped, nil)
-        log_dropped_params(dropped, schema, component_class, action_name)
+        coerced = action_def.schema.coerce(raw, dropped)
+        log_dropped_params(dropped, action_def.params, component_class, action_name)
         coerced
       end
 
-      # Sentinel: a declared key whose value can't be coerced to its type is
-      # DROPPED (not assigned), so the method's keyword default applies — exactly
-      # as if the client had omitted the key. Distinct from a coerced nil/[].
-      DROP = Object.new
-      private_constant :DROP
-
-      # Coerce a value against a declared type. A type is one of:
-      #   * a scalar symbol            (:string/:integer/:float/:boolean)
-      #   * :file                      — a multipart upload (issue #34)
-      #   * a Hash schema              ({ id: :integer, ... })   — nested object
-      #   * a one-element Array        ([:integer] / [{ ... }])  — array of that
-      # Arrays accept both a real JSON array and a Rails-style index hash
-      # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
-      def coerce(value, type, dropped = nil, path = nil)
-        case type
-        when Array
-          coerce_array(value, type.first, dropped, path)
-        when Hash
-          coerce_hash(value, type, dropped, path)
-        when :file
-          coerce_file(value)
-        else
-          coerce_scalar(value, type)
-        end
-      end
-
-      # An uploaded file (issue #34) passes through UNTOUCHED — never .to_s'd,
-      # which would corrupt it into a string the action can't attach. Anything
-      # that isn't an uploaded file (a forged/malformed scalar, an empty input)
-      # returns DROP, so the method's keyword default applies — consistent with
-      # the #16 rule that a value that can't be coerced to its type is dropped,
-      # not fabricated. Duck-types on UploadedFile's interface (original_filename
-      # + a readable IO) rather than naming a class, so a Rack::Test upload, an
-      # ActionDispatch upload, and a Falcon multipart body all qualify.
-      def coerce_file(value)
-        uploaded_file?(value) ? value : DROP
-      end
-
-      def uploaded_file?(value)
-        value.respond_to?(:original_filename) && value.respond_to?(:read)
-      end
-
-      # A real array (or Rails index hash) coerces element-wise. A malformed
-      # present-but-non-array value returns DROP rather than [] — coercing a stray
-      # scalar to an empty array would let a bad payload read as an explicit
-      # "clear everything" on update!(declared_array:).
-      #
-      # An ELEMENT that coerces to DROP (e.g. a non-file in a [:file] array, a
-      # forged/mixed payload) is rejected from the result — the same rule
-      # coerce_hash applies to a dropped value, so the internal DROP sentinel
-      # never leaks into the action. A genuinely empty input array stays [] (an
-      # explicit empty collection), but an array whose every element drops
-      # returns DROP, so the keyword default applies rather than handing the
-      # action a surprise [].
-      def coerce_array(value, element_type, dropped = nil, path = nil)
-        values = array_values(value)
-        return DROP if values.nil?
-        return [] if values.empty?
-
-        coerced =
-          if dropped
-            # Record each element that coerces to DROP (a forged non-file in a
-            # [:file] array) under its bracketed index — reject! below removes
-            # it from the result, so this is its only trace.
-            values.map.with_index do |element, i|
-              element_path = "#{path}[#{i}]"
-              result = coerce(element, element_type, dropped, element_path)
-              dropped << [element_path, :uncoercible] if result.equal?(DROP)
-              result
-            end
-          else
-            values.map { coerce(it, element_type) }
-          end
-        coerced.reject! { it.equal?(DROP) }
-        coerced.empty? ? DROP : coerced
-      end
-
-      # Keep declared keys only (drop undeclared — no mass assignment), recursing
-      # for nested hash/array element types. Symbolizes keys to splat as kwargs.
-      # A key whose value coerces to DROP is skipped (keyword default applies).
-      # `dropped`/`path` are the verbose_errors diagnostics collector — nil (and
-      # cost-free) unless the flag is on.
-      def coerce_hash(value, schema, dropped = nil, path = nil)
-        hash = to_param_hash(value)
-        collect_undeclared(dropped, hash, schema, path) if dropped
-        schema.each_with_object({}) do |(key, type), out|
-          key_name = key.to_s
-          next unless hash.key?(key_name)
-
-          key_path = dropped && join_path(path, key_name)
-          coerced = coerce(hash[key_name], type, dropped, key_path)
-          if coerced.equal?(DROP)
-            dropped << [key_path, :uncoercible] if dropped
-            next
-          end
-
-          out[key.to_sym] = coerced
-        end
-      end
-
-      # ---- verbose_errors dropped-param diagnostics ----------------------
-      # Everything below runs ONLY when the collector exists (flag on); the
-      # production path never reaches these methods.
-
-      def join_path(path, key)
-        path ? "#{path}[#{key}]" : key
-      end
-
-      # Record every input key this schema level doesn't declare. A hash value
-      # expands to its leaf paths so the log shows the full bracketed name the
-      # client posted (invoice[date], not just invoice).
-      def collect_undeclared(dropped, hash, schema, path)
-        declared = schema.keys.map(&:to_s)
-        hash.each do |key, value|
-          next if declared.include?(key)
-
-          record_undeclared(dropped, join_path(path, key), value)
-        end
-      end
-
-      def record_undeclared(dropped, path, value)
-        if value.is_a?(Hash) && value.any?
-          value.each { |key, child| record_undeclared(dropped, "#{path}[#{key}]", child) }
-        else
-          dropped << [path, :undeclared]
-        end
-      end
+      # ---- verbose_errors dropped-param logging --------------------------
+      # ParamSchema collects the dropped entries; the controller formats the ONE
+      # warn line (with the #16/#21 shape hints). Everything below runs ONLY when
+      # the collector exists (flag on); the production path never reaches it.
 
       # ONE warn line per action naming every dropped param with its reason —
       # plus, for the #16/#21 confusion, a hint when a dropped name looks like
-      # the flat/bracketed twin of a declared key.
+      # the flat/bracketed twin of a declared key. `schema` is the RAW declared
+      # hash (action_def.params), read only for the shape hints.
       def log_dropped_params(dropped, schema, component_class, action_name)
         return if dropped.nil? || dropped.empty?
         return unless defined?(::Rails) && ::Rails.respond_to?(:logger) && ::Rails.logger
@@ -440,14 +310,6 @@ module Phlex
 
         hint = shape_hint(path, schema)
         hint ? "undeclared — #{hint}" : "undeclared"
-      end
-
-      # Collect + log for an action with NO declared schema: every posted key is
-      # undeclared by definition (CodeRabbit review on PR #87). Runs only when
-      # the verbose collector exists.
-      def log_schemaless_drops(dropped, component_class, action_name)
-        collect_undeclared(dropped, to_param_hash(params.fetch(:params, {})), {}, nil)
-        log_dropped_params(dropped, {}, component_class, action_name)
       end
 
       # Fires only when a dropped segment matches a DECLARED key at a different
@@ -480,71 +342,14 @@ module Phlex
         end&.first
       end
 
-      # ---- end verbose_errors diagnostics --------------------------------
-
-      def coerce_scalar(value, type)
-        case type
-        when :integer then value.to_i
-        when :float then value.to_f
-        when :boolean then ActiveModel::Type::Boolean.new.cast(value)
-        else value.to_s
-        end
-      end
-
-      # Normalize an array param: a real array passes through; a Rails index hash
-      # ({ "0" => ..., "1" => ... }) becomes its values in index order. Anything
-      # else (a stray scalar, nil) is malformed → nil, so the caller drops the
-      # param rather than fabricating an empty array.
-      def array_values(value)
-        return value.to_a if value.is_a?(Array)
-
-        return unless value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
-
-        to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
-      end
-
-      # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed
-      # Hash so coercion can index it uniformly, then expand bracket notation so
-      # a model-scoped Rails form's flat keys nest (issue #21).
-      def to_param_hash(value)
-        flat =
-          if value.respond_to?(:to_unsafe_h)
-            value.to_unsafe_h.stringify_keys
-          elsif value.is_a?(Hash)
-            value.stringify_keys
-          else
-            return {}
-          end
-
-        expand_bracket_keys(flat)
-      end
-
-      # The client's #collectFields keeps a form input's name verbatim, so a
-      # Rails Form(model: @invoice) posts FLAT bracketed keys like
-      # "invoice[date]". Coercion does exact-key matching, so without this a
-      # nested schema (params: { invoice: { date: … } }) never finds "invoice"
-      # and drops everything. Expand "invoice[date]" => "2026-01-02" into
-      # { "invoice" => { "date" => "2026-01-02" } } — and "items[0][qty]" into
-      # the Rails index-hash form coerce_array already understands — deep-merging
-      # so sibling keys (invoice[date], invoice[status]) coalesce. Keys WITHOUT
-      # brackets and already-nested values pass through untouched, so a
-      # pre-nested object (issue #16) and plain scalars still work. Value types
-      # (a checkbox boolean, an explicit array) are preserved verbatim — unlike a
-      # round-trip through parse_nested_query, which only handles strings.
-      def expand_bracket_keys(flat)
-        flat.each_with_object({}) do |(key, value), out|
-          deep_assign(out, bracket_path(key), value)
-        end
-      end
-
       # Matches each bracket segment in "items_attributes][0][qty]" — the part
-      # after the first "[". Hoisted to a frozen constant so coercing a bracketed
-      # key doesn't recompile the pattern per key on every request.
+      # after the first "[". Hoisted to a frozen constant so the shape-hint path
+      # (verbose only) doesn't recompile the pattern per call.
       BRACKET_SEGMENT = /[^\[\]]+/
       private_constant :BRACKET_SEGMENT
 
-      # "invoice[items_attributes][0][qty]" => ["invoice", "items_attributes",
-      # "0", "qty"]. A key with no brackets is a single-element path.
+      # "invoice[date]" => ["invoice", "date"]. A key with no brackets is a
+      # single-element path. Used only to shape the dropped-param hint.
       def bracket_path(key)
         return [key] unless key.include?("[")
 
@@ -552,28 +357,7 @@ module Phlex
         [head, *rest.scan(BRACKET_SEGMENT)]
       end
 
-      # Walk/create nested hashes along `path`, then merge `value` at the leaf so
-      # a bracket key and a sibling pre-nested object coalesce regardless of which
-      # arrives first ({ "invoice[date]" => …, invoice: { status: … } } keeps
-      # both). #merge_value deep-merges hash/hash collisions and otherwise lets
-      # the later value win (a bracket key colliding with a flat scalar).
-      def deep_assign(hash, path, value)
-        *parents, leaf = path
-        node = parents.reduce(hash) do |acc, segment|
-          acc[segment] = {} unless acc[segment].is_a?(Hash)
-          acc[segment]
-        end
-        node[leaf] = merge_value(node[leaf], value)
-      end
-
-      # Combine an existing leaf value with a new one. Two hashes deep-merge (so
-      # bracket-expanded fields and a pre-nested object for the same key both
-      # survive); any other collision takes the new value.
-      def merge_value(existing, value)
-        return value unless existing.is_a?(Hash) && value.is_a?(Hash)
-
-        existing.merge(value.stringify_keys) { |_k, old, new| merge_value(old, new) }
-      end
+      # ---- end verbose_errors logging ------------------------------------
 
       # Only components that opt into Reactive may be resolved. The signature
       # already gates this; defense in depth against constant injection. The

--- a/benchmark/micro/coerce_params.rb
+++ b/benchmark/micro/coerce_params.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-# Micro-bench: server-side param coercion (ActionsController#coerce_params). It
-# runs on every action that declares a param schema, recursing through nested
-# hashes/arrays and expanding Rails bracket keys. This isolates the coercion of
-# a realistic nested payload (a Rails Form(model:) with an array of nested
-# attributes) so allocation/throughput regressions in the recursion show up.
+# Micro-bench: server-side param coercion. Since issue #109 the coerce family
+# lives in Phlex::Reactive::ParamSchema, COMPILED ONCE at declaration and run per
+# request (the controller's coerce_params is now a thin logging wrapper around
+# schema.coerce). This isolates the per-request work — coercing a realistic
+# nested payload (a Rails Form(model:) with an array of nested attributes)
+# against a pre-compiled schema — so allocation/throughput regressions in the
+# recursion + bracket expansion show up. Baselined pre-#109 at ~35.5k i/s /
+# 207 obj/call / 0 retained; the extraction must hold within noise.
 #
 #   ruby benchmark/micro/coerce_params.rb
 
@@ -12,16 +15,16 @@ require_relative "../support/boot"
 
 # Measure the PRODUCTION path: verbose_errors defaults ON under RAILS_ENV=test
 # (Rails.env.local?), which would add the dropped-param collector to every
-# call. Production defaults OFF — bench what production runs.
+# call. Production defaults OFF — the nil collector is the zero-cost path.
 Phlex::Reactive.verbose_errors = false
 
-controller = Phlex::Reactive::ActionsController.new
-
-schema = {
+# Compiled ONCE at declaration, exactly as Component.action does. The per-request
+# hot path is #coerce, not .compile — so compile outside the measured block.
+schema = Phlex::Reactive::ParamSchema.compile(
   date: :string,
   bank_account_ids: [:integer],
   invoice_items_attributes: [{ id: :integer, quantity: :float, price: :float, _destroy: :boolean }]
-}
+)
 
 # A flat, bracketed payload (what the client's #collectFields posts for a
 # Rails-style nested form) as an ActionController::Parameters, the real input.
@@ -38,9 +41,8 @@ raw = ActionController::Parameters.new(
   "invoice_items_attributes[1][_destroy]" => "true"
 )
 
-# coerce_params reads params.fetch(:params, {}); set it on the controller.
-controller.params = ActionController::Parameters.new(params: raw)
-run = -> { controller.send(:coerce_params, schema) }
+# The production per-request call: coerce the raw params (nil collector).
+run = -> { schema.coerce(raw, nil) }
 
 BenchSupport.header("coerce_params: nested array-of-hash (Rails bracket form)")
 BenchSupport.ips { it.report("coerce_params") { run.call } }

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -154,6 +154,18 @@ module Views
                 code { '@record.update!(params)' }
                 plain ' — take explicit, declared params.'
               end
+              p do
+                plain 'The schema is compiled once at declaration: a typo\'d type symbol raises '
+                code { 'Phlex::Reactive::UnknownParamType' }
+                plain ' at class load rather than silently coercing to a string at click time. A declared '
+                plain 'value that can\'t be coerced to its type (a bad '
+                code { ':date' }
+                plain '/'
+                code { ':decimal' }
+                plain ', a non-file for '
+                code { ':file' }
+                plain ') is dropped — never fabricated — so the action sees its keyword default, not a bogus value.'
+              end
             end
             DocsUI::Callout(:note, title: 'File params (:file / [:file])') do
               plain 'A reactive action can accept an uploaded file (the client switches to multipart FormData when ' \

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -42,6 +42,20 @@ module Phlex
       end
     end
 
+    # Raised at DECLARATION time (Component.action -> ParamSchema.compile) when a
+    # param schema names a type symbol that isn't in the registry — a typo like
+    # `params: { count: :interger }`. A stdlib ArgumentError subclass (NOT a
+    # NameError): the mistake is a bad ARGUMENT to `action`, and callers rescue
+    # ArgumentError, not NameError, for a bad-input contract. Loud at class load
+    # (eager loading in production; first constant reference under Zeitwerk dev)
+    # instead of a silent `to_s` at request time.
+    #
+    # Superclass is fully qualified `::ArgumentError`: the phlex gem defines
+    # Phlex::ArgumentError, and a bare `ArgumentError` here resolves LEXICALLY to
+    # that (Phlex::Reactive -> Phlex), coupling us to a Phlex error rather than
+    # the stdlib one an app catches.
+    class UnknownParamType < ::ArgumentError; end
+
     # Purpose string bound into every identity token's signature so a token
     # minted for phlex-reactive can't be replayed against another verifier use.
     IDENTITY_PURPOSE = "phlex-reactive/identity"
@@ -133,6 +147,63 @@ module Phlex
         return @debug if defined?(@debug)
 
         false
+      end
+
+      # Register an app-defined param type (issue #109). The block receives the
+      # raw client value and returns the coerced value — or Phlex::Reactive::
+      # ParamSchema::DROP to reject it (the keyword default then applies, keeping
+      # the drop-don't-fabricate contract). Register in an INITIALIZER: the
+      # registry is frozen after boot (freeze_param_types!), so a runtime
+      # registration raises, and a schema referencing the type is validated at
+      # declaration.
+      #
+      #   # config/initializers/phlex_reactive.rb
+      #   Phlex::Reactive.param_type(:money) do |v|
+      #     /\A\d+(\.\d{1,2})?\z/.match?(v.to_s) ? BigDecimal(v) : Phlex::Reactive::ParamSchema::DROP
+      #   end
+      #   # then: action :charge, params: { amount: :money }
+      def param_type(name, &block)
+        raise ::ArgumentError, "Phlex::Reactive.param_type requires a block" unless block
+
+        if param_types_frozen?
+          raise Error, "Phlex::Reactive.param_type(#{name.inspect}) called after boot — the param-type " \
+                       "registry is frozen once the app is initialized. Register custom param types in an " \
+                       "initializer (config/initializers/phlex_reactive.rb)."
+        end
+
+        param_types[name.to_sym] = block
+      end
+
+      # The param-type registry: Symbol => callable(value) -> coerced | DROP.
+      # Seeded lazily with the built-ins; ParamSchema.compile validates every
+      # declared type symbol against it, and #coerce dispatches through it.
+      def param_types
+        @param_types ||= Phlex::Reactive::ParamSchema.built_in_types.dup
+      end
+
+      # A declared type symbol is known iff it's a registry key. ParamSchema
+      # asks this at compile so an unknown symbol raises loudly at declaration.
+      def param_type?(name)
+        param_types.key?(name.to_sym)
+      end
+
+      # Freeze the registry so no further param_type registration is accepted —
+      # the initializer-only contract. Called by the engine's after_initialize.
+      # Idempotent.
+      def freeze_param_types!
+        param_types.freeze
+        @param_types_frozen = true
+      end
+
+      def param_types_frozen?
+        @param_types_frozen ||= false
+      end
+
+      # Drop the registry back to the built-ins and unfreeze it. For tests that
+      # register a temporary type; never called in production.
+      def reset_param_types!
+        @param_types = Phlex::Reactive::ParamSchema.built_in_types.dup
+        @param_types_frozen = false
       end
 
       # Emit an `<event>.phlex_reactive` ActiveSupport::Notifications event around

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -60,8 +60,12 @@ module Phlex
       extend ActiveSupport::Concern
       include Phlex::Reactive::Streamable
 
-      # A declared, client-invokable action and its param schema.
-      Action = Data.define(:name, :params)
+      # A declared, client-invokable action and its param schema. `params` keeps
+      # the RAW declared hash (the readable form callers/specs inspect); `schema`
+      # is the compiled Phlex::Reactive::ParamSchema (issue #109) the endpoint
+      # coerces through — built ONCE here at declaration so a typo'd type symbol
+      # raises Phlex::Reactive::UnknownParamType at class load, not at click time.
+      Action = Data.define(:name, :params, :schema)
 
       # A declared client-side computation (data binding). `inputs`/`outputs` are
       # the action-param names of the fields the reducer reads/writes; `reducer`
@@ -139,7 +143,8 @@ module Phlex
         # Array params accept BOTH a JSON array and a Rails-style index hash
         # ({ "0" => ..., "1" => ... }), so a fields_for collection works either way.
         def action(name, params: {})
-          reactive_actions[name.to_sym] = Action.new(name: name.to_sym, params: params)
+          reactive_actions[name.to_sym] =
+            Action.new(name: name.to_sym, params: params, schema: Phlex::Reactive::ParamSchema.compile(params))
         end
 
         def reactive_actions

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -89,6 +89,13 @@ module Phlex
         # the app enabled it. attach_to is idempotent-safe here because this runs
         # once per boot; the events fire for APMs regardless of this flag.
         Phlex::Reactive::LogSubscriber.attach_to(:phlex_reactive) if Phlex::Reactive.log_events
+
+        # Freeze the param-type registry (issue #109): custom types register in
+        # an initializer, which has run by now, so no further registration is
+        # accepted. A schema referencing a type is validated at declaration; the
+        # frozen registry makes runtime registration a loud error rather than a
+        # never-validated type. Idempotent.
+        Phlex::Reactive.freeze_param_types!
       end
     end
   end

--- a/lib/phlex/reactive/param_schema.rb
+++ b/lib/phlex/reactive/param_schema.rb
@@ -165,7 +165,13 @@ module Phlex
           return {}
         end
 
-        coerce_hash(params, @schema, dropped, nil)
+        # The TOP-LEVEL params container is the request's `params[:params]` — a
+        # coerced-away malformed top level (a stray non-hash) is normalized back
+        # to {} here, never DROP: the whole point of the top level is to hold the
+        # coerced kwargs, so a bad container yields "no params", not a dropped
+        # action argument. Nested malformed hashes DO drop (see coerce_hash).
+        coerced = coerce_hash(params, @schema, dropped, nil)
+        coerced.equal?(DROP) ? {} : coerced
       end
 
       private
@@ -234,7 +240,16 @@ module Phlex
       # Keep declared keys only (drop undeclared — no mass assignment), recursing
       # for nested hash/array element types. Symbolizes keys to splat as kwargs.
       # A key whose value coerces to DROP is skipped (keyword default applies).
+      #
+      # A present-but-malformed value (a nested `invoice: null` / `invoice: "x"`
+      # for a hash schema) returns DROP rather than fabricating {} — the same
+      # drop-don't-fabricate rule coerce_array applies to a non-array, so a bad
+      # payload can't read as an explicit empty object on update!(nested:). The
+      # top-level entry (coerce) normalizes that DROP back to {}. A genuinely
+      # empty hash ({} / an empty index form) stays {}.
       def coerce_hash(value, schema, dropped, path)
+        return DROP unless hash_like?(value)
+
         hash = to_param_hash(value)
         collect_undeclared(dropped, hash, schema, path) if dropped
         schema.each_with_object({}) do |(key, type), out|
@@ -292,6 +307,15 @@ module Phlex
         return unless value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
 
         to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
+      end
+
+      # True when `value` is a Hash or an ActionController::Parameters — i.e. a
+      # value to_param_hash unwraps to real keys rather than {}. A nested hash
+      # schema fed anything else (nil, a scalar) is malformed and drops. The
+      # SAME acceptance test to_param_hash uses, kept as a guard so a malformed
+      # input is dropped BEFORE to_param_hash flattens it to a fabricated {}.
+      def hash_like?(value)
+        value.is_a?(Hash) || value.respond_to?(:to_unsafe_h)
       end
 
       # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed

--- a/lib/phlex/reactive/param_schema.rb
+++ b/lib/phlex/reactive/param_schema.rb
@@ -1,0 +1,366 @@
+# frozen_string_literal: true
+
+require "date"
+require "time"
+require "bigdecimal"
+require "active_model"
+require "active_model/type"
+
+module Phlex
+  module Reactive
+    # A COMPILED param schema (issue #109). The coerce family used to live inline
+    # in ActionsController; here it's a standalone unit built ONCE at declaration
+    # (Component.action -> ParamSchema.compile) so:
+    #
+    #   * an unknown type symbol raises Phlex::Reactive::UnknownParamType at class
+    #     load instead of silently `to_s`-ing at request time, and
+    #   * the drop-don't-fabricate coercion is unit-testable without a booted
+    #     request spec.
+    #
+    # The behavior is byte-for-byte what the controller did: the built-ins keep
+    # their exact semantics ("abc".to_i => 0, not DROP; :file duck-type DROP; the
+    # array/hash DROP rules), the bracket-expansion/deep-merge matrix (#16/#21/
+    # #24/#39) is UNCHANGED, and the verbose_errors dropped-param collector (#82/
+    # #87) threads through unchanged — a nil collector is the zero-cost prod path.
+    #
+    # A type is one of:
+    #   * a scalar symbol           (:string/:integer/:float/:boolean/:file/:date/
+    #                                :datetime/:decimal, or an app-registered type)
+    #   * a Hash schema             ({ id: :integer, ... })   — nested object
+    #   * a one-element Array       ([:integer] / [{ ... }])  — array of that
+    class ParamSchema
+      # Sentinel: a declared key whose value can't be coerced to its type is
+      # DROPPED (not assigned), so the method's keyword default applies — exactly
+      # as if the client had omitted the key. Distinct from a coerced nil/[]. A
+      # custom param_type callable returns this to reject a value while keeping
+      # the drop-don't-fabricate contract, so it is PUBLIC.
+      DROP = Object.new
+      DROP.freeze
+
+      class << self
+        # Validate `schema` recursively against the param-type registry and
+        # return a compiled ParamSchema. Raises UnknownParamType at the FIRST
+        # unknown type symbol (naming the full bracketed path), so a typo fails
+        # loudly at declaration. A blank schema compiles to an empty schema (the
+        # action drops everything the client posts).
+        def compile(schema)
+          schema = {} if schema.nil?
+          validate!(schema, nil)
+          new(schema)
+        end
+
+        # The frozen-semantics built-in registry, rebuilt on demand (the module
+        # dups it so app registration doesn't mutate this template). Each entry
+        # is a callable(value) -> coerced | DROP. The scalar casts here are the
+        # EXACT ones the controller ran, so the existing request-spec matrix is
+        # unchanged.
+        # rubocop:disable Style/ItBlockParameter, Style/SymbolProc
+        # Explicit `(value)` params, NOT `it` or `&:to_s`: the date/datetime/decimal
+        # casters wrap an INNER `parse_or_drop { ... }` block, and `it` there would
+        # bind to that inner block's (absent) param, not the caster's value — the
+        # #109 autocorrect trap. Keep the WHOLE family explicit so it reads
+        # uniformly and no caster can be collapsed to a zero-arity lambda.
+        def built_in_types
+          {
+            string: ->(value) { value.to_s },
+            integer: ->(value) { value.to_i },
+            float: ->(value) { value.to_f },
+            boolean: ->(value) { BOOLEAN_TYPE.cast(value) },
+            # :file and the composite types (Hash/Array) are handled structurally
+            # in #coerce, not via a scalar callable — the registry entry exists so
+            # compile-time validation recognizes the symbol. A nil callable means
+            # "handled structurally"; #coerce never dispatches it here.
+            file: nil,
+            date: ->(value) { parse_or_drop { Date.iso8601(value.to_s) } },
+            datetime: ->(value) { parse_or_drop { DateTime.iso8601(value.to_s) } },
+            decimal: ->(value) { parse_or_drop { BigDecimal(value.to_s) } }
+          }
+        end
+        # rubocop:enable Style/ItBlockParameter, Style/SymbolProc
+
+        private
+
+        # Run a parse that raises on bad input (Date/DateTime iso8601, BigDecimal)
+        # and turn the failure into DROP — the keyword default then applies rather
+        # than a fabricated value. ::ArgumentError covers BigDecimal("abc") and a
+        # blank/garbage string; ::Date::Error (an ArgumentError subclass) covers
+        # the iso8601 parsers; ::TypeError covers a nil slipping through.
+        #
+        # MUST be top-level-qualified (::): the phlex gem defines Phlex::Argument
+        # Error (a subclass of the stdlib one), and this file is nested under
+        # Phlex::Reactive, so a bare `ArgumentError` resolves LEXICALLY to
+        # Phlex::ArgumentError — which would NOT catch a stdlib Date::Error and the
+        # parse failure would escape as a 500.
+        def parse_or_drop
+          yield
+        rescue ::ArgumentError, ::TypeError
+          DROP
+        end
+
+        # Walk the schema, validating each type symbol against the registry and
+        # recursing into nested hashes and array element types. `path` is the
+        # bracketed name for a helpful error message.
+        def validate!(schema, path)
+          schema.each do |key, type|
+            validate_type!(type, join(path, key))
+          end
+        end
+
+        def validate_type!(type, path)
+          case type
+          when Array
+            unless type.length == 1
+              raise UnknownParamType, "#{path}: an array type must wrap exactly one element type, " \
+                                      "got #{type.inspect}"
+            end
+
+            validate_type!(type.first, "#{path}[]")
+          when Hash
+            validate!(type, path)
+          when Symbol
+            unless Phlex::Reactive.param_type?(type)
+              raise UnknownParamType, "#{path}: unknown param type #{type.inspect}. Known types: " \
+                                      "#{Phlex::Reactive.param_types.keys.sort.join(", ")}. " \
+                                      "Register a custom type with Phlex::Reactive.param_type(#{type.inspect}) { |v| ... }."
+            end
+          else
+            raise UnknownParamType, "#{path}: a param type must be a Symbol, a Hash schema, or a " \
+                                    "one-element Array, got #{type.inspect}"
+          end
+        end
+
+        def join(path, key)
+          path ? "#{path}[#{key}]" : key.to_s
+        end
+      end
+
+      # ActiveModel's Boolean type, instantiated once — the exact caster the
+      # controller used (an unrecognized value casts to nil, which is KEPT, not
+      # dropped).
+      BOOLEAN_TYPE = ActiveModel::Type::Boolean.new
+      private_constant :BOOLEAN_TYPE
+
+      attr_reader :schema
+
+      def initialize(schema)
+        @schema = schema
+      end
+
+      # Coerce client params against this schema. Anything not in the schema is
+      # dropped — no raw mass assignment reaches the component. The top-level
+      # params (an ActionController::Parameters or a plain Hash) coerce against
+      # the hash schema (same recursion as nested hashes).
+      #
+      # `dropped` is the verbose_errors diagnostics collector: an Array that
+      # accumulates [bracketed_path, :undeclared|:uncoercible] entries. Pass nil
+      # (the production path) and every diagnostic branch early-returns — zero
+      # extra work.
+      def coerce(params, dropped = nil)
+        # A schema-less action drops EVERYTHING the client posted. Under a
+        # verbose collector, record every posted key as :undeclared (forgetting
+        # `params:` entirely is the loudest silent drop — #87); otherwise it's a
+        # cost-free {} return on the production path.
+        if @schema.empty?
+          collect_undeclared(dropped, to_param_hash(params), {}, nil) if dropped
+          return {}
+        end
+
+        coerce_hash(params, @schema, dropped, nil)
+      end
+
+      private
+
+      # Coerce a value against a declared type. Arrays accept both a real JSON
+      # array and a Rails-style index hash ({ "0" => ..., "1" => ... }), so a
+      # fields_for collection works either way.
+      def coerce_value(value, type, dropped, path)
+        case type
+        when Array
+          coerce_array(value, type.first, dropped, path)
+        when Hash
+          coerce_hash(value, type, dropped, path)
+        when :file
+          coerce_file(value)
+        else
+          coerce_scalar(value, type)
+        end
+      end
+
+      # Dispatch a scalar through the registry callable. The symbol is known
+      # (compile validated it), so the lookup always hits.
+      def coerce_scalar(value, type)
+        Phlex::Reactive.param_types.fetch(type).call(value)
+      end
+
+      # An uploaded file (issue #34) passes through UNTOUCHED — never .to_s'd,
+      # which would corrupt it. Anything that isn't an uploaded file returns DROP
+      # (the keyword default applies). Duck-types on UploadedFile's interface
+      # rather than naming a class, so a Rack::Test upload, an ActionDispatch
+      # upload, and a Falcon multipart body all qualify.
+      def coerce_file(value)
+        uploaded_file?(value) ? value : DROP
+      end
+
+      def uploaded_file?(value)
+        value.respond_to?(:original_filename) && value.respond_to?(:read)
+      end
+
+      # A real array (or Rails index hash) coerces element-wise. A malformed
+      # present-but-non-array value returns DROP rather than [] — coercing a stray
+      # scalar to an empty array would let a bad payload read as an explicit
+      # "clear everything". An ELEMENT that coerces to DROP is rejected; an array
+      # whose every element drops returns DROP (keyword default applies), but a
+      # genuinely empty input array stays [].
+      def coerce_array(value, element_type, dropped, path)
+        values = array_values(value)
+        return DROP if values.nil?
+        return [] if values.empty?
+
+        coerced =
+          if dropped
+            values.map.with_index do |element, i|
+              element_path = "#{path}[#{i}]"
+              result = coerce_value(element, element_type, dropped, element_path)
+              dropped << [element_path, :uncoercible] if result.equal?(DROP)
+              result
+            end
+          else
+            values.map { coerce_value(it, element_type, nil, nil) }
+          end
+        coerced.reject! { it.equal?(DROP) }
+        coerced.empty? ? DROP : coerced
+      end
+
+      # Keep declared keys only (drop undeclared — no mass assignment), recursing
+      # for nested hash/array element types. Symbolizes keys to splat as kwargs.
+      # A key whose value coerces to DROP is skipped (keyword default applies).
+      def coerce_hash(value, schema, dropped, path)
+        hash = to_param_hash(value)
+        collect_undeclared(dropped, hash, schema, path) if dropped
+        schema.each_with_object({}) do |(key, type), out|
+          key_name = key.to_s
+          next unless hash.key?(key_name)
+
+          key_path = dropped && join_path(path, key_name)
+          coerced = coerce_value(hash[key_name], type, dropped, key_path)
+          if coerced.equal?(DROP)
+            dropped << [key_path, :uncoercible] if dropped
+            next
+          end
+
+          out[key.to_sym] = coerced
+        end
+      end
+
+      # ---- verbose_errors dropped-param diagnostics ----------------------
+      # Everything below runs ONLY when the collector exists (flag on); the
+      # production path never reaches these methods.
+
+      def join_path(path, key)
+        path ? "#{path}[#{key}]" : key
+      end
+
+      # Record every input key this schema level doesn't declare. A hash value
+      # expands to its leaf paths so the log shows the full bracketed name the
+      # client posted (invoice[date], not just invoice).
+      def collect_undeclared(dropped, hash, schema, path)
+        declared = schema.keys.map(&:to_s)
+        hash.each do |key, value|
+          next if declared.include?(key)
+
+          record_undeclared(dropped, join_path(path, key), value)
+        end
+      end
+
+      def record_undeclared(dropped, path, value)
+        if value.is_a?(Hash) && value.any?
+          value.each { |key, child| record_undeclared(dropped, "#{path}[#{key}]", child) }
+        else
+          dropped << [path, :undeclared]
+        end
+      end
+
+      # ---- end verbose_errors diagnostics --------------------------------
+
+      # Normalize an array param: a real array passes through; a Rails index hash
+      # ({ "0" => ..., "1" => ... }) becomes its values in index order. Anything
+      # else (a stray scalar, nil) is malformed => nil, so the caller drops the
+      # param rather than fabricating an empty array.
+      def array_values(value)
+        return value.to_a if value.is_a?(Array)
+
+        return unless value.respond_to?(:to_unsafe_h) || value.is_a?(Hash)
+
+        to_param_hash(value).sort_by { |k, _| k.to_i }.map(&:last)
+      end
+
+      # Unwrap ActionController::Parameters (or a plain Hash) to a string-keyed
+      # Hash so coercion can index it uniformly, then expand bracket notation so
+      # a model-scoped Rails form's flat keys nest (issue #21).
+      def to_param_hash(value)
+        flat =
+          if value.respond_to?(:to_unsafe_h)
+            value.to_unsafe_h.stringify_keys
+          elsif value.is_a?(Hash)
+            value.stringify_keys
+          else
+            return {}
+          end
+
+        expand_bracket_keys(flat)
+      end
+
+      # The client's #collectFields keeps a form input's name verbatim, so a
+      # Rails Form(model: @invoice) posts FLAT bracketed keys like
+      # "invoice[date]". Coercion does exact-key matching, so without this a
+      # nested schema (params: { invoice: { date: … } }) never finds "invoice"
+      # and drops everything. Expand "invoice[date]" => "2026-01-02" into
+      # { "invoice" => { "date" => "2026-01-02" } } — and "items[0][qty]" into
+      # the Rails index-hash form coerce_array already understands — deep-merging
+      # so sibling keys (invoice[date], invoice[status]) coalesce. Keys WITHOUT
+      # brackets and already-nested values pass through untouched.
+      def expand_bracket_keys(flat)
+        flat.each_with_object({}) do |(key, value), out|
+          deep_assign(out, bracket_path(key), value)
+        end
+      end
+
+      # Matches each bracket segment in "items_attributes][0][qty]" — the part
+      # after the first "[". Hoisted to a frozen constant so coercing a bracketed
+      # key doesn't recompile the pattern per key on every request.
+      BRACKET_SEGMENT = /[^\[\]]+/
+      private_constant :BRACKET_SEGMENT
+
+      # "invoice[items_attributes][0][qty]" => ["invoice", "items_attributes",
+      # "0", "qty"]. A key with no brackets is a single-element path.
+      def bracket_path(key)
+        return [key] unless key.include?("[")
+
+        head, rest = key.split("[", 2)
+        [head, *rest.scan(BRACKET_SEGMENT)]
+      end
+
+      # Walk/create nested hashes along `path`, then merge `value` at the leaf so
+      # a bracket key and a sibling pre-nested object coalesce regardless of which
+      # arrives first. #merge_value deep-merges hash/hash collisions and otherwise
+      # lets the later value win.
+      def deep_assign(hash, path, value)
+        *parents, leaf = path
+        node = parents.reduce(hash) do |acc, segment|
+          acc[segment] = {} unless acc[segment].is_a?(Hash)
+          acc[segment]
+        end
+        node[leaf] = merge_value(node[leaf], value)
+      end
+
+      # Combine an existing leaf value with a new one. Two hashes deep-merge (so
+      # bracket-expanded fields and a pre-nested object for the same key both
+      # survive); any other collision takes the new value.
+      def merge_value(existing, value)
+        return value unless existing.is_a?(Hash) && value.is_a?(Hash)
+
+        existing.merge(value.stringify_keys) { |_k, old, new| merge_value(old, new) }
+      end
+    end
+  end
+end

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe Phlex::Reactive::Component do
       expect(state_klass.reactive_action?(:wat)).to be(false)
       expect(state_klass.reactive_action(:wat)).to be_nil
     end
+
+    it "compiles the param schema at declaration (issue #109)" do
+      expect(state_klass.reactive_action(:set).schema).to be_a(Phlex::Reactive::ParamSchema)
+    end
+
+    it "raises UnknownParamType at CLASS LOAD for a typo'd type symbol (issue #109)" do
+      expect do
+        Class.new do
+          include Phlex::Reactive::Component
+
+          action :set, params: { count: :interger }
+        end
+      end.to raise_error(Phlex::Reactive::UnknownParamType, /interger/)
+    end
   end
 
   describe "state-backed identity" do

--- a/spec/phlex/reactive/param_schema_spec.rb
+++ b/spec/phlex/reactive/param_schema_spec.rb
@@ -152,6 +152,26 @@ RSpec.describe Phlex::Reactive::ParamSchema do
       expect(coerce(schema, params)).to eq(invoice: { date: "2026-01-02", status: "open" })
     end
 
+    it "drops a malformed (non-hash) nested param rather than fabricating {}" do
+      # The hash analog of the malformed-array rule: a nested `invoice: null` or a
+      # stray scalar must NOT become an empty {} (which update!(invoice:) would
+      # read as an explicit no-op object). Drop it so the keyword default applies.
+      schema = { invoice: { date: :string, status: :string } }
+      expect(coerce(schema, { "invoice" => nil })).to eq({})
+      expect(coerce(schema, { "invoice" => "oops" })).to eq({})
+    end
+
+    it "keeps a genuinely empty nested hash as {} (explicit empty object)" do
+      schema = { invoice: { date: :string, status: :string } }
+      expect(coerce(schema, { "invoice" => {} })).to eq(invoice: {})
+    end
+
+    it "records a malformed nested hash as uncoercible for the collector" do
+      dropped = []
+      coerce({ invoice: { date: :string } }, { "invoice" => nil }, dropped)
+      expect(dropped).to include(["invoice", :uncoercible])
+    end
+
     it "coerces the array-of-hash Rails bracket form (the bench payload shape)" do
       schema = {
         date: :string,

--- a/spec/phlex/reactive/param_schema_spec.rb
+++ b/spec/phlex/reactive/param_schema_spec.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Issue #109: the coerce family extracted out of ActionsController into a
+# standalone, compiled-once ParamSchema. Two contracts this spec pins:
+#
+#   1. COMPILE — declaration-time validation. Every type symbol (recursively:
+#      nested hash + array-of-hash element types) is checked against the
+#      registry; an unknown symbol raises Phlex::Reactive::UnknownParamType (an
+#      ArgumentError subclass) at compile, not a silent to_s at request time.
+#   2. COERCE — the drop-don't-fabricate contract, byte-for-byte with the old
+#      controller: built-ins keep their exact semantics (:integer "abc" → 0,
+#      not DROP; :file duck-type DROP; the array/hash DROP rules), and the
+#      verbose_errors collector records path-prefixed [path, reason] entries.
+RSpec.describe Phlex::Reactive::ParamSchema do
+  # The internal DROP sentinel is private; assert on the RESULT of coerce (a
+  # dropped key is simply absent from the coerced hash) rather than the sentinel.
+  def coerce(schema, params, collector = nil)
+    described_class.compile(schema).coerce(params, collector)
+  end
+
+  describe ".compile — declaration-time validation" do
+    it "accepts the shipped built-in scalars" do
+      expect { described_class.compile({ a: :string, b: :integer, c: :float, d: :boolean, e: :file }) }
+        .not_to raise_error
+    end
+
+    it "raises UnknownParamType for a typo'd type symbol" do
+      expect { described_class.compile({ count: :interger }) }
+        .to raise_error(Phlex::Reactive::UnknownParamType, /interger/)
+    end
+
+    it "raises UnknownParamType as an ArgumentError subclass (not a NameError)" do
+      expect(Phlex::Reactive::UnknownParamType.ancestors).to include(ArgumentError)
+      expect { described_class.compile({ x: :nope }) }.to raise_error(ArgumentError)
+    end
+
+    it "validates a NESTED hash element type recursively" do
+      expect { described_class.compile({ invoice: { date: :string, bad: :notatype } }) }
+        .to raise_error(Phlex::Reactive::UnknownParamType, /notatype/)
+    end
+
+    it "validates an ARRAY element type" do
+      expect { described_class.compile({ ids: [:whoops] }) }
+        .to raise_error(Phlex::Reactive::UnknownParamType, /whoops/)
+    end
+
+    it "validates an ARRAY-OF-HASH element type recursively" do
+      schema = { items: [{ id: :integer, qty: :flooat }] }
+      expect { described_class.compile(schema) }
+        .to raise_error(Phlex::Reactive::UnknownParamType, /flooat/)
+    end
+
+    it "names the offending key and the whole registry is not mutated by a failed compile" do
+      expect { described_class.compile({ x: :bogus }) }
+        .to raise_error(Phlex::Reactive::UnknownParamType)
+      # a subsequent VALID compile still works (no half-registration state)
+      expect { described_class.compile({ x: :string }) }.not_to raise_error
+    end
+  end
+
+  describe "#coerce — shipped built-ins, byte-for-byte" do
+    it ":integer casts via to_i (a non-numeric string becomes 0, NOT dropped)" do
+      expect(coerce({ n: :integer }, { "n" => "abc" })).to eq(n: 0)
+      expect(coerce({ n: :integer }, { "n" => "42" })).to eq(n: 42)
+    end
+
+    it ":float casts via to_f" do
+      expect(coerce({ n: :float }, { "n" => "2.5" })).to eq(n: 2.5)
+      expect(coerce({ n: :float }, { "n" => "x" })).to eq(n: 0.0)
+    end
+
+    it ":boolean casts via ActiveModel and KEEPS an unrecognized value as nil (not DROP)" do
+      expect(coerce({ b: :boolean }, { "b" => "1" })).to eq(b: true)
+      expect(coerce({ b: :boolean }, { "b" => "0" })).to eq(b: false)
+      # ActiveModel casts a blank string to nil (its FALSE_VALUES include ""),
+      # and that nil is KEPT (the key is present) — it does NOT DROP. This is the
+      # shipped controller's behavior; a boolean never drops.
+      expect(coerce({ b: :boolean }, { "b" => "" })).to eq(b: nil)
+    end
+
+    it ":string is the default cast (to_s)" do
+      expect(coerce({ s: :string }, { "s" => 5 })).to eq(s: "5")
+    end
+
+    it "drops undeclared keys (no mass assignment)" do
+      expect(coerce({ a: :string }, { "a" => "x", "admin" => "true" })).to eq(a: "x")
+    end
+
+    it "drops a declared key that is absent from the payload (keyword default applies)" do
+      expect(coerce({ a: :string, b: :integer }, { "a" => "x" })).to eq(a: "x")
+    end
+  end
+
+  describe "#coerce — :file duck-type DROP" do
+    let(:upload) do
+      Class.new do
+        def original_filename = "x.png"
+        def read(*) = "bytes"
+      end.new
+    end
+
+    it "passes an uploaded file through untouched" do
+      expect(coerce({ f: :file }, { "f" => upload })).to eq(f: upload)
+    end
+
+    it "drops a non-file value sent to a :file param (keyword default applies)" do
+      expect(coerce({ f: :file }, { "f" => "not-a-file" })).to eq({})
+    end
+  end
+
+  describe "#coerce — array rules (DROP-don't-fabricate)" do
+    it "coerces a real array element-wise" do
+      expect(coerce({ ids: [:integer] }, { "ids" => %w[1 2 3] })).to eq(ids: [1, 2, 3])
+    end
+
+    it "accepts a Rails index hash in index order" do
+      expect(coerce({ ids: [:integer] }, { "ids" => { "0" => "10", "1" => "11" } })).to eq(ids: [10, 11])
+    end
+
+    it "drops a present-but-non-array scalar rather than fabricating [scalar]" do
+      # coercing a stray scalar to [] would read as an explicit 'clear everything'
+      expect(coerce({ ids: [:integer] }, { "ids" => "5" })).to eq({})
+    end
+
+    it "keeps a genuinely empty array as []" do
+      expect(coerce({ ids: [:integer] }, { "ids" => [] })).to eq(ids: [])
+    end
+
+    it "drops an array whose every element drops (a [:file] of non-files)" do
+      expect(coerce({ pages: [:file] }, { "pages" => %w[a b] })).to eq({})
+    end
+  end
+
+  describe "#coerce — nested hash + bracket expansion" do
+    it "recurses into a nested hash schema, dropping undeclared nested keys" do
+      schema = { invoice: { date: :string, status: :string } }
+      params = { "invoice" => { "date" => "2026-01-02", "status" => "open", "secret" => "x" } }
+      expect(coerce(schema, params)).to eq(invoice: { date: "2026-01-02", status: "open" })
+    end
+
+    it "expands flat bracketed keys (Rails Form(model:)) before matching" do
+      schema = { invoice: { date: :string, status: :string } }
+      params = { "invoice[date]" => "2026-01-02", "invoice[status]" => "open" }
+      expect(coerce(schema, params)).to eq(invoice: { date: "2026-01-02", status: "open" })
+    end
+
+    it "deep-merges a bracket key with a sibling pre-nested object" do
+      schema = { invoice: { date: :string, status: :string } }
+      params = { "invoice[date]" => "2026-01-02", "invoice" => { "status" => "open" } }
+      expect(coerce(schema, params)).to eq(invoice: { date: "2026-01-02", status: "open" })
+    end
+
+    it "coerces the array-of-hash Rails bracket form (the bench payload shape)" do
+      schema = {
+        date: :string,
+        bank_account_ids: [:integer],
+        invoice_items_attributes: [{ id: :integer, quantity: :float, price: :float, _destroy: :boolean }]
+      }
+      params = {
+        "date" => "2026-01-02",
+        "bank_account_ids[]" => %w[1 2 3],
+        "invoice_items_attributes[0][id]" => "10",
+        "invoice_items_attributes[0][quantity]" => "2.5",
+        "invoice_items_attributes[0][price]" => "9.99",
+        "invoice_items_attributes[0][_destroy]" => "false"
+      }
+      expect(coerce(schema, params)).to eq(
+        date: "2026-01-02",
+        bank_account_ids: [1, 2, 3],
+        invoice_items_attributes: [{ id: 10, quantity: 2.5, price: 9.99, _destroy: false }]
+      )
+    end
+  end
+
+  describe "#coerce — a schema-less action drops everything" do
+    it "returns {} for an empty schema regardless of payload" do
+      expect(coerce({}, { "anything" => "x" })).to eq({})
+    end
+  end
+
+  describe "new built-in: :date" do
+    it "parses an ISO8601 date" do
+      expect(coerce({ d: :date }, { "d" => "2026-01-02" })).to eq(d: Date.new(2026, 1, 2))
+    end
+
+    it "DROPs an unparseable date (keyword default applies)" do
+      expect(coerce({ d: :date }, { "d" => "not-a-date" })).to eq({})
+    end
+
+    it "DROPs a blank string" do
+      expect(coerce({ d: :date }, { "d" => "" })).to eq({})
+    end
+  end
+
+  describe "new built-in: :datetime" do
+    it "parses an ISO8601 datetime" do
+      expect(coerce({ t: :datetime }, { "t" => "2026-01-02T10:30:00Z" }))
+        .to eq(t: DateTime.iso8601("2026-01-02T10:30:00Z"))
+    end
+
+    it "DROPs an unparseable datetime" do
+      expect(coerce({ t: :datetime }, { "t" => "garbage" })).to eq({})
+    end
+  end
+
+  describe "new built-in: :decimal" do
+    it "parses a decimal via BigDecimal" do
+      expect(coerce({ amount: :decimal }, { "amount" => "9.99" })).to eq(amount: BigDecimal("9.99"))
+    end
+
+    it "DROPs a non-numeric string (BigDecimal ArgumentError)" do
+      expect(coerce({ amount: :decimal }, { "amount" => "abc" })).to eq({})
+    end
+  end
+
+  describe "app-registered custom param types" do
+    around do
+      # These specs register+unregister a temporary type; keep the registry
+      # unfrozen for the duration and restore it afterward.
+      Phlex::Reactive.reset_param_types! if Phlex::Reactive.respond_to?(:reset_param_types!)
+      it.run
+    ensure
+      Phlex::Reactive.reset_param_types! if Phlex::Reactive.respond_to?(:reset_param_types!)
+    end
+
+    it "casts through a registered callable" do
+      Phlex::Reactive.param_type(:shout) {  it.to_s.upcase }
+      expect(coerce({ s: :shout }, { "s" => "hi" })).to eq(s: "HI")
+    end
+
+    it "DROPs when the callable returns the DROP sentinel" do
+      Phlex::Reactive.param_type(:money) {  /\A\d+\z/.match?(it.to_s) ? Integer(it) : Phlex::Reactive::ParamSchema::DROP }
+      expect(coerce({ m: :money }, { "m" => "500" })).to eq(m: 500)
+      expect(coerce({ m: :money }, { "m" => "abc" })).to eq({})
+    end
+
+    it "compiles a schema referencing a registered type without raising" do
+      Phlex::Reactive.param_type(:slug) { it.to_s.downcase.tr(" ", "-") }
+      expect { described_class.compile({ s: :slug }) }.not_to raise_error
+    end
+  end
+
+  describe "registry is frozen after boot" do
+    around do
+      was_frozen = Phlex::Reactive.param_types_frozen?
+      Phlex::Reactive.reset_param_types!
+      it.run
+    ensure
+      Phlex::Reactive.reset_param_types!
+      Phlex::Reactive.freeze_param_types! if was_frozen
+    end
+
+    it "rejects registration after freeze_param_types!" do
+      Phlex::Reactive.freeze_param_types!
+      expect { Phlex::Reactive.param_type(:late) { |v| v } }
+        .to raise_error(Phlex::Reactive::Error, /frozen|boot|initializer/i)
+    end
+  end
+
+  describe "verbose_errors collector plumbing" do
+    it "records an undeclared top-level key with its reason" do
+      dropped = []
+      coerce({ a: :string }, { "a" => "x", "admin" => "true" }, dropped)
+      expect(dropped).to include(["admin", :undeclared])
+    end
+
+    it "records an undeclared NESTED key with its full bracketed path" do
+      dropped = []
+      schema = { invoice_items_attributes: [{ id: :integer }] }
+      coerce(schema, { "invoice_items_attributes" => [{ "id" => "1", "secret" => "x" }] }, dropped)
+      expect(dropped).to include(["invoice_items_attributes[0][secret]", :undeclared])
+    end
+
+    it "records a declared key whose value could not be coerced as uncoercible" do
+      dropped = []
+      coerce({ ids: [:integer] }, { "ids" => "5" }, dropped)
+      expect(dropped).to include(["ids", :uncoercible])
+    end
+
+    it "records a dropped ARRAY ELEMENT with its bracketed index" do
+      dropped = []
+      coerce({ pages: [:file] }, { "pages" => ["not-a-file"] }, dropped)
+      expect(dropped).to include(["pages[0]", :uncoercible])
+    end
+
+    it "does zero collector work when the collector is nil (production path)" do
+      # nil collector must never raise and must produce the same coerced result
+      expect(coerce({ a: :string }, { "a" => "x", "admin" => "true" }, nil)).to eq(a: "x")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the ~200 lines of param coercion (the correctness-critical logic behind #16/#21/#24/#39) out of `ActionsController` into a standalone `Phlex::Reactive::ParamSchema`, **compiled once** at declaration (`Component.action`) instead of interpreted on every request. Two adopter-facing wins on top of a behavior-identical move:

- **Typos fail loud, at boot.** A schema naming an unknown type symbol (`params: { count: :interger }`) now raises **`Phlex::Reactive::UnknownParamType`** (an `ArgumentError` subclass) at class load — validated recursively through nested-hash and array-of-hash element types — instead of silently coercing the value to a `String` at click time.
- **New built-in types + custom registration.** `:date`/`:datetime` (ISO8601, dropped on a parse failure) and `:decimal` (`BigDecimal`, dropped on a non-numeric value) join the built-ins. Register your own with **`Phlex::Reactive.param_type(:money) { |v| … }`** in an initializer — return `Phlex::Reactive::ParamSchema::DROP` to reject a value (the keyword default then applies, keeping the drop-don't-fabricate contract). The registry is frozen after boot, so registration is initializer-only.

The controller shrinks to `action_def.schema.coerce(raw, collector)` and keeps only the verbose-error **log formatting**.

## Behavior is byte-for-byte identical

Every existing built-in keeps its exact semantics (`"abc".to_i → 0` not a drop; the `:file` duck-type drop; the array/hash drop rules; the bracket-expansion and deep-merge matrix), and the `verbose_errors` dropped-param collector (#82/#87) threads through unchanged — a `nil` collector is still the zero-cost production path. The full existing request-spec suite is green **untouched**, which is the definition of done for the move.

## Root cause fixed along the way

The `phlex` gem defines `Phlex::ArgumentError` (a subclass of the stdlib one). This file is nested under `Phlex::Reactive`, so a bare `rescue ArgumentError` resolves **lexically** to `Phlex::ArgumentError` — which would **not** catch a stdlib `Date::Error`, so a bad `:date`/`:decimal` value would surface as a **500** instead of the intended DROP. Fixed at the constant-resolution point: top-level `::ArgumentError`/`::TypeError` in the parse rescue, and `::ArgumentError` as `UnknownParamType`'s superclass. Caught by running the unit spec inside the booted request suite (it passes in isolation but the shadowing only bites once Phlex is loaded).

## Test Coverage

- **`spec/phlex/reactive/param_schema_spec.rb` (new, unit):** compile-time validation (typo raises, nested + array-of-hash recursion), each built-in incl. the new `:date`/`:datetime`/`:decimal` (valid → cast, garbage → DROP → keyword default), custom `param_type` registration, registry frozen after boot, and the verbose collector plumbing.
- **`component_spec`:** schema compiled at declaration; a typo'd type symbol raises `UnknownParamType` at class load.
- **Full existing request suite green untouched** — `verbose_errors`, bracket/nested/file/multipart matrices all pass (the `#16`/`#21`/`#24`/`#39` deep-merge algorithm was **not** rewritten, per perf rule 4).

## Bench (mandatory)

`rake bench:one[coerce_params]`, same machine:

| Metric | Before (main) | After (#109) |
|--------|---------------|--------------|
| Throughput | ~35.5k i/s | ~36.0k i/s |
| Allocations | 207 obj/call | 202 obj/call |
| Retained | 0 | 0 |

Unchanged within noise; 5 fewer allocations/call because the memoized `Boolean` type replaces a per-call `ActiveModel::Type::Boolean.new`. This is a **method-level** measurement, not a request-level claim (the Rails stack + DB dominate a real request).

## Verification

- [x] `bundle exec rubocop` (156 files) clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 544 passed
- [x] docs security page: `cd docs && bundle exec rubocop` clean
- [x] README param types (+ `:date`/`:datetime`/`:decimal` + `param_type`), security page, CHANGELOG (incl. the breaking note)

## Invariants preserved

Schema-coerced params (drop-don't-fabricate) is a security invariant — no behavioral drift, statuses unchanged, nothing ships to the client. pgbus optionality untouched (no transport code changed).

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added declaration-time compilation and validation for action `params:` schemas, including built-in support for `:date`, `:datetime`, and `:decimal`.
  * Added support for custom param types and a `DROP` behavior to omit invalid/uncoercible values (so action keyword defaults apply).
* **Bug Fixes**
  * Improved coercion so malformed or undeclared nested values are dropped rather than fabricated.
  * Added verbose diagnostics for dropped/uncoercible params, including bracketed key paths.
* **Breaking Change**
  * Unknown param type symbols now raise `UnknownParamType` during class load (instead of silently coercing to `String`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->