### PR TITLE
feat(engine): version the signed token payload ("v" key + upgrader chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Versioned identity-token payload + upgrader chain (#111).** Every signed
+  token now carries a `"v"` key (`Phlex::Reactive::TOKEN_VERSION`, currently `1`),
+  and `Phlex::Reactive.verify` runs the payload through an upgrader chain before
+  your component rebuilds from it. This is infrastructure for the NEXT breaking
+  shape change (a rename, per-token expiry, a nonce): instead of every open page
+  breaking at deploy — an old-shape token verifies fine, then blows up later in
+  `from_identity` — the old payload upgrades transparently. Contract:
+  - A token minted **before** versioning existed carries no `"v"`; it is read as
+    version 0 (today's shape) and passes through byte-identical — introducing
+    versioning **invalidated nothing in flight**.
+  - When you change the shape, bump `TOKEN_VERSION` and register
+    **`Phlex::Reactive.register_token_upgrader(old_version) { |payload| … }`**;
+    upgraders run oldest → current.
+  - A token from a **newer** version than the running code (a rolled-back deploy)
+    **fails closed** — `verify` returns `nil`, so the endpoint answers 400, the
+    same path as a tampered token. Never fail-open.
+
+  `from_identity` ignores the extra `"v"` key, so existing components are
+  unaffected. Perf: the one added key costs +3 objects / +480 bytes per
+  `reactive_token` (a single `Hash#merge`); HMAC signing dominates and is
+  unchanged, so throughput is within measurement noise.
+
 - **Public `Phlex::Reactive::TestHelpers` + a no-HTTP `run_reactive` action
   driver (#110).** The gem now ships the test surface it used to keep private.
   Mix it in (`config.include Phlex::Reactive::TestHelpers`) for:

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -458,6 +458,31 @@ module Views
                 code { 'secret_key_base' }
                 plain ' invalidates all outstanding tokens (open tabs must reload).'
               end
+              p do
+                plain 'The signed payload is '
+                strong { 'versioned' }
+                plain ' (a '
+                code { '"v"' }
+                plain ' key, currently '
+                code { 'Phlex::Reactive::TOKEN_VERSION' }
+                plain '). This exists so a future change to the token shape can '
+                strong { 'upgrade tokens already in flight' }
+                plain ' instead of breaking every open page at deploy: verification runs the payload '
+                plain 'through an upgrader chain (oldest → current) before your component rebuilds from it. '
+                plain 'A token minted before versioning existed carries no '
+                code { '"v"' }
+                plain ' and is read as-is — introducing versioning invalidated nothing.'
+              end
+            end
+            DocsUI::Callout(:note, title: 'Unknown token versions fail closed') do
+              plain 'A token signed by a NEWER deploy than the running code (a rollback scenario) verifies its '
+              plain 'signature but carries a version this code does not understand. Rather than guess the newer '
+              plain 'shape, '
+              code { 'Phlex::Reactive.verify' }
+              plain ' returns '
+              code { 'nil' }
+              plain ', so the endpoint answers 400 — the same path as a tampered token. Fail-closed, never '
+              plain 'fail-open.'
             end
           end
         end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -60,6 +60,14 @@ module Phlex
     # minted for phlex-reactive can't be replayed against another verifier use.
     IDENTITY_PURPOSE = "phlex-reactive/identity"
 
+    # The current identity-token payload version (issue #111), stamped into every
+    # signed token under the "v" key. It exists so the NEXT breaking shape change
+    # (a rename, per-token expiry, a nonce) can upgrade tokens already in flight
+    # instead of breaking every open page at deploy. A token minted before this
+    # existed carries no "v" — treated as version 0 (today's shape). Bump this and
+    # register a register_token_upgrader(old_version) when you change the shape.
+    TOKEN_VERSION = 1
+
     # The ActiveSupport::Notifications namespace for the gem's hot-path events
     # (issue #107): action.phlex_reactive, render.phlex_reactive,
     # broadcast.phlex_reactive. APM tools (AppSignal, Datadog, Skylight)
@@ -346,14 +354,65 @@ module Phlex
         base_controller_name.constantize
       end
 
-      # Returns the verified payload hash, or nil if the token is invalid.
+      # Returns the verified, version-upgraded payload hash, or nil if the token
+      # is invalid (bad signature/purpose) OR carries a version this code doesn't
+      # understand. The single verify choke point (issue #111): after the
+      # signature check we run upgrade_token so an older-shape payload is migrated
+      # to the current shape before from_identity ever sees it.
       def verify(token)
-        verifier.verified(token, purpose: IDENTITY_PURPOSE)
+        payload = verifier.verified(token, purpose: IDENTITY_PURPOSE)
+        payload && upgrade_token(payload)
       end
 
-      # Signs a payload hash into an identity token.
+      # Signs a payload hash into an identity token, stamping the current
+      # TOKEN_VERSION (issue #111). The "v" key is the ONLY thing added — a
+      # from_identity that ignores unknown keys is unaffected.
       def sign(payload)
-        verifier.generate(payload, purpose: IDENTITY_PURPOSE)
+        verifier.generate(payload.merge("v" => TOKEN_VERSION), purpose: IDENTITY_PURPOSE)
+      end
+
+      # Migrate a verified payload from whatever version it was signed at up to
+      # TOKEN_VERSION (issue #111). Runs the registered upgraders oldest → current,
+      # then stamps the payload to the current version. Contract:
+      #   * no "v"  → version 0 (the shape from before versioning existed). With no
+      #     v0 upgrader registered this is a pure passthrough — introducing
+      #     versioning invalidates NOTHING already in flight.
+      #   * v == current → returned as-is (the hot path — one integer compare).
+      #   * v  > current → nil. A rolled-back deploy verifying a token minted by
+      #     NEWER code must not guess the newer shape; returning nil fails closed
+      #     through the endpoint's existing `|| raise(InvalidToken)` → 400.
+      def upgrade_token(payload)
+        version = payload.fetch("v", 0)
+        return payload if version == TOKEN_VERSION
+        return nil if version > TOKEN_VERSION
+
+        upgrade_from(payload, version)
+      end
+
+      # Register an upgrader that rewrites a payload signed at `from_version` into
+      # the shape of `from_version + 1` (issue #111). Register in load order at
+      # boot when you bump TOKEN_VERSION; the block receives the payload hash and
+      # returns the migrated hash (the "v" stamp is applied by upgrade_token, so
+      # the block only reshapes the data). Example, for a future count → n rename:
+      #
+      #   Phlex::Reactive.register_token_upgrader(0) do |payload|
+      #     payload.merge("s" => { "n" => payload.dig("s", "count") })
+      #   end
+      def register_token_upgrader(from_version, &block)
+        raise ::ArgumentError, "register_token_upgrader requires a block" unless block
+
+        token_upgraders[Integer(from_version)] = block
+      end
+
+      # from_version => callable(payload) -> migrated payload. Sparse: an entry
+      # exists only for a version that actually changed shape.
+      def token_upgraders
+        @token_upgraders ||= {}
+      end
+
+      # Drop all registered upgraders. For tests that register a temporary one.
+      def reset_token_upgraders!
+        @token_upgraders = {}
       end
 
       # The acting client's SSE connection id during an action, or nil. Set by
@@ -427,6 +486,27 @@ module Phlex
 
       def default_logger
         ::Rails.logger if defined?(::Rails) && ::Rails.respond_to?(:logger)
+      end
+
+      # Walk the upgrader chain from `version` up to TOKEN_VERSION, applying each
+      # registered upgrader in turn (issue #111). A gap in the chain (a version
+      # bumped with no shape change, so no upgrader registered) is a no-op step —
+      # the payload passes through unchanged to the next version. Only stamp the
+      # current "v" if an upgrader ACTUALLY reshaped the payload: a versionless
+      # (v0) token with no upgraders registered — today's case — is returned
+      # byte-identical, so introducing versioning invalidates nothing in flight.
+      # Runs only for a genuinely old token (the v == current hot path already
+      # returned in upgrade_token), so this is off the render path.
+      def upgrade_from(payload, version)
+        upgraded = false
+        version.upto(TOKEN_VERSION - 1) do
+          upgrader = token_upgraders[it]
+          next unless upgrader
+
+          payload = upgrader.call(payload)
+          upgraded = true
+        end
+        upgraded ? payload.merge("v" => TOKEN_VERSION) : payload
       end
 
       def default_verifier

--- a/lib/phlex/reactive/doctor.rb
+++ b/lib/phlex/reactive/doctor.rb
@@ -128,10 +128,12 @@ module Phlex
 
       # A throwaway sign→verify round trip proves the verifier is configured and
       # the key round-trips (a bad secret_key_base or a purpose mismatch fails).
+      # verify legitimately stamps the version key "v" (issue #111), so we check
+      # the original entries survived rather than exact equality.
       def verifier_check
         payload = { "c" => "Phlex::Reactive::Doctor", "probe" => true }
         roundtripped = Phlex::Reactive.verify(Phlex::Reactive.sign(payload))
-        if roundtripped == payload
+        if roundtripped && payload.all? { |k, v| roundtripped[k] == v }
           Check.new(:ok, "identity verifier signs and verifies", name: :verifier)
         else
           Check.new(:fail, "identity verifier did not round-trip a probe payload", name: :verifier,

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe Phlex::Reactive::Component do
       rebuilt.increment
       expect(rebuilt.count).to eq(2)
     end
+
+    it "ignores the token version key (#111) — the leftover \"v\" is harmless" do
+      # verify leaves "v" in the payload; from_identity assembles kwargs only from
+      # the declared record/state keys, so the version marker never reaches new(**).
+      payload = Phlex::Reactive.verify(state_klass.new(count: 9).send(:reactive_token))
+      expect(payload).to have_key("v")
+
+      rebuilt = state_klass.from_identity(payload)
+      expect(rebuilt.count).to eq(9) # rebuilt cleanly despite the extra "v"
+    end
   end
 
   describe "record + state identity (issue #6)" do
@@ -1286,9 +1296,10 @@ RSpec.describe Phlex::Reactive::Component do
   # pin the payload SHAPE (decoded) so an allocation optimization can't silently
   # change what's signed.
   describe "#reactive_token payload (perf invariants)" do
-    it "signs {c, s} for a state-backed component, with string keys" do
+    it "signs {c, s} for a state-backed component, with string keys (+ version marker #111)" do
       token = state_klass.new(count: 5).send(:reactive_token)
-      expect(Phlex::Reactive.verify(token)).to eq("c" => "StateThing", "s" => { "count" => 5 })
+      expect(Phlex::Reactive.verify(token))
+        .to eq("c" => "StateThing", "s" => { "count" => 5 }, "v" => Phlex::Reactive::TOKEN_VERSION)
     end
 
     it "is stable across repeated renders of equal state" do

--- a/spec/phlex/reactive_spec.rb
+++ b/spec/phlex/reactive_spec.rb
@@ -4,10 +4,10 @@ require "spec_helper"
 
 RSpec.describe Phlex::Reactive do
   describe ".sign / .verify" do
-    it "round-trips a payload" do
+    it "round-trips a payload, stamping the current token version" do
       payload = { "c" => "Demo::Counter", "s" => { "count" => 3 } }
       token = described_class.sign(payload)
-      expect(described_class.verify(token)).to eq(payload)
+      expect(described_class.verify(token)).to eq(payload.merge("v" => described_class::TOKEN_VERSION))
     end
 
     it "rejects a tampered token" do
@@ -24,6 +24,51 @@ RSpec.describe Phlex::Reactive do
     it "rejects a token signed for a different purpose" do
       token = described_class.verifier.generate({ "c" => "X" }, purpose: "other")
       expect(described_class.verify(token)).to be_nil
+    end
+  end
+
+  describe "token versioning (#111)" do
+    # Sign a payload directly (no "v" stamp) to simulate a token minted by a
+    # deploy BEFORE versioning existed, or a hand-forged shape at a given version.
+    def raw_sign(payload)
+      described_class.verifier.generate(payload, purpose: described_class::IDENTITY_PURPOSE)
+    end
+
+    after { described_class.reset_token_upgraders! }
+
+    it "stamps the current version into every signed token" do
+      payload = described_class.verify(described_class.sign({ "c" => "X" }))
+      expect(payload["v"]).to eq(described_class::TOKEN_VERSION)
+    end
+
+    it "passes a versionless (v0) token through unchanged — versioning invalidates nothing in flight" do
+      # A token from before this change: no "v" key. It still verifies, and
+      # upgrade_token must treat it as today's shape (v0) and return it as-is.
+      legacy = raw_sign({ "c" => "Demo::Counter", "s" => { "count" => 3 } })
+      expect(described_class.verify(legacy)).to eq({ "c" => "Demo::Counter", "s" => { "count" => 3 } })
+    end
+
+    it "runs a registered upgrader to rewrite an older shape (oldest → current)" do
+      # A future v0 → v1 migration: e.g. the state key was renamed count → n.
+      described_class.register_token_upgrader(0) do
+        it.merge("s" => { "n" => it.dig("s", "count") })
+      end
+      legacy = raw_sign({ "c" => "Demo::Counter", "s" => { "count" => 3 } }) # no "v" => v0
+
+      upgraded = described_class.verify(legacy)
+      expect(upgraded.dig("s", "n")).to eq(3)
+      expect(upgraded["v"]).to eq(described_class::TOKEN_VERSION) # stamped to current after upgrade
+    end
+
+    it "fails closed on a token from a NEWER version than we understand (rolled-back deploy)" do
+      # A newer deploy minted v=99; this older code must not guess — return nil so
+      # the endpoint's `|| raise(InvalidToken)` turns it into a 400.
+      future = raw_sign({ "c" => "X", "v" => described_class::TOKEN_VERSION + 98 })
+      expect(described_class.verify(future)).to be_nil
+    end
+
+    it "still returns nil for a genuinely invalid signature (versioning didn't change this)" do
+      expect(described_class.verify("not-a-real-token")).to be_nil
     end
   end
 

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -144,6 +144,22 @@ RSpec.describe "Reactive actions", type: :request do
 
       expect(response).to have_http_status(:bad_request)
     end
+
+    it "rejects a token from a NEWER version than the running code (#111 — fails closed to 400)" do
+      # A rolled-back deploy verifies a token minted by newer code (v ahead of
+      # TOKEN_VERSION). verify returns nil, and the endpoint's existing
+      # `|| raise(InvalidToken)` turns that into a 400 — no controller change.
+      future = Phlex::Reactive.verifier.generate(
+        { "c" => "TodoItemComponent", "gid" => "x", "v" => Phlex::Reactive::TOKEN_VERSION + 1 },
+        purpose: Phlex::Reactive::IDENTITY_PURPOSE
+      )
+
+      post "/reactive/actions",
+        params: { token: future, act: "toggle" }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "blank field reaches the action; the component guards (issue #8)" do


### PR DESCRIPTION
## Summary

Adds a version marker (`"v"` key) to the signed identity-token payload plus an upgrader chain, so the **next** breaking shape change can upgrade tokens already in flight instead of breaking every open page at deploy.

Without this, an old-shape token still **verifies** (the signature is fine) and then breaks later in `from_identity` (`payload.fetch("gid")` → `KeyError` → 500) or misbehaves silently. Versioning has to exist **before** the first breaking change to be useful — this lands it now, while it invalidates nothing.

## What changed (`lib/phlex/reactive.rb`)

- `TOKEN_VERSION = 1`.
- `sign` merges `"v" => TOKEN_VERSION` — the only key added. `from_identity` ignores unknown keys, so existing components are unaffected.
- `verify` is the single choke point: after the signature check it runs `upgrade_token`.
- `upgrade_token` contract:
  - **no `"v"`** → version 0 (the shape from before versioning). With no v0 upgrader registered, a pure passthrough — introducing versioning invalidated nothing in flight.
  - **`v == current`** → returned as-is (the hot path — one integer compare).
  - **`v > current`** (a rolled-back deploy verifying a token minted by newer code) → `nil`, so the endpoint's existing `|| raise(InvalidToken)` turns it into a 400. **Fails closed, zero controller change.**
- `register_token_upgrader(from_version) { |payload| … }` — upgraders run oldest → current; the `"v"` stamp is applied only when an upgrader actually reshaped the payload.
- `Doctor#verifier_check` now asserts the original entries survived the round trip (verify legitimately adds `"v"`), not exact equality.

## Fail-closed, always

A newer-version token verifies its signature but carries a shape this code doesn't understand. Rather than guess, `verify` returns `nil` → 400, the same path as a tampered token. Verification semantics and purpose scoping are otherwise unchanged.

## Bench (declared hot path — `reactive_token`)

Same-machine before/after via `rake bench:one[token]`. Throughput was noise-dominated during measurement (error bars ±12–93% under concurrent load), and `Benchmark.ips` itself reported the delta inside its error bars — expected, since HMAC signing dominates and is unchanged. The honest, deterministic signal is **allocations**:

| Token | Before (obj / bytes) | After (obj / bytes) | Delta |
|-------|----------------------|---------------------|-------|
| state-backed  | 11 / 1768 | 14 / 2248 | +3 obj / +480 B |
| record-backed | 47 / 4288 | 50 / 4768 | +3 obj / +480 B |

+3 objects / +480 bytes is exactly one `Hash#merge("v" => 1)`. Retained per call: 0 (no leak). It's a per-render allocation; at the request level the Rails stack + DB dominate, so it does not move request throughput.

## Test plan

| Spec | Covers |
|------|--------|
| `spec/phlex/reactive_spec.rb` | current-version round trip carries `"v"`; v0 passthrough unchanged; a registered upgrader rewrites an old shape (oldest → current); `v > current` → nil; invalid signature still → nil |
| `spec/requests/reactive_actions_spec.rb` | a higher-version token → 400 (fails closed through the existing endpoint path) |
| `spec/phlex/reactive/component_spec.rb` | `"v"` ignored by `from_identity`; perf-invariant payload shape updated to include the version marker |

## Verification

- [x] `bundle exec rubocop` — 159 files, clean; docs rubocop clean
- [x] `bundle exec rspec spec/phlex spec/requests spec/generators` — 590 examples, 0 failures
- [x] Backwards compatible — existing tokens (no `"v"`) read as v0, byte-identical
- [x] pgbus optionality untouched (server-only change; no transport/client code)
- [x] docs security page (versioned token + fail-closed note) + CHANGELOG updated

Closes #111

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
