### PR TITLE
refactor(controller): structured Stream value object — stop regex-sniffing our own turbo-stream HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Structured `Phlex::Reactive::Stream` value object — the endpoint stops
+  regex-sniffing its own generated turbo-stream HTML (#114).** The action endpoint
+  used to reverse-engineer stream *semantics* out of *markup*: it substring-scanned
+  every stream for `data-reactive-token-value` and regexed the opening
+  `<turbo-stream>` tag's `action="…"` against a self-render allowlist to decide
+  whether a stream already refreshed the component's signed token. The gem was
+  parsing strings it had just built, and every new stream shape needed a new patch
+  to the heuristics. Now every `to_stream_*` instance primitive and every
+  `Streamable` class builder (`replace`/`update`/`append`/`prepend`/`remove`)
+  returns a `Phlex::Reactive::Stream` — an `ActiveSupport::SafeBuffer` subclass
+  that IS an html_safe String (so it drops into `render turbo_stream:`, ERB/Phlex
+  interpolation, and Turbo test-helper substring asserts unchanged) but also
+  carries `rx_action` / `rx_target` / `rx_renders_root?` set **structurally at
+  construction** plus `rx_carries_token?` computed **once from ground truth** (a
+  build-time scan of the actual bytes, never inferred from the builder kind — the
+  cosmos#1939 guard). The endpoint reads those fields instead of regexing markup;
+  `renders_root: false` on `append`/`prepend` encodes the #44 lesson (a child row's
+  own token in an append `<template>` can never count as the container's refresh)
+  in the *type*, not a regex. Raw strings (`reply.with(…)`, interpolated or
+  `gsub`'d streams) keep the pre-#114 regex path as a permanent fallback, gated on
+  `stream.is_a?(Stream)`. **The wire format is byte-identical** — same
+  token-refresh decisions (#30/#44/#46/#50 pins all green), different mechanism.
+  This is an architecture/correctness win, not a speedup: `rake bench:request`
+  before/after moves within measurement noise (allocations +1 obj/req state-backed,
+  +5 obj/req record-backed; throughput swings inside the ±15–28% error bars).
+
 - **`Phlex::Reactive.flash_builder` → `stream_builder` (and `reset_flash_builder!`
   → `reset_stream_builder!`) (#113).** The memoized `Turbo::Streams::TagBuilder`
   is used well beyond flashes — `reactive_collection` row removal, count-companion

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -228,10 +228,27 @@ module Phlex
         # replace when a hand-built `with(...)` stream omits it. Idempotent: a
         # Response.replace(self)/update(self) already carries the token, so we
         # don't double the self-render.
-        if result.render_self? && streams.none? { it.include?("data-reactive-token-value") }
+        #
+        # GUARD 2 (issue #114): GLOBAL, un-scoped — "does ANY stream carry a
+        # token?", NOT target-scoped. A Stream answers from its precomputed
+        # ground-truth flag (rx_carries_token?), a raw string from a substring
+        # scan. Deliberately NOT rx_refreshes_token_for? (target-scoped): scoping
+        # this guard would regress update/morph of self on an aliased id.
+        if result.render_self? && streams.none? { stream_carries_token?(it) }
           streams = [component.to_stream_replace, *streams]
         end
         streams
+      end
+
+      # GUARD 2 predicate. A Stream with intact metadata answers structurally
+      # (O(1) flag read); a raw string / metadata-degraded object falls back to
+      # the substring scan the endpoint always used.
+      def stream_carries_token?(stream)
+        if stream.is_a?(Phlex::Reactive::Stream) && stream.rx_action
+          stream.rx_carries_token?
+        else
+          stream.include?(Phlex::Reactive::Stream::TOKEN_ATTR)
+        end
       end
 
       # Actions that RE-RENDER the component's own root (so the root's fresh
@@ -240,37 +257,60 @@ module Phlex
       # component, and a reactive child carries its OWN token — that child token is
       # not the component's (issue #44). reactive:token is our inert token-only
       # refresh; replace/update re-render the root.
+      #
+      # Issue #114: a Phlex::Reactive::Stream now knows its own action structurally
+      # (Stream::SELF_RENDER_ACTIONS), so this allowlist survives ONLY for the
+      # LEGACY regex fallback below — the path raw strings (reply.with,
+      # interpolated/degraded streams) take. The primary path is structural.
       SELF_RENDER_ACTIONS = %w[replace update reactive:token].freeze
       private_constant :SELF_RENDER_ACTIONS
 
-      # True when one of `streams` already carries a fresh token by RE-RENDERING
-      # this component itself — i.e. the caller hand-built the actor's own
-      # token-bearing stream, so appending to_stream_token would double it.
+      # GUARD 1 (issue #114): true when one of `streams` already carries a fresh
+      # token by RE-RENDERING this component itself — so appending to_stream_token
+      # would double it. Target+root scoped (distinct from GUARD 2's global scan).
       #
-      # The match requires BOTH (a) the stream's action re-renders the component's
-      # ROOT (replace/update/reactive:token — never append/prepend, which insert
-      # children) AND (b) it targets the component's id AND (c) it actually carries
-      # a token. This is stricter than a same-string substring check on purpose:
-      #   * A sibling component's replace targets a DIFFERENT id → (b) fails, so we
+      # A Phlex::Reactive::Stream answers STRUCTURALLY (rx_refreshes_token_for? —
+      # the three-way test carries_token AND renders_root AND same target, no
+      # regex). A raw string / metadata-degraded object falls back to the legacy
+      # opening-tag regex, which encodes the same rule:
+      #   * A sibling component's replace targets a DIFFERENT id → no match, so we
       #     still refresh ours (issue #30).
       #   * A reactive child row appended/prepended INTO the component carries its
-      #     own token at the component's target, but the action is append/prepend →
-      #     (a) fails, so we still refresh the CONTAINER's token (issue #44). Before
-      #     this, the child's token at the container target suppressed the
-      #     container's refresh and the list was add-once-only.
+      #     own token at the component's target, but append/prepend do NOT
+      #     re-render the root → no match, so we still refresh the CONTAINER's
+      #     token (issue #44). Before this, the child's token at the container
+      #     target suppressed the container's refresh and the list was
+      #     add-once-only.
       def carries_token_for?(streams, component)
-        target = %(target="#{ERB::Util.html_escape(component.id)}")
-        streams.any? do
-          it.include?("data-reactive-token-value") &&
-            it.include?(target) &&
-            self_render_stream_for?(it, target)
+        streams.any? { stream_refreshes_token_for?(it, component.id) }
+      end
+
+      # Per-stream GUARD 1 predicate: a Stream with intact metadata answers
+      # structurally (rx_refreshes_token_for?); a raw string / metadata-degraded
+      # object falls back to the legacy opening-tag regex.
+      def stream_refreshes_token_for?(stream, component_id)
+        if stream.is_a?(Phlex::Reactive::Stream) && stream.rx_action
+          stream.rx_refreshes_token_for?(component_id)
+        else
+          legacy_self_render_token?(stream, component_id)
         end
+      end
+
+      # LEGACY fallback for raw strings (reply.with) and metadata-degraded
+      # streams: the pre-#114 substring + opening-tag regex, kept verbatim as the
+      # floor beneath the structural path.
+      def legacy_self_render_token?(stream, component_id)
+        target = %(target="#{ERB::Util.html_escape(component_id)}")
+        stream.include?("data-reactive-token-value") &&
+          stream.include?(target) &&
+          self_render_stream_for?(stream, target)
       end
 
       # Does this turbo-stream's OPENING tag re-render `target` itself? Matches a
       # `<turbo-stream action="<self-render>" ... target="<id>">` opening tag — the
       # action and target on the SAME tag — so a child row's token embedded in an
       # append/prepend `<template>` can never count as the container's own refresh.
+      # LEGACY: only the raw-string fallback reaches this now.
       def self_render_stream_for?(stream, target)
         open_tag = stream[/<turbo-stream\b[^>]*>/]
         return false unless open_tag&.include?(target)

--- a/lib/phlex/reactive/stream.rb
+++ b/lib/phlex/reactive/stream.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # A Turbo Stream that IS an html_safe String — it drops into
+    # `render turbo_stream:`, ERB/Phlex interpolation, and Turbo test-helper
+    # substring asserts unchanged — but ALSO carries the structural facts the
+    # action endpoint needs: `rx_action`, `rx_target`, `rx_renders_root?`, and a
+    # token flag computed ONCE from ground truth (the html bytes).
+    #
+    # WHY (issue #114): the endpoint used to reverse-engineer turbo-stream
+    # SEMANTICS out of MARKUP — substring-scanning every stream for
+    # `data-reactive-token-value` and regexing the opening tag's `action="..."`
+    # against a self-render allowlist. The gem was parsing strings it just built,
+    # and every new stream shape needed a new patch to the heuristics. A Stream
+    # knows its action, target, and token-ness at CONSTRUCTION, so the endpoint
+    # reads fields instead of scanning markup.
+    #
+    # Subclasses ActiveSupport::SafeBuffer deliberately. The sole thing
+    # `render turbo_stream: [s1, s2]` does to each element is `plain_string << s`
+    # (verified against actionpack 8.1.3 / turbo-rails 2.0.23: the renderer
+    # returns the array unchanged, Response#body= stores it, and Buffer#body does
+    # `buf = +""; each { |chunk| buf << chunk }`). `String#<<` needs `#to_str`,
+    # which a SafeBuffer subclass inherits — so the ivars ride to the wire and
+    # the bytes are byte-identical to today's TagBuilder output. Being IS-A-String
+    # also satisfies every public-API interop requirement (clause 2) for free.
+    #
+    # Metadata-loss is a FEATURE, not a bug. `dup`/`+` keep the class + ivars, so
+    # they stay on the structural path with accurate fields (the bytes are
+    # unchanged). `gsub`/interpolation/`*` reshape the bytes and return a plain
+    # String/SafeBuffer — precisely when the object is no longer a
+    # structurally-known stream and SHOULD be treated as opaque. The endpoint's
+    # `is_a?(Stream) && rx_action` guard turns every such loss into the SAFE
+    # legacy regex path. INVARIANT: never `+`/`gsub`/`<<` a built Stream and keep
+    # using it as a Stream — re-`wrap` the result to recompute the flags.
+    class Stream < ActiveSupport::SafeBuffer
+      # The attribute the client's #extractToken reads. Its PRESENCE (by name) is
+      # what "carries a token" means — the same contract the old substring scan
+      # used, so an accidentally-empty token still flags true (not a regression;
+      # the real cosmos#1939 guard lives upstream in #to_stream_token).
+      TOKEN_ATTR = "data-reactive-token-value"
+
+      # Actions whose OPENING tag re-renders the component's OWN root, so the
+      # root's fresh token rolls the signed identity forward. `append`/`prepend`
+      # insert CHILDREN and are deliberately excluded (issue #44): a child row's
+      # token embedded in an append `<template>` must NEVER count as the
+      # container's refresh. `reactive:token` is our inert token-only refresh.
+      SELF_RENDER_ACTIONS = %w[replace update reactive:token].freeze
+
+      class << self
+        # The single construction seam every builder routes its already-html_safe
+        # output through. `html` MUST already be html_safe (a TagBuilder result or
+        # an explicitly `.html_safe` string) — we do NOT escape, so the wire stays
+        # byte-identical. `renders_root` is set STRUCTURALLY by the builder that
+        # knows its own semantics; `carries_token` is GROUND TRUTH.
+        def wrap(html, action:, target:, renders_root:)
+          new(html.to_s, action: action, target: target, renders_root: renders_root)
+        end
+      end
+
+      def initialize(html = "", action: nil, target: nil, renders_root: false)
+        super(html) # SafeBuffer copies the bytes verbatim — byte-identical wire.
+        @rx_action = action&.to_s
+        @rx_target = target&.to_s
+        @rx_renders_root = renders_root ? true : false
+        # ONE O(bytes) scan at BUILD time — the ground-truth token flag. A
+        # `with(...)` raw string that omits the token and a replace whose render
+        # happened to include one both answer honestly; the flag is NEVER
+        # inferred from `action` (that would reintroduce cosmos#1939).
+        @rx_carries_token = include?(TOKEN_ATTR)
+        freeze # an immutable value object
+      end
+
+      attr_reader :rx_action, :rx_target
+
+      def rx_renders_root? = @rx_renders_root
+      def rx_carries_token? = @rx_carries_token
+
+      # Does THIS stream ALREADY refresh `component_target`'s signed token by
+      # re-rendering its own root? Purely structural — replaces the two-method
+      # opening-tag regex (carries_token_for? + self_render_stream_for?). All must
+      # hold: it carries a token AND re-renders the root AND targets THIS
+      # component AND the action is a self-render action.
+      #   * A sibling replace (different target) → false, so ours still refreshes
+      #     (issue #30).
+      #   * An appended child row (renders_root false) → false, so the container's
+      #     token still refreshes even though the row embeds its own (issue #44).
+      # `component_target` is the RAW dom id (never the escaped `target="..."`
+      # attribute); escaping happens only in the emitted HTML.
+      def rx_refreshes_token_for?(component_target)
+        @rx_carries_token &&
+          @rx_renders_root &&
+          @rx_target == component_target.to_s &&
+          SELF_RENDER_ACTIONS.include?(@rx_action)
+      end
+    end
+  end
+end

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -167,9 +167,16 @@ module Phlex
         # Turbo 8's bundled Idiomorph morphs the subtree in place — preserving a
         # focused <input> + caret — instead of an outerHTML swap (issue #28).
         # Default (morph: false) is the unchanged plain replace.
+        # Wrapped in a Phlex::Reactive::Stream (issue #114) so the endpoint reads
+        # action/target/token-ness structurally. renders_root: true — a replace
+        # re-renders the component's own root (carrying its fresh token); wire
+        # bytes are byte-identical.
         def replace(model = nil, morph: false, **options)
           component = build(model, options)
-          turbo_stream_builder.replace(component.id, html: render_component(component), **morph_method(morph))
+          Phlex::Reactive::Stream.wrap(
+            turbo_stream_builder.replace(component.id, html: render_component(component), **morph_method(morph)),
+            action: "replace", target: component.id, renders_root: true
+          )
         end
 
         # `morph: true` emits `<turbo-stream action="update" method="morph">` so
@@ -178,22 +185,37 @@ module Phlex
         # Default (morph: false) is the unchanged plain update.
         def update(model = nil, morph: false, **options)
           component = build(model, options)
-          turbo_stream_builder.update(component.id, html: render_component(component), **morph_method(morph))
+          Phlex::Reactive::Stream.wrap(
+            turbo_stream_builder.update(component.id, html: render_component(component), **morph_method(morph)),
+            action: "update", target: component.id, renders_root: true
+          )
         end
 
+        # renders_root: false — append inserts a CHILD into `target`; even when
+        # the appended component carries its OWN token, that must never count as
+        # the container's own refresh (issue #44).
         def append(target:, model: nil, **options)
           component = build(model, options)
-          turbo_stream_builder.append(target, html: render_component(component))
+          Phlex::Reactive::Stream.wrap(
+            turbo_stream_builder.append(target, html: render_component(component)),
+            action: "append", target: target, renders_root: false
+          )
         end
 
         def prepend(target:, model: nil, **options)
           component = build(model, options)
-          turbo_stream_builder.prepend(target, html: render_component(component))
+          Phlex::Reactive::Stream.wrap(
+            turbo_stream_builder.prepend(target, html: render_component(component)),
+            action: "prepend", target: target, renders_root: false
+          )
         end
 
         def remove(model = nil, **options)
           component = build(model, options)
-          turbo_stream_builder.remove(component.id)
+          Phlex::Reactive::Stream.wrap(
+            turbo_stream_builder.remove(component.id),
+            action: "remove", target: component.id, renders_root: false
+          )
         end
 
         # --- Broadcasts (server -> client over the stream transport) ---
@@ -426,9 +448,15 @@ module Phlex
       end
 
       # Render THIS already-built instance as a replace stream (used by the
-      # reactive action endpoint after an action mutated state).
+      # reactive action endpoint after an action mutated state). Wrapped in a
+      # Phlex::Reactive::Stream (issue #114) so the endpoint reads the action /
+      # target / token-ness structurally instead of regexing the markup; the wire
+      # bytes are byte-identical.
       def to_stream_replace
-        self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self))
+        Phlex::Reactive::Stream.wrap(
+          self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self)),
+          action: "replace", target: id, renders_root: true
+        )
       end
 
       # Render THIS instance as a MORPHING replace (issue #28):
@@ -438,7 +466,10 @@ module Phlex
       # data-reactive-token-value (so the signed token refreshes). Used by
       # Response.morph / Response.replace(self, morph: true).
       def to_stream_morph
-        self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph)
+        Phlex::Reactive::Stream.wrap(
+          self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph),
+          action: "replace", target: id, renders_root: true
+        )
       end
 
       # `morph: true` emits `<turbo-stream action="update" method="morph">`
