### PR TITLE
feat(component): public Phlex::Reactive::TestHelpers + no-HTTP run_reactive action driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Public `Phlex::Reactive::TestHelpers` + a no-HTTP `run_reactive` action
+  driver (#110).** The gem now ships the test surface it used to keep private.
+  Mix it in (`config.include Phlex::Reactive::TestHelpers`) for:
+  - **`run_reactive(component, :act, **params)`** — the no-HTTP unit driver. It
+    runs the action through the SAME security contract the endpoint enforces —
+    **default-deny** (an undeclared action raises
+    `Phlex::Reactive::TestHelpers::UndeclaredReactiveAction`), the **signed
+    identity round-trip** (a record-backed component's row is re-found; a deleted
+    record raises `ActiveRecord::RecordNotFound`, the endpoint's 404), **schema
+    coercion** (#109), and the same **transaction wrapper** — with no HTTP, and
+    returns a `Result`. A registered authorization error RAISES (the endpoint
+    maps it to 403). So a unit test can no longer pass on a component that would
+    fail a real click.
+  - **`Result`** — wraps the action's return: `replace?` / `remove?` /
+    `redirect?` / `redirect_url` / `streams` / `response`, plus `component` (the
+    instance rebuilt from identity — the one the action ran against). A legacy
+    action returning an arbitrary value reads as an implicit replace.
+  - **`reactive_token_for(component_or_class, payload = {})`** — mint a token the
+    way a component does (class form via the public `Phlex::Reactive.sign`;
+    instance form wraps the private `reactive_token`). No more
+    `component.send(:reactive_token)`.
+  - **`post_reactive_action` / `post_reactive_multipart`** — POST a signed token
+    to **`Phlex::Reactive.action_path`** (never a hardcoded `/reactive/actions`,
+    so a remounted path is honored) exactly as the client encodes it.
+  - **Matchers** `have_reactive_replace`, `have_reactive_remove`,
+    `have_reactive_token_for` (RSpec; loaded only when RSpec is present, so a
+    Minitest app asserts on `Result` predicates directly). The token matcher pins
+    the #44/#46 refresh regression class for adopters.
+
+  The gem's own request suite now runs THROUGH the public module (dogfooding),
+  and the component-generator spec template + the testing docs teach the public
+  API — every `send(:reactive_token)` instruction is gone.
+
 - **`Phlex::Reactive::ParamSchema` — declaration-time validation + app-registerable
   param types (#109).** The ~200 lines of param coercion moved out of
   `ActionsController` into a standalone `Phlex::Reactive::ParamSchema`, **compiled

--- a/README.md
+++ b/README.md
@@ -1758,6 +1758,56 @@ check per dispatch, no string building — so it is safe to leave gated on
 
 ---
 
+## Testing
+
+`Phlex::Reactive::TestHelpers` is the public test surface — mix it in once and
+never reach for a private method or a hand-rolled POST:
+
+```ruby
+# spec/rails_helper.rb
+RSpec.configure do |c|
+  c.include Phlex::Reactive::TestHelpers                  # run_reactive + matchers
+  c.include Phlex::Reactive::TestHelpers, type: :request  # + the HTTP helpers
+end
+```
+
+**`run_reactive` — the no-HTTP action driver.** It runs the action through the
+SAME contract the endpoint enforces — default-deny, the signed identity
+round-trip (a record-backed component's row is re-found), schema coercion, the
+transaction wrapper — with no HTTP, and returns a `Result`. So a unit test can't
+pass on a component that would fail a real click:
+
+```ruby
+result = run_reactive(Counter.new(count: 0), :set, count: "42")  # client sends strings
+expect(result).to have_reactive_replace("counter")
+expect(result.component.instance_variable_get(:@count)).to eq(42)  # :integer, cast
+
+# default-deny, deleted-record, and authorization all surface as the real failures:
+expect { run_reactive(Counter.new(count: 0), :drop_table) }
+  .to raise_error(Phlex::Reactive::TestHelpers::UndeclaredReactiveAction)
+```
+
+`Result` answers `replace?` / `remove?` / `redirect?` / `redirect_url` /
+`streams` / `response`, plus `component` (the instance rebuilt from identity, the
+one the action ran against). A registered authorization error **raises** (the
+endpoint maps it to 403). Matchers: `have_reactive_replace`,
+`have_reactive_remove`, `have_reactive_token_for` — the last pins the token
+refresh so a reply that would silently break the next click fails your test.
+
+**HTTP helpers** — `post_reactive_action(component_or_class, act, params:, payload:)`
+and `post_reactive_multipart(...)` POST a signed token to
+`Phlex::Reactive.action_path` exactly as the client does. **Token minting** —
+`reactive_token_for(component_or_class, payload = {})`.
+
+> `verbose_errors` defaults ON in test (it changes only an error BODY, never a
+> status). Asserting an empty failure body? Set
+> `Phlex::Reactive.verbose_errors = false` in your setup.
+
+See [the testing guide](https://phlex-reactive.zoolutions.llc/docs/testing) for
+the full layer-by-layer walkthrough.
+
+---
+
 ## Documentation
 
 - [Installation & bundler setups](https://phlex-reactive.zoolutions.llc/docs/installation)

--- a/docs/app/views/docs/pages/testing.rb
+++ b/docs/app/views/docs/pages/testing.rb
@@ -13,7 +13,9 @@ module Views
         end
 
         def content
+          setup
           unit_actions
+          unit_driver
           unit_identity
           integration_endpoint
           system_browser
@@ -22,6 +24,46 @@ module Views
         end
 
         private
+
+        def setup
+          DocsUI::Section('Setup: the public test helpers') do
+            DocsUI::Prose() do
+              p do
+                plain 'Mix in '
+                code { 'Phlex::Reactive::TestHelpers' }
+                plain ' once. It ships token minting ('
+                code { 'reactive_token_for' }
+                plain '), the no-HTTP action driver ('
+                code { 'run_reactive' }
+                plain '), request helpers ('
+                code { 'post_reactive_action' }
+                plain '/'
+                code { 'post_reactive_multipart' }
+                plain '), and the '
+                code { 'have_reactive_*' }
+                plain ' matchers — so you never reach for a private method or hand-roll a POST.'
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby)
+              # spec/rails_helper.rb (RSpec)
+              RSpec.configure do |c|
+                c.include Phlex::Reactive::TestHelpers                  # driver + matchers everywhere
+                c.include Phlex::Reactive::TestHelpers, type: :request  # + the HTTP helpers
+              end
+            RUBY
+            DocsUI::Prose() do
+              p do
+                strong { 'Note' }
+                plain ' — '
+                code { 'verbose_errors' }
+                plain ' defaults ON in test (it only changes an error BODY, never a status). If you '
+                plain 'assert an empty failure body, set '
+                code { 'Phlex::Reactive.verbose_errors = false' }
+                plain ' in your setup.'
+              end
+            end
+          end
+        end
 
         def unit_actions
           DocsUI::Section('1. Unit: actions are just methods') do
@@ -39,15 +81,85 @@ module Views
           end
         end
 
-        def unit_identity
-          DocsUI::Section('2. Unit: the identity token round-trips') do
+        def unit_driver
+          DocsUI::Section('2. Unit: run_reactive drives the action through the security contract') do
             DocsUI::Prose() do
-              p { plain 'Verify the signed token rebuilds the same component (and that tampering fails).' }
+              p do
+                plain 'Calling the method directly (above) skips what the real endpoint enforces. '
+                code { 'run_reactive' }
+                plain ' runs the action through the SAME contract — default-deny, the signed identity '
+                plain 'round-trip (the record is re-found), schema coercion — with no HTTP, and returns a '
+                code { 'Result' }
+                plain ' you assert on. So a unit test can\'t pass on a component that would fail a real click.'
+              end
+            end
+            DocsUI::Code(<<~RUBY, lexer: :ruby)
+              test "set coerces the :integer param and replaces the component" do
+                # The client sends strings; the schema declares count: :integer.
+                result = run_reactive(Counter.new(count: 0), :set, count: "42")
+
+                expect(result).to have_reactive_replace("counter")
+                expect(result.component.instance_variable_get(:@count)).to eq(42) # cast, not "42"
+              end
+
+              test "an undeclared action is denied (default-deny)" do
+                expect { run_reactive(Counter.new(count: 0), :drop_table) }
+                  .to raise_error(Phlex::Reactive::TestHelpers::UndeclaredReactiveAction)
+              end
+
+              test "a deleted record surfaces as RecordNotFound (the endpoint's 404)" do
+                item = Todos::Item.new(todo:)
+                todo.destroy!
+                expect { run_reactive(item, :toggle) }.to raise_error(ActiveRecord::RecordNotFound)
+              end
+
+              test "archive removes the row (and carries no replace)" do
+                result = run_reactive(Todos::Item.new(todo:), :archive)
+                expect(result).to have_reactive_remove(Todos::Item.new(todo:))
+              end
+            RUBY
+            DocsUI::Prose() do
+              p do
+                plain 'The '
+                code { 'Result' }
+                plain ' exposes '
+                code { 'replace?' }
+                plain '/'
+                code { 'remove?' }
+                plain '/'
+                code { 'redirect?' }
+                plain '/'
+                code { 'redirect_url' }
+                plain '/'
+                code { 'streams' }
+                plain '/'
+                code { 'response' }
+                plain ', plus '
+                code { 'component' }
+                plain ' — the instance REBUILT from identity, the one the action actually ran against. '
+                plain 'A registered authorization error RAISES (the endpoint maps it to 403); assert with '
+                code { 'raise_error' }
+                plain '.'
+              end
+            end
+          end
+        end
+
+        def unit_identity
+          DocsUI::Section('3. Unit: the identity token round-trips') do
+            DocsUI::Prose() do
+              p do
+                plain 'Verify the signed token rebuilds the same component (and that tampering fails). '
+                code { 'reactive_token_for' }
+                plain ' mints the token the component would — no private '
+                code { 'send' }
+                plain '.'
+              end
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               test "record-backed identity round-trips" do
                 todo = todos(:write_docs)
-                token = Todos::Item.new(todo:).send(:reactive_token)
+                token = reactive_token_for(Todos::Item.new(todo:))
 
                 payload = Phlex::Reactive.verify(token)
                 assert_equal "Todos::Item", payload["c"]
@@ -57,7 +169,7 @@ module Views
               end
 
               test "tampered token is rejected" do
-                token = Counter.new(count: 1).send(:reactive_token)
+                token = reactive_token_for(Counter.new(count: 1))
                 assert_nil Phlex::Reactive.verify(token + "x")
               end
             RUBY
@@ -65,22 +177,21 @@ module Views
         end
 
         def integration_endpoint
-          DocsUI::Section('3. Integration: the action endpoint') do
+          DocsUI::Section('4. Integration: the action endpoint') do
             DocsUI::Prose() do
               p do
-                plain 'POST a signed token to '
-                code { '/reactive/actions' }
-                plain ' and assert the turbo-stream response. Mint the token the same way the component does.'
+                plain 'When you want the FULL HTTP round trip (routing, CSRF, the real status codes), '
+                code { 'post_reactive_action' }
+                plain ' posts a signed token to '
+                code { 'Phlex::Reactive.action_path' }
+                plain ' the way the client does — pass a component instance (or a class + '
+                code { 'payload:' }
+                plain ') and assert the turbo-stream response.'
               end
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               test "increment action returns a turbo-stream replace" do
-                token = Counter.new(count: 1).send(:reactive_token)
-
-                post "/reactive/actions",
-                  params: { token:, act: "increment" }.to_json,
-                  headers: { "Content-Type" => "application/json",
-                             "Accept" => "text/vnd.turbo-stream.html" }
+                post_reactive_action(Counter.new(count: 1), :increment)
 
                 assert_response :success
                 assert_match %r{<turbo-stream action="replace" target="counter">}, response.body
@@ -88,10 +199,7 @@ module Views
               end
 
               test "undeclared action is forbidden" do
-                token = Counter.new(count: 1).send(:reactive_token)
-                post "/reactive/actions",
-                  params: { token:, act: "drop_table" }.to_json,
-                  headers: { "Content-Type" => "application/json" }
+                post_reactive_action(Counter.new(count: 1), :drop_table)
                 assert_response :forbidden
               end
             RUBY
@@ -146,7 +254,7 @@ module Views
         end
 
         def system_browser
-          DocsUI::Section('4. System / browser: the full loop & broadcasts') do
+          DocsUI::Section('5. System / browser: the full loop & broadcasts') do
             DocsUI::Prose() do
               p do
                 plain 'Use a system test (Capybara) or a browser-automation CLI for the end-to-end loop ' \
@@ -185,7 +293,7 @@ module Views
         end
 
         def client_unit
-          DocsUI::Section('5. Client unit tests (bun)') do
+          DocsUI::Section('6. Client unit tests (bun)') do
             DocsUI::Prose() do
               p do
                 plain 'Some client-runtime contracts are timing-sensitive and a full browser can mask them — ' \

--- a/lib/generators/phlex/reactive/component/templates/component_spec.rb.erb
+++ b/lib/generators/phlex/reactive/component/templates/component_spec.rb.erb
@@ -2,6 +2,13 @@
 
 require "rails_helper"
 
+# Uses the public Phlex::Reactive::TestHelpers (reactive_token_for, run_reactive,
+# and the have_reactive_* matchers). Mix them in once in your rails_helper:
+#
+#   RSpec.configure do |c|
+#     c.include Phlex::Reactive::TestHelpers
+#     c.include Phlex::Reactive::TestHelpers, type: :request
+#   end
 RSpec.describe <%= class_name %> do
   describe "reactive declarations" do
 <% action_names.each do |a| -%>
@@ -15,9 +22,19 @@ RSpec.describe <%= class_name %> do
   describe "identity" do
     it "signs the record's GlobalID into a verifiable token" do
       # record = <%= record_name %>_fixture_or_factory
-      # token = described_class.new(<%= record_name %>: record).send(:reactive_token)
+      # token = reactive_token_for(described_class.new(<%= record_name %>: record))
       # expect(Phlex::Reactive.verify(token)["gid"]).to eq(record.to_gid.to_s)
       skip "provide a <%= record_name %> record to assert identity round-trip"
+    end
+  end
+
+  describe "an action (no HTTP)" do
+    it "runs :<%= action_names.first %> through the security contract" do
+      # run_reactive goes THROUGH default-deny + signed identity round-trip (the
+      # record is re-found) + schema coercion, then returns a Result:
+      #   result = run_reactive(described_class.new(<%= record_name %>: record), :<%= action_names.first %>)
+      #   expect(result).to have_reactive_replace(described_class.new(<%= record_name %>: record))
+      skip "provide a <%= record_name %> record to drive the action"
     end
   end
 <% else -%>
@@ -25,9 +42,23 @@ RSpec.describe <%= class_name %> do
   describe "identity" do
     it "signs state into a verifiable token and rebuilds it" do
       component = described_class.new(<%= state_keys.map { |k| "#{k}: #{k == state_keys.first ? "1" : "nil"}" }.join(", ") %>)
-      payload = Phlex::Reactive.verify(component.send(:reactive_token))
+      payload = Phlex::Reactive.verify(reactive_token_for(component))
       expect(payload["c"]).to eq("<%= class_name %>")
       expect(described_class.from_identity(payload)).to be_a(described_class)
+    end
+  end
+
+  describe "an action (no HTTP)" do
+    it "runs :<%= action_names.first %> through the security contract" do
+      # run_reactive goes THROUGH default-deny + the signed identity round-trip +
+      # schema coercion, then returns a Result you assert on. Read the rebuilt
+      # component (result.component) for state changes:
+      result = run_reactive(
+        described_class.new(<%= state_keys.map { |k| "#{k}: #{k == state_keys.first ? "1" : "nil"}" }.join(", ") %>),
+        :<%= action_names.first %>
+      )
+
+      expect(result).to have_reactive_replace(described_class.new(<%= state_keys.map { |k| "#{k}: #{k == state_keys.first ? "1" : "nil"}" }.join(", ") %>))
     end
   end
 <% end -%>

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -462,6 +462,11 @@ loader.ignore("#{lib}/phlex/reactive/version.rb")
 # (generators/phlex/reactive/... defining Phlex::Reactive::Generators::...)
 # deliberately doesn't follow Zeitwerk's rules, so the loader must ignore them.
 loader.ignore("#{lib}/generators")
+# The RSpec matchers file (issue #110) defines RSpec::Matchers, not a
+# Phlex::Reactive::TestHelpers::Matchers constant, so it doesn't follow
+# Zeitwerk's naming — test_helpers.rb requires it explicitly (only when RSpec is
+# present), and the loader must ignore it.
+loader.ignore("#{lib}/phlex/reactive/test_helpers/matchers.rb")
 # The engine is required explicitly below (only when Rails is present) and must
 # not be eager-loaded before that.
 loader.do_not_eager_load("#{__dir__}/reactive/engine.rb")

--- a/lib/phlex/reactive/test_helpers.rb
+++ b/lib/phlex/reactive/test_helpers.rb
@@ -237,7 +237,14 @@ module Phlex
         def remove?
           return false if @response.nil?
 
-          @response.streams.any? { it.include?(%(action="remove")) }
+          # Check the OPENING <turbo-stream> tag, not the whole string: a rendered
+          # body that happens to contain the literal `action="remove"` (a quoted
+          # code sample, say) must not false-positive. Same parse the token check
+          # and the matchers use.
+          @response.streams.any? do
+            open_tag = it[/<turbo-stream\b[^>]*>/] || ""
+            open_tag.include?(%(action="remove"))
+          end
         end
 
         def redirect?

--- a/lib/phlex/reactive/test_helpers.rb
+++ b/lib/phlex/reactive/test_helpers.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # Public test helpers for downstream apps (issue #110). Livewire ships
+    # `Livewire::test(...)`; this is the phlex-reactive equivalent — a public
+    # surface so an app never reaches for the PRIVATE `component.send(:reactive_token)`
+    # or hand-rolls the POST headers the docs used to teach.
+    #
+    # Mix it in from your rails_helper:
+    #
+    #   RSpec.configure do |c|
+    #     c.include Phlex::Reactive::TestHelpers, type: :request  # HTTP helpers
+    #     c.include Phlex::Reactive::TestHelpers                   # + the no-HTTP driver
+    #   end
+    #
+    # The HTTP helpers (post_reactive_action/post_reactive_multipart) need Rails'
+    # integration `post`, so they belong in `type: :request` examples. The no-HTTP
+    # driver (run_reactive) and token minting work anywhere.
+    #
+    # The driver goes THROUGH the endpoint's security contract on purpose —
+    # default-deny, signed identity round-trip (record re-find), schema coercion,
+    # the same transaction wrapper. A helper that skipped it would teach users to
+    # test a component that would fail at the real endpoint.
+    #
+    # NB: `verbose_errors` defaults ON in the test env (Rails.env.local? — issue
+    # #82). It only changes an endpoint FAILURE body (never a status), so it does
+    # not affect these helpers' happy path; a downstream app asserting an empty
+    # failure body may want `Phlex::Reactive.verbose_errors = false` in its setup.
+    module TestHelpers
+      # Raised by run_reactive when the action is not declared with `action
+      # :name`. The endpoint answers this with a 403 (default-deny); the driver
+      # raises so a unit test asserts the contract directly. A dedicated class
+      # (not a bare ArgumentError) so `raise_error(UndeclaredReactiveAction)` is
+      # unambiguous.
+      class UndeclaredReactiveAction < Phlex::Reactive::Error; end
+
+      # Mint an identity token exactly as a component would.
+      #   * CLASS form  — the already-public sign path: Phlex::Reactive.sign(
+      #     payload.merge("c" => klass.name)). Pass the identity pieces yourself
+      #     ("gid" => record.to_gid.to_s, "s" => {...}) when you need them.
+      #   * INSTANCE form — wraps the component's PRIVATE #reactive_token, so the
+      #     token carries the instance's live record/state with no hand-assembly.
+      def reactive_token_for(component_or_class, payload = {})
+        if component_or_class.is_a?(::Class)
+          Phlex::Reactive.sign(payload.merge("c" => component_or_class.name))
+        else
+          component_or_class.send(:reactive_token)
+        end
+      end
+
+      # POST a reactive action as the client's JSON body (token + act + params) to
+      # Phlex::Reactive.action_path — NEVER a hardcoded "/reactive/actions", so a
+      # remounted path (the gem warns about shadowed paths) is honored. Accepts a
+      # component INSTANCE or a CLASS + explicit `payload:` (the identity pieces).
+      def post_reactive_action(component_or_class, act, params: {}, payload: {})
+        token = reactive_action_token(component_or_class, payload)
+        post Phlex::Reactive.action_path,
+          params: { token:, act:, params: }.to_json,
+          headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+      end
+
+      # POST a reactive action as multipart FormData (the client's encoding when a
+      # `:file` param is present, issue #34): token + act flat, params bracketed.
+      # No JSON Content-Type — Rails' test `post` builds the multipart body from
+      # the nested Hash (files ride as UploadedFile values).
+      def post_reactive_multipart(component_or_class, act, params: {}, payload: {})
+        token = reactive_action_token(component_or_class, payload)
+        post Phlex::Reactive.action_path,
+          params: { token:, act:, params: },
+          headers: { "Accept" => "text/vnd.turbo-stream.html" }
+      end
+
+      # The no-HTTP unit driver. Runs `action` on `component` through the SAME
+      # security contract the endpoint enforces, and returns a Result:
+      #
+      #   1. default-deny — an undeclared action raises UndeclaredReactiveAction.
+      #   2. identity round-trip — signs the instance's token, verifies it, and
+      #      rebuilds the component via from_identity (re-finding a record-backed
+      #      component's row; a stale gid raises ActiveRecord::RecordNotFound, the
+      #      endpoint's 404 equivalent). So the action runs against the rebuilt
+      #      instance, exactly as it would after a real POST.
+      #   3. coercion — params pass through the action's compiled ParamSchema
+      #      (issue #109); undeclared keys are dropped, declared ones cast.
+      #   4. transaction — run inside the endpoint's transaction wrapper so
+      #      after_commit broadcasts behave.
+      #   5. authorization — a registered authorization error RAISES (the endpoint
+      #      maps it to 403; a unit test asserts the real exception).
+      def run_reactive(component, action, **params)
+        klass = component.class
+        action_def = klass.reactive_action(action) || raise_undeclared(klass, action)
+
+        rebuilt = rebuild_from_identity(component, klass)
+        coerced = action_def.schema.coerce(stringify_params(params))
+
+        returned = run_reactive_action(rebuilt, action_def, coerced)
+        Result.new(returned:, component: rebuilt)
+      end
+
+      private
+
+      # A component instance mints its own token; a class needs the caller's
+      # explicit identity payload merged under "c".
+      def reactive_action_token(component_or_class, payload)
+        if component_or_class.is_a?(::Class)
+          reactive_token_for(component_or_class, payload)
+        else
+          reactive_token_for(component_or_class)
+        end
+      end
+
+      def raise_undeclared(klass, action)
+        declared = klass.reactive_actions.keys.join(", ")
+        raise UndeclaredReactiveAction,
+          "action :#{action} is not declared on #{klass.name} — declared actions: #{declared}"
+      end
+
+      # Round-trip the identity: sign the instance's identity, verify it, rebuild
+      # via from_identity — so the driver re-finds a record-backed component's row
+      # exactly like the endpoint (and a stale gid raises RecordNotFound).
+      #
+      # The token captures identity AS OF RENDER TIME: a record-backed component
+      # holding a row that was deleted AFTER the page rendered still carries that
+      # row's gid — the real stale-token case (the page showed it, then it was
+      # destroyed, then the action fired). So we sign the gid from the record's id
+      # even when it's already destroyed, then from_identity's GlobalID lookup
+      # returns nil and raises RecordNotFound — the endpoint's 404 equivalent.
+      # A genuinely NEW (never-persisted) record has no id → no gid, matching
+      # reactive_token's own draft contract.
+      def rebuild_from_identity(component, klass)
+        payload = Phlex::Reactive.verify(reactive_token_for(component))
+        klass.from_identity(inject_destroyed_gid(payload, component, klass))
+      end
+
+      # Reproduce the stale-token case. #reactive_token omits the gid for a
+      # non-persisted record — correct for a live draft, but a DESTROYED record is
+      # also non-persisted, and there the page rendered a real gid (while the row
+      # lived) that only went stale on deletion. So when the component holds a
+      # record that was persisted (has an id) but is now destroyed, inject its gid
+      # into the verified payload; from_identity's GlobalID lookup then returns nil
+      # and raises RecordNotFound — the endpoint's 404 equivalent. A genuinely NEW
+      # record (no id) is untouched.
+      def inject_destroyed_gid(payload, component, klass)
+        return payload unless payload.is_a?(::Hash) && !payload.key?("gid")
+
+        record_ivar = klass.respond_to?(:reactive_record_ivar) && klass.reactive_record_ivar
+        record = record_ivar && component.instance_variable_get(record_ivar)
+        return payload unless record.respond_to?(:destroyed?) && record.destroyed? && record.id
+
+        payload.merge("gid" => record.to_gid.to_s)
+      end
+
+      # Coerce the caller's kwargs the way the client's params arrive — every value
+      # is a string on the wire, so a `:integer` param really is cast, not passed
+      # through as a live Integer. Keys are stringified (the schema keys on
+      # strings), values deep-stringified so nested/array params coerce too, but
+      # UploadedFiles (issue #34) and nil pass through untouched.
+      def stringify_params(params)
+        params.each_with_object({}) { |(k, v), h| h[k.to_s] = stringify_param_value(v) }
+      end
+
+      def stringify_param_value(value)
+        case value
+        when ::Hash then value.each_with_object({}) { |(k, v), h| h[k.to_s] = stringify_param_value(v) }
+        when ::Array then value.map { stringify_param_value(it) }
+        when nil then nil
+        when ::String, ::Numeric, true, false then value.to_s
+        else value # UploadedFile and any other rich object rides through as-is
+        end
+      end
+
+      # Run inside the endpoint's transaction wrapper. `coerced` already has
+      # symbol keys (ParamSchema#coerce symbolizes to splat as kwargs), so we
+      # splat it exactly as the endpoint does. Kept tiny and dependency tolerant:
+      # no ActiveRecord (a state-only component in a bare app) just yields.
+      def run_reactive_action(component, action_def, coerced)
+        transaction_wrapper do
+          if coerced.any?
+            component.public_send(action_def.name, **coerced)
+          else
+            component.public_send(action_def.name)
+          end
+        end
+      end
+
+      def transaction_wrapper(&)
+        if defined?(::ActiveRecord::Base)
+          ::ActiveRecord::Base.transaction(&)
+        else
+          yield
+        end
+      end
+
+      # The action's outcome, in the same terms the endpoint reasons about.
+      # Wraps the action's RETURN VALUE:
+      #   * a Phlex::Reactive::Response — honored explicitly (replace/remove/
+      #     redirect derived from it, exposed via #response).
+      #   * anything else — the legacy contract (return value ignored by the
+      #     endpoint, which falls back to the single self-replace). So a legacy
+      #     action reports replace? true and #response nil.
+      #
+      # #streams reproduces the endpoint's actor streams (issue #110) — including
+      # the token-refresh injection response_streams performs — so a matcher can
+      # assert on exactly what the client would receive.
+      class Result
+        # The Response the action returned, or nil when it returned a legacy
+        # (non-Response) value.
+        attr_reader :response
+
+        # The component the action actually ran against — the instance REBUILT
+        # from the round-tripped identity, NOT the one passed to run_reactive (the
+        # endpoint always acts on a rebuilt instance). Read its ivars to assert
+        # state-backed changes: `run_reactive(c, :set, count: "42").component`.
+        attr_reader :component
+
+        # A stream re-renders `component`'s root (so its fresh token counts as the
+        # refresh) iff its action is one of these — never append/prepend, which
+        # insert children carrying their OWN token (issue #44). Same set the
+        # endpoint's carries_token_for? uses.
+        SELF_RENDER_ACTIONS = %w[replace update reactive:token].freeze
+
+        def initialize(returned:, component:)
+          @returned = returned
+          @component = component
+          @response = returned if returned.is_a?(Phlex::Reactive::Response)
+        end
+
+        # A legacy return (no Response) is the implicit single self-replace. A
+        # Response replaces unless it removes or redirects (render_self? is false
+        # for those, and for a .streams/.with that opts out).
+        def replace?
+          return true if @response.nil?
+
+          @response.render_self?
+        end
+
+        def remove?
+          return false if @response.nil?
+
+          @response.streams.any? { it.include?(%(action="remove")) }
+        end
+
+        def redirect?
+          !@response.nil? && @response.redirect?
+        end
+
+        def redirect_url
+          @response&.redirect_url
+        end
+
+        # The actor's turbo-stream strings, exactly as the endpoint would render
+        # them (response_streams) — a legacy return is the single self-replace; a
+        # Response is honored, with the same token-refresh streams appended.
+        def streams
+          @streams ||= build_streams
+        end
+
+        private
+
+        # Mirrors ActionsController#response_streams. Kept in lockstep with the
+        # endpoint so the driver's streams match the real reply (issue #110).
+        def build_streams
+          return [@component.to_stream_replace] unless @response.is_a?(Phlex::Reactive::Response)
+          return [redirect_stream(@response.redirect_url)] if @response.redirect?
+
+          streams = @response.streams
+          if @response.refresh_token? && !carries_token_for?(streams, @response.token_component)
+            return [*streams, @response.token_component.to_stream_token]
+          end
+
+          if @response.render_self? && streams.none? { it.include?("data-reactive-token-value") }
+            streams = [@component.to_stream_replace, *streams]
+          end
+          streams
+        end
+
+        def redirect_stream(url)
+          %(<turbo-stream action="reactive:visit" data-url="#{ERB::Util.html_escape(url)}"></turbo-stream>)
+        end
+
+        # A stream already carries `component`'s fresh token iff it re-renders that
+        # component's root at its own id AND carries a token — same test the
+        # endpoint uses to avoid doubling the token (issue #44).
+        def carries_token_for?(streams, component)
+          target = %(target="#{ERB::Util.html_escape(component.id)}")
+          streams.any? do
+            next false unless it.include?("data-reactive-token-value") && it.include?(target)
+
+            open_tag = it[/<turbo-stream\b[^>]*>/]
+            open_tag&.include?(target) && SELF_RENDER_ACTIONS.include?(open_tag[/\baction="([^"]+)"/, 1])
+          end
+        end
+      end
+    end
+  end
+end
+
+# The RSpec matchers (have_reactive_replace/remove/token_for) are optional: load
+# them only when RSpec is present, so a Minitest app can mix in TestHelpers and
+# assert on Result predicates directly with no RSpec dependency.
+require "phlex/reactive/test_helpers/matchers" if defined?(RSpec::Matchers)

--- a/lib/phlex/reactive/test_helpers/matchers.rb
+++ b/lib/phlex/reactive/test_helpers/matchers.rb
@@ -90,9 +90,9 @@ end
 # Pins the #44/#46 token-refresh regression class: a reply that fails to roll the
 # component's signed token forward makes the next action reject silently. This
 # matcher asserts a fresh data-reactive-token-value for the component IS present.
-RSpec::Matchers.define :have_reactive_token_for do |component|
+RSpec::Matchers.define :have_reactive_token_for do |component_or_id|
   match do |result|
-    @id = component.id
+    @id = Phlex::Reactive::TestHelpers.matcher_target_id(component_or_id)
     @streams = result.streams
     target = %(target="#{ERB::Util.html_escape(@id)}")
     @streams.any? { |stream| stream.include?("data-reactive-token-value") && stream.include?(target) }

--- a/lib/phlex/reactive/test_helpers/matchers.rb
+++ b/lib/phlex/reactive/test_helpers/matchers.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# RSpec matchers for reactive action Results (issue #110). Loaded lazily by
+# Phlex::Reactive::TestHelpers only when RSpec is present, so the gem never hard
+# depends on RSpec — a Minitest app mixes in TestHelpers and simply asserts on
+# Result predicates (result.replace?, result.streams) directly.
+#
+#   expect(run_reactive(component, :toggle)).to have_reactive_replace(component)
+#   expect(run_reactive(component, :archive)).to have_reactive_remove(component)
+#   expect(run_reactive(component, :increment)).to have_reactive_token_for(component)
+#
+# Each matcher accepts a component INSTANCE or a bare DOM id String, and prints a
+# diff worth reading on failure (the stream actions/targets it actually saw).
+#
+# Style/ItBlockParameter is disabled FILE-WIDE on purpose: in RSpec::Matchers
+# .define, the `do |arg|` param is the EXPECTED value and `match do |actual|` the
+# MATCHED value — two distinct objects. Collapsing either to the implicit `it`
+# (as the cop's autocorrect does) conflates them and silently guts the matcher.
+# rubocop:disable Style/ItBlockParameter
+module Phlex
+  module Reactive
+    module TestHelpers
+      # The DOM id a matcher argument targets: a String is the id verbatim; a
+      # component instance answers #id.
+      def self.matcher_target_id(component_or_id)
+        component_or_id.is_a?(::String) ? component_or_id : component_or_id.id
+      end
+
+      # A compact listing of the turbo-stream action="..." target="..." pairs in
+      # `streams` — the readable core of every failure message.
+      def self.describe_streams(streams)
+        pairs = streams.map do |stream|
+          open_tag = stream[/<turbo-stream\b[^>]*>/] || stream
+          action = open_tag[/\baction="([^"]+)"/, 1] || "?"
+          target = open_tag[/\btarget="([^"]+)"/, 1]
+          target ? "#{action}->##{target}" : action
+        end
+        pairs.empty? ? "(no streams)" : pairs.join(", ")
+      end
+
+      # True when a turbo-stream's opening tag re-renders `id` with one of
+      # `actions` at that target. Shared by the replace/remove target checks.
+      def self.stream_action_targets?(stream, actions, id)
+        open_tag = stream[/<turbo-stream\b[^>]*>/] || ""
+        actions.include?(open_tag[/\baction="([^"]+)"/, 1]) &&
+          open_tag.include?(%(target="#{ERB::Util.html_escape(id)}"))
+      end
+    end
+  end
+end
+
+RSpec::Matchers.define :have_reactive_replace do |component_or_id|
+  match do |result|
+    @id = Phlex::Reactive::TestHelpers.matcher_target_id(component_or_id)
+    @streams = result.streams
+    result.replace? &&
+      @streams.any? { |stream| Phlex::Reactive::TestHelpers.stream_action_targets?(stream, %w[replace update], @id) }
+  end
+
+  failure_message do
+    "expected the reactive Result to replace ##{@id}, " \
+      "but it did not (streams: #{Phlex::Reactive::TestHelpers.describe_streams(@streams)})"
+  end
+
+  failure_message_when_negated do
+    "expected the reactive Result NOT to replace ##{@id}, but it did " \
+      "(streams: #{Phlex::Reactive::TestHelpers.describe_streams(@streams)})"
+  end
+end
+
+RSpec::Matchers.define :have_reactive_remove do |component_or_id|
+  match do |result|
+    @id = Phlex::Reactive::TestHelpers.matcher_target_id(component_or_id)
+    @streams = result.streams
+    result.remove? &&
+      @streams.any? { |stream| Phlex::Reactive::TestHelpers.stream_action_targets?(stream, %w[remove], @id) }
+  end
+
+  failure_message do
+    "expected the reactive Result to remove ##{@id}, " \
+      "but it did not (streams: #{Phlex::Reactive::TestHelpers.describe_streams(@streams)})"
+  end
+
+  failure_message_when_negated do
+    "expected the reactive Result NOT to remove ##{@id}, but it did " \
+      "(streams: #{Phlex::Reactive::TestHelpers.describe_streams(@streams)})"
+  end
+end
+
+# Pins the #44/#46 token-refresh regression class: a reply that fails to roll the
+# component's signed token forward makes the next action reject silently. This
+# matcher asserts a fresh data-reactive-token-value for the component IS present.
+RSpec::Matchers.define :have_reactive_token_for do |component|
+  match do |result|
+    @id = component.id
+    @streams = result.streams
+    target = %(target="#{ERB::Util.html_escape(@id)}")
+    @streams.any? { |stream| stream.include?("data-reactive-token-value") && stream.include?(target) }
+  end
+
+  failure_message do
+    "expected the reactive Result to carry a fresh signed token for ##{@id} " \
+      "(a data-reactive-token-value at its target), but none was present — the next action " \
+      "from ##{@id} would be rejected with a stale token (streams: " \
+      "#{Phlex::Reactive::TestHelpers.describe_streams(@streams)})"
+  end
+
+  failure_message_when_negated do
+    "expected the reactive Result NOT to carry a fresh token for ##{@id}, but it did"
+  end
+end
+# rubocop:enable Style/ItBlockParameter

--- a/spec/phlex/reactive/test_helpers_spec.rb
+++ b/spec/phlex/reactive/test_helpers_spec.rb
@@ -197,6 +197,11 @@ RSpec.describe Phlex::Reactive::TestHelpers do
         expect(result).to have_reactive_token_for(CounterComponent.new(count: 1))
       end
 
+      it "also accepts a bare DOM id (the documented component-or-id contract)" do
+        result = run_reactive(CounterComponent.new(count: 0), :increment)
+        expect(result).to have_reactive_token_for("counter")
+      end
+
       it "fails readably when NO fresh token for the component is present" do
         result = run_reactive(TodoItemComponent.new(todo:), :archive) # remove: no token
         expect { expect(result).to have_reactive_token_for(TodoItemComponent.new(todo:)) }

--- a/spec/phlex/reactive/test_helpers_spec.rb
+++ b/spec/phlex/reactive/test_helpers_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The public Phlex::Reactive::TestHelpers (issue #110): a no-HTTP `run_reactive`
+# driver, its Result wrapper, token minting, and RSpec matchers. The driver's
+# whole point is that it goes THROUGH the endpoint's security contract — default
+# deny, signed identity round-trip (record re-find), schema coercion, the same
+# transaction wrapper — so a unit test can't validate a component that would fail
+# at the real endpoint. These specs lock exactly that.
+RSpec.describe Phlex::Reactive::TestHelpers do
+  # Mix the module into these examples the way a downstream app would
+  # (config.include Phlex::Reactive::TestHelpers). The driver needs no request
+  # type; the HTTP helpers do (covered by the dogfooded request suite).
+  include described_class
+
+  let(:todo) { Todo.create!(title: "write docs", done: false) }
+
+  describe "#reactive_token_for" do
+    it "mints a verifiable token from a CLASS (public sign path, no state)" do
+      token = reactive_token_for(CounterComponent)
+      payload = Phlex::Reactive.verify(token)
+
+      expect(payload["c"]).to eq("CounterComponent")
+    end
+
+    it "merges an explicit payload into the class-form token" do
+      token = reactive_token_for(TodoItemComponent, "gid" => todo.to_gid.to_s)
+      payload = Phlex::Reactive.verify(token)
+
+      expect(payload["c"]).to eq("TodoItemComponent")
+      expect(payload["gid"]).to eq(todo.to_gid.to_s)
+    end
+
+    it "mints from an INSTANCE by wrapping the private reactive_token (state signed)" do
+      payload = Phlex::Reactive.verify(reactive_token_for(CounterComponent.new(count: 7)))
+
+      expect(payload["c"]).to eq("CounterComponent")
+      expect(payload.dig("s", "count")).to eq(7)
+    end
+
+    it "signs an instance-form record component's gid" do
+      payload = Phlex::Reactive.verify(reactive_token_for(TodoItemComponent.new(todo:)))
+
+      expect(payload["gid"]).to eq(todo.to_gid.to_s)
+    end
+  end
+
+  describe "#run_reactive — the no-HTTP driver" do
+    context "with default-deny (only declared actions run)" do
+      it "raises UndeclaredReactiveAction for an undeclared action" do
+        expect { run_reactive(CounterComponent.new(count: 1), :drop_table) }
+          .to raise_error(Phlex::Reactive::TestHelpers::UndeclaredReactiveAction, /drop_table/)
+      end
+
+      it "names the declared actions in the error (a readable message)" do
+        expect { run_reactive(CounterComponent.new(count: 1), :nope) }
+          .to raise_error(Phlex::Reactive::TestHelpers::UndeclaredReactiveAction, /increment/)
+      end
+    end
+
+    context "with identity round-trip (sign -> verify -> from_identity)" do
+      it "re-finds the record so the action runs against the DB row" do
+        result = run_reactive(TodoItemComponent.new(todo:), :toggle)
+
+        expect(todo.reload.done?).to be(true)
+        expect(result).to be_replace
+      end
+
+      it "raises RecordNotFound for a stale gid (the endpoint's 404 equivalent)" do
+        component = TodoItemComponent.new(todo:)
+        todo.destroy!
+
+        expect { run_reactive(component, :toggle) }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with schema coercion (declared params cast; undeclared dropped)" do
+      it "casts a declared :integer param before the method sees it" do
+        # The client always sends strings; the schema declares count: :integer.
+        # The action runs against the REBUILT instance (identity round-trip), so
+        # assert on result.component, not the original.
+        result = run_reactive(CounterComponent.new(count: 0), :set, count: "42")
+
+        expect(result.component.instance_variable_get(:@count)).to eq(42)
+      end
+
+      it "drops an undeclared param (no raw mass assignment)" do
+        # :increment declares NO params; a stray key must never reach it (a
+        # TypeError/ArgumentError would prove it leaked through as a kwarg).
+        result = nil
+        expect { result = run_reactive(CounterComponent.new(count: 0), :increment, injected: "x") }
+          .not_to raise_error
+        expect(result.component.instance_variable_get(:@count)).to eq(1)
+      end
+    end
+
+    context "with a registered authorization error" do
+      it "SURFACES a registered authorization error by raising (unit-test contract)" do
+        # CounterComponent#boom raises CounterComponent::Denied, registered in the
+        # dummy app's authorization_errors. The endpoint maps it to 403; the
+        # driver raises it so a unit test can assert on the real exception.
+        expect { run_reactive(CounterComponent.new(count: 1), :boom) }
+          .to raise_error(CounterComponent::Denied)
+      end
+    end
+
+    context "with the transaction wrapper" do
+      it "runs the action inside a DB transaction (matches the endpoint)" do
+        component = TodoItemComponent.new(todo:)
+        expect(ActiveRecord::Base).to receive(:transaction).and_call_original
+
+        run_reactive(component, :toggle)
+      end
+    end
+  end
+
+  describe "Result" do
+    it "wraps a Response.replace as replace? (and exposes streams)" do
+      result = run_reactive(TodoItemComponent.new(todo:), :toggle)
+
+      expect(result).to be_replace
+      expect(result).not_to be_remove
+      expect(result).not_to be_redirect
+      expect(result.streams).to be_an(Array)
+      expect(result.streams.join).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "reports remove? for Response.remove and carries NO replace" do
+      result = run_reactive(TodoItemComponent.new(todo:), :archive)
+
+      expect(result).to be_remove
+      expect(result).not_to be_replace
+      expect(result.streams.join).to include(%(action="remove"))
+    end
+
+    it "reports redirect? + redirect_url for Response.redirect" do
+      result = run_reactive(CounterComponent.new(count: 0), :go_home)
+
+      expect(result).to be_redirect
+      expect(result.redirect_url).to eq("/todos")
+    end
+
+    it "treats a LEGACY arbitrary return value as an implicit replace" do
+      # :increment returns the Integer @count (the legacy contract — value
+      # ignored by the endpoint, which falls back to the single self-replace).
+      result = run_reactive(CounterComponent.new(count: 0), :increment)
+
+      expect(result).to be_replace
+      expect(result).not_to be_remove
+      expect(result.response).to be_nil # no Response object was returned
+    end
+
+    it "exposes the returned Response object when the action returned one" do
+      result = run_reactive(TodoItemComponent.new(todo:), :archive)
+
+      expect(result.response).to be_a(Phlex::Reactive::Response)
+    end
+  end
+
+  describe "matchers" do
+    describe "have_reactive_replace" do
+      it "passes a Result that replaces the given component" do
+        result = run_reactive(TodoItemComponent.new(todo:), :toggle)
+        expect(result).to have_reactive_replace(TodoItemComponent.new(todo:))
+      end
+
+      it "also accepts a bare DOM id" do
+        result = run_reactive(CounterComponent.new(count: 0), :increment)
+        expect(result).to have_reactive_replace("counter")
+      end
+
+      it "fails with a readable message when the target id doesn't match" do
+        result = run_reactive(CounterComponent.new(count: 0), :increment)
+        expect { expect(result).to have_reactive_replace("not-counter") }
+          .to raise_error(RSpec::Expectations::ExpectationNotMetError, /not-counter/)
+      end
+    end
+
+    describe "have_reactive_remove" do
+      it "passes a Result that removes the given component" do
+        result = run_reactive(TodoItemComponent.new(todo:), :archive)
+        expect(result).to have_reactive_remove(TodoItemComponent.new(todo:))
+      end
+
+      it "fails readably against a replace result" do
+        result = run_reactive(CounterComponent.new(count: 0), :increment)
+        expect { expect(result).to have_reactive_remove("counter") }
+          .to raise_error(RSpec::Expectations::ExpectationNotMetError, /remove/)
+      end
+    end
+
+    describe "have_reactive_token_for (pins the #44/#46 token-refresh regression)" do
+      it "passes when the reply refreshes the component's signed token" do
+        result = run_reactive(CounterComponent.new(count: 0), :increment)
+        expect(result).to have_reactive_token_for(CounterComponent.new(count: 1))
+      end
+
+      it "fails readably when NO fresh token for the component is present" do
+        result = run_reactive(TodoItemComponent.new(todo:), :archive) # remove: no token
+        expect { expect(result).to have_reactive_token_for(TodoItemComponent.new(todo:)) }
+          .to raise_error(RSpec::Expectations::ExpectationNotMetError, /token/)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,16 @@ RSpec.configure do
   it.file_fixture_path = File.expand_path("fixtures/files", __dir__)
   it.include ActionDispatch::TestProcess::FixtureFile
 
-  # Shared request helpers (token_for / post_action) — issue #40.
+  # The public test helpers (issue #110): the no-HTTP run_reactive driver, token
+  # minting, and the have_reactive_* matchers, mixed in exactly as a downstream
+  # app would (this IS the shipped setup). The HTTP helpers
+  # (post_reactive_action / post_reactive_multipart) need integration `post`, so
+  # they belong to request examples.
+  it.include Phlex::Reactive::TestHelpers
+  it.include Phlex::Reactive::TestHelpers, type: :request
+
+  # The gem's legacy request helpers (token_for / post_action, issue #40) now
+  # delegate to the public module — dogfooding the shipped API.
   it.include ActionRequestHelpers, type: :request
 
   # In the dummy app the verifier comes from secret_key_base; align the test

--- a/spec/requests/support/action_request_helpers.rb
+++ b/spec/requests/support/action_request_helpers.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-# Shared helpers for the request suite (issue #40). Every request spec mints a
-# signed identity token and POSTs it to the action endpoint exactly as a
-# component would. These two helpers were copy-pasted across the suite; they now
-# live here and are mixed into `type: :request` examples via rails_helper.rb.
+# The gem's own request suite dogfoods the PUBLIC Phlex::Reactive::TestHelpers
+# (issue #110) — the honesty check that the shipped helper actually works. The
+# legacy names (token_for / post_action) that the suite grew up on (issue #40)
+# now thinly delegate to the public API, so every existing request spec exercises
+# the public module verbatim.
 #
-# `post_multipart` (the #34 file path) stays LOCAL to file_params_spec.rb — it
-# sends multipart FormData, not a JSON body, so it doesn't belong in this shared
-# JSON helper.
+# post_multipart stays LOCAL to file_params_spec.rb (it predates the public
+# post_reactive_multipart and asserts a slightly different shape); it too rides
+# token_for below, so it goes through the public token path.
 module ActionRequestHelpers
-  # Mint a token exactly as a component would, using the app's verifier.
+  include Phlex::Reactive::TestHelpers
+
+  # Legacy alias: the suite mints class-form tokens as token_for(klass, payload).
   def token_for(klass, payload = {})
-    Phlex::Reactive.sign(payload.merge("c" => klass.name))
+    reactive_token_for(klass, payload)
   end
 
-  # POST a reactive action as a JSON body (token + act + params), the encoding
-  # the client uses when no file input is present.
+  # Legacy alias: post_action(klass, act:, payload:, params:) -> the public
+  # post_reactive_action(klass, act, params:, payload:). The wire (JSON body,
+  # action_path, headers) is the public helper's, so the suite proves it.
   def post_action(klass, act:, payload: {}, params: {})
-    post "/reactive/actions",
-      params: { token: token_for(klass, payload), act:, params: }.to_json,
-      headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+    post_reactive_action(klass, act, params:, payload:)
   end
 end


### PR DESCRIPTION
## Summary

Ships the public test surface the gem used to keep private (issue #110). Livewire has `Livewire::test(...)`; phlex-reactive told users to call the **private** `component.send(:reactive_token)` and hand-roll the POST headers. Now downstream apps mix in `Phlex::Reactive::TestHelpers` and test through the public API — and, crucially, the driver goes **through the same security contract** the endpoint enforces, so a unit test can't pass on a component that would fail a real click.

## What ships

- **`run_reactive(component, :act, **params)`** — the no-HTTP unit driver. Exercises, not skips, the contract:
  - **default-deny** — an undeclared action raises `Phlex::Reactive::TestHelpers::UndeclaredReactiveAction`
  - **signed identity round-trip** — sign → verify → `from_identity` (a record-backed component's row is re-found; a deleted record raises `ActiveRecord::RecordNotFound`, the endpoint's 404 equivalent)
  - **schema coercion** (#109) — a declared `:integer` arrives cast; an undeclared param is dropped
  - the same **transaction wrapper**
  - a registered **authorization error RAISES** (the endpoint maps it to 403; the driver surfaces it — correct for unit tests)
- **`Result`** — `replace?` / `remove?` / `redirect?` / `redirect_url` / `streams` / `response`, plus `component` (the instance **rebuilt from identity** — the one the action ran against; read its ivars for state changes). A legacy arbitrary return value reads as an implicit replace. `#streams` reproduces the endpoint's actor streams incl. the token refresh.
- **`reactive_token_for(component_or_class, payload = {})`** — class form via the public `Phlex::Reactive.sign`; instance form wraps the private `reactive_token`.
- **`post_reactive_action` / `post_reactive_multipart`** — POST to `Phlex::Reactive.action_path` (never a hardcoded `/reactive/actions`, so a remounted path is honored).
- **Matchers** `have_reactive_replace`, `have_reactive_remove`, `have_reactive_token_for` — RSpec-only (loaded when RSpec is present, so a Minitest app asserts on `Result` predicates directly). The token matcher pins the #44/#46 refresh regression class for adopters, and every matcher prints a failure diff worth reading.

## Dogfood + docs

- The gem's **own request suite runs THROUGH the public module** — the legacy `token_for` / `post_action` (issue #40) now delegate to `TestHelpers`. 175 request specs green = the honesty check.
- The **component-generator spec template** and the **testing docs page** are rewritten to the public API — every `send(:reactive_token)` instruction is gone; a `run_reactive` example added.
- README **Testing** section + CHANGELOG entry added.

## Test plan

| Layer | Result |
|-------|--------|
| `spec/phlex/reactive/test_helpers_spec.rb` (new, 24 ex) | default-deny raise · stale-gid → RecordNotFound · `:integer` cast · undeclared-param drop · authz raise · transaction wrapper · Result predicates incl. legacy-return → replace · matchers incl. readable messages |
| `spec/phlex spec/requests spec/generators` | 582 examples, 0 failures |
| `bundle exec rubocop` (159 files) + `docs && rubocop` | clean |

## Verification

- [x] `bundle exec rubocop` passes (root, 159 files) + docs rubocop
- [x] `bundle exec rspec spec/phlex spec/requests spec/generators` — 582 examples, 0 failures
- [x] Backwards compatible — existing components + request specs unchanged (they run through the delegating helper)
- [x] pgbus optionality untouched (no transport code changed)

## Known traps handled

- `verbose_errors` defaults ON in test (`Rails.env.local?`) — documented in the module + docs (it changes only an error BODY, never a status).
- The stale-gid case: `reactive_token` omits the gid for a non-persisted record (a draft), and a **destroyed** record is also non-persisted — so the driver injects the destroyed record's gid to reproduce the real "rendered while it lived, deleted before the click" 404.

Closes #110

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public testing helpers for reactive components: a no-HTTP `run_reactive` driver, identity token helpers, and HTTP/multipart request helpers.
  * Introduced a `Result` wrapper with actionable predicates and endpoint-aligned turbo-stream/redirect/response details.
  * Added RSpec matchers for asserting replace/remove behavior and token usage.

* **Documentation**
  * Expanded the README and testing guide with setup steps, examples, and updated integration/unit test patterns.
  * Updated generated component spec templates to use the public helpers.

* **Tests**
  * Added a comprehensive spec suite covering the `run_reactive` contract and matchers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->