### PR TITLE
feat(streamable): morph: on the update verbs + flash_builder → stream_builder rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`morph:` on the update verbs (#113).** The `update` family now takes the same
+  `morph:` flag `replace` already had, closing the verb-matrix asymmetry: Turbo 8
+  supports `method="morph"` on `action="update"`, so an inner-HTML update can morph
+  in place instead of swapping. This matters most for a **cross-tab
+  `broadcast_update_to`** into a component a peer is editing — a plain update tore
+  down their focus/caret; `morph: true` patches the inner HTML in place and keeps
+  it. Threaded through every update surface:
+  - `Streamable.update(model, morph: true)` (class builder) and
+    `#to_stream_update(morph: true)` (instance primitive) — emit
+    `method="morph"`.
+  - `broadcast_update_to(*streamables, morph: true)` — carries the attr through
+    `attributes:` (the broadcast path has no `method:` kwarg), so it works on
+    **both** Action Cable and pgbus; the pgbus-absent fallback is unchanged.
+  - `Response.update(component, morph: true)` and `Reply#update(morph: true)` —
+    `reply.update(morph: true)`.
+
+  **Default `false` everywhere → byte-identical to today** (no `method=` attribute),
+  so existing components are unaffected. No new dependency — Idiomorph ships with
+  `turbo-rails >= 2.0`.
+
 - **Versioned identity-token payload + upgrader chain (#111).** Every signed
   token now carries a `"v"` key (`Phlex::Reactive::TOKEN_VERSION`, currently `1`),
   and `Phlex::Reactive.verify` runs the payload through an upgrader chain before
@@ -155,6 +175,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ends by telling you to run `bin/rails phlex_reactive:doctor` to verify.
 
 ### Changed
+
+- **`Phlex::Reactive.flash_builder` → `stream_builder` (and `reset_flash_builder!`
+  → `reset_stream_builder!`) (#113).** The memoized `Turbo::Streams::TagBuilder`
+  is used well beyond flashes — `reactive_collection` row removal, count-companion
+  updates, `also_update` — so the `flash_` name misled. Renamed to `stream_builder`
+  / `reset_stream_builder!`. **`flash_builder` and `reset_flash_builder!` stay as
+  permanent aliases** (no deprecation warnings), so the engine's reload hook and
+  any app code keep working unchanged. Purely a rename — behavior is identical.
 
 - **BREAKING (declaration-time): an unknown param type symbol now raises (#109).**
   Before, a schema naming a type the coercer didn't recognize (a typo like

--- a/README.md
+++ b/README.md
@@ -312,10 +312,13 @@ The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
 |---|---|
 | `#id` | Stable DOM id == Turbo Stream target. Must match the root element's `id`. Record-backed components default to `dom_id(record)` (issue #81); everything else implements it (`def id`). An explicit `def id` always wins. |
 | `.replace(model = nil, morph: false, **opts)` | `<turbo-stream action=replace target=id>` of a freshly built component; `morph: true` adds `method="morph"` |
-| `.update` / `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
+| `.update(model = nil, morph: false, **opts)` | `<turbo-stream action=update target=id>` (inner-HTML update); `morph: true` adds `method="morph"` so Turbo morphs the inner HTML in place (issue #113) |
+| `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
 | `.broadcast_replace_to(*streamables, model:, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
-| `.broadcast_append_to(*streamables, target:, model:)` / `_update_` / `_prepend_` / `_remove_` | The broadcast variants |
-| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_update` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `reply`); `#to_stream_morph` morphs in place |
+| `.broadcast_update_to(*streamables, model:, morph: false)` | Broadcast an inner-HTML update; `morph: true` morphs in place, so a peer editing the component keeps its focus/caret (issue #113) |
+| `.broadcast_append_to(*streamables, target:, model:)` / `_prepend_` / `_remove_` | The other broadcast variants |
+| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `reply`); `#to_stream_morph` morphs in place |
+| `#to_stream_update(morph: false)` | Inner-HTML update of the *already-built* instance; `morph: true` morphs in place (issue #113) |
 
 Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 
@@ -1048,8 +1051,8 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 
 | Builder | Reply |
 |---|---|
-| `reply.replace` / `reply.update` | re-render in place (default; `replace` is an outerHTML swap, `update` morphs inner HTML) |
-| `reply.morph` / `reply.replace(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (issue #28) |
+| `reply.replace` / `reply.update(morph: false)` | re-render in place (default; `replace` swaps the whole element via outerHTML, `update` swaps only the inner HTML) |
+| `reply.morph` / `reply.replace(morph: true)` / `reply.update(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (`replace` #28; `update` #113) |
 | `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
 | `.also_replace(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
 | `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped, wrapped in a level-carrying `<div>` — see [Flash levels](#flash-levels)) or a Phlex component (rendered verbatim; off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |

--- a/docs/app/views/docs/pages/architecture.rb
+++ b/docs/app/views/docs/pages/architecture.rb
@@ -87,7 +87,9 @@ module Views
                   code { 'replace' }
                   plain ' swaps outerHTML, '
                   code { 'update' }
-                  plain ' morphs inner HTML).'
+                  plain ' swaps inner HTML; pass '
+                  code { 'morph: true' }
+                  plain ' to either to morph in place).'
                 end
                 li do
                   code { 'reply.morph' }

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -105,8 +105,9 @@ module Views
               - `.broadcast_replace_to(*streamables, model:, morph:)` — replace the
                 element with id `component.id`. Pass `morph: true` for a cross-tab
                 morph (see below).
-              - `.broadcast_update_to(*streamables, model:)` — replace its *inner*
-                HTML.
+              - `.broadcast_update_to(*streamables, model:, morph:)` — replace its
+                *inner* HTML. Pass `morph: true` for a cross-tab morph, so a peer
+                editing the component keeps its focus/caret (see below).
               - `.broadcast_append_to(*streamables, target:, model:)` — append into
                 container `target`.
               - `.broadcast_prepend_to(*streamables, target:, model:)` — prepend into
@@ -249,10 +250,19 @@ module Views
               ```
 
               This emits `method="morph"` on the broadcast `<turbo-stream>`, so
-              idiomorph patches the existing DOM rather than replacing it. Only
-              `broadcast_replace_to` takes `morph:` — `update` already patches inner
-              HTML, and `append` / `prepend` / `remove` don't replace an existing
-              element.
+              idiomorph patches the existing DOM rather than replacing it.
+
+              `broadcast_update_to` takes `morph:` too — a plain `update` swaps the
+              *inner* HTML (still tearing down a focused input mid-edit), so
+              `morph: true` patches the inner HTML in place instead, keeping a peer's
+              caret:
+
+              ```ruby
+              Totals.broadcast_update_to(@order, :totals, model: @order, morph: true)
+              ```
+
+              `append` / `prepend` / `remove` don't replace an existing element, so
+              they take no `morph:`.
             MD
           end
         end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -293,20 +293,24 @@ module Phlex
       end
 
       # A Turbo::Streams::TagBuilder bound to an off-request view context, used
-      # to build standalone streams (e.g. a Response flash append) not tied to a
-      # specific component's id. Cached PER THREAD alongside the context it's
-      # bound to (see off_request_view_context for why per-thread).
-      def flash_builder
+      # to build standalone streams not tied to a specific component's id — a
+      # Response flash append, a reactive_collection row removal, a count
+      # companion update, an also_update companion. Cached PER THREAD alongside
+      # the context it's bound to (see off_request_view_context for why
+      # per-thread). Renamed from flash_builder (issue #113): the builder does
+      # far more than flashes, so the name misled. flash_builder stays a
+      # permanent alias below so the engine's to_prepare and app code keep working.
+      def stream_builder
         off_request_view_context_cache[:builder]
       end
 
       # The off-request view context for the current thread, built once and
-      # reused for both the flash builder and standalone component renders.
+      # reused for both the stream builder and standalone component renders.
       # Cached PER THREAD, not per process: an ActionView context carries mutable
       # output_buffer/view_flow state (render_in's capture swaps it), so sharing
       # one instance across threads can interleave content on a threaded server.
       # Rebuilt when the renderer object changes or the generation is bumped
-      # (reset_flash_builder! / Rails code reload), so a reloaded controller is
+      # (reset_stream_builder! / Rails code reload), so a reloaded controller is
       # never served stale.
       def off_request_view_context
         off_request_view_context_cache[:view_context]
@@ -315,10 +319,18 @@ module Phlex
       # Invalidate the per-thread context + builder for ALL threads by bumping
       # the generation; each thread rebuilds lazily on next use. Registered on
       # Rails' reloader by the engine; also used by specs. Thread-safe (an
-      # integer bump, no shared structure to tear down).
-      def reset_flash_builder!
+      # integer bump, no shared structure to tear down). Renamed from
+      # reset_flash_builder! (issue #113); the old name stays a permanent alias
+      # below so the engine's to_prepare hook keeps working.
+      def reset_stream_builder!
         @off_request_view_context_generation = off_request_view_context_generation + 1
       end
+
+      # Permanent aliases for the pre-#113 names. Kept forever (no deprecation)
+      # so the engine's to_prepare hook and any app code calling the old names
+      # keep working unchanged.
+      alias flash_builder stream_builder
+      alias reset_flash_builder! reset_stream_builder!
 
       def off_request_view_context_generation
         @off_request_view_context_generation ||= 0

--- a/lib/phlex/reactive/engine.rb
+++ b/lib/phlex/reactive/engine.rb
@@ -74,7 +74,7 @@ module Phlex
       # fresh after boot. See Streamable.reset_all_view_contexts!.
       config.to_prepare do
         Phlex::Reactive::Streamable.reset_all_view_contexts!
-        Phlex::Reactive.reset_flash_builder!
+        Phlex::Reactive.reset_stream_builder!
       end
 
       # Boot-time guard (issue #26): warn if the action path doesn't resolve to

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -48,9 +48,11 @@ module Phlex
         Response.morph(@component)
       end
 
-      # Morph only inner HTML (preserves the root element + its token attr).
-      def update
-        Response.update(@component)
+      # Update only inner HTML (preserves the root element + its token attr).
+      # `morph: true` morphs the inner HTML in place (issue #113) so a
+      # cross-tab/per-field update keeps a focused input's caret.
+      def update(morph: false)
+        Response.update(@component, morph:)
       end
 
       # Reactive collections (issue #35) — add/remove a row in a declared

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -36,8 +36,12 @@ module Phlex
         # carries the fresh signed token, so the next action verifies.
         def morph(component) = new(streams: [component.to_stream_morph], subject_component: component)
 
-        # Morph only inner HTML (preserves the root element + its token attr).
-        def update(component) = new(streams: [component.to_stream_update], subject_component: component)
+        # Update only inner HTML (preserves the root element + its token attr).
+        # `morph: true` morphs the inner HTML in place (issue #113) instead of
+        # replacing it, so a cross-tab update keeps a peer's focus/caret.
+        def update(component, morph: false)
+          new(streams: [component.to_stream_update(morph:)], subject_component: component)
+        end
 
         # Remove the component's element from the DOM. Uses the instance
         # to_stream_remove (the component already knows its own #id — no
@@ -131,7 +135,7 @@ module Phlex
         # or an already-built dom-id string (e.g. the value the row used as #id).
         def collection_row_remove(definition, model)
           if model.is_a?(String)
-            Phlex::Reactive.flash_builder.remove(model)
+            Phlex::Reactive.stream_builder.remove(model)
           else
             definition.item.remove(model)
           end
@@ -175,7 +179,7 @@ module Phlex
         # Phlex::Reactive.flash_component); component content renders VERBATIM
         # — the caller owns the markup, no wrapper, no double-wrapping.
         def flash_stream(level, content, target:, dismiss_after: nil)
-          Phlex::Reactive.flash_builder.append(target, html: flash_html(level, content, dismiss_after))
+          Phlex::Reactive.stream_builder.append(target, html: flash_html(level, content, dismiss_after))
         end
 
         # Resolve flash `content` to HTML, carrying the level (issue #77):
@@ -241,7 +245,7 @@ data-reactive-flash-level="#{level_attr}"#{dismiss_attr(dismiss_after)}>#{body}<
         # (a Phlex component instance or an HTML string). Used by #also_update to
         # re-render a companion element that isn't itself a Streamable component.
         def update_stream(target, content)
-          Phlex::Reactive.flash_builder.update(target, html: render_html(content))
+          Phlex::Reactive.stream_builder.update(target, html: render_html(content))
         end
 
         # Build a `reactive:js` turbo-stream carrying server-pushed client DOM

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -172,9 +172,13 @@ module Phlex
           turbo_stream_builder.replace(component.id, html: render_component(component), **morph_method(morph))
         end
 
-        def update(model = nil, **options)
+        # `morph: true` emits `<turbo-stream action="update" method="morph">` so
+        # Turbo 8 morphs the inner HTML in place instead of replacing it (issue
+        # #113) — a cross-tab update no longer clobbers a peer's focus/caret.
+        # Default (morph: false) is the unchanged plain update.
+        def update(model = nil, morph: false, **options)
           component = build(model, options)
-          turbo_stream_builder.update(component.id, html: render_component(component))
+          turbo_stream_builder.update(component.id, html: render_component(component), **morph_method(morph))
         end
 
         def append(target:, model: nil, **options)
@@ -225,12 +229,17 @@ module Phlex
           end
         end
 
-        def broadcast_update_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
+        # `morph: true` makes the live cross-tab update morph in place (issue
+        # #113), so a peer tab editing this component keeps its focus/caret
+        # instead of an inner-HTML clobber. Like broadcast_replace_to's morph
+        # flag, it rides through `attributes:` (the broadcast path has no
+        # `method:` kwarg) via morph_attributes.
+        def broadcast_update_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
           instrument_broadcast("update", streamables) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_update_to(
               *streamables, target: component.id, html: render_component(component),
-              **broadcast_transport_opts(exclude:, visible_to:)
+              **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
             )
           end
         end
@@ -432,8 +441,16 @@ module Phlex
         self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph)
       end
 
-      def to_stream_update
-        self.class.turbo_stream_builder.update(id, html: self.class.render_component(self))
+      # `morph: true` emits `<turbo-stream action="update" method="morph">`
+      # (issue #113) so Turbo 8 morphs the inner HTML in place, preserving a
+      # focused <input> + caret across a per-field update. Default (morph:
+      # false) is the unchanged plain update. Passing `method: :morph` inline
+      # (as #to_stream_morph does) keeps the plain call's wire byte-identical.
+      # Used by Response.update.
+      def to_stream_update(morph: false)
+        builder = self.class.turbo_stream_builder
+        html = self.class.render_component(self)
+        morph ? builder.update(id, html:, method: :morph) : builder.update(id, html:)
       end
 
       # Render a TOKEN-ONLY refresh stream (issue #30): a tiny

--- a/spec/phlex/reactive/reply_spec.rb
+++ b/spec/phlex/reactive/reply_spec.rb
@@ -67,7 +67,15 @@ RSpec.describe Phlex::Reactive::Reply do
     end
 
     it "update mirrors Response.update(self)" do
-      expect(counter.reply.update.streams.first).to include('action="update"')
+      stream = counter.reply.update.streams.first
+      expect(stream).to include('action="update"')
+      expect(stream).not_to include("method=") # plain update by default
+    end
+
+    it "update(morph: true) mirrors Response.update(self, morph: true) — issue #113" do
+      stream = counter.reply.update(morph: true).streams.first
+      expect(stream).to include('action="update"')
+      expect(stream).to include('method="morph"')
     end
 
     it "remove mirrors Response.remove(self) — render_self false" do

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -156,6 +156,19 @@ RSpec.describe Phlex::Reactive::Response do
       response = described_class.replace(counter).also_replace(item)
       expect(response.streams.last).not_to include("method=")
     end
+
+    # Issue #113: Response.update gains the same morph: flag replace already has.
+    it "update(morph: true) emits a morphing update" do
+      response = described_class.update(counter, morph: true)
+      expect(response.streams.first).to include('action="update"')
+      expect(response.streams.first).to include('method="morph"')
+    end
+
+    it "update defaults to a plain update (no morph attr) — back-compat" do
+      response = described_class.update(counter)
+      expect(response.streams.first).to include('action="update"')
+      expect(response.streams.first).not_to include("method=")
+    end
   end
 
   # Issue #77: the flash level must reach the wire. String content gets a

--- a/spec/phlex/reactive/streamable_morph_spec.rb
+++ b/spec/phlex/reactive/streamable_morph_spec.rb
@@ -49,4 +49,35 @@ RSpec.describe "Streamable morph (issue #28)" do
       expect(TodoItemComponent.replace(todo)).not_to include("method=")
     end
   end
+
+  # Issue #113: the update verbs gain the same morph: flag replace already has.
+  # Turbo 8 supports method="morph" on action="update", so an inner-HTML update
+  # can morph in place — a cross-tab update no longer clobbers a peer's caret.
+  describe "#to_stream_update (instance primitive)" do
+    it "adds method=\"morph\" when morph: true" do
+      stream = CounterComponent.new(count: 0).to_stream_update(morph: true)
+      expect(stream).to include('action="update"')
+      expect(stream).to include('method="morph"')
+      expect(stream).to include('target="counter"')
+    end
+
+    it "stays a plain update (no morph attr) by default — back-compat" do
+      stream = CounterComponent.new(count: 0).to_stream_update
+      expect(stream).to include('action="update"')
+      expect(stream).not_to include("method=")
+    end
+  end
+
+  describe ".update(model, morph:) class builder" do
+    it "adds method=\"morph\" when morph: true" do
+      stream = TodoItemComponent.update(todo, morph: true)
+      expect(stream).to include('action="update"')
+      expect(stream).to include('method="morph"')
+      expect(stream).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
+    end
+
+    it "omits method= by default (unchanged)" do
+      expect(TodoItemComponent.update(todo)).not_to include("method=")
+    end
+  end
 end

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -193,4 +193,39 @@ RSpec.describe "Streamable view-context memoization (performance)" do
       expect { Phlex::Reactive.render(CsrfFormComponent.new(todo:)) }.not_to raise_error
     end
   end
+
+  # Issue #113: the builder is used well beyond flashes (row-removal, count
+  # updates, also_update), so flash_builder → stream_builder and
+  # reset_flash_builder! → reset_stream_builder!. The old names stay as
+  # permanent aliases so the engine's to_prepare hook and app code keep working.
+  describe "stream_builder / reset_stream_builder! rename (issue #113)" do
+    it "exposes stream_builder returning a Turbo::Streams::TagBuilder" do
+      expect(Phlex::Reactive.stream_builder).to be_a(Turbo::Streams::TagBuilder)
+    end
+
+    it "keeps flash_builder as a permanent alias for stream_builder" do
+      expect(Phlex::Reactive.flash_builder).to be(Phlex::Reactive.stream_builder)
+    end
+
+    it "responds to reset_stream_builder! and reset_flash_builder! (permanent alias)" do
+      expect(Phlex::Reactive).to respond_to(:reset_stream_builder!)
+      expect(Phlex::Reactive).to respond_to(:reset_flash_builder!)
+    end
+
+    it "reset_stream_builder! rebuilds the memoized builder" do
+      first = Phlex::Reactive.stream_builder
+      Phlex::Reactive.reset_stream_builder!
+      expect(Phlex::Reactive.stream_builder).not_to be(first)
+    ensure
+      Phlex::Reactive.reset_stream_builder!
+    end
+
+    it "reset_flash_builder! (the alias) also rebuilds the memoized builder" do
+      first = Phlex::Reactive.stream_builder
+      Phlex::Reactive.reset_flash_builder!
+      expect(Phlex::Reactive.stream_builder).not_to be(first)
+    ensure
+      Phlex::Reactive.reset_stream_builder!
+    end
+  end
 end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe "Reactive actions", type: :request do
       html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
       expect(html).not_to include("method=")
     end
+
+    # Issue #113: broadcast_update_to gains the same morph: flag. A cross-tab
+    # update into a component a peer is editing morphs in place, so the peer
+    # keeps its focus/caret instead of an inner-HTML clobber. The morph flag
+    # rides through `attributes:` (the broadcast path has no method: kwarg).
+    # The pgbus-absent fallback (this Action Cable path) is unchanged unless
+    # morph: true is asked for.
+    it "broadcasts a morphing update when morph: true (issue #113)" do
+      broadcasts = capture_turbo_stream_broadcasts("todos") do
+        TodoItemComponent.broadcast_update_to("todos", model: todo, morph: true)
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="update"')
+      expect(html).to include('method="morph"')
+    end
+
+    it "broadcasts a plain update (no morph attr) by default" do
+      broadcasts = capture_turbo_stream_broadcasts("todos") do
+        TodoItemComponent.broadcast_update_to("todos", model: todo)
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="update"')
+      expect(html).not_to include("method=")
+    end
   end
 
   describe "record + state component (InlineEditComponent, issue #6)" do


### PR DESCRIPTION
Closes #113

The flash follow-ups deferred from PR #84 (Wave E, item 4).

## What changed

### 1. `morph:` on the update verbs — closes the verb-matrix asymmetry

`replace`/`broadcast_replace_to` already took `morph:` (PR #84); the `update` family did not — even though Turbo 8 supports `method="morph"` on `action="update"`. Concretely, a cross-tab `broadcast_update_to` into a component a peer is mid-edit on tore down their focus/caret. It now morphs the inner HTML in place instead.

Threaded through every update surface, reusing the existing `morph_method` / `morph_attributes` helpers:

| Surface | Change |
|---|---|
| `Streamable.update(model, morph:)` | class builder — emits `method="morph"` via `morph_method` |
| `#to_stream_update(morph:)` | instance primitive — inline `method: :morph` (like `#to_stream_morph`) |
| `broadcast_update_to(*streamables, morph:)` | rides `attributes:` via `morph_attributes` (the broadcast path has no `method:` kwarg) — works on Action Cable **and** pgbus |
| `Response.update(component, morph:)` | |
| `Reply#update(morph:)` | `reply.update(morph: true)` |

**Default `false` everywhere → byte-identical to today** (no `method=` attribute). No new dependency (Idiomorph ships with `turbo-rails >= 2.0`).

### 2. `flash_builder` → `stream_builder` rename

`Phlex::Reactive.flash_builder` (and `reset_flash_builder!`) is used well beyond flashes — `reactive_collection` row removal, count-companion updates, `also_update`. Renamed to `stream_builder` / `reset_stream_builder!`; all internal call sites moved (engine `to_prepare`, `response.rb` ×3).

**`flash_builder` and `reset_flash_builder!` stay as permanent aliases** (no deprecation), so the engine's reload hook and any app code keep working unchanged.

## Test plan

- `streamable_morph_spec` — `morph: true` emits `method="morph"` on update through the class builder + `#to_stream_update`; `morph: false`/omitted is byte-identical (pinned)
- `response_spec` / `reply_spec` — `Response.update(morph:)` and `reply.update(morph:)`; plain calls carry no `method=`
- `reactive_actions_spec` — `broadcast_update_to(..., morph: true)` carries the attr; the **pgbus-absent (Action Cable) fallback is unchanged by default**
- `streamable_view_context_spec` — `stream_builder` / `reset_stream_builder!` exist; `flash_builder` / `reset_flash_builder!` aliases still resolve and rebuild the memo

## Invariants held

- **pgbus optional** — the capability-gated Action Cable fallback is untouched; the morph flag rides the shared broadcast body, so both transports behave identically
- **self-targeting `#id`** preserved; no wire change unless `morph: true` is asked for
- **Performance** — the morph plumbing is a structural clone of PR #84's already-benched `replace` path (`morph_method`/`morph_attributes` return `{}` on the default path), so the plain update stays allocation-identical. No new hot-path baseline needed; the added kwarg is a compile-time detail on the default call.

## Verification

- [x] `bundle exec rubocop` — clean (gem + `cd docs && bundle exec rubocop`)
- [x] `bundle exec rspec spec/phlex spec/requests` — 593 examples, 0 failures
- [x] Docs + CHANGELOG updated (README stream/reply tables, broadcasting + architecture pages)
