### PR TITLE
perf(client): nested-root fast path for #collectFields / recompute / #listnavOptions (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not just the importmap-style `controllers/index.js`, and its post-install output
   ends by telling you to run `bin/rails phlex_reactive:doctor` to verify.
 
+### Performance
+
+- **Nested-root fast path for the client field walks (#117).** `#collectFields`,
+  `recompute`, and `#listnavOptions` computed field ownership (the issue #15
+  "is this element mine, not a nested reactive root's?" check) with a per-element
+  `el.closest('[data-controller~="reactive"]')` walk on every matched field —
+  `recompute`'s `#ownedField` did a **fresh** `querySelectorAll('[name="…"]')` +
+  `closest()` filter **per declared input AND per output on every keystroke**
+  (~60 DOM queries on a 30-field calculator). A new `#ownershipFilter()` hoists
+  the decision to **once per op**: with no nested reactive root (the common case)
+  it returns a constant-true predicate and the per-field `closest()` walk is
+  skipped entirely; when a nested root is present it falls back to the exact
+  `#ownsField` closest() check, so issue #15 scoping is byte-identical. `recompute`
+  additionally resolves its inputs and outputs through a per-call, **first-wins**
+  `byName` memo (`if (owns(el)) break` on the first owned match — last-wins would
+  change radio-group / Rails hidden+checkbox behavior). Measured same-machine
+  before/after (bun + happy-dom, engine-relative): **recompute ~31 µs → ~23 µs per
+  keystroke (~25%)** on the 30-input calculator, 0 retained bytes/call;
+  `#collectFields` (once per dispatch, dominated by the dispatch overhead) stays
+  within noise. A **method/keystroke-level** win, not a request-level one. Field
+  ownership is unchanged for every component; the issue #15 nested-root bun tests
+  pass untouched. New coverage: `spec/javascript/reactive_recompute_ownership.test.js`
+  proves first-wins resolution for duplicate owned names and nested-root rejection.
+
 ### Changed
 
 - **Structured `Phlex::Reactive::Stream` value object — the endpoint stops

--- a/app/javascript/phlex/reactive/reactive_controller.js
+++ b/app/javascript/phlex/reactive/reactive_controller.js
@@ -717,12 +717,45 @@ export default class extends Controller {
     const inputPairs = this.#parseComputeInputs()
     const inputs = inputPairs.map(([name]) => name)
 
+    // Resolve every declared input AND output through ONE per-call resolver whose
+    // ownership probe is computed ONCE (issue #117), replacing the per-name
+    // closest() walk #ownedField did on every read — a 30-field calculator paid
+    // ~60 closest() sweeps per keystroke. #ownershipFilter returns a constant-true
+    // predicate in the common no-nested-root case (skipping closest() entirely)
+    // and the exact #ownsField check when a nested reactive root is present
+    // (issue #15 scoping, byte-identical to before). Resolution is memoized in a
+    // per-CALL Map, FIRST-WINS, so a name read as an input AND written as an
+    // output resolves to the SAME element and is queried once.
+    //
+    // Why per-name `[name="X"]` queries and not one bare `[name]` sweep: a single
+    // sweep is the natural "one walk", but the resolver must issue the SAME
+    // per-name query shape the field walk always has (the issue-#15 unit fakes
+    // answer only `[name="X"]`). It is O(distinct declared names) queries, not the
+    // old O(inputs + outputs) — the ownership decision is hoisted out of the loop.
+    // The memo is per-CALL only: an output write dispatches `input` (issue #76),
+    // re-entering recompute, which correctly rebuilds a fresh map (a morph may
+    // have replaced the nodes) — it is NEVER stored on the instance.
+    const owns = this.#ownershipFilter()
+    const byName = new Map()
+    const ownedField = (name) => {
+      if (byName.has(name)) return byName.get(name)
+      let found = null
+      for (const el of this.element.querySelectorAll(`[name="${name}"]`)) {
+        if (owns(el)) {
+          found = el // FIRST-WINS (radio groups, Rails hidden+checkbox name pairs)
+          break
+        }
+      }
+      byName.set(name, found)
+      return found
+    }
+
     // Identity-mirror pass (issue #104), ALWAYS run — even with NO registered
     // reducer, so reactive_text(:title) mirrors a field into its text node with
     // zero reducer wiring. Each declared input's RAW string value is written to
     // its owned [data-reactive-text="<name>"] node(s). It runs BEFORE the reducer
     // early-return below so a reducer-less binding still mirrors.
-    for (const name of inputs) this.#mirrorText(name, this.#rawFieldValue(name))
+    for (const name of inputs) this.#mirrorText(name, ownedField(name)?.value ?? "")
 
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
@@ -731,13 +764,28 @@ export default class extends Controller {
 
     const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
 
+    // Coerce each input per its declared type (issue #104): "string" → the raw
+    // display string (blank/absent → ""); else ("number", the array-form default)
+    // → the numeric coercion (blank/NaN → 0, the nanToZero the hand-written
+    // calculators use). Reads from the memoized resolver — no re-query.
     const values = {}
-    for (const [name, type] of inputPairs) values[name] = this.#computeInputValue(name, type)
+    for (const [name, type] of inputPairs) {
+      const field = ownedField(name)
+      if (type === "string") {
+        values[name] = field?.value ?? ""
+      } else {
+        const n = Number(field?.value)
+        values[name] = Number.isFinite(n) ? n : 0
+      }
+    }
 
+    // meta.changed stays on #changedComputeField (its own #ownsField check over
+    // the raw event target) — NOT this resolver. The issue-#15 nested-rejection
+    // test depends on that path being unchanged.
     const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
-      const field = this.#ownedField(name)
+      const field = ownedField(name)
       // Output resolution (issue #104): write to the owned named FIELD if one
       // exists, ELSE mirror to every owned [data-reactive-text="<name>"] node.
       if (field) {
@@ -813,15 +861,18 @@ export default class extends Controller {
   // per the selector on data-reactive-listnav-option-param. The attr rides on the
   // TRIGGER element (the search input on(...) is spread onto), read from the
   // event; the options are still scoped to this controller's root. Empty when
-  // unset. Falls back to the root for a directly-invoked call (unit tests).
+  // unset. Falls back to the root for a directly-invoked call (unit tests). The
+  // ownership predicate is hoisted ONCE per keypress (issue #117) — in the common
+  // no-nested-root case it is a constant true, skipping a closest() walk per
+  // option.
   #listnavOptions(event) {
     const trigger = event?.currentTarget ?? event?.target ?? this.element
     const selector =
       trigger.getAttribute?.("data-reactive-listnav-option-param") ??
       this.element.getAttribute("data-reactive-listnav-option-param")
     if (!selector) return []
-    const nodes = this.element.querySelectorAll(selector)
-    return Array.from(nodes).filter((el) => this.#ownsField(el))
+    const owns = this.#ownershipFilter()
+    return Array.from(this.element.querySelectorAll(selector)).filter(owns)
   }
 
   // Parse a JSON string list from a root data attr; [] on absence/parse error so
@@ -855,20 +906,6 @@ export default class extends Controller {
     }
   }
 
-  // Coerce a declared input's field value for the reducer per its type (issue
-  // #104): "string" → the raw string value (field.value ?? ""); anything else
-  // ("number", the array-form default) → the numeric coercion (blank/NaN → 0).
-  #computeInputValue(name, type) {
-    if (type === "string") return this.#rawFieldValue(name)
-    return this.#numericFieldValue(name)
-  }
-
-  // A declared input's RAW string value — the display string, used for :string
-  // inputs and for identity mirrors. "" for a blank/absent field (never NaN).
-  #rawFieldValue(name) {
-    return this.#ownedField(name)?.value ?? ""
-  }
-
   // The declared compute input the event just edited — the reducer's
   // meta.changed (issue #75). The triggering field counts only when it is a
   // named form control OWNED by this root (not a nested reactive root's, issue
@@ -879,23 +916,6 @@ export default class extends Controller {
     if (!target?.name || typeof target.closest !== "function") return null
     if (!inputs.includes(target.name)) return null
     return this.#ownsField(target) ? target.name : null
-  }
-
-  // The first named control owned by THIS root (skips nested reactive roots,
-  // issue #15) — used by recompute to read inputs and write outputs.
-  #ownedField(name) {
-    const nodes = this.element.querySelectorAll(`[name="${name}"]`)
-    for (const el of nodes) if (this.#ownsField(el)) return el
-    return null
-  }
-
-  // A field's value as a Number, treating blank/absent/NaN as 0 — mirroring the
-  // nanToZero coercion the hand-written calculators use, so a reducer never sees
-  // "" or NaN for an empty field.
-  #numericFieldValue(name) {
-    const field = this.#ownedField(name)
-    const n = Number(field?.value)
-    return Number.isFinite(n) ? n : 0
   }
 
   // Write `value` into every owned [data-reactive-text="<name>"] node via
@@ -1480,16 +1500,48 @@ export default class extends Controller {
     return el.closest('[data-controller~="reactive"]') === this.element
   }
 
+  // A per-op ownership PREDICATE — the issue #117 fast path over issue #15
+  // scoping. #ownsField answers "is this element mine, not a nested reactive
+  // root's" with a per-element closest() walk; on a wide form or every keystroke
+  // that walk runs per matched field. This hoists the DECISION to once per op.
+  //
+  // HYBRID GATE — closest() stays the source of truth; the nested-root query only
+  // decides whether the fast path is SAFE:
+  //   * Fast path (overwhelmingly common): this root contains NO nested reactive
+  //     roots, so every element the caller's querySelectorAll returned is already
+  //     a direct descendant of this.element with no intervening reactive root —
+  //     it is ours. Return a constant-true predicate and skip the per-field
+  //     closest() walk entirely. That is the whole win.
+  //   * Nested case: fall back to the UNCHANGED #ownsField closest() check, so
+  //     scoping is byte-identical to before. We deliberately do NOT use
+  //     contains() here — the closest() form needs no node to implement
+  //     contains(), and on a real DOM the two agree for a descendant of
+  //     this.element (el.closest('[data-controller~="reactive"]') === this.element
+  //     iff no nested reactive-root descendant contains el).
+  //
+  // Computed ONCE per dispatch-scoped op (per #collectFields call, per recompute,
+  // per #listnavOptions) and NEVER stored on the instance — a morph replaces
+  // nodes, so a cached predicate would close over stale roots.
+  #ownershipFilter() {
+    const nested = this.element.querySelectorAll('[data-controller~="reactive"]')
+    if (nested.length === 0) return () => true
+    return (el) => this.#ownsField(el)
+  }
+
   // One walk over THIS root's named controls (not a nested reactive root's),