@@ -450,7 +481,8 @@ module Phlex
       def to_stream_update(morph: false)
         builder = self.class.turbo_stream_builder
         html = self.class.render_component(self)
-        morph ? builder.update(id, html:, method: :morph) : builder.update(id, html:)
+        rendered = morph ? builder.update(id, html:, method: :morph) : builder.update(id, html:)
+        Phlex::Reactive::Stream.wrap(rendered, action: "update", target: id, renders_root: true)
       end
 
       # Render a TOKEN-ONLY refresh stream (issue #30): a tiny
@@ -476,14 +508,22 @@ module Phlex
       # has no reactive_token method at all, so it still returns false correctly.
       def to_stream_token
         token = respond_to?(:reactive_token, true) ? reactive_token : nil
-        %(<turbo-stream action="reactive:token" target="#{ERB::Util.html_escape(id)}" data-reactive-token-value="#{ERB::Util.html_escape(token)}"></turbo-stream>)
+        html = %(<turbo-stream action="reactive:token" target="#{ERB::Util.html_escape(id)}" data-reactive-token-value="#{ERB::Util.html_escape(token)}"></turbo-stream>)
+        # Both interpolations are ERB::Util.html_escape'd, so .html_safe is a
+        # byte-identical relabel. renders_root: true — reactive:token IS a
+        # self-render for token purposes (it's in SELF_RENDER_ACTIONS) — unifies
+        # the actor's own token stream onto the structural path (issue #114).
+        Phlex::Reactive::Stream.wrap(html.html_safe, action: "reactive:token", target: id, renders_root: true)
       end
 
       # Render THIS instance as a remove stream. The component already knows its
       # own #id, so no record/class reconstruction is needed (works for record-
       # and state-backed components alike). Used by Response.remove.
       def to_stream_remove
