### PR TITLE
perf(client): memoize #extractToken's two per-id regexes (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   aggregator over `component/{registry,dsl,identity,helpers}.rb` — pure code
   motion, constant paths unchanged.
 
+### Performance
+
+- **`#extractToken` per-id regex memoization (#118).** The client's
+  `#extractToken` (`reactive_controller.js`) compiled its two self-matching
+  `RegExp` objects — the `reactive:token` matcher and the self replace/update
+  matcher — on **every** response, even though the root's `id` is page-stable.
+  They are now memoized on the instance keyed on `this.element.id`, rebuilt only
+  when the id changes (a re-render that re-identifies the root must scan for the
+  new target, never a stale one — covered by a new id-change bun test). The regex
+  **patterns are byte-identical**; only their allocation moved, so token
+  self-matching semantics are unchanged (the #44/#46/#47 pins stay green).
+  **Measured, not assumed** (`rake bench:client`, bun 1.3 / M2 Max): before/after
+  is within run-to-run noise (~4.4 µs on a 2 KB body, ~9–11 µs on a 500 KB 200-row
+  collection, both sides), because `#extractToken` is already **~0.25% of the
+  `DOMParser` ceiling** (~4 ms on that 500 KB body) — removing two allocations per
+  call sits below the timing floor of the dispatch-driven bench. It is a
+  correctness/cleanliness win on a hot path, **not** a throughput change; per the
+  issue's decision rule, recorded as "measured — not worth further optimization"
+  and closed.
+
 ### Added
 
 - **Client dispatch micro-bench harness — `rake bench:client` (#116).** The client

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -497,6 +497,7 @@ export default class extends Controller {
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
   #timeoutMsCache // page-stable request timeout (ms), resolved once per controller (issue #101)
+  #tokenRegexCache // { id, token, self } — #extractToken's two per-id RegExps, rebuilt on id change (issue #118)
   // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
   // refcount correctly and never clobber each other:
   #busyPending = 0 // root aria-busy pending counter (remove only at zero)
@@ -1447,27 +1448,44 @@ export default class extends Controller {
       return html.match(/data-reactive-token-value="([^"]+)"/)?.[1]
     }
 
+    const { token, self } = this.#tokenRegexes(id)
+
     // The dedicated token-only refresh for THIS element (partial updates / the
     // collection container) — an attribute on the <turbo-stream> itself.
-    const tokenStream = html.match(
-      new RegExp(
-        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
-      ),
-    )
+    const tokenStream = html.match(token)
     if (tokenStream) return tokenStream[1]
 
     // A full self re-render: a replace/update of THIS element whose template root
     // carries the fresh token. Scope the token search to that one stream so a
     // sibling/child token elsewhere in the body can't leak in.
-    const selfStream = html.match(
-      new RegExp(
-        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
-      ),
-    )
+    const selfStream = html.match(self)
     if (selfStream) return selfStream[1].match(/data-reactive-token-value="([^"]+)"/)?.[1]
 
     // Nothing re-rendered our id — keep the current token.
     return undefined
+  }
+
+  // The two per-id RegExps #extractToken uses to self-match this element's next
+  // token (issue #118). `this.element.id` is page-stable, so these are compiled
+  // ONCE and reused across every response — instead of allocating two fresh
+  // RegExps per round trip. The memo is KEYED ON THE ID and rebuilt when it
+  // changes: a re-render that re-identifies the root must scan for the NEW target,
+  // never the stale one (or the token would freeze — see the id-change bun test).
+  // The PATTERNS are byte-identical to the pre-memo inline literals; only their
+  // allocation moved.
+  #tokenRegexes(id) {
+    const cache = this.#tokenRegexCache
+    if (cache && cache.id === id) return cache
+    const escaped = escapeRegExp(id)
+    return (this.#tokenRegexCache = {
+      id,
+      token: new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escaped}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
+      ),
+      self: new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escaped}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
+      ),
+    })
   }
 
   // True when `el` is collected by THIS reactive root and not by a nested one.

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -579,7 +579,16 @@ module Views
                   code { 'DOMParser' }
                   plain ' parse of that same 500KB body is ~4.3 ms — '
                   strong { '~450× slower' }
