### PR TITLE
feat(controller): component-aware around_action seam (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Component-aware `around_action` seam (#112).** Register a wrapper with
+  `Phlex::Reactive.around_action { |ctx, &action| … }` and it folds into the
+  endpoint **between** `with_connection_id` and the action's transaction — so it
+  sees the resolved component instance, the declared action name, and the
+  **coerced** params (a frozen `Phlex::Reactive::ActionContext`), and a rejection
+  never opens a transaction. This is the seam for audit logging, component-aware
+  rate limiting, and assertions; the base controller (`base_controller_name`)
+  stays the seam for HTTP-layer concerns (auth, CSRF, coarse per-IP throttling)
+  that don't need the resolved action. Contract: **each wrapper MUST return
+  `action.call`'s value** — the endpoint type-checks the action's return for a
+  `Phlex::Reactive::Response`, so a wrapper that returns its logger's result
+  silently downgrades every reply to the implicit self-replace. A wrapper raising
+  a registered `authorization_errors` error renders as 403; an unregistered raise
+  is a 500. Wrappers nest in registration order (last-registered outermost). The
+  empty stack (the default) adds only one `Array#empty?` check to the hot path;
+  `Phlex::Reactive.reset_around_actions!` resets it for tests. See the README
+  "Two seams" section and the security page.
 - **Versioned identity-token payload + upgrader chain (#111).** Every signed
   token now carries a `"v"` key (`Phlex::Reactive::TOKEN_VERSION`, currently `1`),
   and `Phlex::Reactive.verify` runs the payload through an upgrader chain before

--- a/README.md
+++ b/README.md
@@ -1507,7 +1507,45 @@ Phlex::Reactive.error_flash = ->(kind) do
   else                  "Something went wrong — please try again."
   end
 end
+
+# Component-aware wrapper around every action (audit / rate-limit / assert).
+# Sees the resolved component, action name, and COERCED params; runs inside
+# the connection-id scope but OUTSIDE the transaction. See "Two seams" below.
+Phlex::Reactive.around_action do |ctx, &action|
+  RateLimiter.check!(ctx.request.remote_ip, ctx.action_name) # raise -> 403
+  result = action.call
+  AuditLog.record!(actor: Current.user, action: ctx.action_name)
+  result # <- REQUIRED: return the continuation's value
+end
 ```
+
+#### Two seams: HTTP-layer (`base_controller_name`) vs component-layer (`around_action`)
+
+There are two places to wrap a reactive action, and they see different things:
+
+| | Base controller (`base_controller_name`) | `Phlex::Reactive.around_action` |
+|---|---|---|
+| **Layer** | HTTP request | the resolved component action |
+| **Sees** | headers, session, `request` | the component instance, action name, **coerced** params, `request` |
+| **Runs** | full Rails filter chain | inside `with_connection_id`, **outside** the transaction |
+| **Use for** | auth, CSRF, coarse per-IP rate limiting | audit logging, component-aware rate limiting, assertions |
+
+Plain Rails `around_action` / `rate_limit` on a dedicated base controller already
+covers attributes, authentication, and coarse per-IP throttling — but that layer
+never sees the resolved component, the declared action name, or the coerced
+params, and can't sit *inside* the connection-id scope yet *outside* the action's
+transaction. `Phlex::Reactive.around_action` is that component-aware seam. `ctx` is
+a frozen `Phlex::Reactive::ActionContext` (`component`, `action_name`, `params`,
+`request`); the fold runs *after* token verify, default-deny, and param coercion,
+so a wrapper can never widen what's invokable.
+
+**Contract — each wrapper MUST return `action.call`'s value.** The endpoint
+type-checks the action's return for a `Phlex::Reactive::Response`; a wrapper that
+ends on its logger's return value instead silently downgrades every reply to the
+implicit self-replace. A wrapper raising a registered `authorization_errors` error
+renders as 403; an unregistered raise is a 500. Multiple wrappers nest in
+registration order (last-registered outermost). Tests reset the stack with
+`Phlex::Reactive.reset_around_actions!`.
 
 If you set a custom `action_path`, expose it to the client:
 

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -142,16 +142,52 @@ module Phlex
       # for the duration of the action via Phlex::Reactive.current_connection_id,
       # so a broadcast in the action can pass exclude: reactive_connection_id
       # and skip the actor's own echo.
+      #
+      # The component-aware around_action stack (issue #112) folds in HERE —
+      # INSIDE with_connection_id (so a wrapper's own broadcast can exclude the
+      # actor) but OUTSIDE transaction_wrapper (so a rate-limit rejection never
+      # opens a transaction, and an audit wrapper observes commit/rollback). The
+      # fold returns the continuation's value unchanged, so the action's
+      # Phlex::Reactive::Response survives to response_streams.
       def run_action(component, action_def, coerced)
         Phlex::Reactive.with_connection_id(request.headers["X-Pgbus-Connection"]) do
-          transaction_wrapper do
-            if coerced.any?
-              component.public_send(action_def.name, **coerced)
-            else
-              component.public_send(action_def.name)
+          with_around_actions(component, action_def, coerced) do
+            transaction_wrapper do
+              if coerced.any?
+                component.public_send(action_def.name, **coerced)
+              else
+                component.public_send(action_def.name)
+              end
             end
           end
         end
+      end
+
+      # Fold the registered around_action wrappers around `block`, innermost being
+      # the transactioned action. The empty-stack fast path is a bare `yield` —
+      # the default request gains only one Array#empty? check. Each wrapper is
+      # called with the frozen ActionContext and the continuation as its block, so
+      # a well-behaved wrapper returns action.call's value and the action's
+      # Response propagates out unchanged (issue #112).
+      #
+      # Fold: seed the accumulator with the innermost action, then walk the stack
+      # oldest → newest wrapping each wrapper AROUND the accumulated continuation.
+      # The FIRST-registered wrapper wraps the action, and each later wrapper wraps
+      # that — so the LAST-registered runs OUTERMOST (LIFO nesting).
+      def with_around_actions(component, action_def, coerced, &block)
+        stack = Phlex::Reactive.around_actions
+        return yield if stack.empty?
+
+        ctx = Phlex::Reactive::ActionContext.new(
+          component: component,
+          action_name: action_def.name,
+          params: coerced,
+          request: request
+        )
+
+        stack.reduce(block) do |inner, wrapper|
+          -> { wrapper.call(ctx, &inner) }
+        end.call
       end
 
       # Turn the action's return value into the turbo-stream(s) to render for

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -178,10 +178,16 @@ module Phlex
         stack = Phlex::Reactive.around_actions
         return yield if stack.empty?
 
+        # A frozen DUP of the coerced params, not the live hash: the same hash is
+        # splatted into the action below, so sharing it would let a wrapper mutate
+        # ctx.params and alter the action's actual inputs — breaking both the
+        # observe-only context contract and the schema-coercion guarantee. The
+        # dup+freeze runs only when a wrapper is registered (never the empty-stack
+        # hot path).
         ctx = Phlex::Reactive::ActionContext.new(
           component: component,
           action_name: action_def.name,
-          params: coerced,
+          params: coerced.dup.freeze,
           request: request
         )
 

--- a/benchmark/micro/around_action.rb
+++ b/benchmark/micro/around_action.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Micro-bench: the component-aware around_action fold's EMPTY-STACK path (issue
+# #112). Every default request (no wrapper registered) now passes through
+# ActionsController#with_around_actions, whose fast path is a single
+# `Array#empty?` check followed by `yield`. This isolates that per-request
+# overhead against a bare `yield` — the pre-#112 shape — so the acceptance
+# criterion "the empty-stack path is unchanged within noise" is a MEASURED
+# before/after, not a claim.
+#
+# The two harness objects mirror run_action's structure with real METHODS (not
+# per-call lambdas — those would add allocations the controller never pays): one
+# yields straight to the inner action (pre-#112), one folds through the shipped
+# empty-stack guard (#112). We reproduce the fold here (rather than drive a full
+# HTTP request) so the number is the fold's cost alone, not the Rails stack + DB
+# that dominate a real request.
+#
+#   ruby benchmark/micro/around_action.rb
+
+require_relative "../support/boot"
+
+# The two measured paths, as real methods (not per-call lambdas — those would add
+# allocations the controller never pays). Both take an explicit block argument, so
+# the only difference between them is the fold guard the controller actually runs.
+module AroundActionBench
+  module_function
+
+  # BEFORE (#112): the endpoint yielded straight to the (transactioned) action.
+  def bare
+    yield
+  end
+
+  # AFTER (#112): with_around_actions with an EMPTY stack — the production default.
+  # `return yield if stack.empty?` is the whole hot path (byte-identical to the
+  # controller's fold); no ActionContext is built, no wrapper runs. Reads the real
+  # (empty) config stack so Array#empty? measures the shipped object.
+  def empty_fold(&block)
+    stack = Phlex::Reactive.around_actions
+    return yield if stack.empty?
+
+    # Unreachable in this bench (stack is empty) — present so the measured method
+    # is the same shape as the controller's fold.
+    stack.reduce(block) { |inner, w| -> { w.call(&inner) } }.call
+  end
+end
+
+Phlex::Reactive.reset_around_actions!
+inner = -> { 42 }
+
+BenchSupport.header("around_action: empty-stack fold vs bare yield (per-request hot path)")
+BenchSupport.ips do
+  it.report("bare yield (pre-#112)") { AroundActionBench.bare(&inner) }
+  it.report("empty-stack fold (#112)") { AroundActionBench.empty_fold(&inner) }
+end
+
+BenchSupport.header("around_action allocations (per call)")
+BenchSupport.allocations("bare yield (pre-#112)") { AroundActionBench.bare(&inner) }
+BenchSupport.allocations("empty-stack fold (#112)") { AroundActionBench.empty_fold(&inner) }

--- a/docs/app/views/docs/pages/security.rb
+++ b/docs/app/views/docs/pages/security.rb
@@ -19,6 +19,7 @@ module Views
           params_rule
           secrets_rule
           csrf_auth
+          two_seams
           failure_modes
           failure_ux
           error_flash_ux
@@ -179,6 +180,60 @@ module Views
 
               - `skip_before_action :authenticate` for the action endpoint (subclass it), or
               - keep public components state-backed and authorize per-action where it matters.
+            MD
+          end
+        end
+
+        def two_seams
+          DocsUI::Section('Two seams: HTTP-layer vs component-layer') do
+            md <<~MD
+              There are **two** places to wrap a reactive action, and they see different things.
+              Reach for the one that matches your concern:
+
+              | | Base controller (`base_controller_name`) | `Phlex::Reactive.around_action` |
+              |---|---|---|
+              | **Layer** | HTTP request | the resolved component action |
+              | **Sees** | headers, session, `request` | the component instance, action name, **coerced** params, `request` |
+              | **Runs** | full Rails filter chain | inside `with_connection_id`, **outside** the transaction |
+              | **Use for** | auth, CSRF, coarse per-IP rate limiting | audit logging, component-aware rate limiting, assertions |
+
+              Plain Rails `around_action` / `rate_limit` on a dedicated base controller already
+              covers attributes, authentication, and coarse per-IP throttling. What that layer
+              **cannot** see is the resolved component, the declared action name, or the coerced
+              params — and it can't position itself *inside* the connection-id scope but *outside*
+              the action's transaction. `Phlex::Reactive.around_action` is that component-aware seam:
+            MD
+            DocsUI::Code(<<~'RUBY', lexer: :ruby)
+              # config/initializers/phlex_reactive.rb
+              Phlex::Reactive.around_action do |ctx, &action|
+                Rails.logger.tagged("reactive", "#{ctx.component.class}##{ctx.action_name}") do
+                  # A rate-limit rejection here NEVER opens a transaction (this seam
+                  # sits outside transaction_wrapper). Raise a registered error -> 403.
+                  RateLimiter.check!(ctx.request.remote_ip, ctx.action_name)
+
+                  result = action.call
+                  AuditLog.record!(actor: Current.user, action: ctx.action_name)
+                  result   # <- REQUIRED: return the continuation's value (see below)
+                end
+              end
+            RUBY
+            md <<~MD
+              `ctx` is a frozen `Phlex::Reactive::ActionContext` — `component`, `action_name`,
+              `params` (already **schema-coerced**; dropped keys are gone), and `request`. The
+              fold sits **after** token verify, component resolution, default-deny, and param
+              coercion, so a wrapper can never widen what's invokable.
+
+              **The one contract that bites: each wrapper MUST return `action.call`'s value.** The
+              endpoint type-checks the action's return for a `Phlex::Reactive::Response`
+              (`replace` / `remove` / `redirect` / …); a wrapper that ends on its logger's return
+              value instead silently downgrades **every** reply to the implicit self-replace. Name
+              the result and return it, as above.
+
+              A wrapper raising an error registered in `Phlex::Reactive.authorization_errors`
+              renders as **403** (with the same diagnostics as an in-action `authorize!`);
+              an unregistered raise is a **500**, exactly as today. Multiple wrappers nest in
+              registration order — the last-registered runs outermost. Tests reset the stack with
+              `Phlex::Reactive.reset_around_actions!`.
             MD
           end
         end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -75,6 +75,16 @@ module Phlex
     # Payloads carry NAMES/outcome/sizes ONLY — never the token, params, or state.
     INSTRUMENTATION_NAMESPACE = "phlex_reactive"
 
+    # What a component-aware around_action wrapper sees (issue #112). Frozen: a
+    # wrapper OBSERVES the resolved action — it must not mutate the context to
+    # widen invokability (the token verify, component resolution, default-deny,
+    # and schema coercion have already run and are not negotiable here).
+    #   * component    — the resolved, identity-rebuilt component instance
+    #   * action_name  — the declared action Symbol about to run
+    #   * params       — the SCHEMA-COERCED params (dropped keys already gone)
+    #   * request      — the ActionDispatch::Request (remote_ip, headers, ...)
+    ActionContext = Data.define(:component, :action_name, :params, :request)
+
     class << self
       # The message verifier used to sign/verify component identity tokens.
       # Defaults to a purpose-scoped verifier derived from secret_key_base.
@@ -222,6 +232,47 @@ module Phlex
       # NAMES/outcome/sizes ONLY — never token/params/state.
       def instrument(event, payload = {}, &)
         ::ActiveSupport::Notifications.instrument("#{event}.#{INSTRUMENTATION_NAMESPACE}", payload, &)
+      end
+
+      # Register a COMPONENT-AWARE around_action wrapper (issue #112). The block
+      # is folded into the endpoint BETWEEN with_connection_id and the action's
+      # transaction — so it sees the resolved component instance, the declared
+      # action name, and the coerced params (an ActionContext), and a rejection
+      # NEVER opens a transaction. This is the seam for audit logging,
+      # component-aware rate limiting, and assertions; the base controller
+      # (base_controller_name) remains the seam for HTTP-layer concerns (auth,
+      # CSRF, coarse per-IP rate limiting) that don't need the resolved action.
+      #
+      #   Phlex::Reactive.around_action do |ctx, &action|
+      #     RateLimiter.check!(ctx.request.remote_ip, ctx.action_name) # raise -> 403
+      #     result = action.call
+      #     AuditLog.record!(actor: Current.user, action: ctx.action_name)
+      #     result   # <- REQUIRED: return the continuation's value
+      #   end
+      #
+      # CONTRACT — each wrapper MUST return `action.call`'s value. The endpoint
+      # type-checks the action's return for a Phlex::Reactive::Response; a wrapper
+      # that returns its logger's result instead silently downgrades every reply
+      # to the implicit self-replace. Wrappers nest in registration order with the
+      # LAST-registered outermost. Register in an initializer.
+      def around_action(&block)
+        raise ::ArgumentError, "Phlex::Reactive.around_action requires a block" unless block
+
+        around_actions << block
+      end
+
+      # The registered around_action wrappers, oldest first. The endpoint folds
+      # them so the last-registered runs outermost; an empty stack is the default
+      # hot path (the controller short-circuits with `return yield`).
+      def around_actions
+        @around_actions ||= []
+      end
+
+      # Drop all registered around_action wrappers. For test isolation (the
+      # shipped hook — specs registering a temporary wrapper reset around every
+      # example); never called in production.
+      def reset_around_actions!
+        @around_actions = []
       end
 
       def verifier

--- a/spec/requests/around_action_spec.rb
+++ b/spec/requests/around_action_spec.rb
@@ -61,6 +61,26 @@ RSpec.describe "Phlex::Reactive.around_action", type: :request do
 
       expect(frozen).to be(true)
     end
+
+    it "freezes ctx.params so a wrapper cannot alter the action's coerced inputs" do
+      # The context shares no mutable state with the action: ctx.params is a
+      # FROZEN dup, so a wrapper mutating it raises rather than silently swapping
+      # the value the action is about to receive.
+      raised = nil
+      Phlex::Reactive.around_action do |ctx, &action|
+        ctx.params[:count] = 999
+      rescue FrozenError => e
+        raised = e
+        action.call
+      end
+
+      post_action(CounterComponent, payload: { "s" => { "count" => 9 } }, act: "set", params: { count: "3" })
+
+      expect(response).to have_http_status(:ok)
+      expect(raised).to be_a(FrozenError)
+      # The action received the SCHEMA-COERCED 3, not the wrapper's injected 999.
+      expect(response.body).to match(/>\s*3\s*</)
+    end
   end
 
   describe "the return-value contract (issue #112 — a wrapper MUST return the continuation)" do

--- a/spec/requests/around_action_spec.rb
+++ b/spec/requests/around_action_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Component-aware around_action seam (issue #112). A wrapper stack folded into
+# the endpoint BETWEEN with_connection_id and transaction_wrapper — so a wrapper
+# sees the resolved component instance, the declared action name, and the coerced
+# params, and a rejection never opens a transaction. Distinct from the
+# base-controller seam (HTTP-layer: auth/CSRF/coarse rate limiting), which never
+# sees the resolved action.
+RSpec.describe "Phlex::Reactive.around_action", type: :request do
+  # The stack is process-global config; reset it around every example so one
+  # spec's wrapper never leaks into another (the shipped test-isolation hook).
+  around do
+    Phlex::Reactive.reset_around_actions!
+    it.run
+    Phlex::Reactive.reset_around_actions!
+  end
+
+  describe "the empty stack (default hot path)" do
+    it "is byte-identical to no wrapper — a plain increment still replaces self" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="replace"')
+      expect(response.body).to include('target="counter"')
+      expect(response.body).to match(/>\s*2\s*</) # 1 -> 2
+    end
+  end
+
+  describe "the context the wrapper sees" do
+    it "carries the resolved component instance, the action name, the coerced params, and the request" do
+      seen = {}
+      Phlex::Reactive.around_action do |ctx, &action|
+        seen[:component]   = ctx.component
+        seen[:action_name] = ctx.action_name
+        seen[:params]      = ctx.params
+        seen[:request]     = ctx.request
+        action.call
+      end
+
+      post_action(CounterComponent, payload: { "s" => { "count" => 9 } }, act: "set", params: { count: "3" })
+
+      expect(response).to have_http_status(:ok)
+      expect(seen[:component]).to be_a(CounterComponent)
+      expect(seen[:action_name]).to eq(:set)
+      # Coerced, not raw: "3" (string on the wire) has been cast to Integer 3 by
+      # the schema before the fold runs.
+      expect(seen[:params]).to eq({ count: 3 })
+      expect(seen[:request]).to respond_to(:remote_ip)
+    end
+
+    it "freezes the context (a wrapper cannot widen invokability by mutating it)" do
+      frozen = nil
+      Phlex::Reactive.around_action do |ctx, &action|
+        frozen = ctx.frozen?
+        action.call
+      end
+
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(frozen).to be(true)
+    end
+  end
+
+  describe "the return-value contract (issue #112 — a wrapper MUST return the continuation)" do
+    it "lets a Phlex::Reactive::Response survive the stack (remove is honored, not downgraded to a replace)" do
+      todo = Todo.create!(title: "moderate me", done: false)
+
+      # A well-behaved wrapper: it returns action.call's value, so the action's
+      # Response.remove reaches response_streams unchanged.
+      Phlex::Reactive.around_action do |_ctx, &action|
+        result = action.call
+        result
+      end
+
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "archive")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="remove"')
+      expect(response.body).not_to include('action="replace"')
+    end
+
+    it "downgrades to the implicit self-replace when a wrapper swallows the return value (the documented footgun)" do
+      # A MISBEHAVING wrapper: it returns its own trailing value (a truthy log
+      # line), not action.call's. response_streams sees a non-Response and falls
+      # back to the implicit single replace — proving the contract is real.
+      Phlex::Reactive.around_action do |_ctx, &action|
+        action.call
+        "logged" # <- WRONG: not the continuation's value
+      end
+
+      todo = Todo.create!(title: "moderate me", done: false)
+      post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "archive")
+
+      expect(response).to have_http_status(:ok)
+      # The Response.remove was dropped; the endpoint fell back to a self replace.
+      expect(response.body).to include('action="replace"')
+      expect(response.body).not_to include('action="remove"')
+    end
+  end
+
+  describe "the fold sits OUTSIDE the transaction (a rejection opens no transaction)" do
+    it "leaves no DB write when a wrapper raises BEFORE calling the continuation" do
+      todo = Todo.create!(title: "keep me", done: false)
+
+      Phlex::Reactive.around_action do |_ctx, &_action|
+        raise CounterComponent::Denied, "rate limited before the action ran"
+      end
+
+      expect do
+        post_action(TodoItemComponent, payload: { "gid" => todo.to_gid.to_s }, act: "toggle")
+      end.not_to(change { todo.reload.done? })
+
+      # The registered error maps to 403, and the action never ran — no toggle.
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "error mapping" do
+    it "maps a wrapper raising a registered authorization error to 403" do
+      Phlex::Reactive.around_action do |_ctx, &_action|
+        raise CounterComponent::Denied, "denied in the wrapper"
+      end
+
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "lets an UNREGISTERED wrapper error surface as a 500 (same as today)" do
+      Phlex::Reactive.around_action do |_ctx, &_action|
+        raise "unregistered boom"
+      end
+
+      expect do
+        post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+      end.to raise_error("unregistered boom")
+    end
+  end
+
+  describe "multiple wrappers nest LIFO (the stack folds outermost-first)" do
+    it "runs the last-registered wrapper OUTERMOST around the earlier ones" do
+      order = []
+      Phlex::Reactive.around_action do |_ctx, &action|
+        order << :first_before
+        result = action.call
+        order << :first_after
+        result
+      end
+      Phlex::Reactive.around_action do |_ctx, &action|
+        order << :second_before
+        result = action.call
+        order << :second_after
+        result
+      end
+
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(response).to have_http_status(:ok)
+      # Registration appends; folding wraps so the LAST-registered runs OUTERMOST.
+      expect(order).to eq(%i[second_before first_before first_after second_after])
+    end
+  end
+end


### PR DESCRIPTION
Closes #112

## What & why

Adds a **component-aware** wrapper seam — `Phlex::Reactive.around_action`. Attributes, authentication, and coarse per-IP rate limiting were already possible via a dedicated `base_controller_name` + plain Rails `around_action`/`rate_limit`. What was genuinely missing is a wrapper that sees the **resolved component instance**, the **declared action name**, and the **coerced params**, and can sit **inside `with_connection_id` but outside the transaction** — so a rate-limit rejection never opens a transaction and an audit wrapper can observe commit/rollback.

```ruby
# config/initializers/phlex_reactive.rb
Phlex::Reactive.around_action do |ctx, &action|
  RateLimiter.check!(ctx.request.remote_ip, ctx.action_name) # raise -> 403
  result = action.call
  AuditLog.record!(actor: Current.user, action: ctx.action_name)
  result # <- REQUIRED: return the continuation's value
end
```

`ctx` is a frozen `Phlex::Reactive::ActionContext(component, action_name, params, request)`.

## Design

- **Where it folds:** `run_action`, between `with_connection_id` and `transaction_wrapper`. Strictly **after** token verify, component resolution, default-deny, and schema coercion — no wrapper can widen invokability.
- **Empty-stack fast path:** `return yield if stack.empty?`. The default request gains one `Array#empty?` check and allocates nothing.
- **Return-value contract (documented prominently):** each wrapper MUST return `action.call`'s value. `response_streams` type-checks the action's return for a `Phlex::Reactive::Response`; a wrapper that ends on its logger's return value silently downgrades every reply to the implicit self-replace. This footgun has its own spec.
- **Error mapping:** a wrapper raising a registered `authorization_errors` error → 403 (existing rescue, with #82 diagnostics); an unregistered raise → 500, same as today.
- **Nesting:** wrappers nest in registration order — last-registered outermost (LIFO).
- **Test isolation:** `Phlex::Reactive.reset_around_actions!`.

The two seams are documented side by side (README "Two seams" + the security page): base controller for HTTP-layer concerns, `around_action` for component-layer concerns.

## Test plan

`spec/requests/around_action_spec.rb` (9 examples):

- ctx carries the resolved component / action name / **coerced** params / request, and is frozen
- a `Phlex::Reactive::Response` survives the stack (a `remove` is honored, not downgraded)
- a wrapper that swallows the return value downgrades to the implicit self-replace (the documented footgun)
- a wrapper raising **before** the continuation leaves **no DB write** (the fold is outside the transaction)
- registered raise → 403; unregistered raise → 500
- multiple wrappers nest LIFO
- empty stack is byte-identical to no wrapper

## Performance

`benchmark/micro/around_action.rb` (auto-discovered by `rake bench:micro`) — empty-stack fold vs bare yield, same machine:

| path | throughput | allocations |
|---|---|---|
| bare yield (pre-#112) | ~22.5M i/s (~50 ns/i) | **0 objects / 0 bytes / 0 retained** |
| empty-stack fold (#112) | ~16.3M i/s (~63 ns/i) | **0 objects / 0 bytes / 0 retained** |

The default path **allocates nothing**. The ~10 ns/call delta is a **method-level** number in a tight loop (one frame + `Array#empty?`); at the **request level** (Rails stack + DB in the milliseconds) it is below the noise floor.

## Verification

- [x] `bundle exec rubocop` — 161 files, no offenses
- [x] `bundle exec rspec spec/phlex spec/requests` — 588 passed
- [x] docs: `bundle exec rspec` (68 passed) + `bundle exec rubocop` clean
- [x] Backwards compatible — empty stack is the default; existing components unchanged
- [x] pgbus optionality untouched (the fold is transport-agnostic)

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component-aware action wrappers that can run around reactive actions with access to the resolved component, action name, request, and validated params.
  * Wrapper behavior now supports multiple layers, with the most recently added wrapper running outermost.

* **Bug Fixes**
  * Improved error handling so authorization failures in registered wrappers return the expected access-denied response.

* **Documentation**
  * Expanded the changelog, README, and security docs with examples and guidance on where wrapper logic runs and how it should return results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->