-        self.class.turbo_stream_builder.remove(id)
+        Phlex::Reactive::Stream.wrap(
+          self.class.turbo_stream_builder.remove(id),
+          action: "remove", target: id, renders_root: false
+        )
       end
     end
   end

--- a/spec/phlex/reactive/stream_spec.rb
+++ b/spec/phlex/reactive/stream_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #114: Phlex::Reactive::Stream is a structured value object that IS an
+# html_safe String (so it drops into `render turbo_stream:`, ERB/Phlex
+# interpolation, and Turbo test-helper substring asserts unchanged) but ALSO
+# carries the structural facts the endpoint needs — action / target /
+# renders_root — plus a token flag computed ONCE from GROUND TRUTH (the html
+# bytes), never inferred from the builder kind. It replaces the endpoint's
+# regex-sniffing of its own generated turbo-stream markup with structural reads.
+RSpec.describe Phlex::Reactive::Stream do
+  # A minimal html_safe replace stream that carries the token attribute.
+  def replace_html(target: "counter", token: "TOK")
+    inner = %(<div id="#{target}" data-reactive-token-value="#{token}">x</div>)
+    %(<turbo-stream action="replace" target="#{target}"><template>#{inner}</template></turbo-stream>).html_safe
+  end
+
+  # A minimal append stream whose CHILD carries its own token, at the container
+  # target — the issue #44 shape.
+  def append_html(target: "list", token: "ROWTOK")
+    inner = %(<li id="row_1" data-reactive-token-value="#{token}">row</li>)
+    %(<turbo-stream action="append" target="#{target}"><template>#{inner}</template></turbo-stream>).html_safe
+  end
+
+  describe ".wrap — structural attributes" do
+    subject(:stream) do
+      described_class.wrap(replace_html, action: "replace", target: "counter", renders_root: true)
+    end
+
+    it "carries action, target, renders_root set structurally at construction" do
+      expect(stream.rx_action).to eq("replace")
+      expect(stream.rx_target).to eq("counter")
+      expect(stream.rx_renders_root?).to be(true)
+    end
+
+    it "coerces action/target to strings and renders_root to a boolean" do
+      s = described_class.wrap(replace_html, action: :replace, target: :counter, renders_root: "yes")
+      expect(s.rx_action).to eq("replace")
+      expect(s.rx_target).to eq("counter")
+      expect(s.rx_renders_root?).to be(true)
+    end
+  end
+
+  describe "#rx_carries_token? — GROUND TRUTH, never inferred from action" do
+    it "is true when the html actually contains the token attribute" do
+      s = described_class.wrap(replace_html, action: "replace", target: "counter", renders_root: true)
+      expect(s.rx_carries_token?).to be(true)
+    end
+
+    # The load-bearing cosmos#1939 guard: a stream whose ACTION is a self-render
+    # (replace) but whose HTML omits the token must answer false — otherwise the
+    # endpoint would skip the fallback token refresh and reintroduce the
+    # add-once-only bug class.
+    it "is false when the action is replace but the html omits the token attribute" do
+      inner = %(<div id="counter">no token here</div>)
+      html = %(<turbo-stream action="replace" target="counter"><template>#{inner}</template></turbo-stream>).html_safe
+      s = described_class.wrap(html, action: "replace", target: "counter", renders_root: true)
+      expect(s.rx_carries_token?).to be(false)
+    end
+
+    it "is true for an append whose CHILD embeds a token (ground truth reads the bytes)" do
+      s = described_class.wrap(append_html, action: "append", target: "list", renders_root: false)
+      expect(s.rx_carries_token?).to be(true)
+    end
+  end
+
+  describe "IS-A html_safe String (mandatory public-API interop)" do
+    subject(:stream) do
+      described_class.wrap(replace_html, action: "replace", target: "counter", renders_root: true)
+    end
+
+    it "is an ActiveSupport::SafeBuffer and reports html_safe?" do
+      expect(stream).to be_a(ActiveSupport::SafeBuffer)
+      expect(stream.html_safe?).to be(true)
+    end
+
+    it "responds to to_str (implicit String conversion for String#<<)" do
+      expect(stream).to respond_to(:to_str)
+      expect(stream.to_str).to eq(replace_html)
+    end
+
+    it "is byte-identical to the wrapped html (no escaping, byte-identical wire)" do
+      expect(stream.to_s).to eq(replace_html.to_s)
+      expect(String.new(stream)).to eq(replace_html.to_s)
+    end
+
+    it "substring-asserts like a String (Turbo test-helper interop)" do
+      expect(stream).to include('action="replace"')
+      expect(stream).to include('target="counter"')
+      expect(stream).to include("data-reactive-token-value")
+    end
+
+    it "interpolates into another string, degrading to a plain (safe) String" do
+      combined = "PREFIX#{stream}"
+      expect(combined).to include("PREFIX")
+      expect(combined).to include('action="replace"')
+    end
+  end
+
+  describe "immutability + metadata-loss story (spec #114 item 4)" do
+    subject(:stream) do
+      described_class.wrap(replace_html, action: "replace", target: "counter", renders_root: true)
+    end
+
+    it "is frozen (an immutable value object)" do
+      expect(stream).to be_frozen
+    end
+
+    # dup KEEPS the class + ivars (only unfreezes). It therefore takes the
+    # STRUCTURAL path with ACCURATE fields — the bytes are identical. (Do NOT
+    # expect a dup to degrade to the legacy path; it does not.)
+    it "dup keeps the class and the structural attributes" do
+      d = stream.dup
+      expect(d).to be_a(described_class)
+      expect(d.rx_action).to eq("replace")
+      expect(d.rx_target).to eq("counter")
+      expect(d.rx_carries_token?).to be(true)
+    end
+
+    # gsub reshapes the bytes and returns a plain String — is_a?(Stream) is
+    # false, so the endpoint treats it as an opaque raw string (legacy path).
+    it "gsub returns a plain String that has lost the Stream metadata" do
+      g = stream.gsub("replace", "update")
+      expect(g).not_to be_a(described_class)
+      expect(g).not_to respond_to(:rx_action)
+    end
+  end
+
+  describe "#rx_refreshes_token_for? — structural token dedupe (replaces the regex)" do
+    it "is true for a token-bearing self-replace at the component's own target" do
+      s = described_class.wrap(replace_html(target: "counter"), action: "replace", target: "counter", renders_root: true)
+      expect(s.rx_refreshes_token_for?("counter")).to be(true)
+    end
+
+    # Issue #30: a SIBLING component's replace targets a DIFFERENT id, so it must
+    # NOT count as the actor's own token refresh.
+    it "is false for a replace targeting a DIFFERENT id (sibling — issue #30)" do
+      s = described_class.wrap(replace_html(target: "other"), action: "replace", target: "other", renders_root: true)
+      expect(s.rx_refreshes_token_for?("counter")).to be(false)
+    end
+
+    # Issue #44: an appended reactive ROW carries its OWN token at the container
+    # target, but renders_root is false — it inserts a CHILD, it does not
+    # re-render the container's root — so it must NEVER count as the container's
+    # own token refresh.
+    it "is false for an append even when the child row embeds a token (issue #44)" do
+      s = described_class.wrap(append_html(target: "list"), action: "append", target: "list", renders_root: false)
+      expect(s.rx_carries_token?).to be(true) # the child's token IS in the bytes...
+      expect(s.rx_refreshes_token_for?("list")).to be(false) # ...but renders_root false ⇒ no refresh
+    end
+
+    it "is false for a remove stream (renders_root false, no token)" do
+      html = %(<turbo-stream action="remove" target="counter"></turbo-stream>).html_safe
+      s = described_class.wrap(html, action: "remove", target: "counter", renders_root: false)
+      expect(s.rx_refreshes_token_for?("counter")).to be(false)
+    end
+
+    it "is a self-render for the inert reactive:token stream" do
+      html = %(<turbo-stream action="reactive:token" target="counter" ) +
+             %(data-reactive-token-value="TOK"></turbo-stream>)
+      s = described_class.wrap(html.html_safe, action: "reactive:token", target: "counter", renders_root: true)
+      expect(s.rx_refreshes_token_for?("counter")).to be(true)
+    end
+  end
+end

--- a/spec/requests/stream_value_object_spec.rb
+++ b/spec/requests/stream_value_object_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #114: the endpoint reads turbo-stream SEMANTICS structurally off a
+# Phlex::Reactive::Stream value object instead of regex-sniffing the markup it
+# just built. These specs lock the NEW guarantees the refactor must hold beyond
+# the pre-existing #30/#44/#46/#50 request pins (which stay green unchanged):
+#   * string interop — a Stream renders through a real controller + interpolates
+#     html_safe (the PUBLIC-API contract that forced the SafeBuffer subclass);
+#   * byte-identity — `render turbo_stream: [Stream, raw]` is byte-identical to
+#     the pre-refactor array output (a gem-upgrade pin on the String#<< contract);
+#   * the builders genuinely emit Streams end-to-end (the structural path is
+#     actually exercised, not silently falling through to the legacy regex).
+RSpec.describe "Structured Stream value object (issue #114)", type: :request do
+  let(:todo) { Todo.create!(title: "structural", done: false) }
+
+  describe "string interop — a Stream IS an html_safe String" do
+    it "the class builders return Phlex::Reactive::Stream instances" do
+      stream = CounterComponent.replace(count: 3)
+      expect(stream).to be_a(Phlex::Reactive::Stream)
+      expect(stream).to be_a(ActiveSupport::SafeBuffer)
+      expect(stream.html_safe?).to be(true)
+      expect(stream.rx_action).to eq("replace")
+      expect(stream.rx_target).to eq("counter")
+    end
+
+    it "the instance builders return Phlex::Reactive::Stream instances" do
+      # A fresh instance per call — a Phlex component may only render once.
+      expect(CounterComponent.new(count: 1).to_stream_replace).to be_a(Phlex::Reactive::Stream)
+      expect(CounterComponent.new(count: 1).to_stream_morph).to be_a(Phlex::Reactive::Stream)
+      expect(CounterComponent.new(count: 1).to_stream_update).to be_a(Phlex::Reactive::Stream)
+      expect(CounterComponent.new(count: 1).to_stream_remove).to be_a(Phlex::Reactive::Stream)
+      expect(CounterComponent.new(count: 1).to_stream_token).to be_a(Phlex::Reactive::Stream)
+    end
+
+    it "a Stream renders through render turbo_stream: unchanged (public-API drop-in)" do
+      # ActionController's turbo_stream renderer + Rack body assembly only call
+      # String#<< / #to_str on each element — a SafeBuffer subclass splices in
+      # byte-for-byte. This drives it through the real dummy controller.
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "increment")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include('<turbo-stream action="replace"')
+      expect(response.body).to include('target="counter"')
+    end
+
+    it "interpolates into another string as html_safe bytes" do
+      stream = CounterComponent.replace(count: 2)
+      combined = "<div>#{stream}</div>"
+      expect(combined).to start_with("<div><turbo-stream")
+      expect(combined).to include('action="replace"')
+    end
+  end
+
+  describe "byte-identity — the wire is unchanged (gem-upgrade pin)" do
+    it "an array of a Stream + a raw string assembles byte-identically" do
+      stream = CounterComponent.replace(count: 5)
+      raw = %(<turbo-stream action="append" target="flash"><template>x</template></turbo-stream>).html_safe
+
+      resp = ActionDispatch::Response.new
+      resp.body = [stream, raw]
+
+      expect(resp.body).to eq(stream.to_s + raw.to_s)
+    end
+  end
+
+  describe "the structural path is genuinely exercised" do
+    # bump_with_self_stream: the reply's own streams ALREADY include a
+    # self-replace (a Stream at the actor's target carrying the token), so the
+    # endpoint must NOT append a second token stream — proven structurally.
+    it "does not double the token when the reply already self-renders (bump_with_self_stream)" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "bump_with_self_stream")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.scan('target="counter"').size).to eq(1)
+      expect(response.body).to include("data-reactive-token-value")
+      expect(response.body).not_to include('action="reactive:token"') # no appended token stream
+    end
+
+    # bump_with_sibling: the reply streams a DIFFERENT component's replace (its
+    # own token, a different target) — the endpoint must STILL refresh THIS
+    # component's token (target-scoped structural dedupe, issue #30).
+    it "still refreshes the actor's token when the reply streams a sibling (bump_with_sibling)" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "bump_with_sibling")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="reactive:token"')
+      expect(response.body).to include('target="counter"')
+    end
+
+    # bump_with_js (reply.morph.js): the morph re-renders the root and carries the
+    # token, so GUARD 2 finds it and injects NO fallback self-replace. The
+    # reactive:js stream also targets the root (its ops scope there) but its
+    # action is reactive:js — NOT a self-render — so it never counts as the token
+    # refresh and no reactive:token is appended. Exactly ONE render stream (the
+    # morph replace); the js stream carries no rendered body.
+    it "does not let a reactive:js stream count as the token refresh (bump_with_js)" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 1 } }, act: "bump_with_js")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="reactive:js"')
+      expect(response.body).to include('action="replace"') # the morph
+      expect(response.body).to include('method="morph"')
+      expect(response.body).to include("data-reactive-token-value") # the morph carries the token
+      expect(response.body.scan('action="replace"').size).to eq(1) # not doubled with a fallback replace
+      expect(response.body).not_to include('action="reactive:token"') # morph already refreshed it
+    end
+  end
+
+  describe "raw strings still take the legacy fallback path" do
+    # bump_via_partial replies with a RAW turbo-stream String (reply.streams
+    # "<...>") — not a Stream. The endpoint must recognize it lacks the actor's
+    # token and append the token-only refresh via the legacy path.
+    it "appends the token-only refresh for a raw reply.streams string (bump_via_partial)" do
+      post_action(CounterComponent, payload: { "s" => { "count" => 4 } }, act: "bump_via_partial")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('target="counter-mirror"') # the raw caller stream
+      expect(response.body).to include('action="reactive:token"') # legacy path appended the token
+      expect(response.body).to include('target="counter"')
+      expect(response.body).not_to include('action="replace"')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The action endpoint used to reverse-engineer turbo-stream **semantics** out of **markup**: `response_streams` substring-scanned every stream for `data-reactive-token-value`, and `carries_token_for?` / `self_render_stream_for?` regexed the opening `<turbo-stream>` tag's `action="…"` against a `SELF_RENDER_ACTIONS` allowlist. The gem was parsing strings it had just built, and every new stream shape required a new patch to the string heuristics — the long apologetic comments there were the evidence.