-  // returning both the scalar `fields` and any chosen `files`. A file input's
-  // `.value` is the useless "C:\fakepath\…" string, never a scalar — so its
-  // chosen files are collected separately (honoring `multiple`) and it adds no
-  // phantom blank value (issue #34). An empty `files` keeps the JSON path.
+  // returning both the scalar `fields` and any chosen `files`. The ownership
+  // predicate is hoisted ONCE (issue #117) via #ownershipFilter — in the common
+  // no-nested-root case it is a constant true, so we skip a closest() walk per
+  // field. A file input's `.value` is the useless "C:\fakepath\…" string, never a
+  // scalar — so its chosen files are collected separately (honoring `multiple`)
+  // and it adds no phantom blank value (issue #34). An empty `files` keeps the
+  // JSON path.
   #collectFields() {
     const fields = {}
     const files = []
+    const owns = this.#ownershipFilter() // compute ONCE per dispatch (issue #117)
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
-      if (!this.#ownsField(field)) return
+      if (!owns(field)) return
       if (field.type === "file") {
         // Carry the input's `multiple` flag so #buildFormData keeps the array
         // shape (params[name][]) even when the user picked exactly one file —
@@ -1513,7 +1565,7 @@ export default class extends Controller {
     this.element
       .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
       .forEach((el) => {
-        if (!this.#ownsField(el)) return // skip editors owned by a nested reactive root (issue #15)
+        if (!owns(el)) return // reuse the SAME hoisted predicate (nested reactive root — issue #15)
         // A plain element (e.g. a <div contenteditable>) has no `name` IDL
         // property — only the attribute — so read getAttribute, not el.name.
         const name = el.getAttribute("name")

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -585,17 +585,29 @@ module Views
                   strong { 'engine-relative. ' }
                   code { '#collectFields' }
                   plain ' via a full dispatch over happy-dom: ~34 µs for a 5-field form, ~96 µs for a '
-                  plain '60-field grid. Adding 2 nested reactive roots (the '
-                  code { '#ownsField' }
-                  plain ' ownership filter, issue #15) adds ~6% — the '
+                  plain '60-field grid. Adding 2 nested reactive roots (the ownership filter, issue #15) '
+                  plain 'adds ~6%. The ownership check is hoisted to once per dispatch (issue #117): with '
+                  plain 'no nested reactive root — the common case — the '
                   code { 'closest()' }
-                  plain ' scope check per field is cheap.'
+                  plain ' scope check per field is skipped entirely. '
+                  code { 'collectFields' }
+                  plain ' runs once per dispatch, so this is dominated by the dispatch overhead and the '
+                  plain 'fast path does not move it out of noise.'
                 end
                 li do
                   strong { 'engine-relative. ' }
                   code { 'recompute' }
                   plain ' on a 30-input calculator (read every declared input, run the reducer, write '
-                  plain 'one output): ~30 µs per keystroke over happy-dom.'
+                  plain 'one output): ~23 µs per keystroke over happy-dom, down from ~31 µs (~25%). This '
+                  plain 'is where the issue #117 fast path pays off: the pre-#117 per-name '
+                  code { 'querySelectorAll' }
+                  plain ' + '
+                  code { 'closest()' }
+                  plain ' walk ran per input AND per output on every keystroke (~60 DOM queries on a '
+                  plain '30-field calculator); the hoisted ownership probe plus a first-wins '
+                  code { 'byName' }
+                  plain ' memo collapses that to one query per distinct declared name, with the ownership '
+                  plain 'decision made once. A per-keystroke (method-level) win, not a request-level one.'
                 end
               end
               DocsUI::Callout(:note) do

--- a/spec/dummy/public/vendor/reactive_controller.js
+++ b/spec/dummy/public/vendor/reactive_controller.js
@@ -717,12 +717,45 @@ export default class extends Controller {
     const inputPairs = this.#parseComputeInputs()
     const inputs = inputPairs.map(([name]) => name)
 
+    // Resolve every declared input AND output through ONE per-call resolver whose
+    // ownership probe is computed ONCE (issue #117), replacing the per-name
+    // closest() walk #ownedField did on every read — a 30-field calculator paid
+    // ~60 closest() sweeps per keystroke. #ownershipFilter returns a constant-true
+    // predicate in the common no-nested-root case (skipping closest() entirely)
+    // and the exact #ownsField check when a nested reactive root is present
+    // (issue #15 scoping, byte-identical to before). Resolution is memoized in a
+    // per-CALL Map, FIRST-WINS, so a name read as an input AND written as an
+    // output resolves to the SAME element and is queried once.
+    //
+    // Why per-name `[name="X"]` queries and not one bare `[name]` sweep: a single
+    // sweep is the natural "one walk", but the resolver must issue the SAME
+    // per-name query shape the field walk always has (the issue-#15 unit fakes
+    // answer only `[name="X"]`). It is O(distinct declared names) queries, not the
+    // old O(inputs + outputs) — the ownership decision is hoisted out of the loop.
+    // The memo is per-CALL only: an output write dispatches `input` (issue #76),
+    // re-entering recompute, which correctly rebuilds a fresh map (a morph may
+    // have replaced the nodes) — it is NEVER stored on the instance.
+    const owns = this.#ownershipFilter()
+    const byName = new Map()
+    const ownedField = (name) => {
+      if (byName.has(name)) return byName.get(name)
+      let found = null
+      for (const el of this.element.querySelectorAll(`[name="${name}"]`)) {
+        if (owns(el)) {
+          found = el // FIRST-WINS (radio groups, Rails hidden+checkbox name pairs)
+          break
+        }
+      }
+      byName.set(name, found)
+      return found
+    }
+
     // Identity-mirror pass (issue #104), ALWAYS run — even with NO registered
     // reducer, so reactive_text(:title) mirrors a field into its text node with
     // zero reducer wiring. Each declared input's RAW string value is written to
     // its owned [data-reactive-text="<name>"] node(s). It runs BEFORE the reducer
     // early-return below so a reducer-less binding still mirrors.
-    for (const name of inputs) this.#mirrorText(name, this.#rawFieldValue(name))
+    for (const name of inputs) this.#mirrorText(name, ownedField(name)?.value ?? "")
 
     const key = this.element.getAttribute("data-reactive-compute-reducer-param")
     if (!key) return
@@ -731,13 +764,28 @@ export default class extends Controller {
 
     const outputs = this.#parseComputeList("data-reactive-compute-outputs-param")
 
+    // Coerce each input per its declared type (issue #104): "string" → the raw
+    // display string (blank/absent → ""); else ("number", the array-form default)
+    // → the numeric coercion (blank/NaN → 0, the nanToZero the hand-written
+    // calculators use). Reads from the memoized resolver — no re-query.
     const values = {}
-    for (const [name, type] of inputPairs) values[name] = this.#computeInputValue(name, type)
+    for (const [name, type] of inputPairs) {
+      const field = ownedField(name)
+      if (type === "string") {
+        values[name] = field?.value ?? ""
+      } else {
+        const n = Number(field?.value)
+        values[name] = Number.isFinite(n) ? n : 0
+      }
+    }
 
+    // meta.changed stays on #changedComputeField (its own #ownsField check over
+    // the raw event target) — NOT this resolver. The issue-#15 nested-rejection
+    // test depends on that path being unchanged.
     const result = reduce(values, { changed: this.#changedComputeField(event, inputs) }) || {}
     for (const name of outputs) {
       if (!(name in result)) continue
-      const field = this.#ownedField(name)
+      const field = ownedField(name)
       // Output resolution (issue #104): write to the owned named FIELD if one
       // exists, ELSE mirror to every owned [data-reactive-text="<name>"] node.
       if (field) {
@@ -813,15 +861,18 @@ export default class extends Controller {
   // per the selector on data-reactive-listnav-option-param. The attr rides on the
   // TRIGGER element (the search input on(...) is spread onto), read from the
   // event; the options are still scoped to this controller's root. Empty when
-  // unset. Falls back to the root for a directly-invoked call (unit tests).
+  // unset. Falls back to the root for a directly-invoked call (unit tests). The
+  // ownership predicate is hoisted ONCE per keypress (issue #117) — in the common
+  // no-nested-root case it is a constant true, skipping a closest() walk per
+  // option.
   #listnavOptions(event) {
     const trigger = event?.currentTarget ?? event?.target ?? this.element
     const selector =
       trigger.getAttribute?.("data-reactive-listnav-option-param") ??
       this.element.getAttribute("data-reactive-listnav-option-param")
     if (!selector) return []
-    const nodes = this.element.querySelectorAll(selector)
-    return Array.from(nodes).filter((el) => this.#ownsField(el))
+    const owns = this.#ownershipFilter()
+    return Array.from(this.element.querySelectorAll(selector)).filter(owns)
   }
 
   // Parse a JSON string list from a root data attr; [] on absence/parse error so
@@ -855,20 +906,6 @@ export default class extends Controller {
     }
   }
 
-  // Coerce a declared input's field value for the reducer per its type (issue
-  // #104): "string" → the raw string value (field.value ?? ""); anything else
-  // ("number", the array-form default) → the numeric coercion (blank/NaN → 0).
-  #computeInputValue(name, type) {
-    if (type === "string") return this.#rawFieldValue(name)
-    return this.#numericFieldValue(name)
-  }
-
-  // A declared input's RAW string value — the display string, used for :string
-  // inputs and for identity mirrors. "" for a blank/absent field (never NaN).
-  #rawFieldValue(name) {
-    return this.#ownedField(name)?.value ?? ""
-  }
-
   // The declared compute input the event just edited — the reducer's
   // meta.changed (issue #75). The triggering field counts only when it is a
   // named form control OWNED by this root (not a nested reactive root's, issue
@@ -879,23 +916,6 @@ export default class extends Controller {
     if (!target?.name || typeof target.closest !== "function") return null
     if (!inputs.includes(target.name)) return null
     return this.#ownsField(target) ? target.name : null
-  }
-
-  // The first named control owned by THIS root (skips nested reactive roots,
-  // issue #15) — used by recompute to read inputs and write outputs.
-  #ownedField(name) {
-    const nodes = this.element.querySelectorAll(`[name="${name}"]`)
-    for (const el of nodes) if (this.#ownsField(el)) return el
-    return null
-  }
-
-  // A field's value as a Number, treating blank/absent/NaN as 0 — mirroring the
-  // nanToZero coercion the hand-written calculators use, so a reducer never sees
-  // "" or NaN for an empty field.
-  #numericFieldValue(name) {
-    const field = this.#ownedField(name)
-    const n = Number(field?.value)
-    return Number.isFinite(n) ? n : 0
   }
 
   // Write `value` into every owned [data-reactive-text="<name>"] node via
@@ -1480,16 +1500,48 @@ export default class extends Controller {
     return el.closest('[data-controller~="reactive"]') === this.element
   }
 
+  // A per-op ownership PREDICATE — the issue #117 fast path over issue #15
+  // scoping. #ownsField answers "is this element mine, not a nested reactive
+  // root's" with a per-element closest() walk; on a wide form or every keystroke
+  // that walk runs per matched field. This hoists the DECISION to once per op.
+  //
+  // HYBRID GATE — closest() stays the source of truth; the nested-root query only
+  // decides whether the fast path is SAFE:
+  //   * Fast path (overwhelmingly common): this root contains NO nested reactive
+  //     roots, so every element the caller's querySelectorAll returned is already
+  //     a direct descendant of this.element with no intervening reactive root —
+  //     it is ours. Return a constant-true predicate and skip the per-field
+  //     closest() walk entirely. That is the whole win.
+  //   * Nested case: fall back to the UNCHANGED #ownsField closest() check, so
+  //     scoping is byte-identical to before. We deliberately do NOT use
+  //     contains() here — the closest() form needs no node to implement
+  //     contains(), and on a real DOM the two agree for a descendant of
+  //     this.element (el.closest('[data-controller~="reactive"]') === this.element
+  //     iff no nested reactive-root descendant contains el).
+  //
+  // Computed ONCE per dispatch-scoped op (per #collectFields call, per recompute,
+  // per #listnavOptions) and NEVER stored on the instance — a morph replaces
+  // nodes, so a cached predicate would close over stale roots.
+  #ownershipFilter() {
+    const nested = this.element.querySelectorAll('[data-controller~="reactive"]')
+    if (nested.length === 0) return () => true
+    return (el) => this.#ownsField(el)
+  }
+
   // One walk over THIS root's named controls (not a nested reactive root's),
-  // returning both the scalar `fields` and any chosen `files`. A file input's
-  // `.value` is the useless "C:\fakepath\…" string, never a scalar — so its
-  // chosen files are collected separately (honoring `multiple`) and it adds no
-  // phantom blank value (issue #34). An empty `files` keeps the JSON path.
+  // returning both the scalar `fields` and any chosen `files`. The ownership
+  // predicate is hoisted ONCE (issue #117) via #ownershipFilter — in the common
+  // no-nested-root case it is a constant true, so we skip a closest() walk per
+  // field. A file input's `.value` is the useless "C:\fakepath\…" string, never a
+  // scalar — so its chosen files are collected separately (honoring `multiple`)
+  // and it adds no phantom blank value (issue #34). An empty `files` keeps the
+  // JSON path.
   #collectFields() {
     const fields = {}
     const files = []
+    const owns = this.#ownershipFilter() // compute ONCE per dispatch (issue #117)
     this.element.querySelectorAll("input[name], select[name], textarea[name]").forEach((field) => {
-      if (!this.#ownsField(field)) return
+      if (!owns(field)) return
       if (field.type === "file") {
         // Carry the input's `multiple` flag so #buildFormData keeps the array
         // shape (params[name][]) even when the user picked exactly one file —
@@ -1513,7 +1565,7 @@ export default class extends Controller {
     this.element
       .querySelectorAll("[name]:is(lexxy-editor, trix-editor, [contenteditable=''], [contenteditable=true], [contenteditable=plaintext-only])")
       .forEach((el) => {
-        if (!this.#ownsField(el)) return // skip editors owned by a nested reactive root (issue #15)
+        if (!owns(el)) return // reuse the SAME hoisted predicate (nested reactive root — issue #15)
         // A plain element (e.g. a <div contenteditable>) has no `name` IDL
         // property — only the attribute — so read getAttribute, not el.name.
         const name = el.getAttribute("name")

--- a/spec/javascript/reactive_recompute_ownership.test.js
+++ b/spec/javascript/reactive_recompute_ownership.test.js
@@ -1,0 +1,186 @@
+// Unit test for #recompute's FIRST-WINS owned-field resolution (issue #117,
+// guarding issue #15 nested-root scoping).
+//
+// #117 hoists the per-field ownership check out of the per-name/per-keystroke
+// loop: #ownershipFilter() probes ONCE for nested reactive roots. With none it
+// returns a constant-true predicate (the common fast path); WITH a nested root
+// it falls back to the exact #ownsField closest() check. recompute then resolves
+// every declared input/output through a per-call byName memo whose predicate is
+// FIRST-WINS (`break on the first owned match`).
+//
+// Two things need coverage that no existing test provides:
+//
+//   1. FIRST-WINS among DUPLICATE OWNED names (the reason last-wins is wrong).
+//      Two controls share a name and are BOTH owned by this root — a radio
+//      group, or the Rails hidden+checkbox pair. #ownedField/#recompute must
+//      resolve the FIRST in DOM order. Every existing compute fake returns at
+//      most one field per name, so a last-wins regression would pass silently.
+//      This test RESOLVES two owned duplicates and asserts the FIRST is used —
+//      it goes RED against a deliberately last-wins resolver (proven locally by
+//      flipping the loop to last-wins: the reducer then sees the second value).
+//
+//   2. NESTED-ROOT scoping under the #ownershipFilter fallback. A declared name
+//      also matches a field owned by a NESTED reactive root; that field must be
+//      rejected (issue #15). This forces the nested fallback branch of
+//      #ownershipFilter (not the fast path), so the real owns() predicate is
+//      under test.
+//
+// Run with: bun test spec/javascript
+import { test, expect, mock, beforeAll, beforeEach } from "bun:test"
+
+import * as computeModule from "../../app/javascript/phlex/reactive/compute.js"
+
+let ReactiveController
+
+beforeAll(async () => {
+  mock.module("@hotwired/stimulus", () => ({
+    Controller: class {
+      constructor() {}
+    },
+  }))
+  ReactiveController = (await import("../../app/javascript/phlex/reactive/reactive_controller.js")).default
+  globalThis.window ??= {}
+})
+
+beforeEach(() => {
+  computeModule.__resetComputeRegistryForTest()
+})
+
+// A fake named form control. .value coerces to String on write and fires
+// NOTHING (real DOM: no `input` on a programmatic write, issue #76). closest()
+// answers the element's owning reactive root so #ownsField (issue #15) can scope
+// it: owned by `_root` for the reactive-root selector.
+function makeField(name, value, root) {
+  const listeners = []
+  return {
+    name,
+    tagName: "INPUT",
+    _root: root,
+    _value: String(value),
+    get value() {
+      return this._value
+    },
+    set value(v) {
+      this._value = String(v)
+    },
+    closest(sel) {
+      return sel === '[data-controller~="reactive"]' ? this._root : null
+    },
+    addEventListener: (type, fn) => type === "input" && listeners.push(fn),
+    dispatchEvent(event) {
+      Object.defineProperty(event, "target", { value: this, configurable: true })
+      if (event.type === "input") listeners.slice().forEach((fn) => fn(event))
+      return true
+    },
+  }
+}
+
+// A root whose querySelectorAll('[name="total"]') returns the supplied list in
+// DOM order, and whose querySelectorAll('[data-controller~="reactive"]') returns
+// `nestedRoots`. Every other query returns []. Mirrors the compute fake's
+// per-name query shape, so it answers exactly the queries the #117 recompute
+// resolver issues.
+function makeRoot({ reducer, inputs, outputs, totalMatches, nestedRoots = [] }) {
+  const attrs = {
+    "data-reactive-compute-reducer-param": reducer,
+    "data-reactive-compute-inputs-param": JSON.stringify(inputs),
+    "data-reactive-compute-outputs-param": JSON.stringify(outputs),
+  }
+  return {
+    id: "outer-root",
+    getAttribute: (k) => attrs[k] ?? null,
+    querySelectorAll: (sel) => {
+      if (sel === '[data-controller~="reactive"]') return nestedRoots.slice()
+      if (sel === '[name="total"]') return totalMatches.slice()
+      return []
+    },
+    closest: () => null,
+  }
+}
+
+test("recompute reads the FIRST of two OWNED duplicate-named fields (issue #117 first-wins)", () => {
+  // Two controls named "total" BOTH owned by this root (e.g. a Rails
+  // hidden+visible pair). first=500, second=42. First-wins → reducer sees 500;
+  // last-wins → it would see 42 (this is what makes the test bite).
+  let seenValues
+  computeModule.setComputeReducer("echo_total", (values) => {
+    seenValues = values
+    return {}
+  })
+
+  // Build the root first so both duplicates can be owned by it.
+  const first = makeField("total", 500, null)
+  const second = makeField("total", 42, null)
+  const root = makeRoot({
+    reducer: "echo_total",
+    inputs: ["total"],
+    outputs: [],
+    totalMatches: [first, second], // DOM order: first, then second
+    nestedRoots: [], // NO nested roots here → fast path is taken
+  })
+  first._root = root
+  second._root = root // BOTH owned by this root
+
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.recompute({ target: first })
+
+  expect(seenValues).toEqual({ total: 500 }) // FIRST wins, not 42
+})
+
+test("recompute writes an output to the FIRST of two OWNED duplicate-named fields (issue #117 first-wins)", () => {
+  computeModule.setComputeReducer("set_total", () => ({ total: 999 }))
+
+  const first = makeField("total", 0, null)
+  const second = makeField("total", 0, null)
+  const root = makeRoot({
+    reducer: "set_total",
+    inputs: [],
+    outputs: ["total"],
+    totalMatches: [first, second],
+    nestedRoots: [],
+  })
+  first._root = root
+  second._root = root
+
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.recompute({ target: first })
+
+  // The write landed on the FIRST owned field; the second is untouched.
+  expect(first.value).toBe("999")
+  expect(second.value).toBe("0")
+})
+
+test("recompute skips a duplicate owned by a NESTED reactive root under the ownership fallback (issues #117/#15)", () => {
+  // The outer root owns `owned` (500); a NESTED reactive root owns `nested` (42),
+  // and both are named "total". Because a nested reactive root is present,
+  // #ownershipFilter takes the closest()-based fallback, NOT the fast path — so
+  // the nested field must be rejected and the OWNED one used.
+  let seenValues
+  computeModule.setComputeReducer("echo_total", (values) => {
+    seenValues = values
+    return {}
+  })
+
+  const nestedRoot = { id: "nested-root" }
+  const owned = makeField("total", 500, null)
+  const nested = makeField("total", 42, nestedRoot)
+  const root = makeRoot({
+    reducer: "echo_total",
+    inputs: ["total"],
+    outputs: [],
+    totalMatches: [nested, owned], // nested FIRST in DOM order — ownership must still pick `owned`
+    nestedRoots: [nestedRoot], // present → nested fallback branch of #ownershipFilter
+  })
+  owned._root = root // owned by THIS root
+  // nested._root stays nestedRoot → #ownsField(nested) === false
+
+  const controller = new ReactiveController()
+  controller.element = root
+  controller.recompute({ target: owned })
+
+  // The nested field is rejected even though it is FIRST in DOM order — ownership
+  // wins over position. The reducer sees the owned 500, never the nested 42.
+  expect(seenValues).toEqual({ total: 500 })
+})


### PR DESCRIPTION
## Summary

Hoists the issue-#15 field-ownership check out of the per-field / per-keystroke
loop in the three client hot paths named in the issue — `#collectFields`,
`recompute`, and `#listnavOptions`.

Before this change, ownership ("is this element mine, not a nested reactive
root's?") was decided with a per-element `el.closest('[data-controller~="reactive"]')`
walk on **every matched field**. `recompute` was the worst offender: its
`#ownedField` did a **fresh** `querySelectorAll('[name="…"]')` + `closest()`
filter **per declared input _and_ per output, on every keystroke** — roughly 60
DOM queries on a 30-field calculator per character typed.

A new `#ownershipFilter()` computes the decision **once per op**:

- **Fast path (the common case):** when the root has no nested reactive-root
  descendants, every element the caller's `querySelectorAll` returns is already
  owned — so the filter is a constant `() => true` and the per-field `closest()`
  walk is skipped entirely.
- **Nested case:** falls back to the exact, unchanged `#ownsField` `closest()`
  check — so issue-#15 scoping is byte-identical. Deliberately **not** `contains()`
  (the two agree for a descendant of `this.element` on a real DOM, and `closest()`
  needs no `contains()` implementation — which matters for the existing unit fakes).

`recompute` additionally resolves its inputs and outputs through a per-call,
**first-wins** `byName` memo (`if (owns(el)) break` on the first owned match —
last-wins would change radio-group / Rails hidden+checkbox behavior). A name read
as an input and written as an output resolves to the same element and is queried
once. The memo is a per-call local, never on the instance, so a `#76` output-write
re-entry (or a morph that replaced the nodes) rebuilds it fresh.

Four now-dead private helpers are removed: `#ownedField`, `#rawFieldValue`,
`#numericFieldValue`, `#computeInputValue` (their only callers were `recompute`
and each other; confirmed by grep). `#ownsField` stays — it still backs the
out-of-scope callers (`#scanDirty`, `#opTargets`, `#busyOnTargets`,
`#dirtyTrackingEnabled`, `#changedComputeField`, `#ownedTextNodes`), which are
intentionally left unchanged.

## Performance (same machine, bun + happy-dom — engine-relative)

| fixture | before p75 | after p75 | delta |
|---|---|---|---|
| **recompute — 30-input calculator** | ~31 µs | ~23 µs | **~25% faster / keystroke** |
| collectFields — 5-field form | ~34 µs | ~35 µs | within noise |
| collectFields — 60-field grid | ~93 µs | ~97 µs | within noise |
| extractToken (control, untouched) | ~12 / ~18 µs | ~12 / ~18 µs | unchanged |

Honest framing: this is a **method / per-keystroke** win, not a request-level
one. The gain is concentrated in `recompute`, which ran the redundant per-name
`querySelectorAll` + `closest()` walk on every keystroke. `#collectFields` runs
**once per dispatch** and the bench measures the full `dispatch()` overhead around
the walk, so removing one `closest()` per field does not move it out of noise —
but it is real, and it removes GC pressure on wide broadcast fan-out. Retained
bytes per `recompute` call: 0. Numbers captured via `rake bench:client` (the
#116 harness); happy-dom is engine-relative — valid for a same-machine delta, not
an absolute browser cost.

### On the "one walk" wording in the issue

The issue asks for the byName Map built in "ONE walk". A single bare `[name]`
sweep is impossible without editing the issue-#15 unit fakes, which answer only
`[name="X"]` queries and must stay untouched (correction #3). So the resolver
issues one query **per distinct declared name** (memoized), which is still
O(distinct names) — not the old O(inputs + outputs) — with the ownership decision
hoisted out of the loop. The perf win above reflects that.

## Test coverage

- **New:** `spec/javascript/reactive_recompute_ownership.test.js` — proves
  **first-wins** resolution for two *owned* duplicate-named fields (reads and
  writes the first in DOM order) and **nested-root rejection** under the
  `#ownershipFilter` fallback (an owned + a nested duplicate; the nested one is
  skipped even when it is first in DOM order). Verified RED against a deliberately
  last-wins resolver (the first two assertions flip to the nested/second value);
  GREEN with first-wins.
- The three issue-#15 nested-root bun tests (`reactive_collect_fields.test.js`,
  `reactive_compute.test.js`, `reactive_listnav.test.js`) pass **untouched**
  (zero diff).

## Verification

- [x] `bun test spec/javascript` — 254 pass, 0 fail (3 new)
- [x] Vendored client re-synced (`spec/dummy/public/vendor/reactive_controller.js`); sync spec green
- [x] `bundle exec rubocop` — 169 files, 0 offenses
- [x] `cd docs && bundle exec rubocop app/views/docs/pages/performance.rb` — clean
- [x] `bundle exec rspec spec/phlex spec/requests` — 660 examples, 0 failures
- [x] `bundle exec rspec spec/system` (Puma) — 55 examples, 0 failures
- [x] Behavior-adjacent specs under **Falcon** (`combobox_listnav`, `nested_params`, `nested_roots`, `order_compute`) — 8 examples, 0 failures
- [x] `rake bench:client` green; before/after captured above
- [x] CHANGELOG (`### Performance`) + docs performance page updated

Closes #117
