### PR TITLE
perf(ci): benchmark/micro/verify.rb — isolate token verify/sign cost (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   keys — auto-discovered by `rake bench:micro`. It also benched `model_param_name`
   (the audit's measure-first candidate: 815k i/s, 8 obj/call — immaterial next to
   the ~37 μs build, so **measured and left alone**, no memoization).
+- **`benchmark/micro/verify.rb` — isolate token verify/sign cost; the
+  digest/serializer question is now measured and closed (#120).** `verify` runs
+  before anything else on every reactive request (a garbage-token flood pays it),
+  and `sign` runs once per rendered component (N× for an N-row collection) — yet
+  neither had ever been measured in isolation (`token.rb` covers sign-side
+  *assembly*, not the HMAC), and the default digest/serializer was never compared.
+  The new bench (auto-discovered by `rake bench:micro`, no harness change) reports
+  four verify cost classes — **valid** state/record (~136k/147k i/s, 20 obj), a
+  **tampered** token that pays the full constant-time HMAC compare (~203k i/s,
+  ~6× slower than garbage), and a **garbage** flood that bails at format parsing
+  (~1.2M i/s, 4 obj) — plus `sign` ×1 (~155k i/s, 12 obj) and the **collection
+  cost** `sign` ×100 (~1.6k i/s, 1200 obj, linear). It also compares the app
+  default (SHA1, json+marshal) against SHA256 and a strict JSON serializer for
+  both verify and sign: **every variant falls within measurement noise**, so
+  phlex-reactive **ships no runtime change and no opt-in recipe** — the setter
+  (`Phlex::Reactive.verifier = …`) is documented as the escape hatch if your own
+  profile ever shows verify hot, but the data says it will not. Verification
+  semantics, purpose scoping, and default-deny are untouched — this issue
+  *measures*. Numbers and the "measured, closed" verdict are on the performance
+  page. Pure tooling + docs; no production-code change.
+
 - **Client dispatch micro-bench harness — `rake bench:client` (#116).** The client
   hot path (`app/javascript/.../reactive_controller.js`) was named a hot path in
   `.claude/rules/performance.md` but had **no bench of any kind** — every claim

--- a/benchmark/micro/verify.rb
+++ b/benchmark/micro/verify.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# Micro-bench: Phlex::Reactive.verify and .sign — the two MessageVerifier HMAC
+# paths that run on EVERY reactive interaction (issue #120).
+#
+#   * verify runs pre-EVERYTHING on every request (ActionsController#verified_payload
+#     is the first line — before default-deny, before coercion), so a garbage-token
+#     flood pays it too.
+#   * sign runs ONCE per rendered component (reactive_token) — N times for an
+#     N-row reactive collection, so the ×100 number below is the collection cost.
+#
+# token.rb covers the sign-side ASSEMBLY (building the payload hash + ivar reads);
+# THIS file isolates the HMAC itself and answers a question the repo's own perf
+# rule forbids leaving unmeasured: is verify cheap, and does the digest/serializer
+# choice move it? See docs/performance.rb "Verify & sign numbers".
+#
+#   ruby benchmark/micro/verify.rb
+#   rake bench:one[verify]
+
+require_relative "../support/boot"
+require "active_support/message_verifier"
+
+PURPOSE = Phlex::Reactive::IDENTITY_PURPOSE
+
+# --- Fixtures ---------------------------------------------------------------
+# Real tokens minted the way a render does — via the components, so the payload
+# shapes ({c, s} state-backed, {c, gid} record-backed) match production exactly.
+state    = CounterComponent.new(count: 42)                 # {c, s}
+todo     = Todo.create!(title: "t", done: false)
+record   = TodoItemComponent.new(todo:)                    # {c, gid}
+state_token  = state.send(:reactive_token)
+record_token = record.send(:reactive_token)
+
+# A TAMPERED token: corrupt the signature deterministically. A signed token is
+# `payload--signature`; flip the last char of the segment AFTER the final `--`
+# (the HMAC), leaving the format intact so verify runs the FULL constant-time
+# HMAC compare before rejecting. (Corrupting via sub("a", "b") on the whole
+# string is fragile — it might hit the payload, or the char might be absent.)
+def tamper(token)
+  head, _, sig = token.rpartition("--")
+  flipped = sig[-1] == "0" ? "1" : "0"
+  "#{head}--#{sig[0...-1]}#{flipped}"
+end
+tampered_token = tamper(state_token)
+
+# A GARBAGE string: not remotely a signed token. verify bails at FORMAT parsing
+# (no valid base64 payload / no `--` split) — it never reaches the HMAC compare.
+# This is why tampered ≠ garbage: tampered pays the full HMAC (constant-time
+# compare of the whole digest); garbage pays only the early format bail. Under a
+# bad-token flood the attacker sends garbage, so the cheaper number is the flood
+# cost — but a near-miss forgery attempt pays the tampered (full-HMAC) cost.
+garbage_token = "x" * 64
+
+# --- verify throughput ------------------------------------------------------
+BenchSupport.header("verify throughput (per token)")
+BenchSupport.ips do
+  it.report("valid (state {c,s})") { Phlex::Reactive.verify(state_token) }
+  it.report("valid (record {c,gid})") { Phlex::Reactive.verify(record_token) }
+  it.report("tampered (full HMAC)") { Phlex::Reactive.verify(tampered_token) }
+  it.report("garbage (format bail)") { Phlex::Reactive.verify(garbage_token) }
+end
+
+BenchSupport.header("verify allocations (per call)")
+Phlex::Reactive.verify(state_token) # warm
+BenchSupport.allocations("valid (state)")    { Phlex::Reactive.verify(state_token) }
+BenchSupport.allocations("valid (record)")   { Phlex::Reactive.verify(record_token) }
+BenchSupport.allocations("tampered")         { Phlex::Reactive.verify(tampered_token) }
+BenchSupport.allocations("garbage")          { Phlex::Reactive.verify(garbage_token) }
+
+# --- sign throughput: 1 and 100 (the collection-scale cost) -----------------
+# Sign the exact payloads reactive_token builds. ×100 is the per-CALL cost of
+# rendering a 100-row reactive collection (one sign per row).
+state_payload  = { "c" => "CounterComponent", "s" => { "count" => 42 } }
+record_payload = { "c" => "TodoItemComponent", "gid" => todo.to_gid.to_s }
+
+BenchSupport.header("sign throughput (×1 and ×100)")
+BenchSupport.ips do
+  it.report("state ×1")   { Phlex::Reactive.sign(state_payload) }
+  it.report("record ×1")  { Phlex::Reactive.sign(record_payload) }
+  it.report("state ×100") { 100.times { Phlex::Reactive.sign(state_payload) } }
+  it.report("record ×100") { 100.times { Phlex::Reactive.sign(record_payload) } }
+end
+
+BenchSupport.header("sign allocations (per call)")
+Phlex::Reactive.sign(state_payload) # warm
+BenchSupport.allocations("state ×1")   { Phlex::Reactive.sign(state_payload) }
+BenchSupport.allocations("record ×1")  { Phlex::Reactive.sign(record_payload) }
+BenchSupport.allocations("state ×100") { 100.times { Phlex::Reactive.sign(state_payload) } }
+
+# --- digest / serializer comparison -----------------------------------------
+# The default verifier takes whatever Rails.application.message_verifier hands
+# back: SHA1 digest, the JSON-with-Marshal-fallback serializer. Does pinning
+# SHA256 or a strict JSON serializer move the number? Build explicit verifiers
+# on the SAME secret + purpose so only the one variable changes. Each round-trips
+# a token it minted itself (a cross-verifier token wouldn't verify).
+secret = Rails.application.secret_key_base
+
+variants = {
+  "app default (SHA1, json+marshal)" => Phlex::Reactive.verifier,
+  "SHA1  + JSON serializer" => ActiveSupport::MessageVerifier.new(secret, digest: "SHA1", serializer: JSON),
+  "SHA256 + json+marshal (default)" => ActiveSupport::MessageVerifier.new(secret, digest: "SHA256"),
+  "SHA256 + JSON serializer" => ActiveSupport::MessageVerifier.new(secret, digest: "SHA256", serializer: JSON)
+}
+# Mint one token per variant (same {c,s} payload) so the verify measures the
+# variant's own round-trip, not a decode failure.
+variant_tokens = variants.transform_values { it.generate(state_payload, purpose: PURPOSE) }
+
+# The ips block is named `|bench|` (not the implicit `it`) ON PURPOSE: it wraps a
+# `variants.each do |label, verifier|` whose ordinary params make a bare `it` a
+# Ruby SyntaxError ("`it` is not allowed when an ordinary parameter is defined").
+# The inner report blocks reference the captured `verifier`/`token`, so `it` there
+# would be the report block's own (nil) param, not the verifier — Style/ItBlock
+# Parameter can't see either, so disable it on the two report lines.
+BenchSupport.header("verify throughput by digest/serializer (valid state token)")
+BenchSupport.ips do |bench|
+  variants.each do |label, verifier|
+    token = variant_tokens[label]
+    bench.report(label) { verifier.verified(token, purpose: PURPOSE) } # rubocop:disable Style/ItBlockParameter
+  end
+end
+
+BenchSupport.header("sign throughput by digest/serializer (state payload)")
+BenchSupport.ips do |bench|
+  variants.each do |label, verifier|
+    bench.report(label) { verifier.generate(state_payload, purpose: PURPOSE) } # rubocop:disable Style/ItBlockParameter
+  end
+end

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -19,6 +19,7 @@ module Views
           measuring
           before_change
           numbers
+          verify_and_sign
           client_numbers
           ci
           every_change
@@ -328,7 +329,7 @@ module Views
             end
             DocsUI::Code(<<~SHELL, lexer: :shell)
               rake bench           # the micro-benchmark suite (alias for bench:micro)
-              rake bench:micro     # render, reactive_token, coerce_params — isolates each method
+              rake bench:micro     # render, reactive_token, verify/sign, coerce_params — isolates each method
               rake bench:request   # end-to-end POST /reactive/actions through the full Rack stack
               rake bench:client    # the client dispatch hot path (extractToken, collectFields, recompute) via bun
               rake bench:one[render]  # a single micro-bench by name
@@ -544,6 +545,97 @@ module Views
                   plain 're-find + DB write, which is the security model working as designed (state lives in '
                   plain 'the database), not overhead to remove.'
                 end
+              end
+            end
+          end
+        end
+
+        def verify_and_sign
+          DocsUI::Section('Verify & sign numbers') do
+            DocsUI::Prose() do
+              p do
+                plain 'The two MessageVerifier HMAC paths run on every interaction: '
+                code { 'Phlex::Reactive.verify' }
+                plain ' before anything else on every request ('
+                code { 'ActionsController#verified_payload' }
+                plain ' is the first line — a garbage-token flood pays it too), and '
+                code { 'Phlex::Reactive.sign' }
+                plain ' once per rendered component ('
+                code { 'reactive_token' }
+                plain ' — so N times for an N-row reactive collection). '
+                code { 'benchmark/micro/verify.rb' }
+                plain ' isolates both. Ruby 3.4 +YJIT, Apple Silicon, the dummy app:'
+              end
+              h3 { 'verify — four cost classes' }
+              ul do
+                li do
+                  strong { 'garbage' }
+                  plain ' ('
+                  code { '"x" * 64' }
+                  plain ', the flood cost): ~1.2M i/s (0.8 μs), 4 obj/call. A malformed token bails at '
+                  plain 'format parsing before the HMAC ever runs, so a bad-token flood is the '
+                  em { 'cheapest' }
+                  plain ' path — nothing to optimize.'
+                end
+                li do
+                  strong { 'tampered' }
+                  plain ' (valid shape, corrupted signature): ~203k i/s (4.9 μs), 9 obj/call — '
+                  strong { '6× slower than garbage' }
+                  plain '. A near-miss forgery pays the full constant-time HMAC compare of the whole '
+                  plain 'digest; garbage never gets there. That gap is the security model working as '
+                  plain 'designed (no early-exit oracle on the signature).'
+                end
+                li do
+                  strong { 'valid, state-backed' }
+                  plain ' ('
+                  code { '{c, s}' }
+                  plain '): ~136k i/s (7.4 μs), 20 obj/call.'
+                end
+                li do
+                  strong { 'valid, record-backed' }
+                  plain ' ('
+                  code { '{c, gid}' }
+                  plain '): ~147k i/s (6.8 μs), 20 obj/call. (The GlobalID re-find + DB load happens '
+                  plain 'downstream, in the action — not in verify.)'
+                end
+              end
+              h3 { 'sign — per component, and at collection scale' }
+              ul do
+                li do
+                  code { 'sign' }
+                  plain ' ×1 (state or record): ~155k i/s (6.5 μs), 12 obj/call.'
+                end
+                li do
+                  code { 'sign' }
+                  plain ' ×100 — '
+                  strong { 'the collection cost' }
+                  plain ' (rendering a 100-row reactive collection signs once per row): ~1.6k i/s '
+                  plain '(610 μs), 1200 obj/call. It scales linearly, as expected — the HMAC is '
+                  plain 'unavoidable and there is no shared work across rows to hoist.'
+                end
+              end
+              h3 { 'Digest / serializer: measured, and the question is closed' }
+              p do
+                plain 'The default verifier uses whatever '
+                code { 'Rails.application.message_verifier' }
+                plain ' hands back — SHA1 with the JSON-with-Marshal-fallback serializer. The bench '
+                plain 'compares that against explicitly-built verifiers on the same secret with SHA256 '
+                plain 'and/or a strict JSON serializer, for both verify and sign. '
+                strong { 'Every variant falls within measurement noise' }
+                plain ' — the differences reorder run-to-run and benchmark-ips reports them as '
+                em { '"difference falls within error"' }
+                plain '. The HMAC over a ~120-byte payload is not where the time goes, and the '
+                plain 'serializer choice does not move it either.'
+              end
+              DocsUI::Callout(:note) do
+                plain 'Verdict: verify is not a bottleneck (a garbage flood is ~1.2M i/s, and even a ' \
+                      'valid verify is ~7 μs against a full action that is ~600 μs), and no ' \
+                      'digest/serializer configuration wins measurably — so phlex-reactive ships no ' \
+                      'opt-in recipe and keeps the app default. If your own profile ever shows verify ' \
+                      'as hot, the setter is there — '
+                code { 'Phlex::Reactive.verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA256")' }
+                plain ' — but the measurement says you will not need it. The question is closed until ' \
+                      'the numbers say otherwise.'
               end
             end
           end


### PR DESCRIPTION
## Summary

`verify` runs before **any** other work on every reactive request (`ActionsController#verified_payload` is the first line — a garbage-token flood pays it too), and `sign` runs **once per rendered component** (`reactive_token`, so N× for an N-row reactive collection). Yet neither had ever been measured in isolation — `benchmark/micro/token.rb` covers sign-side *assembly*, not the HMAC — and the default digest/serializer was never compared. The repo's own performance rule forbids a claim without a measurement; this closes the gap honestly.

Bench + docs only. **No runtime change ships** — the measurement decided that.

## What's added

`benchmark/micro/verify.rb`, on the shared `BenchSupport` harness, auto-discovered by `rake bench:micro` (no harness change):

- **`verify` — four cost classes** (i/s + obj/call each): valid state `{c,s}`, valid record `{c,gid}`, a **tampered** token (deterministically corrupt the segment after the last `--`, so it pays the full constant-time HMAC compare), and a **garbage** string (`"x" * 64`, bails at format parsing before the HMAC). Comments explain why tampered ≠ garbage (full HMAC vs early format bail).
- **`sign` — ×1 and ×100**, record- and state-backed. The ×100 is the collection-scale cost (one sign per row).
- **Digest/serializer comparison**: the app default (SHA1, json+marshal) vs an explicitly-built SHA256 verifier and a strict JSON serializer, on the same secret + purpose, for both verify and sign.

## Representative numbers (Ruby 3.4 +YJIT, Apple Silicon, dummy app)

| verify | i/s | μs | obj/call |
| --- | --- | --- | --- |
| garbage (format bail) | ~1.2M | 0.8 | 4 |
| tampered (full HMAC) | ~203k | 4.9 | 9 |
| valid, state `{c,s}` | ~136k | 7.4 | 20 |
| valid, record `{c,gid}` | ~147k | 6.8 | 20 |

| sign | i/s | μs | obj/call |
| --- | --- | --- | --- |
| ×1 (state / record) | ~155k | 6.5 | 12 |
| ×100 (100-row collection) | ~1.6k | 610 | 1200 |

A garbage flood is the *cheapest* path (nothing to optimize); a near-miss forgery pays the full HMAC (~6× slower than garbage) — the security model working as designed, no early-exit oracle on the signature.

## Outcome — the digest/serializer question is measured and closed

Every variant falls **within measurement noise** — the ordering reorders run-to-run and benchmark-ips reports the differences as "within error". SHA1 vs SHA256 and json+marshal vs strict JSON do not move verify or sign. So:

- **No opt-in recipe ships.** phlex-reactive keeps the app default.
- The performance page records the "measured, closed" verdict and documents the existing `Phlex::Reactive.verifier = …` setter as the escape hatch if your own profile ever shows verify hot — but the data says it will not.

## Invariants

Verification semantics, purpose scoping, and default-deny are **untouched** — this issue *measures*. Any verifier change is app-level opt-in documentation only.

## Test / verification plan

- `rake bench:micro` auto-discovers `verify.rb` and completes; the crashed-bench-fails contract is preserved (no harness edit).
- `rake bench:one[verify]` resolves the new file.
- `bundle exec rubocop` (gem, 170 files) — clean.
- `cd docs && bundle exec rubocop app/views/docs/pages/performance.rb` — clean.
- `bundle exec rspec spec/phlex spec/requests` — 660 examples, 0 failures.
- CHANGELOG entry (`### Added`, `#120`) + performance page (verify/sign numbers, incl. the ×100 collection number) updated.

Closes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Verify & sign” performance subsection with clearer, isolated benchmark guidance.
  * Included verification cost breakdowns (garbage, tampered, and valid state/record) and signing cost measurements at single and collection scales.
  * Documented benchmark findings comparing verifier digest/serializer options and provided an override example if needed.

* **Chores**
  * Updated the changelog with the latest benchmark results and clarified there’s no production runtime behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->