This introduces `Phlex::Reactive::Stream` — an `ActiveSupport::SafeBuffer` subclass that **is** an html_safe String (so it drops into `render turbo_stream:`, ERB/Phlex interpolation, and Turbo test-helper substring asserts unchanged) but **also** carries the structural facts the endpoint needs:

- `rx_action` / `rx_target` / `rx_renders_root?` — set **structurally at construction** by the builder that knows its own semantics.
- `rx_carries_token?` — computed **once from ground truth** (a build-time scan of the actual bytes), never inferred from the builder kind. This is the cosmos#1939 guard: a self-render whose HTML happens to omit the token answers `false`, so the fallback token refresh still fires.

Every `to_stream_*` instance primitive and every `Streamable` class builder (`replace`/`update`/`append`/`prepend`/`remove`) now returns a `Stream`. `renders_root: false` on `append`/`prepend` encodes the **#44** lesson (a child row's own token embedded in an append `<template>` must never count as the container's refresh) in the **type**, not a regex.

### The endpoint dispatch

Two token guards, each with the correct scope, read the fields structurally:

- **Guard 1** (`carries_token_for?`, target+root scoped) → `rx_refreshes_token_for?(component.id)` for a `Stream`; the legacy opening-tag regex for a raw string.
- **Guard 2** (`render_self?` global scan) → `rx_carries_token?` **alone** (not target-scoped — scoping it would regress `update`/`morph` of self on an aliased id).