-                  plain ': the targeted regex is why token extraction never parses the body into a document.'
+                  plain ': the targeted regex is why token extraction never parses the body into a document. '
+                  plain 'The two per-id regexes are '
+                  strong { 'memoized on the stable root id' }
+                  plain ' (issue #118) — compiled once, reused across every response, rebuilt only if the id '
+                  plain 'changes — but this was '
+                  strong { 'measured, not assumed: ' }
+                  plain 'extractToken is already ~0.25% of the '
+                  code { 'DOMParser' }
+                  plain ' ceiling, so removing two regex allocations per call is a correctness/cleanliness win '
+                  plain 'that sits below the timing floor of the dispatch-driven bench. Not worth further optimization.'
                 end
                 li do
                   strong { 'engine-relative. ' }

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -497,6 +497,7 @@ export default class extends Controller {
   #throttleTimers = new Map() // trigger element -> Map(action -> suppression timer)
   #actionPathCache // page-stable action path, resolved once per controller
   #timeoutMsCache // page-stable request timeout (ms), resolved once per controller (issue #101)
+  #tokenRegexCache // { id, token, self } — #extractToken's two per-id RegExps, rebuilt on id change (issue #118)
   // Loading-state bookkeeping (issue #99). All keyed so overlapping enqueues
   // refcount correctly and never clobber each other:
   #busyPending = 0 // root aria-busy pending counter (remove only at zero)
@@ -1447,27 +1448,44 @@ export default class extends Controller {
       return html.match(/data-reactive-token-value="([^"]+)"/)?.[1]
     }
 
+    const { token, self } = this.#tokenRegexes(id)
+
     // The dedicated token-only refresh for THIS element (partial updates / the
     // collection container) — an attribute on the <turbo-stream> itself.
-    const tokenStream = html.match(
-      new RegExp(
-        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
-      ),
-    )
+    const tokenStream = html.match(token)
     if (tokenStream) return tokenStream[1]
 
     // A full self re-render: a replace/update of THIS element whose template root
     // carries the fresh token. Scope the token search to that one stream so a
     // sibling/child token elsewhere in the body can't leak in.
-    const selfStream = html.match(
-      new RegExp(
-        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escapeRegExp(id)}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
-      ),
-    )
+    const selfStream = html.match(self)
     if (selfStream) return selfStream[1].match(/data-reactive-token-value="([^"]+)"/)?.[1]
 
     // Nothing re-rendered our id — keep the current token.
     return undefined
+  }
+
+  // The two per-id RegExps #extractToken uses to self-match this element's next
+  // token (issue #118). `this.element.id` is page-stable, so these are compiled
+  // ONCE and reused across every response — instead of allocating two fresh
+  // RegExps per round trip. The memo is KEYED ON THE ID and rebuilt when it
+  // changes: a re-render that re-identifies the root must scan for the NEW target,
+  // never the stale one (or the token would freeze — see the id-change bun test).
+  // The PATTERNS are byte-identical to the pre-memo inline literals; only their
+  // allocation moved.
+  #tokenRegexes(id) {
+    const cache = this.#tokenRegexCache
+    if (cache && cache.id === id) return cache
+    const escaped = escapeRegExp(id)
+    return (this.#tokenRegexCache = {
+      id,
+      token: new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="reactive:token"[^>]*\\btarget="${escaped}"[^>]*\\bdata-reactive-token-value="([^"]+)"`,
+      ),
+      self: new RegExp(
+        `<turbo-stream\\b[^>]*\\baction="(?:replace|update)"[^>]*\\btarget="${escaped}"[^>]*>([\\s\\S]*?)</turbo-stream>`,
+      ),
+    })
   }
 
   // True when `el` is collected by THIS reactive root and not by a nested one.

--- a/spec/javascript/reactive_extract_token.test.js
+++ b/spec/javascript/reactive_extract_token.test.js
@@ -231,6 +231,61 @@ test("matches an id containing regex metacharacters (escapeRegExp)", async () =>
   expect(captured[1].token).toBe("DOTTED-FRESH")
 })
 
+test("re-render under a NEW id self-matches the new id — memoized regexes never serve stale (issue #118)", async () => {
+  // #extractToken compiles two per-id RegExps (the reactive:token and the self
+  // replace/update matchers). They're memoized on the instance keyed on
+  // this.element.id (issue #118) — so a stable id compiles them ONCE across many
+  // responses. The correctness guard: if the root's id CHANGES (a re-render that
+  // re-identifies the element), the memo MUST rebuild for the new id, or the next
+  // extraction would scan for the OLD target and miss the new self-token,
+  // freezing the token forever. A memo keyed on nothing (regex cached once,
+  // ignoring the id) makes this test RED: the beta dispatch keeps ALPHA's token.
+  const root = fakeRoot("alpha")
+  const controller = buildController(root, "TOKEN-INITIAL")
+  stubEnv()
+
+  // A mutable body holder so each dispatch can return a body targeting the id in
+  // force at that moment (the file's stubFetchReturning captures a fixed body).
+  let body = ""
+  const captured = []
+  globalThis.fetch = (path, opts) => {
+    captured.push(JSON.parse(opts.body))
+    return Promise.resolve({
+      redirected: false,
+      ok: true,
+      headers: { get: () => "text/vnd.turbo-stream.html" },
+      text: () => Promise.resolve(body),
+    })
+  }
+
+  // First response re-renders id="alpha" and rolls its token to ALPHA-FRESH.
+  // This compiles (and memoizes) the alpha-keyed regexes.
+  body =
+    `<turbo-stream action="replace" target="alpha">` +
+    `<template><div id="alpha" data-controller="reactive" data-reactive-token-value="ALPHA-FRESH">a</div></template>` +
+    `</turbo-stream>`
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+  expect(captured[0].token).toBe("TOKEN-INITIAL")
+
+  // The root is re-identified to "beta" (a new id lands on this.element). The next
+  // response re-renders id="beta" — so #extractToken must scan for target="beta".
+  // The second POST carries the FIRST response's fresh token (ALPHA-FRESH); its
+  // response then rolls the token to BETA-FRESH — but ONLY if the memo rebuilt for
+  // the new id. A stale (alpha-keyed) regex misses the beta-targeted stream and
+  // returns undefined, freezing the token at ALPHA-FRESH.
+  root.id = "beta"
+  body =
+    `<turbo-stream action="replace" target="beta">` +
+    `<template><div id="beta" data-controller="reactive" data-reactive-token-value="BETA-FRESH">b</div></template>` +
+    `</turbo-stream>`
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+  expect(captured[1].token).toBe("ALPHA-FRESH") // second POST used the first response's fresh token
+
+  // The THIRD POST must carry BETA-FRESH — proof the memo rebuilt for the new id.
+  await controller.dispatch({ params: { action: "go", params: "{}" }, preventDefault: () => {} })
+  expect(captured[2].token).toBe("BETA-FRESH")
+})
+
 test("escapeRegExp escapes regex metacharacters", () => {
   expect(escapeRegExp("a.b:c")).toBe("a\\.b:c")
   expect(escapeRegExp("x+y*z")).toBe("x\\+y\\*z")


### PR DESCRIPTION
## What & why

`#extractToken` (`app/javascript/phlex/reactive/reactive_controller.js`) reads THIS controller's next signed token out of the turbo-stream response body after every action (issue #46). It did so by compiling **two fresh `RegExp` objects per response** — the `reactive:token` matcher and the self replace/update matcher — even though the reactive root's `id` (which both patterns interpolate) is **page-stable**.

This memoizes those two regexes on the instance, keyed on `this.element.id`, rebuilt only when the id changes. ~5 lines of behavior, client-only, **no protocol surface**.

This is **step 0 only** of a proposal whose header-based headline the audit's adversarial verifier refuted. Per the issue: the `X-Phlex-Reactive-Token` response header is **out of scope and deliberately not built**.

## The invariant

The regex **patterns are byte-identical** to the pre-memo inline literals — only their allocation moved. Token self-matching semantics are unchanged; the #44/#46/#47 pins stay green untouched.

The one correctness guard memoization introduces: the memo must **rebuild when the id changes**, or a re-render that re-identifies the root would keep scanning for the stale target and freeze the token. That's the new test.

## Measure, then STOP (the issue's decision rule)

`rake bench:client` (bun 1.3 / JavaScriptCore, Apple M2 Max), before = `main`, after = this branch:

| Bench | Before (main) | After (this branch) |
|---|---|---|
| `#extractToken`, ~2 KB single-component body | ~4.3 µs | ~4.4–4.8 µs |
| `#extractToken`, ~500 KB 200-row collection | ~9.8 µs | ~9.5–11.0 µs |
| `DOMParser` parse of the same 500 KB body (ceiling) | ~3.75 ms | ~3.6–4.8 ms |

Before/after is **within run-to-run noise on both sizes** (the DOMParser ceiling itself swung ~3.6→4.8 ms across runs — that's the machine noise band, and it dwarfs the two-allocation delta). That is the honest result: `#extractToken` is already **~0.25% of the `DOMParser` ceiling** (~9.8 µs vs ~3750 µs on the 500 KB body), and the dispatch that drives it allocates fetch/JSON/event objects that dominate the two regexes.

**Decision (per the issue):** token pickup is far under 10% of the render-message ceiling, so this is recorded as **"measured — not worth further optimization"** on the docs performance page and the issue is closed. It's a correctness/cleanliness win that keeps the hot path from re-compiling a stable regex on every round trip — **not** a throughput change, and framed as such.

## Test coverage

- **New** in `reactive_extract_token.test.js`: an id-change staleness test — after a response under id `alpha`, the root is re-identified to `beta`; the next self-render under `beta` must roll the token to `BETA-FRESH`. **Verified RED** against a deliberately-broken cached-once memo (it froze at `ALPHA-FRESH`), so the test genuinely bites a stale-memo regression.
- The existing #44/#46/#47 self-token pins (collection container vs prepended row, morph attribute order, sibling-id, prefix-id, escapeRegExp) stay green.

## Verification

- [x] `bun test spec/javascript` — 252 pass
- [x] Vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`), diff-verified identical to source
- [x] `bundle exec rubocop` (lib) + `cd docs && bundle exec rubocop` (perf page) clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 660 pass
- [x] `spec/system` green under Puma (55); token-relevant specs (counter, reactive_rows, partial_grid, todos) green under Falcon
- [x] Docs performance page + CHANGELOG (`### Performance`) updated with honest framing

Closes #118

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