Raw strings (`reply.with(…)`, interpolated or `gsub`'d streams) keep the pre-#114 regex as a **permanent fallback**, gated on `stream.is_a?(Stream) && stream.rx_action`. Response helpers (flash / js / update / redirect streams) deliberately stay raw — they never carry the component's own token.

### Metadata-loss is a feature

`dup`/`+` keep the class and ivars, so they stay on the structural path with accurate fields (the bytes are unchanged). `gsub` / interpolation / `*` reshape the bytes and return a plain String/SafeBuffer — precisely when the object is no longer a structurally-known stream and *should* be treated as opaque. The `is_a?(Stream)` guard turns every such loss into the safe legacy path.

## Test plan

- `spec/phlex/reactive/stream_spec.rb` — `wrap` ground-truth attrs (carries_token from bytes, **not** action); IS-A html_safe String byte-identity; frozen + metadata-loss (`dup` keeps class+ivars, `gsub` degrades to a plain String → legacy); the `rx_refreshes_token_for?` truth table (self-replace true, sibling #30 false, append-with-child-token #44 false, remove false, reactive:token true).
- `spec/requests/stream_value_object_spec.rb` — builders return `Stream`s end-to-end; `render turbo_stream:` byte-identity (a gem-upgrade pin on the `String#<<` contract); the structural path is genuinely exercised (`bump_with_self_stream` / `bump_with_sibling` / `bump_with_js`); a raw `reply.streams` string still takes the legacy fallback (`bump_via_partial`).
- All pre-existing **#30 / #44 / #46 / #50** request pins stay green — the wire is byte-identical, same decisions, different mechanism.

## Verification

- `bundle exec rspec spec/phlex spec/requests` — **630 passed**
- `bundle exec rubocop` — clean (164 files)
- Client `#extractToken` **untouched** (no JS in the diff) — out of scope per the issue; it parses the HTTP body text and must stay.
- Adversarial review: 4 independent lenses (token-guards, safety-invariants, ground-truth-token, interop-completeness), 127 tool calls against the real files, **zero confirmed findings**.

### `rake bench:request` before/after (same machine — honest framing)

This is an **architecture / correctness win, not a speedup.** The deltas are noise:

| metric | before | after |
|---|---|---|
| state-backed i/s | 938 (±27.8%) | 1090 (±15.5%) |
| record-backed i/s | 958 (±6.2%) | 816 (±9.6%) |
| state-backed obj/req | 940 | 941 |
| record-backed obj/req | 1415 | 1420 |

The two i/s runs disagree in **direction** (state up, record down) inside ±15–28% error bars — measurement noise on a shared machine, not a signal. Allocations are essentially flat (+1 / +5 obj/req: the `Stream` wrapper replacing a bare `SafeBuffer`). The build-time `include?` scan replaces the old decision-time scan, so net work is similar.

Closes #114

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
