### PR TITLE
docs: living showcase — every example page runs the code it teaches (+ flagship demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,14 +295,21 @@ The [inline edit example](https://phlex-reactive.zoolutions.llc/docs/example-inl
 | Example | What it shows |
 |---|---|
 | [Counter](https://phlex-reactive.zoolutions.llc/docs/example-counter) | State-backed, the smallest reactive component |
-| [Payment split](https://phlex-reactive.zoolutions.llc/docs/example-payment-split) | Live sum-to-total rebalancer — nested bracketed params, a disabled computed field, auto-collected siblings (#64–#67) |
+| [Payment split](https://phlex-reactive.zoolutions.llc/docs/example-payment-split) | Nested bracketed params, auto-collected siblings, and a live `reactive_compute` + `reactive_text` preview (#64–#67, #104) |
 | [Cross-tab chat](https://phlex-reactive.zoolutions.llc/docs/example-chat) | Record-backed action **+ pgbus broadcast** → live sync across tabs/browsers |
-| [Live todo list](https://phlex-reactive.zoolutions.llc/docs/example-todo-list) | Per-row components, add/toggle/rename/delete, Enter-to-add, broadcast on change |
-| [Inline edit](https://phlex-reactive.zoolutions.llc/docs/example-inline-edit) | Show ↔ edit mode toggle, replacing a Stimulus controller + 3 routes |
-| [Notifications / badges](https://phlex-reactive.zoolutions.llc/docs/example-notifications) | Pure broadcast (no client action) — a job pushes a re-render |
+| [Live todo list](https://phlex-reactive.zoolutions.llc/docs/example-todo-list) | Per-row components, add/toggle/rename/archive, optimistic toggle + delete, Enter-to-add, broadcast on change |
+| [Inline edit + dirty tracking](https://phlex-reactive.zoolutions.llc/docs/example-inline-edit) | Show ↔ edit toggle plus an "Unsaved" badge + leave-guard, with zero shipped state |
+| [Notifications / badges](https://phlex-reactive.zoolutions.llc/docs/example-notifications) | Pure broadcast — a background event pushes a re-render, plus a `broadcast_js_to` cross-tab pulse |
+| [Reactive collections](https://phlex-reactive.zoolutions.llc/docs/example-collections) | Add/remove rows + a running count + an empty state, declared **once** with `reactive_collection`, optimistic dismiss |
+| [Loading states](https://phlex-reactive.zoolutions.llc/docs/example-loading-states) | `disable_with:` + `busy_on` + `aria-busy`, with a latency toggle to make the pending window visible |
+| [Client-only ops](https://phlex-reactive.zoolutions.llc/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS |
+| [Failure surface](https://phlex-reactive.zoolutions.llc/docs/example-failure) | `error_flash` + `data-reactive-error` + `dismiss_after:` — what you get for free when an action fails |
+| [Team inbox (flagship)](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox) | The whole toolkit in one UI: collection rows, optimistic archive that **reverts on failure**, cross-tab broadcast, an `on_client` kebab, error flashes |
 
-The cross-tab chat in ~60 lines of Ruby (and zero JS) is the showcase — see
-[docs/examples/chat.md](https://phlex-reactive.zoolutions.llc/docs/example-chat).
+Every page renders its **real** reactive component inline (source read straight
+off the file), so the demo and the code can never drift. The
+[Team inbox](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox) is the
+flagship — every feature composed into one believable UI.
 
 ---
 
@@ -1862,9 +1869,15 @@ the full layer-by-layer walkthrough.
 - [Testing reactive components](https://phlex-reactive.zoolutions.llc/docs/testing)
 - [Performance & benchmarking](https://phlex-reactive.zoolutions.llc/docs/performance)
 - Examples: [counter](https://phlex-reactive.zoolutions.llc/docs/example-counter) ·
+  [payment split](https://phlex-reactive.zoolutions.llc/docs/example-payment-split) ·
   [chat](https://phlex-reactive.zoolutions.llc/docs/example-chat) · [todo list](https://phlex-reactive.zoolutions.llc/docs/example-todo-list) ·
   [inline edit](https://phlex-reactive.zoolutions.llc/docs/example-inline-edit) ·
-  [notifications](https://phlex-reactive.zoolutions.llc/docs/example-notifications)
+  [notifications](https://phlex-reactive.zoolutions.llc/docs/example-notifications) ·
+  [collections](https://phlex-reactive.zoolutions.llc/docs/example-collections) ·
+  [loading states](https://phlex-reactive.zoolutions.llc/docs/example-loading-states) ·
+  [client-only ops](https://phlex-reactive.zoolutions.llc/docs/example-client-ops) ·
+  [failure surface](https://phlex-reactive.zoolutions.llc/docs/example-failure) ·
+  [team inbox](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox)
 
 ## Credits & prior art
 

--- a/docs/app/javascript/application.js
+++ b/docs/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+// Register the client-side compute reducers (reactive_compute) on load.
+import "reducers/preview"

--- a/docs/app/javascript/controllers/latency_toggle_controller.js
+++ b/docs/app/javascript/controllers/latency_toggle_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+import {
+  enableLatencySim,
+  disableLatencySim,
+  LATENCY_KEY,
+} from "phlex/reactive/reactive_controller"
+
+// A docs-owned latency toggle. The docs site is deliberately a demo site, so we
+// import the simulator's named exports DIRECTLY from the gem's client runtime
+// (auto-pinned by the engine) rather than gating on the app-authored
+// `<meta name="phlex-reactive-env" content="development">` console handle — that
+// gate exists to keep window.PhlexReactive off a real production page, which is
+// the opposite of what a live demo site wants. No gem change; no env spoofing.
+//
+// State lives in sessionStorage under LATENCY_KEY (read live per action by the
+// reactive controller), so flipping the checkbox takes effect on the very next
+// click with no reload. We reflect the current key value on connect so the
+// control survives a Turbo navigation.
+export default class extends Controller {
+  static values = { ms: { type: Number, default: 400 } }
+
+  connect() {
+    this.element.checked = this.#active()
+  }
+
+  toggle() {
+    if (this.element.checked) {
+      enableLatencySim(this.msValue)
+    } else {
+      disableLatencySim()
+    }
+  }
+
+  #active() {
+    if (typeof sessionStorage === "undefined") return false
+    const ms = Number(sessionStorage.getItem(LATENCY_KEY))
+    return Number.isFinite(ms) && ms > 0
+  }
+}

--- a/docs/app/javascript/reducers/preview.js
+++ b/docs/app/javascript/reducers/preview.js
@@ -1,0 +1,13 @@
+import { setComputeReducer } from "phlex/reactive/compute"
+
+// The client twin of PostPreviewComponent#char_count (the Ruby seed). Registered
+// under the "preview" reducer key, it recomputes the character counter IN-BROWSER
+// on every `input` — no round trip. The identity mirror (the title heading) needs
+// no reducer output; only the derived char_count does.
+//
+// Keep this in lockstep with the Ruby seed (`"#{title.length}/80"`): the whole
+// point of reactive_compute is one math contract, two execution sites (the client
+// paints instantly, the server re-render reconciles to the identical value).
+setComputeReducer("preview", ({ title }) => ({
+  char_count: `${(title ?? "").length}/80`,
+}))

--- a/docs/app/models/demo.rb
+++ b/docs/app/models/demo.rb
@@ -74,6 +74,21 @@ class Demo
         # subscriber, excluding the sender's own connection:
         render ChatRoomComponent.new(room: "lobby", messages: ChatMessage.for_room("lobby"))
       RUBY
+    },
+    {
+      slug: 'team-inbox',
+      title: 'Team inbox',
+      group: 'Records',
+      blurb: 'The flagship — reactive_collection rows + optimistic archive (revert on ' \
+             'failure) + disable_with + cross-tab broadcast + an on_client kebab + error_flash.',
+      component: 'TeamInboxComponent',
+      build: -> { TeamInboxComponent.new },
+      call_site: <<~RUBY
+        # A believable inbox composing the whole toolkit. Archive is optimistic
+        # (hides instantly, reverts if the server denies a locked message); every
+        # change broadcasts to teammates' tabs; the row kebab is a pure client op:
+        render TeamInboxComponent.new
+      RUBY
     }
   ].freeze
 

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -26,7 +26,9 @@ class Doc
     { slug: 'example-loading-states', title: 'Loading states',         group: 'Examples',
       view: 'ExampleLoadingStates' },
     { slug: 'example-client-ops', title: 'Client-only ops', group: 'Examples',
-      view: 'ExampleClientOps' }
+      view: 'ExampleClientOps' },
+    { slug: 'example-failure', title: 'Failure surface', group: 'Examples',
+      view: 'ExampleFailure' }
   ].freeze
 
   attr_reader :slug, :title, :group, :view_name

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -22,7 +22,9 @@ class Doc
     { slug: 'example-collections',   title: 'Collections',             group: 'Examples', view: 'ExampleCollections' },
     { slug: 'example-notifications', title: 'Notifications',           group: 'Examples',
       view: 'ExampleNotifications' },
-    { slug: 'example-chat',          title: 'Cross-tab chat',          group: 'Examples', view: 'ExampleChat' }
+    { slug: 'example-chat',          title: 'Cross-tab chat',          group: 'Examples', view: 'ExampleChat' },
+    { slug: 'example-loading-states', title: 'Loading states',         group: 'Examples',
+      view: 'ExampleLoadingStates' }
   ].freeze
 
   attr_reader :slug, :title, :group, :view_name

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -24,7 +24,9 @@ class Doc
       view: 'ExampleNotifications' },
     { slug: 'example-chat',          title: 'Cross-tab chat',          group: 'Examples', view: 'ExampleChat' },
     { slug: 'example-loading-states', title: 'Loading states',         group: 'Examples',
-      view: 'ExampleLoadingStates' }
+      view: 'ExampleLoadingStates' },
+    { slug: 'example-client-ops', title: 'Client-only ops', group: 'Examples',
+      view: 'ExampleClientOps' }
   ].freeze
 
   attr_reader :slug, :title, :group, :view_name

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -28,7 +28,9 @@ class Doc
     { slug: 'example-client-ops', title: 'Client-only ops', group: 'Examples',
       view: 'ExampleClientOps' },
     { slug: 'example-failure', title: 'Failure surface', group: 'Examples',
-      view: 'ExampleFailure' }
+      view: 'ExampleFailure' },
+    { slug: 'example-team-inbox', title: 'Team inbox (flagship)', group: 'Examples',
+      view: 'ExampleTeamInbox' }
   ].freeze
 
   attr_reader :slug, :title, :group, :view_name

--- a/docs/app/models/inbox_message.rb
+++ b/docs/app/models/inbox_message.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class InboxMessage < ApplicationRecord
+  validates :subject, presence: true
+
+  scope :active, -> { order(read: :asc, created_at: :desc, id: :desc) }
+
+  # The shared stream the inbox broadcasts archive/mark-read over, so two open
+  # tabs (teammates on the same inbox) stay in sync.
+  def self.stream_key = %w[team-inbox all]
+end

--- a/docs/app/models/notification.rb
+++ b/docs/app/models/notification.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Notification < ApplicationRecord
+  validates :title, presence: true
+
+  # The single stream notification add/dismiss broadcasts on, so two open tabs
+  # (or the badge on another page) stay in sync.
+  def self.stream_key = %w[notifications all]
+end

--- a/docs/app/models/todo.rb
+++ b/docs/app/models/todo.rb
@@ -2,4 +2,9 @@
 
 class Todo < ApplicationRecord
   validates :title, presence: true
+
+  # The single stream every todo change broadcasts on. A real app would scope
+  # this to the owning record (`[list, :todos]`); the demo keeps one shared list
+  # so two open tabs sync with each other.
+  def self.stream_key = %w[todos all]
 end

--- a/docs/app/reactive_components/client_tabs_component.rb
+++ b/docs/app/reactive_components/client_tabs_component.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# Issue #95: a component whose ENTIRE interactivity is client-side on_client ops —
+# tabs that switch panels, a menu that closes on any outside click, and an
+# accessible drawer with a transition + focus op — with ZERO server round trips.
+# It deliberately declares NO actions: there is no token-bearing trigger anywhere,
+# and the system spec's fetch spy proves nothing is ever posted. The root carries
+# the window-bound outside-close trigger permanently (a client op costs nothing per
+# stray page click, unlike a server action).
+class ClientTabsComponent < Phlex::HTML
+  include Phlex::Reactive::Component
+
+  def id = 'client-tabs'
+
+  def view_template
+    # The fade transition classes for the drawer's js.toggle(transition:). Scoped
+    # inline so the demo is self-contained (no global CSS needed).
+    style do
+      css = '.ct-fade{transition:opacity .2s ease} .ct-fade-from{opacity:0} .ct-fade-to{opacity:1} ' \
+            '#ct-panel-1,#ct-panel-2{padding:.75rem 0} .ct-tab.active{font-weight:600;color:var(--color-primary)}'
+      raw(safe(css)) # rubocop:disable Rails/OutputSafety
+    end
+    div(**mix(reactive_root, on_client(:click, js.hide('#ct-menu'), outside: true),
+              class: 'flex flex-col gap-4')) do
+      tabs
+      panels
+      menu
+      drawer
+    end
+  end
+
+  private
+
+  def tabs
+    div(role: 'tablist', class: 'flex gap-2 border-b border-base-300') do
+      tab_button(1, 'Overview', active: true)
+      tab_button(2, 'Details', active: false)
+    end
+  end
+
+  # One op chain per tab: hide every panel, show the picked one, restyle the tab
+  # buttons — the canonical "I had to write a Stimulus controller" case, now one
+  # line of declared client ops.
+  def tab_button(index, label, active:)
+    ops = js.hide('.ct-panel').show("#ct-panel-#{index}")
+            .remove_class('.ct-tab', 'active').add_class("#ct-tab-#{index}", 'active')
+
+    button(**mix(on_client(:click, ops),
+                 id: "ct-tab-#{index}", class: ['ct-tab px-3 py-1', ('active' if active)].compact,
+                 data: { testid: "tab-#{index}" })) { label }
+  end
+
+  def panels
+    div(id: 'ct-panel-1', class: 'ct-panel', data: { testid: 'panel-1' }) do
+      'The Overview panel — shown by default.'
+    end
+    div(id: 'ct-panel-2', class: 'ct-panel', hidden: true, data: { testid: 'panel-2' }) do
+      'The Details panel — revealed by a pure client op.'
+    end
+  end
+
+  def menu
+    div(class: 'flex flex-col gap-2') do
+      button(**mix(on_client(:click, js.show('#ct-menu')),
+                   class: 'btn btn-sm w-fit', data: { testid: 'menu-open' })) { 'Open menu' }
+      div(id: 'ct-menu', hidden: true, class: 'rounded-box border border-base-300 p-3',
+          data: { testid: 'menu' }) { 'Menu content — click anywhere outside to close.' }
+    end
+  end
+
+  # Issue #96: a drawer opened with a TRANSITION (animated fade), an aria-expanded
+  # attr op on the trigger, and a FOCUS op landing on the first focusable control
+  # inside the drawer — the exact accessible-disclosure pattern, one op chain.
+  def drawer
+    open = js
+           .toggle('#ct-drawer', transition: %w[ct-fade ct-fade-from ct-fade-to])
+           .set_attr(:root, 'aria-expanded', 'true')
+           .focus_first('#ct-drawer')
+
+    div(class: 'flex flex-col gap-2') do
+      button(**mix(on_client(:click, open),
+                   id: 'ct-drawer-trigger', class: 'btn btn-sm w-fit',
+                   data: { testid: 'drawer-open' })) { 'Open drawer' }
+      div(id: 'ct-drawer', hidden: true, class: 'rounded-box border border-base-300 p-3 flex gap-2',
+          data: { testid: 'drawer' }) do
+        button(class: 'btn btn-xs', data: { testid: 'drawer-first' }) { 'First action' }
+        button(class: 'btn btn-xs', data: { testid: 'drawer-second' }) { 'Second action' }
+      end
+    end
+  end
+end

--- a/docs/app/reactive_components/dirty_form_component.rb
+++ b/docs/app/reactive_components/dirty_form_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Dirty-field tracking (issue #103) with ZERO shipped state. The browser already
+# holds the last server-rendered value: input.defaultValue IS the attribute from
+# the last render, so dirty = current ≠ default — no state travels to the client.
+#
+#   * reactive_root(track_dirty: true, warn_unsaved: true) — every input on this
+#     root re-scans on change (track_dirty mixes input->reactive#trackDirty onto
+#     the root's data-action), and warn_unsaved arms a navigate-away guard gated
+#     on the LIVE dirty count.
+#   * reactive_field(:title, value:, dirty: true) — the field carries the
+#     trackDirty descriptor (redundant with the root here, but shows the per-field
+#     opt-in).
+#   * The "Unsaved" badge is revealed purely by CSS ([data-reactive-dirty]) — no
+#     Ruby, no per-field JS. It appears on the first keystroke and clears when the
+#     morph reply writes a fresh defaultValue equal to the input's value.
+#
+# save morphs so the reply re-renders the field with the NEW value as its fresh
+# default; the post-morph re-scan then finds it clean and the badge clears with no
+# full-page reload.
+class DirtyFormComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+  action :save, params: { title: :string }
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, 'dirtyform')
+
+  def save(title:)
+    @todo.update!(title:) if title.present?
+    reply.morph
+  end
+
+  def view_template
+    # The badge is hidden until the root carries data-reactive-dirty (set live by
+    # trackDirty when current ≠ default), then revealed — pure CSS, no Ruby.
+    style do
+      # Static CSS, no user input — Phlex safe(), not Rails html_safe.
+      css = '[data-testid="dirty-badge"]{display:none} ' \
+            '[data-reactive-dirty] [data-testid="dirty-badge"]{display:inline-flex}'
+      raw(safe(css)) # rubocop:disable Rails/OutputSafety
+    end
+    div(**reactive_root(track_dirty: true, warn_unsaved: true, class: 'flex items-center gap-2')) do
+      # The field's baseline is its own defaultValue (= @todo.title from this
+      # render). dirty: true also wires trackDirty onto the field itself.
+      input(**mix(reactive_field(:title, value: @todo.title, dirty: true),
+                  class: 'input input-bordered input-sm', data: { testid: 'title' }))
+      # Revealed purely by CSS while the root is dirty — no Ruby toggles it.
+      span(class: 'badge badge-warning badge-sm', data: { testid: 'dirty-badge' }) { 'Unsaved' }
+      button(**mix(on(:save), class: 'btn btn-sm btn-primary', data: { testid: 'save' })) { 'Save' }
+      span(class: 'text-sm opacity-60', data: { testid: 'current' }) { @todo.title }
+    end
+  end
+end

--- a/docs/app/reactive_components/failure_surface_component.rb
+++ b/docs/app/reactive_components/failure_surface_component.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# The user-visible failure surface (issue #100). Reactive actions don't only
+# succeed — this shows what an adopter gets for free when one fails:
+#   * `boom` denies inside a DECLARED action (a registered authorization error) →
+#     the endpoint returns 403. With Phlex::Reactive.error_flash configured, the
+#     rescue renders a turbo-stream flash the browser SHOWS, and the client sets
+#     data-reactive-error="http" on this root (style it with CSS).
+#   * `succeed` is a normal action whose re-render CLEARS data-reactive-error.
+#   * `flash_now` emits a self-dismissing flash (dismiss_after:) the document-level
+#     handler removes after the timeout.
+class FailureSurfaceComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  # Registered in config/initializers/phlex_reactive.rb so `boom`'s denial maps to
+  # a clean 403 (client kind=http) instead of a 500.
+  class Denied < StandardError; end
+
+  reactive_state :count
+  action :succeed
+  action :flash_now
+  action :boom
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = 'failure-surface'
+
+  def succeed = @count += 1
+
+  # Denies inside the action → 403 (client kind=http), the failure the demo shows.
+  # Declared so the page renders under the render-time undeclared-action guard.
+  def boom = raise(Denied, 'boom')
+
+  # A short-lived flash so the demo can watch it appear then disappear.
+  def flash_now
+    reply.replace.flash(:notice, 'Saved — this toast self-dismisses', dismiss_after: 2500)
+  end
+
+  def view_template
+    # Reveal the error banner ONLY while the root carries data-reactive-error —
+    # pure CSS, no Ruby toggle.
+    style do
+      css = '[data-testid="error-banner"]{display:none} ' \
+            '[data-reactive-error] [data-testid="error-banner"]{display:block}'
+      raw(safe(css)) # rubocop:disable Rails/OutputSafety
+    end
+    div(**reactive_root(class: 'flex flex-col gap-3')) do
+      div(class: 'alert alert-error', role: 'alert', data: { testid: 'error-banner' }) do
+        'The last action failed — data-reactive-error is set on the root.'
+      end
+
+      div(class: 'flex items-center gap-3') do
+        span(class: 'text-sm opacity-70') do
+          plain 'Succeeded '
+          span(data: { testid: 'count' }) { @count.to_s }
+          plain ' times'
+        end
+      end
+
+      div(class: 'flex gap-2') do
+        button(**mix(on(:succeed), class: 'btn btn-sm btn-success', data: { testid: 'succeed' })) { 'Succeed' }
+        button(**mix(on(:boom), class: 'btn btn-sm btn-error', data: { testid: 'boom' })) { 'Trigger a failure' }
+        button(**mix(on(:flash_now), class: 'btn btn-sm', data: { testid: 'flash-now' })) { 'Self-dismissing flash' }
+      end
+
+      # The flash target for the error_flash + dismiss_after: toasts.
+      div(id: 'flash', class: 'flex flex-col gap-1', data: { testid: 'flash' })
+    end
+  end
+end

--- a/docs/app/reactive_components/inbox_empty_component.rb
+++ b/docs/app/reactive_components/inbox_empty_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# The empty-state for the Team inbox reactive_collection. Removed by its stable
+# #id when the first message arrives, appended back when the last is archived.
+class InboxEmptyComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+
+  def id = 'inbox-empty'
+
+  def view_template
+    li(id:, class: 'py-8 text-center text-sm opacity-60', data: { testid: 'inbox-empty' }) do
+      'Inbox zero 🎉 — nothing left to triage.'
+    end
+  end
+end

--- a/docs/app/reactive_components/inbox_message_component.rb
+++ b/docs/app/reactive_components/inbox_message_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# One Team-inbox row. Keyed off an InboxMessage so its #id is a stable dom_id —
+# the append/remove target for the collection helper and the broadcast.
+#
+# The row carries NO token of its own (no reactive_attrs): its archive/mark-read
+# buttons dispatch the CONTAINER's actions (keyed by id) via the generic reactive
+# controller it sits inside. The kebab menu is a pure on_client toggle — zero
+# round trips. It includes Component only to build those dispatches + the client op.
+class InboxMessageComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  def self.model_param_name = :message
+
+  def initialize(message:)
+    @message = message
+  end
+
+  def id = dom_id(@message)
+
+  def view_template
+    li(id:, class: row_classes, data: { testid: 'inbox-row', read: @message.read?.to_s }) do
+      unread_dot
+      div(class: 'min-w-0 flex-1') do
+        div(class: 'truncate text-sm font-medium', data: { testid: 'subject' }) { @message.subject }
+        div(class: 'text-xs opacity-60') { "from #{@message.sender}" }
+      end
+      kebab_menu
+    end
+  end
+
+  private
+
+  def row_classes
+    ['flex items-center gap-3 border-b border-base-200 px-3 py-2',
+     ('opacity-60' if @message.read?)].compact
+  end
+
+  def unread_dot
+    span(class: ['inline-block size-2 rounded-full',
+                 (@message.read? ? 'bg-transparent' : 'bg-primary')].compact,
+         data: { testid: 'unread-dot' })
+  end
+
+  # A pure on_client kebab: clicking toggles this row's menu; a click outside the
+  # menu closes it. No token, no POST. The menu holds the reactive archive/mark-read
+  # dispatches (the CONTAINER's actions, keyed by this row's id).
+  def kebab_menu
+    menu_id = "#{id}-menu"
+    div(class: 'relative') do
+      button(**mix(on_client(:click, js.toggle("##{menu_id}")),
+                   class: 'btn btn-ghost btn-xs', data: { testid: 'kebab' })) { '⋯' }
+      div(id: menu_id, hidden: true,
+          class: 'absolute right-0 z-10 mt-1 flex w-40 flex-col rounded-box border ' \
+                 'border-base-300 bg-base-100 p-1 shadow',
+          data: { testid: 'kebab-menu' }) do
+        mark_read_button unless @message.read?
+        archive_button
+      end
+    end
+  end
+
+  def mark_read_button
+    button(**mix(on(:mark_read, id: @message.id),
+                 class: 'btn btn-ghost btn-xs justify-start', data: { testid: 'mark-read' })) { 'Mark read' }
+  end
+
+  # optimistic: { hide: true, to: "##{id}" } hides THIS row the instant you click
+  # (the row is tokenless, so to: must target the row's own id, not :root — that
+  # would hide the whole inbox). disable_with guards a double-click. reply.remove +
+  # broadcast_remove drop it everywhere; a DENIED archive reverts the hide.
+  def archive_button
+    button(**mix(on(:archive, id: @message.id, disable_with: '…', optimistic: { hide: true, to: "##{id}" }),
+                 class: 'btn btn-ghost btn-xs justify-start text-error', data: { testid: 'archive' })) { 'Archive' }
+  end
+end

--- a/docs/app/reactive_components/inline_edit_component.rb
+++ b/docs/app/reactive_components/inline_edit_component.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Record-backed reactive component that ALSO carries transient mode as signed
+# state (issue #6). `record` is re-found via GlobalID; `attribute` (which column)
+# and `editing` (the show ↔ edit mode) are signed state that must survive every
+# action round trip — the classic "click to edit, Enter to save, Escape to
+# cancel" widget that would otherwise be a Stimulus controller plus three routes.
+class InlineEditComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :record
+  reactive_state :attribute, :editing
+
+  action :edit
+  action :cancel
+  action :save, params: { value: :string }
+
+  def initialize(record:, attribute: :title, editing: false)
+    @record = record
+    @attribute = attribute.to_sym
+    @editing = editing
+  end
+
+  def id = dom_id(@record, "inline_#{@attribute}")
+
+  def edit = @editing = true
+  def cancel = @editing = false
+
+  def save(value:)
+    @record.update!(@attribute => value)
+    @editing = false
+  end
+
+  def view_template
+    span(**reactive_root(class: 'inline-flex items-center gap-2')) do
+      if @editing
+        # The input only holds the value — the form fields it collects travel with
+        # whichever action fires. `on(:save)` lives on the Save button, not the
+        # input, so focusing the field doesn't dispatch save and collapse edit mode.
+        # Escape in the field cancels — event: "keydown.esc" is Stimulus's native
+        # keyboard filter, so ONLY Escape fires it (Enter is free to save elsewhere).
+        input(**mix(on(:cancel, event: 'keydown.esc'),
+                    name: 'value', value: current_value,
+                    class: 'input input-bordered input-sm', data: { testid: 'field' }))
+        button(**mix(on(:save), class: 'btn btn-sm btn-primary', data: { testid: 'save' })) { 'Save' }
+        button(**mix(on(:cancel), class: 'btn btn-sm btn-ghost', data: { testid: 'cancel' })) { 'Cancel' }
+      else
+        span(**mix(on(:edit),
+                   class: 'cursor-pointer border-b border-dashed border-base-content/40',
+                   data: { testid: 'display' })) { current_value.presence || '—' }
+        span(class: 'text-xs opacity-50') { '(click to edit)' }
+      end
+    end
+  end
+
+  private
+
+  def current_value = @record.public_send(@attribute).to_s
+end

--- a/docs/app/reactive_components/latency_component.rb
+++ b/docs/app/reactive_components/latency_component.rb
@@ -27,6 +27,14 @@ class LatencyComponent < Phlex::HTML
   def bump = @count += 1
 
   def view_template
+    # Reveal the spinner ONLY while busy_on marks it with data-reactive-busy —
+    # pure CSS, no Ruby toggle.
+    style do
+      # Static CSS, no user input — Phlex safe(), not Rails html_safe.
+      css = '[data-testid="latency-spinner"]{display:none} ' \
+            '[data-testid="latency-spinner"][data-reactive-busy]{display:inline-block}'
+      raw(safe(css)) # rubocop:disable Rails/OutputSafety
+    end
     div(**reactive_root(class: 'flex items-center gap-3')) do
       # disable_with: swaps the label and disables the button while the action is
       # in flight — invisible on localhost until the simulator injects a delay.

--- a/docs/app/reactive_components/latency_component.rb
+++ b/docs/app/reactive_components/latency_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# A tiny state-backed counter whose `bump` action is FAST server-side (no sleep)
+# — exactly the localhost case where the ~5 ms round trip makes the busy window
+# (aria-busy, disable_with:) flash by unobservably.
+#
+# It exists so the docs can DEMONSTRATE the loading/optimistic affordances: with
+# the latency simulator toggled on (Views::Examples::LatencyToggle), every action
+# is delayed client-side, so `disable_with:` text swaps and the `busy_on` spinner
+# become visible without any server-side stall. Toggle the sim off and the same
+# button is instant again — the affordance was always there, just too fast to see.
+class LatencyComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+  action :bump
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = 'latency'
+
+  # No sleep: the busy window is created purely by the client latency simulator,
+  # not by a slow server action.
+  def bump = @count += 1
+
+  def view_template
+    div(**reactive_root(class: 'flex items-center gap-3')) do
+      # disable_with: swaps the label and disables the button while the action is
+      # in flight — invisible on localhost until the simulator injects a delay.
+      button(**mix(on(:bump, disable_with: 'Bumping…'),
+                   class: 'btn btn-sm btn-primary', data: { testid: 'latency-bump' })) { 'Bump' }
+      # A scoped busy indicator: data-reactive-busy toggles ONLY while bump is in
+      # flight, revealed with pure CSS (loading loading-spinner), no Ruby.
+      span(**mix(busy_on(:bump),
+                 class: 'loading loading-spinner loading-sm', data: { testid: 'latency-spinner' }))
+      span(class: 'text-2xl tabular-nums w-10 text-center',
+           data: { testid: 'latency-count' }) { @count.to_s }
+    end
+  end
+end

--- a/docs/app/reactive_components/loading_button_component.rb
+++ b/docs/app/reactive_components/loading_button_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Declarative loading states (issue #99) — no Stimulus, no bespoke JS.
+#
+#   * on(:save, disable_with: "Saving…") — the button DISABLES and swaps its text
+#     to "Saving…" the instant the request is enqueued, reverting when the round
+#     trip settles. Because a disabled button fires no further clicks, a rapid
+#     double-click enqueues exactly ONE POST — so @count bumps by one, not two.
+#     The disable IS the dedup (the client queue serializes, it doesn't dedupe).
+#   * busy_on(:save) — a spinner element that carries data-reactive-busy only
+#     while `save` is in flight, styled with pure CSS (daisyUI loading-spinner).
+#
+# The action is intentionally FAST server-side — flip the latency toggle above it
+# to actually SEE the disabled + "Saving…" + spinner window on localhost.
+class LoadingButtonComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_state :count
+  action :save
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = 'loading-button'
+
+  def save = @count += 1
+
+  def view_template
+    div(**reactive_root(class: 'flex items-center gap-3')) do
+      button(**mix(on(:save, disable_with: 'Saving…'),
+                   class: 'btn btn-sm btn-primary', data: { testid: 'save' })) { 'Save' }
+      # A scoped busy indicator: data-reactive-busy toggles ONLY while save is in
+      # flight, so daisyUI's spinner shows with zero Ruby.
+      span(**mix(busy_on(:save),
+                 class: 'loading loading-spinner loading-sm', data: { testid: 'spinner' }))
+      span(class: 'text-sm opacity-70', data: { testid: 'saved-count' }) do
+        plain 'Saved '
+        span { @count.to_s }
+        plain ' times'
+      end
+    end
+  end
+end

--- a/docs/app/reactive_components/loading_button_component.rb
+++ b/docs/app/reactive_components/loading_button_component.rb
@@ -28,6 +28,14 @@ class LoadingButtonComponent < Phlex::HTML
   def save = @count += 1
 
   def view_template
+    # The spinner is present in the DOM always; this scoped rule reveals it ONLY
+    # while busy_on marks it with data-reactive-busy — pure CSS, no Ruby toggle.
+    style do
+      # Static CSS, no user input — Phlex safe(), not Rails html_safe.
+      css = '[data-testid="spinner"]{display:none} ' \
+            '[data-testid="spinner"][data-reactive-busy]{display:inline-block}'
+      raw(safe(css)) # rubocop:disable Rails/OutputSafety
+    end
     div(**reactive_root(class: 'flex items-center gap-3')) do
       button(**mix(on(:save, disable_with: 'Saving…'),
                    class: 'btn btn-sm btn-primary', data: { testid: 'save' })) { 'Save' }

--- a/docs/app/reactive_components/notification_bell_component.rb
+++ b/docs/app/reactive_components/notification_bell_component.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# A live notification bell (issue #35 broadcasts). It subscribes to a shared
+# stream and shows an unread count. "Simulate a background event" stands in for a
+# job finishing: it bumps the count and BROADCASTS the re-rendered bell to every
+# subscribed tab (so a second window updates with no action of its own), then
+# fires a `broadcast_js_to` nudge — a pure client-side pulse animation applied on
+# the OTHER tabs with no re-render at all.
+#
+# This is the "the server just pushes" shape: the count update rides a normal
+# broadcast_replace, and the attention-grab (the pulse) rides broadcast_js_to,
+# which ships a whitelisted DOM op — not HTML — to every subscriber.
+class NotificationBellComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::TurboStreamFrom
+
+  STREAM = %w[notification-bell all].freeze
+
+  reactive_state :unread
+  action :simulate_event
+
+  def initialize(unread: 0)
+    @unread = unread.to_i
+  end
+
+  def id = 'notification-bell'
+
+  # Bump the count, then push the update to EVERY subscribed tab (the actor
+  # included — a replace is id-deduped, so the actor's own HTTP reply and the
+  # broadcast reconcile to the same DOM). broadcast_replace_to rebuilds the bell
+  # from the given state (unread:). The broadcast_js_to nudge pulses the bell on
+  # the OTHER tabs only (exclude: the actor, who already saw the bump).
+  def simulate_event
+    @unread += 1
+    NotificationBellComponent.broadcast_replace_to(*STREAM, unread: @unread)
+    NotificationBellComponent.broadcast_js_to(
+      *STREAM,
+      js.add_class('#bell-icon', 'animate-bounce'),
+      exclude: reactive_connection_id
+    )
+  end
+
+  def view_template
+    div(**reactive_root(class: 'flex items-center gap-3')) do
+      turbo_stream_from(*STREAM) # subscribe to the pushed updates
+
+      div(id: 'bell-icon', class: 'relative inline-flex') do
+        span(class: 'text-2xl') { '🔔' }
+        if @unread.positive?
+          span(class: 'badge badge-error badge-sm absolute -right-2 -top-2',
+               data: { testid: 'bell-count' }) { @unread.to_s }
+        end
+      end
+
+      button(**mix(on(:simulate_event),
+                   class: 'btn btn-sm btn-primary', data: { testid: 'simulate' })) do
+        'Simulate a background event'
+      end
+    end
+  end
+end

--- a/docs/app/reactive_components/notification_row_component.rb
+++ b/docs/app/reactive_components/notification_row_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# A single notification row in the reactive_collection demo (issue #35). Keyed
+# off a Notification record so its #id is a stable dom_id — the append/remove
+# target for the collection helper.
+#
+# The row carries NO token of its own (no reactive_attrs): its dismiss button
+# dispatches the CONTAINER's `dismiss` action via the generic reactive controller
+# it sits inside, so the client sends the container's token. It includes Component
+# only to build that dispatch — the same attrs whether the row is rendered on
+# first paint or streamed in by reply.append.
+class NotificationRowComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  def self.model_param_name = :notification
+
+  def initialize(notification:)
+    @notification = notification
+  end
+
+  def id = dom_id(@notification)
+
+  def view_template
+    li(id:, class: 'flex items-center justify-between gap-3 border-b border-base-200 py-2',
+       data: { testid: 'notification' }) do
+      span(class: 'text-sm') { @notification.title }
+      # optimistic: { hide: true } hides the row the instant you click, before the
+      # round trip; reply.remove then drops it so it never flashes back. dismiss is
+      # the CONTAINER's action (the row has no token of its own) — so `to:` targets
+      # THIS row by its own id, NOT :root (which would be the whole list). Keyed by id.
+      button(**mix(on(:dismiss, id: @notification.id, optimistic: { hide: true, to: "##{id}" }),
+                   class: 'btn btn-xs btn-ghost', data: { testid: 'dismiss' })) { '×' }
+    end
+  end
+end

--- a/docs/app/reactive_components/notifications_empty_component.rb
+++ b/docs/app/reactive_components/notifications_empty_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# The empty-state shown when the notifications list is empty (issue #35). The
+# reactive_collection helper removes it by its stable #id when the first row is
+# added, and appends it back into the container when the last row is dismissed.
+# A static view (Streamable only) — built argument-free.
+class NotificationsEmptyComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+
+  def id = 'notifications-empty'
+
+  def view_template
+    li(id:, class: 'py-3 text-sm opacity-60', data: { testid: 'empty-state' }) do
+      'All caught up — no notifications.'
+    end
+  end
+end

--- a/docs/app/reactive_components/notifications_list_component.rb
+++ b/docs/app/reactive_components/notifications_list_component.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# The reactive_collection demo container (issue #35). Declares the list contract
+# ONCE — the row component, the container id, a companion count badge, an
+# empty-state, and a size resolver — so add/dismiss append/remove a row + bump the
+# count + toggle the empty-state with ONE reply call each, no per-action
+# bookkeeping.
+#
+# State-backed (no single record), so it rebuilds from a signed token on each
+# action. The size resolver reads the live DB count — always correct, never an
+# off-by-one client increment. Dismiss also emits a self-dismissing flash
+# (dismiss_after:) so the "Dismissed" toast clears itself after a beat.
+class NotificationsListComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::TurboStreamFrom
+
+  reactive_collection :notifications,
+                      item: NotificationRowComponent,
+                      container: 'notifications',
+                      count: 'notifications-count',
+                      empty: NotificationsEmptyComponent,
+                      size: -> { Notification.count }
+
+  action :add, params: { title: :string }
+  action :dismiss, params: { id: :integer }
+
+  def id = 'notifications-list'
+
+  # Append the new row + bump the count + clear the empty-state in ONE reply, and
+  # broadcast the row to the OTHER tabs (append inserts a child, so exclude: the
+  # actor or their own tab doubles it).
+  def add(title:)
+    title = title.to_s.strip
+    return reply.replace if title.blank?
+
+    notification = Notification.create!(title:)
+    NotificationRowComponent.broadcast_append_to(*Notification.stream_key, target: 'notifications',
+                                                                           model: notification,
+                                                                           exclude: reactive_connection_id)
+    reply.append(:notifications, notification)
+  end
+
+  # Remove the row + bump the count + restore the empty-state in ONE reply, plus a
+  # self-dismissing flash. The broadcast_remove keeps other tabs in sync.
+  def dismiss(id:)
+    notification = Notification.find(id)
+    notification.destroy!
+    NotificationRowComponent.broadcast_remove_to(*Notification.stream_key, model: notification,
+                                                                           exclude: reactive_connection_id)
+    reply.remove(:notifications, notification).flash(:notice, 'Notification dismissed', dismiss_after: 3000)
+  end
+
+  def view_template
+    div(**reactive_root(class: 'flex flex-col gap-3')) do
+      turbo_stream_from(*Notification.stream_key) # cross-tab sync
+
+      div(class: 'flex items-center gap-2') do
+        span(class: 'font-medium') { 'Notifications' }
+        span(id: 'notifications-count', class: 'badge badge-neutral badge-sm',
+             data: { testid: 'count' }) { Notification.count.to_s }
+      end
+
+      ul(id: 'notifications', class: 'flex flex-col') do
+        if Notification.exists?
+          Notification.order(:created_at, :id).each { render NotificationRowComponent.new(notification: it) }
+        else
+          render NotificationsEmptyComponent.new
+        end
+      end
+
+      div(class: 'flex gap-2') do
+        input(name: 'title', placeholder: 'New notification…', autocomplete: 'off',
+              class: 'input input-bordered input-sm flex-1', data: { testid: 'new-notification' })
+        button(**mix(on(:add), class: 'btn btn-sm btn-primary', data: { testid: 'add' })) { 'Add' }
+      end
+
+      # The flash target the dismiss reply appends its self-dismissing toast into.
+      div(id: 'flash', class: 'flex flex-col gap-1', data: { testid: 'flash' })
+    end
+  end
+end

--- a/docs/app/reactive_components/post_preview_component.rb
+++ b/docs/app/reactive_components/post_preview_component.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# reactive_text + typed-compute (issue #104) — a live title preview and character
+# counter that update IN-BROWSER as you type, with NO round trip, then a save
+# reconciles through the server.
+#
+# Two things mirror the `title` field client-side:
+#   * The preview heading is an IDENTITY MIRROR — reactive_text(:title) with no
+#     reducer output. The declared input's raw string syncs to its text node on
+#     every `input`, so the heading tracks the field with zero reducer wiring.
+#   * The character counter is a reducer OUTPUT written to a text node — the
+#     "preview" reducer (typed inputs { title: :string }) returns
+#     { char_count: `${title.length}/80` }, which has no matching form field, so it
+#     lands on the [data-reactive-text="char_count"] node via textContent.
+#
+# save fires the reactive `save` action; the server persists the title and
+# re-renders, SEEDING the same derived heading + counter so the morph repaints
+# them from the authoritative value (the reconcile contract reactive_compute
+# documents — the server render must seed what the reducer would).
+class PostPreviewComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :todo
+
+  # Typed inputs (hash form): `title` is read RAW (a :string), never coerced
+  # through Number. The lone output — char_count — has no form field, so it
+  # resolves to the [data-reactive-text="char_count"] node.
+  reactive_compute :preview,
+                   inputs: { title: :string },
+                   outputs: %i[char_count]
+
+  action :save, params: { title: :string }
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  def id = dom_id(@todo, 'preview')
+
+  # Persisted path: save the title, then re-render self. The re-render seeds the
+  # SAME derived preview + counter the JS reducer would, so the morph reconciles.
+  def save(title:)
+    @todo.update!(title:) if title.present?
+    reply.replace
+  end
+
+  def view_template
+    div(**mix(reactive_root(class: 'flex flex-col gap-3'), reactive_compute_attrs(:preview))) do
+      # The live preview heading — an identity mirror of `title`. Seed it with the
+      # server's current value so the first paint (and any morph) is correct.
+      h3(class: 'text-lg font-semibold', data: { testid: 'preview' }) do
+        reactive_text(:title, @todo.title)
+      end
+
+      # The character counter — a reducer output written to this text node. Seed it
+      # server-side too (same contract) so a morph doesn't repaint stale text.
+      small(class: 'opacity-60', data: { testid: 'counter' }) do
+        reactive_text(:char_count, char_count(@todo.title))
+      end
+
+      # The title field drives BOTH: the client recompute/mirror on `input` (no
+      # round trip) AND, on the save button, the reactive save action. mix so the
+      # recompute action deep-merges with reactive_field's data: (Never-Do #8).
+      input(**mix(
+        reactive_field(:title, value: @todo.title, type: 'text',
+                               class: 'input input-bordered', data: { testid: 'title' }),
+        { data: { action: 'input->reactive#recompute' } }
+      ))
+      button(**mix(on(:save), class: 'btn btn-sm btn-primary w-fit', data: { testid: 'save' })) { 'Save' }
+
+      # A SERVER-ONLY echo of the PERSISTED title (a plain text node, NOT a
+      # reactive_text mirror) — the client never touches it, so it's the barrier
+      # that a save round trip actually reconciled.
+      span(class: 'text-xs opacity-50', data: { testid: 'saved' }) do
+        plain 'Saved: '
+        span { @todo.title }
+      end
+    end
+  end
+
+  private
+
+  # The server twin of the JS reducer's counter — seeds the same derived string on
+  # render so the morph reconciles from the authoritative value.
+  def char_count(title) = "#{title.to_s.length}/80"
+end

--- a/docs/app/reactive_components/team_inbox_component.rb
+++ b/docs/app/reactive_components/team_inbox_component.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# The FLAGSHIP example (issue #149): a believable Team inbox that composes the
+# whole reactive toolkit in one UI —
+#   * reactive_collection rows (archive/mark-read append/remove + count + empty);
+#   * an optimistic: archive that hides the row in the same gesture, reverting if
+#     the server denies (a "locked" message);
+#   * disable_with: guarding the archive button against a double-click;
+#   * cross-tab broadcast_*_to so a teammate's tab stays in sync;
+#   * an on_client kebab menu on each row (pure client op, zero round trips);
+#   * error_flash + a self-dismissing dismiss_after: toast on the reply.
+#
+# State-backed container (no single record); the size resolver reads the live DB
+# count. Rows are tokenless and dispatch these actions keyed by message id.
+class TeamInboxComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::TurboStreamFrom
+
+  # A locked message refuses to archive — registered in the initializer so the
+  # denial is a clean 403 the client reverts the optimistic hide on.
+  class Locked < StandardError; end
+
+  SUBJECTS = ['Deploy finished', 'New signup', 'Payment received', 'Support ticket #4821',
+              'Weekly digest'].freeze
+  SENDERS = %w[ci billing support system].freeze
+
+  reactive_collection :messages,
+                      item: InboxMessageComponent,
+                      container: 'inbox-messages',
+                      count: 'inbox-count',
+                      empty: InboxEmptyComponent,
+                      size: -> { InboxMessage.count }
+
+  action :archive, params: { id: :integer }
+  action :mark_read, params: { id: :integer }
+  action :simulate_incoming
+
+  def id = 'team-inbox'
+
+  # Archive (+ count + empty), broadcast the removal to teammates, and confirm with
+  # a self-dismissing flash. A locked message denies → 403 → the client reverts the
+  # optimistic hide (the row snaps back) and error_flash surfaces the reason.
+  def archive(id:)
+    message = InboxMessage.find(id)
+    raise Locked, 'This message is locked and cannot be archived.' if message.sender == 'locked'
+
+    message.destroy!
+    InboxMessageComponent.broadcast_remove_to(*InboxMessage.stream_key, model: message,
+                                                                        exclude: reactive_connection_id)
+    reply.remove(:messages, message).flash(:notice, 'Archived', dismiss_after: 2000)
+  end
+
+  # Mark read: persist, re-render the row for the actor, and broadcast the updated
+  # row to teammates (a replace is id-deduped, so exclude: just spares a redundant echo).
+  def mark_read(id:)
+    message = InboxMessage.find(id)
+    message.update!(read: true)
+    InboxMessageComponent.broadcast_replace_to(*InboxMessage.stream_key, model: message,
+                                                                         exclude: reactive_connection_id)
+    reply.replace
+  end
+
+  # Stand in for a teammate/job pushing a new message: create + broadcast_append to
+  # every subscribed tab. reply.append updates the actor's own list + count + empty.
+  def simulate_incoming
+    message = InboxMessage.create!(subject: sample_subject, sender: sample_sender)
+    InboxMessageComponent.broadcast_append_to(*InboxMessage.stream_key, target: 'inbox-messages',
+                                                                        model: message,
+                                                                        exclude: reactive_connection_id)
+    reply.append(:messages, message)
+  end
+
+  def view_template
+    div(**reactive_root(class: 'flex flex-col gap-3')) do
+      turbo_stream_from(*InboxMessage.stream_key) # cross-tab sync
+
+      header
+      ul(id: 'inbox-messages', class: 'flex flex-col rounded-box border border-base-300') do
+        if InboxMessage.exists?
+          InboxMessage.active.each { render InboxMessageComponent.new(message: it) }
+        else
+          render InboxEmptyComponent.new
+        end
+      end
+
+      div(id: 'flash', class: 'flex flex-col gap-1', data: { testid: 'flash' })
+    end
+  end
+
+  private
+
+  def header
+    div(class: 'flex items-center justify-between') do
+      div(class: 'flex items-center gap-2') do
+        span(class: 'font-semibold') { 'Team inbox' }
+        span(id: 'inbox-count', class: 'badge badge-neutral badge-sm',
+             data: { testid: 'inbox-count' }) { InboxMessage.count.to_s }
+      end
+      button(**mix(on(:simulate_incoming, disable_with: '…'),
+                   class: 'btn btn-sm btn-primary', data: { testid: 'simulate-incoming' })) do
+        'Simulate incoming'
+      end
+    end
+  end
+
+  # Deterministic-ish rotation off the DB count (no Random needed at render time).
+  def sample_subject = SUBJECTS[InboxMessage.count % SUBJECTS.size]
+  def sample_sender  = SENDERS[InboxMessage.count % SENDERS.size]
+end

--- a/docs/app/reactive_components/todo_empty_component.rb
+++ b/docs/app/reactive_components/todo_empty_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# The empty-state shown when the todo list has no rows. The reactive_collection
+# helper removes it by its stable #id when the first row is added, and appends it
+# back when the last row is archived. A static view (Streamable only) — it has no
+# actions or state, it's just a broadcastable/self-targeting element.
+class TodoEmptyComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+
+  def id = 'todos-empty'
+
+  def view_template
+    li(id:, class: 'py-3 text-sm opacity-60', data: { testid: 'todos-empty' }) do
+      'Nothing here yet — add your first todo above.'
+    end
+  end
+end

--- a/docs/app/reactive_components/todo_item_component.rb
+++ b/docs/app/reactive_components/todo_item_component.rb
@@ -2,9 +2,17 @@
 
 # Record-backed reactive row. Identity is the Todo's GlobalID (reactive_record),
 # so the signed token re-finds the record server-side — never trusts client state.
-# Demonstrates a toggle, an inline rename that saves on Enter (via the Stimulus
-# keyboard filter event: "keydown.enter"), and an archive that removes the row
-# from the DOM via reply.remove.
+#
+# Demonstrates the full per-row toolkit, all without a Stimulus controller:
+#   * an OPTIMISTIC toggle (checked: :keep) that flips the checkbox the instant
+#     you click, before the round trip; the morph reconciles from server truth, a
+#     failure snaps it back;
+#   * an inline rename that saves on Enter and morphs in place so the field keeps
+#     focus + caret (reply.morph over reply.replace);
+#   * an OPTIMISTIC archive (hide: true) that hides the row NOW; reply.remove then
+#     drops it, so it never flashes back;
+#   * a broadcast on every change so the OTHER tabs see the same row update
+#     (exclude: reactive_connection_id suppresses the actor's own echo).
 class TodoItemComponent < Phlex::HTML
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
@@ -21,36 +29,59 @@ class TodoItemComponent < Phlex::HTML
   # Streamable#dom_id is render-context-free.
   def id = dom_id(@todo)
 
+  # Toggle done, then broadcast the reconciled row to the other tabs. A replace is
+  # keyed by dom id, so idiomorph dedupes it for the actor even without exclude:;
+  # passing exclude: keeps every action on one consistent pattern.
   def toggle
     @todo.update!(done: !@todo.done?)
+    broadcast
   end
 
-  # Morph in place so the rename input keeps focus + caret after an Enter save.
+  # Morph in place so the rename input keeps focus + caret after an Enter save,
+  # then broadcast the new title to the other tabs.
   def rename(title:)
     @todo.update!(title:) if title.present?
+    broadcast
     reply.morph
   end
 
-  # Reply: drop this row from the DOM in place (no doomed self re-render).
+  # Destroy the record, drop this tab's row in place (reply.remove — no doomed
+  # self re-render), and broadcast the removal to the other tabs. Remove is
+  # idempotent, so exclude: only spares the actor a redundant echo.
   def archive
     @todo.destroy!
+    TodoItemComponent.broadcast_remove_to(*Todo.stream_key, model: @todo, exclude: reactive_connection_id)
     reply.remove
   end
 
   def view_template
     li(**mix(reactive_root, class: 'flex items-center gap-2 py-1',
                             data: { testid: 'todo', done: @todo.done?.to_s })) do
-      button(**mix(on(:toggle), class: 'btn btn-xs btn-circle',
-                                data: { testid: 'toggle' })) { @todo.done? ? '✓' : '○' }
+      # The optimistic checkbox: checked: :keep lets the native flip happen NOW
+      # (it skips the unconditional preventDefault), so the box ticks in the same
+      # gesture; the morph then overwrites with server truth, a failure reverts it.
+      input(type: 'checkbox', checked: @todo.done?,
+            **mix(on(:toggle, event: 'change', optimistic: { checked: :keep }),
+                  class: 'checkbox checkbox-sm', data: { testid: 'toggle' }))
       # Enter saves the rename (event: "keydown.enter" is Stimulus's native
-      # keyboard filter, so ONLY Enter fires it — not every keystroke). The
-      # Todo's title travels as the `title` param (a named control of this row).
+      # keyboard filter, so ONLY Enter fires it). The Todo's title travels as the
+      # `title` param (a named control of this row).
       input(**mix(on(:rename, event: 'keydown.enter'),
                   name: 'title', value: @todo.title,
                   data: { testid: 'todo-title' },
                   class: ['input input-sm flex-1', ('line-through opacity-60' if @todo.done?)]))
-      button(**mix(on(:archive), class: 'btn btn-xs btn-ghost',
-                                 data: { testid: 'archive' })) { 'archive' }
+      # Instant delete: hide the row NOW (optimistic), remove it on the reply.
+      # disable_with: guards against a rapid double-click firing archive twice.
+      button(**mix(on(:archive, disable_with: '…', optimistic: { hide: true, to: :root }),
+                   class: 'btn btn-xs btn-ghost', data: { testid: 'archive' })) { 'archive' }
     end
+  end
+
+  private
+
+  # Re-render this row into every OTHER subscribed tab — exclude the actor, whose
+  # own reply.morph / self-replace already updated them.
+  def broadcast
+    TodoItemComponent.broadcast_replace_to(*Todo.stream_key, model: @todo, exclude: reactive_connection_id)
   end
 end

--- a/docs/app/reactive_components/todo_list_component.rb
+++ b/docs/app/reactive_components/todo_list_component.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
-# Record-backed list with an `add` action that creates a Todo and appends the
-# new row's component in the action response. Each row is its own reactive
-# component (TodoItemComponent), self-targeting by GlobalID.
+# The live todo list: a record-backed list whose `add` action creates a Todo,
+# appends the new row's component to the actor's own reply, AND broadcasts that
+# row to every OTHER subscribed tab so two open windows stay in sync. Each row is
+# its own reactive component (TodoItemComponent), self-targeting by GlobalID.
+#
+# State-backed root (a stable placeholder token) — the rows carry the real record
+# identity. `disable_with:` on Add stops a rapid double-click from creating two
+# todos, and `on_client` clears the composer with zero round trips.
 class TodoListComponent < Phlex::HTML
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::TurboStreamFrom
 
   reactive_state :build_token # stable placeholder state for the list root
   action :add, params: { title: :string }
@@ -16,28 +22,52 @@ class TodoListComponent < Phlex::HTML
 
   def id = 'todo-list'
 
+  # Create the todo, append the new row to the OTHER tabs, then re-render self so
+  # the actor sees the row + the empty-state clears + the composer resets. An
+  # append INSERTS a child (not id-deduped like a replace), so exclude: the actor
+  # or their own subscribed tab would get the row a second time on top of this
+  # self re-render.
   def add(title:)
     title = title.to_s.strip
     return if title.blank?
 
-    Todo.create!(title:)
+    todo = Todo.create!(title:)
+    TodoItemComponent.broadcast_append_to(*Todo.stream_key, target: 'todos',
+                                                            model: todo, exclude: reactive_connection_id)
   end
 
   def view_template
     div(**reactive_root(class: 'flex flex-col gap-3')) do
+      turbo_stream_from(*Todo.stream_key) # subscribe to cross-tab updates
+
       ul(id: 'todos', class: 'flex flex-col') do
-        Todo.order(:created_at, :id).each { render TodoItemComponent.new(todo: it) }
+        if Todo.exists?
+          Todo.order(:created_at, :id).each { render TodoItemComponent.new(todo: it) }
+        else
+          render TodoEmptyComponent.new
+        end
       end
 
       div(class: 'flex gap-2') do
-        # Enter in the field adds the todo — the same :add action the button
-        # fires on click. event: "keydown.enter" is Stimulus's native keyboard
-        # filter, so only Enter dispatches (not every keystroke). The field's
-        # value rides as the `title` param (a named control of this root).
+        # Enter in the field adds the todo — the same :add action the button fires
+        # on click. event: "keydown.enter" is Stimulus's native keyboard filter,
+        # so only Enter dispatches. The field's value rides as the `title` param.
         input(**mix(on(:add, event: 'keydown.enter'),
                     name: 'title', placeholder: 'New todo…', autocomplete: 'off',
                     class: 'input input-bordered flex-1', data: { testid: 'new-todo' }))
-        button(**mix(on(:add), class: 'btn btn-primary', data: { testid: 'add' })) { 'Add' }
+        # disable_with: stops a rapid double-click from creating two todos.
+        button(**mix(on(:add, disable_with: 'Adding…'),
+                     class: 'btn btn-primary', data: { testid: 'add' })) { 'Add' }
+        # Client-only tips toggle: show/hide the hint with ZERO round trip — no
+        # token, no POST, ever. Pure UX polish the one generic controller applies
+        # locally (js.toggle flips the [hidden] flag).
+        button(**mix(on_client(:click, js.toggle('#todo-tips')),
+                     class: 'btn btn-ghost', data: { testid: 'tips-toggle' })) { 'Tips' }
+      end
+
+      p(id: 'todo-tips', hidden: true, class: 'text-xs opacity-60',
+        data: { testid: 'todo-tips' }) do
+        'Press Enter to add · click the checkbox to toggle · Enter in a row saves the rename.'
       end
     end
   end

--- a/docs/app/views/docs/pages/example_chat.rb
+++ b/docs/app/views/docs/pages/example_chat.rb
@@ -13,6 +13,7 @@ module Views
         end
 
         def content
+          try_it
           intro
           model
           message
@@ -25,6 +26,23 @@ module Views
         end
 
         private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              A **real** chat room, rendered right here. Type a message and Send —
+              it creates a `ChatMessage`, appends it to the list, and broadcasts to
+              every subscriber over Turbo Streams (open a second tab to watch it
+              arrive live). The sender is excluded from the broadcast
+              (`exclude: reactive_connection_id`), so Send appends exactly once. No
+              Stimulus, no hand-picked Turbo target.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: ChatRoomComponent.new(room: 'lobby', messages: ChatMessage.for_room('lobby').last(50)),
+              filename: 'app/components/chat_room_component.rb'
+            )
+          end
+        end
 
         def intro
           DocsUI::Section('The example that proves the model') do

--- a/docs/app/views/docs/pages/example_client_ops.rb
+++ b/docs/app/views/docs/pages/example_client_ops.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      class ExampleClientOps < DocsUI::Page
+        title 'Example: client-only ops'
+        eyebrow 'Examples'
+
+        def lead
+          'Some interactions never need the server — tabs, a menu that closes on an ' \
+            'outside click, an accessible drawer with a transition + focus. `on_client` ' \
+            'runs a whitelist of DOM ops locally, with ZERO round trips and ZERO ' \
+            'custom JavaScript.'
+        end
+
+        def content
+          try_it
+          how
+          ops
+          when_to_use
+        end
+
+        private
+
+        def try_it
+          DocsUI::Section('Try it — nothing here hits the server') do
+            md <<~MD
+              Switch tabs, open the menu (then click anywhere outside to close it),
+              open the drawer (it fades in and focus lands on its first button).
+              Every one of these is a client op — **no token, no POST, ever**. Open
+              the network tab: you will see nothing. The component declares **no
+              actions** at all.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: ClientTabsComponent.new,
+              filename: 'app/components/client_tabs_component.rb'
+            )
+          end
+        end
+
+        def how
+          DocsUI::Section('How it works') do
+            md <<~MD
+              `on_client(:click, ops)` binds a chain of DOM ops to an event and runs
+              them locally through the one generic reactive controller. The ops are a
+              **frozen whitelist** — `show`/`hide`/`toggle`, `add_class`/
+              `remove_class`/`toggle_class`, `set_attr`/`toggle_attr`/`remove_attr`,
+              `focus`/`focus_first`, `dispatch` — each a pure, local DOM mutation.
+              Nothing is read back, nothing is sent anywhere.
+
+              - **Tabs:** `js.hide(".ct-panel").show("#ct-panel-1")` plus class ops on
+                the tab buttons — the "I had to write a Stimulus controller" case, now
+                one line.
+              - **Outside-close menu:** `on_client(:click, js.hide("#ct-menu"),
+                outside: true)` on the **root** fires on any click *outside* the menu.
+                A client op costs nothing per stray page click (unlike a server action).
+              - **Accessible drawer:** `js.toggle("#ct-drawer", transition: [...])`
+                animates it, `set_attr(:root, "aria-expanded", "true")` updates the
+                trigger, and `focus_first("#ct-drawer")` moves focus to the first
+                control inside — the exact accessible-disclosure pattern, one chain.
+            MD
+          end
+        end
+
+        def ops
+          DocsUI::Section('The op vocabulary') do
+            md <<~MD
+              Ops are built with the server-side `js` helper and serialized into a
+              `data-reactive-ops` attribute the client interprets. An op name not on
+              the whitelist is warn-and-skipped (client-side default-deny) — a stale
+              or newer ops attribute can never break the page. `focus`/`focus_first`
+              are allowed here (an actor's own gesture) but **rejected** from a
+              broadcast, where stealing focus in every subscriber's tab would be hostile.
+            MD
+            DocsUI::Callout(:tip) do
+              md <<~MD
+                Reach for `on_client` whenever the interaction is purely presentational
+                — toggling a disclosure, closing a popover, moving focus. Reach for a
+                reactive `action` (a token + POST) only when the server must **decide**
+                or **persist** something.
+              MD
+            end
+          end
+        end
+
+        def when_to_use
+          DocsUI::Section('The zero-fetch contract') do
+            md <<~MD
+              Because the component declares no actions and every trigger is
+              `on_client`, a click here never mints a token and never posts. That is
+              the tested contract: the browser suite spies on `fetch` and asserts it
+              is called **zero** times across every tab switch, menu toggle, and
+              drawer open.
+            MD
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_collections.rb
+++ b/docs/app/views/docs/pages/example_collections.rb
@@ -4,505 +4,124 @@ module Views
   module Docs
     module Pages
       class ExampleCollections < DocsUI::Page
-        title 'Example: collections (add/remove rows + count + empty-state)'
+        title 'Example: reactive collections'
         eyebrow 'Examples'
 
         def lead
-          'An add/remove-row list — line items, attachments, tags, comments, a notifications list — declares its ' \
-            'append/remove + count + empty-state contract once on the container, so each action is a single call.'
+          'An add/remove-row list — line items, attachments, tags, a notifications ' \
+            'feed — declares its append/remove + running count + empty-state contract ' \
+            'ONCE on the container, so each action is a single `reply.append` / ' \
+            '`reply.remove`. Plus optimistic dismiss and a self-dismissing flash.'
         end
 
         def content
-          intro
-          declare_collection
-          row_and_empty
+          try_it
+          declare_once
+          the_row
+          the_empty_state
           what_each_reply_emits
-          add_to_top
-          instant_feedback
-          why_count_right
-          repeated_add_remove
-          cross_tab
-          related
+          notes
         end
 
         private
 
-        def intro
-          DocsUI::Section('Example: reactive collections (add/remove rows + count + empty-state)') do
-            DocsUI::Prose() do
-              p do
-                plain 'An add/remove-row list — line items, attachments, tags, comments, a notifications list — is '
-                plain 'one of the most common reactive surfaces. Each one re-implements the same orchestration by '
-                plain 'hand in every action: append the new row to the right container, remove it on delete, keep a '
-                strong { 'count badge' }
-                plain ' in sync, and swap an '
-                strong { 'empty-state' }
-                plain ' in and out as the list crosses 0↔1. Each is easy to get subtly wrong (off-by-one badge, '
-                plain 'empty-state not toggled, container id drift between the static render and the action), and '
-                plain "it's duplicated per list."
-              end
-              p do
-                code { 'reactive_collection' }
-                plain ' declares that contract '
-                strong { 'once' }
-                plain ' on the container, so each action is a single call.'
-              end
-            end
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              Add a notification and dismiss it. Each **add** appends the row, bumps
+              the count badge, and clears the empty-state in ONE reply; each
+              **dismiss** removes the row (optimistically — it hides the instant you
+              click), restores the empty-state when the last one goes, and shows a
+              self-dismissing toast. Turn on the latency toggle to watch the
+              optimistic hide before the round trip lands.
+            MD
+            render Views::Examples::LatencyToggle.new(delay_ms: 600)
+            render Views::Examples::LiveExample.new(
+              component: NotificationsListComponent.new,
+              filename: 'app/components/notifications_list_component.rb'
+            )
           end
         end
 
-        def declare_collection
-          DocsUI::Section('Declare the collection on the container') do
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notifications_list.rb')
-              class NotificationsList < ApplicationComponent
-                include Phlex::Reactive::Component
+        def declare_once
+          DocsUI::Section('Declare the list contract once') do
+            md <<~MD
+              `reactive_collection` names the row component, the container DOM id, an
+              optional count-badge id, an optional empty-state component, and a
+              **size resolver** (a proc that reads the live count). After that, an
+              action governs the reply with a single call — no hand-deriving the
+              container id, the count, and the empty-state in every action.
 
-                reactive_collection :notifications,
-                  item: NotificationRow,          # the per-row Streamable component
-                  container: "notifications",     # the DOM id rows live in
-                  count: "notifications-count",   # optional companion id (the size badge)
-                  empty: NotificationsEmpty,      # optional empty-state component
-                  size: -> { current_user.todos.size }  # this list's live size (re-counted server-side)
+              - `reply.append(:notifications, record)` → row stream + count + clears
+                the empty-state.
+              - `reply.remove(:notifications, record)` → row remove + count +
+                restores the empty-state.
 
-                action :add, params: {title: :string}
-                action :dismiss, params: {id: :integer}   # default-deny + schema-coerced to Integer
-
-                def id = "notifications-list"
-
-                def add(title:)
-                  todo = current_user.todos.create!(title:)
-                  reply.append(:notifications, todo)   # row + bump count + clear empty-state
-                end
-
-                def dismiss(id:)
-                  todo = current_user.todos.find(id)   # scope the lookup + authorize BEFORE destroy!
-                  authorize! todo, :destroy?
-                  todo.destroy!
-                  reply.remove(:notifications, todo)   # pass the RECORD → its dom_id is the remove target
-                end
-
-                def view_template
-                  todos = current_user.todos.order(:created_at, :id)
-
-                  div(**reactive_root) do
-                    span(id: "notifications-count") { todos.size.to_s }
-
-                    ul(id: "notifications") do
-                      if todos.any?
-                        todos.each { |t| render NotificationRow.new(todo: t) }
-                      else
-                        render NotificationsEmpty.new
-                      end
-                    end
-
-                    div do
-                      input(name: "title", placeholder: "New notification…", autocomplete: "off")
-                      # disable_with: swaps the label + disables while the create is in flight,
-                      # so a rapid double-click enqueues exactly one add.
-                      button(**mix(on(:add, disable_with: "Adding…"))) { "Add" }
-                    end
-                  end
-                end
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                plain 'The same three things the helper streams in and out on each delta — the row, the count, the '
-                plain 'empty-state — are what '
-                code { 'view_template' }
-                plain ' renders on first paint, so the initial server render and the reactive deltas cannot drift.'
-              end
-              ul do
-                li do
-                  strong { 'Params are schema-coerced and default-deny.' }
-                  plain ' '
-                  code { 'params: {id: :integer}' }
-                  plain ' coerces the client value to an Integer; anything not in the schema is dropped before '
-                  plain 'reaching '
-                  code { 'dismiss' }
-                  plain '. A delete action still needs a real check: '
-                  strong { 'scope the lookup' }
-                  plain ' ('
-                  code { 'current_user.todos.find' }
-                  plain ') and '
-                  code { 'authorize!' }
-                  plain ' the record '
-                  strong { 'before' }
-                  plain ' '
-                  code { 'destroy!' }
-                  plain ' — the signed token proves identity, not permission.'
-                end
-                li do
-                  strong { 'Pass the record to ' }
-                  code { 'reply.remove' }
-                  plain '. The remove target is the row component'
-                  plain "'s "
-                  code { 'dom_id' }
-                  plain ' — so '
-                  code { 'reply.remove(:notifications, todo)' }
-                  plain ' hands it the record (fetched '
-                  strong { 'before' }
-                  plain ' '
-                  code { 'destroy!' }
-                  plain ', while it still answers '
-                  code { 'dom_id' }
-                  plain '). A raw integer id is not a dom_id and would target the wrong node; pass the record (or its '
-                  code { 'dom_id' }
-                  plain ' string) instead.'
-                end
-                li do
-                  code { 'disable_with: "Adding…"' }
-                  plain ' on the Add button disables it and swaps its label while the '
-                  code { 'create!' }
-                  plain ' is in flight — a collection add is the canonical pending-state case (see '
-                  em { 'Instant feedback' }
-                  plain ' below).'
-                end
-              end
-            end
+              The size resolver reads `Notification.count` server-side, so the badge
+              is always correct — never an off-by-one client increment.
+            MD
           end
         end
 
-        def row_and_empty
-          DocsUI::Section('The row and empty-state components') do
-            DocsUI::Prose() do
-              p do
-                plain 'The row is a plain '
-                code { 'Streamable' }
-                plain ' keyed off the record, so its '
-                code { '#id' }
-                plain ' is a stable '
-                code { 'dom_id' }
-                plain ' — the append/remove target. Its dismiss button dispatches the '
-                strong { "container's" }
-                plain ' '
-                code { 'dismiss' }
-                plain ' action via the generic reactive controller it sits inside (it carries no token of its own):'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notification_row.rb')
-              class NotificationRow < ApplicationComponent
-                include Phlex::Reactive::Component   # only to use `on` for the dismiss trigger
+        def the_row
+          DocsUI::Section('The row (tokenless — it dispatches the container)') do
+            md <<~MD
+              `NotificationRowComponent` carries **no token of its own**: its dismiss
+              button dispatches the *container's* `dismiss` action (keyed by the
+              record id) via the generic controller it sits inside. That's why a
+              streamed-in row (via `reply.append`) is fully interactive without any
+              re-wiring. `optimistic: { hide: true }` hides the row the instant you
+              click; `reply.remove` then drops it, so it never flashes back.
+            MD
+            DocsUI::Code(read_component('notification_row_component.rb'),
+                         lexer: :ruby, filename: 'app/components/notification_row_component.rb')
+          end
+        end
 
-                def self.model_param_name = :todo
-                def initialize(todo:) = @todo = todo
-                def id = dom_id(@todo)
-
-                def view_template
-                  li(id:, class: "notification") do
-                    span(class: "body") { @todo.title }
-                    # optimistic hide: true hides the row the instant × is clicked,
-                    # then reply.remove takes it out — no flash-back on success.
-                    button(**mix(on(:dismiss, id: @todo.id,
-                      confirm: "Dismiss?", optimistic: {hide: true, to: :root}))) { "×" }
-                  end
-                end
-              end
-
-              class NotificationsEmpty < ApplicationComponent
-                include Phlex::Reactive::Streamable
-
-                def id = "notifications-empty"
-                def view_template = div(id:, class: "empty-state") { "No notifications" }
-              end
-            RUBY
+        def the_empty_state
+          DocsUI::Section('The empty-state') do
+            md <<~MD
+              A static Streamable component with a stable `#id`. The collection helper
+              removes it by that id when the first row is added and appends it back
+              when the last row is dismissed — you never toggle it by hand.
+            MD
+            DocsUI::Code(read_component('notifications_empty_component.rb'),
+                         lexer: :ruby, filename: 'app/components/notifications_empty_component.rb')
           end
         end
 
         def what_each_reply_emits
           DocsUI::Section('What each reply emits') do
-            DocsUI::Prose() do
-              ul do
-                li do
-                  code { 'reply.append(name, model)' }
-                  plain ' — append the row into the container · update the count · remove the empty-state when the '
-                  plain 'list crosses 0→1.'
-                end
-                li do
-                  code { 'reply.prepend(name, model)' }
-                  plain ' — as '
-                  code { 'append' }
-                  plain ', row goes to the top.'
-                end
-                li do
-                  code { 'reply.remove(name, model)' }
-                  plain ' — remove the row by its '
-                  code { 'dom_id' }
-                  plain ' · update the count · append the empty-state back when the list crosses →0.'
-                end
-              end
-              p do
-                plain 'The empty-state is touched '
-                strong { 'only at the boundary' }
-                plain ' — adding to an already-populated list, or removing while rows remain, leaves it alone.'
-              end
+            md <<~MD
+              One `reply.append` / `reply.remove` expands into a **multi-stream**
+              turbo reply: the row (append/remove), the count companion (replace),
+              and the empty-state (remove/append). `dismiss` chains a
+              `.flash(:notice, "…", dismiss_after: 3000)` so a toast appears in the
+              `#flash` region and clears itself after 3 s — no timer in your Ruby.
+              Every mutation also broadcasts to the other tabs with
+              `exclude: reactive_connection_id`, so a second window stays in sync.
+            MD
+          end
+        end
+
+        def notes
+          DocsUI::Section('Notes') do
+            DocsUI::Callout(:tip) do
+              md <<~MD
+                `count:` and `empty:` are optional — a list with just rows omits them
+                and those streams simply aren't emitted. The row component owns its
+                own actions; the collection is only about the container-level
+                add/remove reply. See
+                [Broadcasting & live updates](/docs/broadcasting).
+              MD
             end
           end
         end
 
-        def add_to_top
-          DocsUI::Section('Add to the top (prepend)') do
-            DocsUI::Prose() do
-              p do
-                plain 'A notifications list usually shows the newest first. '
-                code { 'reply.prepend' }
-                plain ' is '
-                code { 'append' }
-                plain "'s twin — same row + count + empty-state contract, but the row lands at the "
-                strong { 'top' }
-                plain ' of the container instead of the bottom:'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notifications_list.rb')
-              def add(title:)
-                todo = current_user.todos.create!(title:)
-                reply.prepend(:notifications, todo)   # newest notification on top
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                plain 'Keep the first render in agreement: order the '
-                code { 'view_template' }
-                plain ' query the same way ('
-                code { 'order(created_at: :desc)' }
-                plain ' for newest-first) so a reload matches what '
-                code { 'prepend' }
-                plain ' streams in.'
-              end
-            end
-          end
-        end
-
-        def instant_feedback
-          DocsUI::Section('Instant feedback: pending Add, optimistic dismiss, failed create') do
-            DocsUI::Prose() do
-              p do
-                plain "A collection's add and dismiss buttons are the canonical place for pending-state and "
-                plain 'optimistic UX — the round trip includes a DB write, so the row should not appear frozen:'
-              end
-              ul do
-                li do
-                  code { 'disable_with: "Adding…"' }
-                  plain ' on '
-                  strong { 'Add' }
-                  plain ' — disables the button and swaps its label from enqueue until the reply settles. A '
-                  plain 'disabled button fires no further clicks, so a fast double-click enqueues exactly one '
-                  code { 'create!' }
-                  plain '. Style dimming/spinners off '
-                  code { '[aria-busy="true"]' }
-                  plain ' / '
-                  code { 'busy_on(:add)' }
-                  plain ' — both are on for free during the round trip.'
-                end
-                li do
-                  code { 'optimistic: {hide: true, to: :root}' }
-                  plain ' on '
-                  strong { 'dismiss' }
-                  plain ' — hides the row the instant × is clicked, before the round trip. Because '
-                  code { 'reply.remove' }
-                  plain ' does '
-                  strong { 'not' }
-                  plain ' re-render the row root, the hide is left standing on success (the row then removes) — '
-                  plain 'no flash-back. A failed dismiss replays the inverse and the row reappears.'
-                end
-              end
-              p do
-                plain 'When the create can fail (a blank title, a validation), catch it and flash instead of letting '
-                plain 'the 500 surface — a self-dismissing '
-                code { 'reply.flash' }
-                plain ' keeps the list intact:'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notifications_list.rb')
-              def add(title:)
-                todo = current_user.todos.new(title:)
-                if todo.save
-                  reply.append(:notifications, todo)
-                else
-                  # No row, no count change — just a flash that clears itself after 4s.
-                  reply.streams.flash(:error, todo.errors.full_messages.to_sentence, dismiss_after: 4000)
-                end
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                code { 'reply.streams' }
-                plain ' (no arguments) emits the flash + the container'
-                plain "'s token-only refresh and "
-                strong { 'nothing else' }
-                plain ' — the list is untouched, and the '
-                code { 'title' }
-                plain ' field the user is mid-typing in is never torn down. '
-                code { 'dismiss_after:' }
-                plain ' removes the flash after the timeout with no follow-up action.'
-              end
-            end
-          end
-        end
-
-        def why_count_right
-          DocsUI::Section('Why the count is always right') do
-            DocsUI::Prose() do
-              p do
-                code { 'size:' }
-                plain ' is '
-                strong { 're-counted server-side after the mutation' }
-                plain ', not incremented on a number the client holds. That is deliberate:'
-              end
-              ul do
-                li do
-                  strong { 'No off-by-one.' }
-                  plain ' The badge reflects the database, not an optimistic guess.'
-                end
-                li do
-                  strong { 'No state shipped to the client.' }
-                  plain ' A client-held count would violate the signed-identity rule (the DOM never carries raw '
-                  plain 'state) and would drift under concurrent changes from other tabs.'
-                end
-                li do
-                  strong { 'First render and deltas agree.' }
-                  plain ' Both read the same '
-                  code { 'size:' }
-                  plain ' source.'
-                end
-              end
-              li do
-                strong { 'Scope it to this list.' }
-                plain ' '
-                code { 'size:' }
-                plain ' resolves in the container'
-                plain "'s context, so it counts "
-                strong { 'this' }
-                plain ' list — '
-                code { 'current_user.todos.size' }
-                plain ', not a global '
-                code { 'Todo.count' }
-                plain '. A per-parent list scopes through its record ('
-                code { '-> { @record.items.size }' }
-                plain ') so two parents on one page each report their own size.'
-              end
-              p do
-                code { 'count:' }
-                plain ', '
-                code { 'empty:' }
-                plain ', and '
-                code { 'size:' }
-                plain ' are all optional — omit them and '
-                code { 'reply.append' }
-                plain ' emits just the row stream.'
-              end
-            end
-          end
-        end
-
-        def repeated_add_remove
-          DocsUI::Section("Repeated add/remove: the container's token rolls forward") do
-            DocsUI::Prose() do
-              p do
-                code { 'reply.append' }
-                plain ' / '
-                code { 'reply.remove' }
-                plain " don't re-render the whole container (that would clobber the streamed-in rows), so they ride "
-                plain 'the same token-only refresh as '
-                code { 'reply.streams' }
-                plain ': each reply emits an inert '
-                code { '<turbo-stream action="reactive:token">' }
-                plain ' that rolls the '
-                strong { "list root's" }
-                plain ' signed token forward. That is the load-bearing part — the add/remove trigger lives on the '
-                plain 'list root, so without the refresh the list would be '
-                strong { 'add-once-only' }
-                plain ' (correct on the first click, then every later dispatch rejected because the container'
-                plain "'s token went stale, with no error). The helper bakes this in, so repeated adds and removes "
-                plain 'just work.'
-              end
-              p do
-                plain 'This holds even when the '
-                strong { 'rows are themselves reactive' }
-                plain ' (each row carries its own signed token) and they are appended directly '
-                strong { 'into' }
-                plain ' the container element (the container'
-                plain "'s "
-                code { '#id' }
-                plain ' is the append target). A reactive child'
-                plain "'s token, embedded in the appended content at the container's target, is "
-                strong { 'not' }
-                plain " the container's own refresh — the endpoint only counts a stream that re-renders the "
-                plain "container's root ("
-                code { 'replace' }
-                plain '/'
-                code { 'update' }
-                plain '/'
-                code { 'reactive:token' }
-                plain '), so the container'
-                plain "'s token still rolls forward and the list keeps working (#44). The "
-                strong { 'client' }
-                plain ' applies the same rule when it reads the next token out of the response: it takes the token '
-                plain 'that re-renders '
-                strong { 'its own' }
-                plain ' element id (the trailing '
-                code { 'reactive:token' }
-                plain ' stream for the container), never the first token in the body — which, for a '
-                plain 'prepended/appended reactive row, is the '
-                strong { "row's" }
-                plain " token, not the list's. Reading the first match made the list add-once-only "
-                strong { 'in the browser' }
-                plain ' even though the server response was correct (#46).'
-              end
-            end
-          end
-        end
-
-        def cross_tab
-          DocsUI::Section('Cross-tab: keep broadcasting the row') do
-            DocsUI::Prose() do
-              p do
-                code { 'reactive_collection' }
-                plain ' governs the '
-                strong { "actor's" }
-                plain ' HTTP reply. For a '
-                strong { 'live' }
-                plain ' list where other viewers see the row appear, broadcast the row as well, excluding the '
-                plain 'actor (who already got the reply):'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/notifications_list.rb')
-              def add(title:)
-                todo = current_user.todos.create!(title:)
-                NotificationRow.broadcast_append_to(
-                  current_user, :notifications,
-                  target: "notifications", model: todo,
-                  exclude: reactive_connection_id
-                )
-                reply.append(:notifications, todo)
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                code { 'reactive_collection' }
-                plain ' is the per-actor add/remove + count + empty-state wrapper; the broadcast is the cross-tab '
-                plain 'fan-out. They compose — both target the same container id.'
-              end
-            end
-          end
-        end
-
-        def related
-          DocsUI::Section('Related') do
-            DocsUI::Prose() do
-              ul do
-                li do
-                  strong { 'Notifications / badges' }
-                  plain ' — pure-broadcast badges (no client action), the natural complement when the server '
-                  plain 'pushes a re-render.'
-                end
-                li do
-                  strong { 'Live todo list' }
-                  plain ' — the hand-rolled add/toggle/remove this helper distills.'
-                end
-              end
-            end
-          end
+        # Read a reactive component's own source off disk so the code shown here can
+        # never drift from the components the demo renders.
+        def read_component(basename)
+          Rails.root.join('app/reactive_components', basename).read.strip
         end
       end
     end

--- a/docs/app/views/docs/pages/example_failure.rb
+++ b/docs/app/views/docs/pages/example_failure.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      class ExampleFailure < DocsUI::Page
+        title 'Example: failure surface'
+        eyebrow 'Examples'
+
+        def lead
+          'Reactive actions don’t only succeed. This shows what an adopter gets for ' \
+            'free when one fails: a server-rendered flash (`error_flash`), a ' \
+            '`data-reactive-error` hook you style with CSS, and self-dismissing ' \
+            'toasts (`dismiss_after:`).'
+        end
+
+        def content
+          try_it
+          error_flash
+          error_hook
+          timeout
+        end
+
+        private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              Click **Trigger a failure** — the action denies server-side (a declared
+              authorization error → 403). The endpoint renders a flash the browser
+              shows, and the root gets `data-reactive-error="http"`, which reveals the
+              error banner via pure CSS. **Succeed** clears it. **Self-dismissing
+              flash** shows a toast that removes itself after `dismiss_after:`.
+            MD
+            render Views::Examples::LatencyToggle.new(delay_ms: 500)
+            render Views::Examples::LiveExample.new(
+              component: FailureSurfaceComponent.new(count: 0),
+              filename: 'app/components/failure_surface_component.rb'
+            )
+          end
+        end
+
+        def error_flash
+          DocsUI::Section('Server-rendered failure flashes (error_flash)') do
+            md <<~MD
+              Set `Phlex::Reactive.error_flash = ->(kind) { "…" }` and the action
+              endpoint renders a turbo-stream flash into your `flash_target` whenever
+              an action fails — a denied action (403, `kind: "http"`), a timeout
+              (`kind: "timeout"`), or a network error (`kind: "offline"`). You write
+              the copy; the framework surfaces it. It's opt-in: with `error_flash`
+              unset, failures are silent (the client still sets `data-reactive-error`).
+            MD
+          end
+        end
+
+        def error_hook
+          DocsUI::Section('The data-reactive-error hook') do
+            md <<~MD
+              On any failed action the client sets `data-reactive-error="<kind>"` on
+              the component root; a successful re-render clears it. Style the wait/
+              failure state with a plain attribute selector — here the error banner is
+              `display:none` until `[data-reactive-error]` is present. No Ruby toggles
+              it, and it survives a morph because it's driven off the attribute, not
+              the HTML.
+            MD
+          end
+        end
+
+        def timeout
+          DocsUI::Section('Timeouts and offline') do
+            md <<~MD
+              The client aborts a request that exceeds `phlex-reactive-timeout`
+              (default 30 s; set the meta lower to demo it) with
+              `kind: "timeout"`, and a fetch that fails offline with
+              `kind: "offline"` — both flow through the same `error_flash` +
+              `data-reactive-error` surface as a 403. Crucially, the per-component
+              request queue does **not** wedge: after a timeout, the next action
+              still round-trips. Flip the latency simulator on to make the in-flight
+              window observable.
+            MD
+            DocsUI::Callout(:note) do
+              md <<~MD
+                A live timeout needs a page-level `phlex-reactive-timeout` meta set
+                below the simulated delay, which would affect every demo on the page.
+                The timeout/offline behavior is covered end-to-end in the gem's own
+                browser suite; here we demo the 403 → `error_flash` path, which shares
+                the exact same client surface.
+              MD
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_inline_edit.rb
+++ b/docs/app/views/docs/pages/example_inline_edit.rb
@@ -4,457 +4,108 @@ module Views
   module Docs
     module Pages
       class ExampleInlineEdit < DocsUI::Page
-        title 'Example: inline edit (show ↔ edit)'
+        title 'Example: inline edit + dirty tracking'
         eyebrow 'Examples'
 
         def lead
-          'The classic “click to edit a field in place” pattern — one component with two ' \
-            'actions, instead of a Stimulus controller plus three routes and partials.'
+          'Click-to-edit that replaces a Stimulus controller plus three routes: ' \
+            'Enter saves, Escape cancels, focus survives the morph. Plus dirty-field ' \
+            'tracking — an “Unsaved” badge and a leave-guard — with ZERO state shipped ' \
+            'to the client.'
         end
 
         def content
+          inline_edit
           the_component
-          rendering
-          notes
-          loading_states
           dirty_tracking
-          validation_error
-          live_as_you_type
-          broadcasting
+          dirty_component
+          notes
         end
 
         private
 
-        def the_component
-          DocsUI::Section('The component') do
-            DocsUI::Prose() do
-              p do
-                plain 'In plain Hotwire this is a Stimulus controller plus three routes ('
-                code { 'inline_edit' }
-                plain ', '
-                code { 'inline_update' }
-                plain ', '
-                code { 'inline_cancel' }
-                plain ') and partials. Here it is one component with two actions.'
-              end
-            end
-            DocsUI::Code(<<~'RUBY', lexer: :ruby, filename: 'app/components/fields/inline_edit.rb')
-              class Fields::InlineEdit < ApplicationComponent
-                include Phlex::Reactive::Component
-
-                reactive_record :record
-                reactive_state :attribute, :editing     # which field, and the mode
-
-                action :edit
-                action :cancel
-                action :save, params: { value: :string }
-
-                def initialize(record:, attribute:, editing: false)
-                  @record = record
-                  @attribute = attribute.to_sym
-                  @editing = editing
-                end
-
-                def id = dom_id(@record, "inline_#{@attribute}")
-
-                def edit   = @editing = true
-                def cancel = @editing = false
-
-                def save(value:)
-                  authorize! @record, :update?
-                  @record.update!(@attribute => value)
-                  @editing = false
-                end
-
-                def view_template
-                  span(**reactive_root) do
-                    if @editing
-                      # reactive_input(:value) binds the field to the `value:` param —
-                      # no hand-written name: "value" to forget. The trigger stays on
-                      # the button, so focusing the field can't dispatch and collapse
-                      # edit mode. Enter still saves via a keydown.enter binding on the
-                      # field; Escape cancels on the Cancel button. event: "keydown.*"
-                      # is Stimulus's native keyboard filter, so each fires only on its
-                      # key — no JS.
-                      reactive_input(:value, value: current_value, autocomplete: "off",
-                                     **on(:save, event: "keydown.enter"))
-                      button(**on(:save, disable_with: "Saving…")) { "Save" }
-                      button(**on(:cancel, event: "keydown.esc")) { "Cancel" }
-                    else
-                      span(**on(:edit), class: "editable") { current_value.presence || "—" }
-                    end
-                  end
-                end
-
-                private
-
-                def current_value = @record.public_send(@attribute)
-              end
-            RUBY
+        def inline_edit
+          DocsUI::Section('Try it — click to edit') do
+            md <<~MD
+              Click the value below to edit it, then **Enter** (or Save) to persist
+              and **Escape** (or Cancel) to back out. The mode (`editing`) rides in
+              the signed token alongside the record's GlobalID, so the show ↔ edit
+              flip is one reactive round trip — no client state, no bespoke JS.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: InlineEditComponent.new(record: inline_demo_todo, attribute: :title),
+              filename: 'app/components/inline_edit_component.rb'
+            )
           end
         end
 
-        def rendering
-          DocsUI::Section('Render it for any field') do
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              render Fields::InlineEdit.new(record: @user, attribute: :name)
-              render Fields::InlineEdit.new(record: @user, attribute: :email)
-            RUBY
+        def the_component
+          DocsUI::Section('How it works') do
+            md <<~MD
+              `reactive_record :record` signs the record's GlobalID;
+              `reactive_state :attribute, :editing` signs which column and the mode.
+              Every action re-finds the record server-side and re-renders. `save`
+              lives on the **Save button**, not the input — so focusing the field
+              doesn't dispatch save and collapse edit mode. `Escape` is bound with
+              `event: "click keydown.esc"`, Stimulus's native keyboard filter.
+            MD
+          end
+        end
+
+        def dirty_tracking
+          DocsUI::Section('Try it — dirty tracking') do
+            md <<~MD
+              Edit the field: an **“Unsaved”** badge appears on the first keystroke
+              and the browser warns before you navigate away. Save and it clears —
+              all with **no state shipped to the client**. The browser already holds
+              the last server-rendered value in `input.defaultValue`, so
+              *dirty = current ≠ default*; the badge is revealed purely by CSS while
+              the root carries `data-reactive-dirty`.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: DirtyFormComponent.new(todo: dirty_demo_todo),
+              filename: 'app/components/dirty_form_component.rb'
+            )
+          end
+        end
+
+        def dirty_component
+          DocsUI::Section('How dirty tracking works') do
+            md <<~MD
+              `reactive_root(track_dirty: true, warn_unsaved: true)` mixes
+              `input->reactive#trackDirty` onto the root and arms a navigate-away
+              guard gated on the live dirty count. `reactive_field(:title, dirty:
+              true)` opts the field in too. On `save` the action morphs, so the
+              reply re-renders the field with the NEW value as its fresh
+              `defaultValue` — the post-morph re-scan finds it clean and the badge
+              clears without a full-page reload.
+            MD
           end
         end
 
         def notes
           DocsUI::Section('Notes') do
-            DocsUI::Prose() do
-              ul do
-                li do
-                  strong { 'Two pieces of identity' }
-                  plain ': '
-                  code { 'reactive_record :record' }
-                  plain ' (the row, re-found via GlobalID) and '
-                  code { 'reactive_state :attribute, :editing' }
-                  plain ' (which field, what mode). Both are signed; the client cannot switch '
-                  code { '@attribute' }
-                  plain ' to a column it should not edit because the value is signed into the token.'
-                end
-                li do
-                  strong { 'Mode is server state.' }
-                  plain ' '
-                  code { 'edit' }
-                  plain '/'
-                  code { 'cancel' }
-                  plain '/'
-                  code { 'save' }
-                  plain ' flip '
-                  code { '@editing' }
-                  plain ' and re-render the same element — no separate “edit” route or partial.'
-                end
-                li do
-                  strong { 'Authorize on save.' }
-                  plain ' '
-                  code { 'edit' }
-                  plain '/'
-                  code { 'cancel' }
-                  plain ' are harmless view toggles; '
-                  code { 'save' }
-                  plain ' mutates, so it authorizes.'
-                end
-                li do
-                  strong { 'Enter saves, Escape cancels.' }
-                  plain ' '
-                  code { 'on(:save, event: "keydown.enter")' }
-                  plain ' and '
-                  code { 'on(:cancel, event: "keydown.esc")' }
-                  plain ' bind each key to its own element — '
-                  code { 'event:' }
-                  plain ' passes Stimulus’s native keyboard filter straight through, so the trigger fires '
-                  plain 'only on that key. (One action per element: keep the Enter-save on the input and '
-                  plain 'the Escape-cancel on the Cancel button.)'
-                end
-                li do
-                  strong { 'The display text is the click target.' }
-                  plain ' '
-                  code { 'span(**on(:edit))' }
-                  plain ' turns the display text into the trigger. Add '
-                  code { 'tabindex' }
-                  plain ' if you need a11y on non-button triggers.'
-                end
-                li do
-                  strong { 'Rich-text fields work too.' }
-                  plain ' A named '
-                  code { 'lexxy-editor' }
-                  plain ', '
-                  code { 'trix-editor' }
-                  plain ', or '
-                  code { '[contenteditable]' }
-                  plain ' is auto-collected on submit alongside plain inputs — so '
-                  code { 'save' }
-                  plain ' receives its value, not a blank.'
-                end
-              end
-            end
-          end
-        end
-
-        def loading_states
-          DocsUI::Section('Loading state on Save') do
-            DocsUI::Prose() do
-              p do
-                plain 'Between the click and the re-render, the Save button should show it is working — and a '
-                plain 'mutating button should swallow a rapid double-click. '
-                code { 'disable_with:' }
-                plain ' does both: it disables the trigger and swaps its text while the action is in flight, '
-                plain 'reverting when the round trip settles (success '
-                em { 'or' }
-                plain ' failure).'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              # Shorthand — disable + text swap while `save` is pending:
-              button(**on(:save, disable_with: "Saving…")) { "Save" }
-
-              # Full form — disable + a loading class + a text swap:
-              button(**on(:save, loading: { disable: true, class: "opacity-50", text: "Saving…" })) { "Save" }
-            RUBY
-            DocsUI::Prose() do
-              p do
-                plain 'Independent of any '
-                code { 'loading:' }
-                plain ' hint, '
-                strong { 'every' }
-                plain ' reactive round trip marks the DOM for the whole enqueue → settle window, so you can style '
-                plain 'spinners and dimming with pure CSS: the trigger and root carry '
-                code { 'data-reactive-busy="save"' }
-                plain ', the root carries '
-                code { 'aria-busy="true"' }
-                plain ', and '
-                code { 'busy_on(:save)' }
-                plain ' marks any element inside the root so it toggles '
-                code { 'data-reactive-busy' }
-                plain ' only while '
-                code { 'save' }
-                plain ' is in flight — a scoped spinner with zero Ruby.'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              button(**on(:save, disable_with: "Saving…")) { "Save" }
-              span(**busy_on(:save), class: "spinner")
-            RUBY
-            DocsUI::Callout(:note) do
-              plain 'The disable + text swap apply only at enqueue, never during a '
-              code { 'debounce:' }
-              plain ' quiet period — so a debounced live-as-you-type field (whose element '
-              em { 'is' }
-              plain ' the input) is never disabled mid-typing.'
-            end
-          end
-        end
-
-        def dirty_tracking
-          DocsUI::Section('Dirty tracking — enable Save only when it changed') do
-            DocsUI::Prose() do
-              p do
-                plain 'An inline editor should light up Save (or show an “Unsaved” badge) only once the value '
-                plain 'actually changed, and can warn before you navigate away with edits pending — '
-                strong { 'without shipping any client state' }
-                plain '. The browser already holds the last server-rendered value: '
-                code { 'input.defaultValue' }
-                plain ' is the attribute from the last render, so '
-                em { 'dirty = current ≠ default' }
-                plain ' is read straight from the DOM — nothing to snapshot, nothing to sign.'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              def view_template
-                span(**reactive_root(track_dirty: true, warn_unsaved: true)) do
-                  if @editing
-                    reactive_input(:value, value: current_value, dirty: true,
-                                   autocomplete: "off", **on(:save, event: "keydown.enter"))
-                    span(class: "unsaved-badge") { "Unsaved" }  # shown via [data-reactive-dirty]
-                    button(**on(:save, disable_with: "Saving…")) { "Save" }
-                    button(**on(:cancel, event: "keydown.esc")) { "Cancel" }
-                  else
-                    span(**on(:edit), class: "editable") { current_value.presence || "—" }
-                  end
-                end
-              end
-            RUBY
-            DocsUI::Prose() do
-              ul do
-                li do
-                  code { 'track_dirty: true' }
-                  plain ' on the root re-scans every field it owns on change; '
-                  code { 'dirty: true' }
-                  plain ' on a '
-                  code { 'reactive_field' }
-                  plain '/'
-                  code { 'reactive_input' }
-                  plain ' opts that one field in. Each changed field gets '
-                  code { 'data-reactive-dirty="true"' }
-                  plain ' and the root gets '
-                  code { 'data-reactive-dirty="<count>"' }
-                  plain ' — absent at zero, so '
-                  code { '[data-reactive-dirty]' }
-                  plain ' matches only while the form is dirty.'
-                end
-                li do
-                  code { 'warn_unsaved: true' }
-                  plain ' arms a navigate-away guard (browser '
-                  code { 'beforeunload' }
-                  plain ' + Turbo '
-                  code { 'turbo:before-visit' }
-                  plain ') gated on the live dirty count — a clean form never blocks.'
-                end
-                li do
-                  strong { 'Baselines reset on the server re-render.' }
-                  plain ' A '
-                  code { 'reply.morph' }
-                  plain ' save renders the field with the saved value as its '
-                  em { 'new' }
-                  plain ' default, so the badge clears with no reload — the client re-scans after the morph writes '
-                  plain 'the fresh '
-                  code { 'default*' }
-                  plain ' attributes.'
-                end
-              end
-            end
-            DocsUI::Code(<<~CSS, lexer: :css)
-              /* You own the styling — phlex-reactive ships no CSS for these. */
-              .unsaved-badge { display: none; }
-              [data-reactive-dirty] .unsaved-badge { display: inline; }
-              [data-reactive-dirty] button[data-testid="save"] { pointer-events: auto; opacity: 1; }
-            CSS
-          end
-        end
-
-        def validation_error
-          DocsUI::Section('Surfacing a validation error') do
-            DocsUI::Prose() do
-              p do
-                code { 'save' }
-                plain ' above uses '
-                code { 'update!' }
-                plain ', which raises on invalid input. To show the error instead, use non-bang '
-                code { 'update' }
-                plain ' and return '
-                code { 'reply' }
-                plain ' with a flash.'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              def save(value:)
-                authorize! @record, :update?
-                if @record.update(@attribute => value)
-                  @editing = false
-                  reply.replace
-                else
-                  reply.replace.flash(:error, @record.errors.full_messages.to_sentence)
-                end
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                plain 'The flash '
-                code { 'content' }
-                plain ' is supplied explicitly (off-request — no Rails '
-                code { 'flash' }
-                plain ') and appends into '
-                code { 'Phlex::Reactive.flash_target' }
-                plain ' (default '
-                code { '<div id="flash">' }
-                plain '). A string is escaped and wrapped in a level-carrying '
-                code { '<div class="reactive-flash reactive-flash--error" data-reactive-flash-level="error">' }
-                plain ' so errors and notices style differently; pass a Phlex component instead for '
-                plain 'fully custom markup (rendered verbatim, no wrapper), or set '
-                code { 'Phlex::Reactive.flash_component' }
-                plain ' once to render every string flash through your own component ('
-                code { 'new(level:, content:)' }
-                plain ').'
-              end
-            end
-          end
-        end
-
-        def live_as_you_type
-          DocsUI::Section('Live-as-you-type (a spreadsheet-like grid)') do
-            DocsUI::Prose() do
-              p do
-                plain 'For per-field editing where a '
-                strong { 'debounced save fires while the user is still typing or tabbing' }
-                plain ', a plain '
-                code { 'reply.replace' }
-                plain ' is wrong: it is an outerHTML swap that destroys the '
-                code { '<input>' }
-                plain ' you are typing in — focus and the in-progress value vanish. Return '
-                code { 'reply.morph' }
-                plain ' instead. It emits '
-                code { '<turbo-stream action="replace" method="morph">' }
-                plain ', so Turbo 8’s bundled Idiomorph morphs the subtree in place — the focused field '
-                plain 'and its caret survive the save.'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              action :update, params: { name: :string }
-
-              def update(name:)
-                authorize! @record, :update?
-                @record.update!(name:) if name.present?
-                reply.morph   # morph in place — keep focus + caret. The action is named
-                              # `update`, but `reply.morph` is unambiguous (the verb is on reply).
-              end
-
-              def view_template
-                div(**reactive_root) do
-                  # The field both holds the value AND triggers the debounced save.
-                  input(**mix(on(:update, event: "input", debounce: 300),
-                    name: "name", value: @record.name))
-                end
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                code { 'reply.replace(morph: true)' }
-                plain ' is the same thing via the opt-in flag; the morphed root still carries a '
-                plain 'fresh signed token, so the next edit verifies.'
-              end
-              p do
-                strong { 'Advance to the next field on save.' }
-                plain ' Chain '
-                code { '.js' }
-                plain ' onto any reply to push client DOM ops that run '
-                em { 'after' }
-                plain ' the render, so a focus op sees the freshly morphed DOM — natural for a grid where Enter '
-                plain 'should hop to the next cell:'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              def update(name:)
-                authorize! @record, :update?
-                @record.update!(name:) if name.present?
-                # Morph in place (keep caret), THEN focus the next field:
-                reply.morph.js(js.focus("[name=next_field]"))
-              end
-            RUBY
-            DocsUI::Prose() do
-              p do
-                plain 'When the morph target is a '
-                em { 'sibling' }
-                plain ' cell rather than the field you are typing in, prefer '
-                code { 'reply.streams' }
-                plain ' — it emits exactly the streams you name plus a tiny token-only refresh (no full-self '
-                plain 'replace), so a neighbouring '
-                code { '<input>' }
-                plain ' the user is mid-typing in is never torn down while the total cell updates.'
-              end
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              def update(quantity:, price:)
-                @item.update!(quantity:, price:)
-                reply.streams(Totals.update(@item))   # re-stream ONLY the total cell
-              end
-            RUBY
-          end
-        end
-
-        def broadcasting
-          DocsUI::Section('Want it to update other viewers too?') do
-            DocsUI::Prose() do
-              p { plain 'Broadcast on save.' }
-            end
-            DocsUI::Code(<<~RUBY, lexer: :ruby)
-              def save(value:)
-                authorize! @record, :update?
-                @record.update!(@attribute => value)
-                @editing = false
-                Fields::InlineEdit.broadcast_replace_to(
-                  @record, model: @record, attribute: @attribute
-                )
-              end
-            RUBY
             DocsUI::Callout(:tip) do
-              plain 'Now everyone viewing that record sees the new value land in place.'
+              md <<~MD
+                Both widgets bind to their own demo record, so editing them here
+                won't touch the [live todo list](/docs/example-todo-list). In your
+                app the same `InlineEditComponent` works against any record +
+                attribute — `render InlineEditComponent.new(record: @user,
+                attribute: :name)`.
+              MD
             end
           end
+        end
+
+        # Dedicated demo records, found-or-created so repeated page renders reuse
+        # one row instead of piling up duplicates. Kept separate from the todo-list
+        # rows so editing here is isolated.
+        def inline_demo_todo
+          Todo.find_or_create_by!(title: 'Click me to rename inline')
+        end
+
+        def dirty_demo_todo
+          Todo.find_or_create_by!(title: 'Edit me to see the Unsaved badge')
         end
       end
     end

--- a/docs/app/views/docs/pages/example_loading_states.rb
+++ b/docs/app/views/docs/pages/example_loading_states.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      class ExampleLoadingStates < DocsUI::Page
+        title 'Example: loading states'
+        eyebrow 'Examples'
+
+        def lead
+          'Declarative pending affordances — `disable_with:` swaps a button label ' \
+            'and disables it in flight, `busy_on` reveals a scoped spinner, and the ' \
+            'always-on `aria-busy` / `data-reactive-busy` hooks let you style the ' \
+            'wait with pure CSS. No Stimulus, no bespoke JavaScript.'
+        end
+
+        def content
+          try_it
+          disable_with
+          busy
+          double_submit
+          notes
+        end
+
+        private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              A localhost round trip is ~5 ms — the pending window flashes by
+              before you can see it. **Flip the toggle on** and every reactive
+              action is delayed client-side, so the affordances below become
+              observable. It's a pure client concern: no token, no POST.
+            MD
+            render Views::Examples::LatencyToggle.new(delay_ms: 500)
+            render Views::Examples::LiveExample.new(
+              component: LoadingButtonComponent.new(count: 0),
+              filename: 'app/components/loading_button_component.rb'
+            )
+          end
+        end
+
+        def disable_with
+          DocsUI::Section('disable_with: — swap the label, disable in flight') do
+            md <<~MD
+              `on(:save, disable_with: "Saving…")` swaps the button's text and
+              disables it the instant the request is enqueued, reverting when the
+              round trip settles. It's the shorthand for
+              `loading: { disable: true, text: "Saving…" }` — Livewire's
+              `wire:loading` + `phx-disable-with` without a Stimulus controller.
+            MD
+          end
+        end
+
+        def busy
+          DocsUI::Section('busy_on — a scoped spinner, styled with CSS') do
+            md <<~MD
+              `busy_on(:save)` puts `data-reactive-busy` on an element ONLY while
+              `save` is in flight. Reveal it with pure CSS — here daisyUI's
+              `loading loading-spinner` — no Ruby toggles it. Every reactive root
+              also always carries `aria-busy="true"` during any in-flight action,
+              so you can style the whole component's wait state with an
+              attribute selector.
+            MD
+          end
+        end
+
+        def double_submit
+          DocsUI::Section('No double-submit — the disable IS the dedup') do
+            md <<~MD
+              With the latency simulator on, click **Save** twice quickly: the
+              count still advances by **one**. A disabled button fires no further
+              clicks, so the second press lands on a dead control and never
+              enqueues a second POST. The client queue serializes requests per
+              component; `disable_with:` is what dedupes them.
+            MD
+          end
+        end
+
+        def notes
+          DocsUI::Section('Notes') do
+            DocsUI::Callout(:tip) do
+              md <<~MD
+                The latency toggle is a docs convenience, not a gem feature you
+                ship. In your own app the simulator is exposed on
+                `window.PhlexReactive.enableLatencySim(ms)` when you author
+                `<meta name="phlex-reactive-env" content="development">` — see
+                [Installation](/docs/installation). Production stays untouched.
+              MD
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_notifications.rb
+++ b/docs/app/views/docs/pages/example_notifications.rb
@@ -13,6 +13,7 @@ module Views
         end
 
         def content
+          try_it
           intro
           badge
           who_receives
@@ -25,6 +26,23 @@ module Views
         end
 
         private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              A **real** live bell. Click "Simulate a background event" — it stands
+              in for a job finishing. The count bumps and the bell re-renders via a
+              `broadcast_replace_to`, so **every tab** you have open on this page
+              updates (open a second tab to see it). It also fires a
+              `broadcast_js_to` pulse — a whitelisted DOM op, not HTML — so the bell
+              on the *other* tabs bounces to grab attention, with no re-render at all.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: NotificationBellComponent.new(unread: 0),
+              filename: 'app/components/notification_bell_component.rb'
+            )
+          end
+        end
 
         def intro
           DocsUI::Section('When the server just pushes') do

--- a/docs/app/views/docs/pages/example_payment_split.rb
+++ b/docs/app/views/docs/pages/example_payment_split.rb
@@ -24,6 +24,7 @@ module Views
         end
 
         def content
+          try_live_compute
           two_variants
           what
           component
@@ -36,6 +37,24 @@ module Views
         end
 
         private
+
+        def try_live_compute
+          DocsUI::Section('Try it — a client-side compute') do
+            md <<~MD
+              Before the payment-split walkthrough, here's the `reactive_compute` +
+              `reactive_text` shape in its smallest form: a live post preview. Type
+              in the field — the heading mirrors the title and the counter recomputes
+              **in the browser with no round trip** (an `input->reactive#recompute`
+              runs the `preview` JS reducer). Click **Save** and the server persists
+              and re-renders, seeding the identical derived text — the one-math-two-
+              sites contract `reactive_compute` exists to enforce.
+            MD
+            render Views::Examples::LiveExample.new(
+              component: PostPreviewComponent.new(todo: preview_demo_todo),
+              filename: 'app/components/post_preview_component.rb'
+            )
+          end
+        end
 
         def two_variants
           DocsUI::Section('Two flavors of the same rebalance') do
@@ -355,6 +374,12 @@ module Views
               end
             end
           end
+        end
+
+        # A dedicated demo record for the live compute preview, found-or-created so
+        # repeated page renders reuse one row.
+        def preview_demo_todo
+          Todo.find_or_create_by!(title: 'Type here to preview')
         end
 
         def component_source

--- a/docs/app/views/docs/pages/example_team_inbox.rb
+++ b/docs/app/views/docs/pages/example_team_inbox.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      class ExampleTeamInbox < DocsUI::Page
+        title 'Example: Team inbox (the flagship)'
+        eyebrow 'Examples'
+
+        def lead
+          'One believable UI that composes the whole toolkit: reactive_collection ' \
+            'rows, an optimistic archive that reverts on failure, disable_with:, ' \
+            'cross-tab broadcasts, an on_client row menu, and error_flash — with no ' \
+            'Stimulus controller and no hand-picked Turbo target.'
+        end
+
+        def content
+          try_it
+          whats_here
+          the_container
+          the_row
+          revert
+          notes
+        end
+
+        private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              A real Team inbox. **Simulate incoming** pushes a new message (and
+              broadcasts it to teammates). Open a row's **⋯** menu (a pure client op)
+              to **Mark read** or **Archive**. Archive hides the row instantly and
+              confirms with a self-dismissing toast. Try archiving the **locked**
+              message — the server refuses, so the optimistic hide **reverts** and an
+              error flash explains why. Turn on the latency toggle to watch the
+              optimistic hide and the `disable_with:` guard.
+            MD
+            render Views::Examples::LatencyToggle.new(delay_ms: 700)
+            render Views::Examples::LiveExample.new(
+              component: TeamInboxComponent.new,
+              filename: 'app/components/team_inbox_component.rb'
+            )
+          end
+        end
+
+        def whats_here
+          DocsUI::Section('Every feature, in one component') do
+            md <<~MD
+              | Feature | Where |
+              |---|---|
+              | **`reactive_collection`** — rows + running count + empty-state declared once | the container |
+              | **Optimistic archive** — `optimistic: { hide: true }` hides the row in the same gesture | the row's Archive |
+              | **Revert on failure** — a denied archive snaps the row back + shows an error flash | the "locked" message |
+              | **`disable_with:`** — the Archive / Simulate buttons dedupe a double-click | container + row |
+              | **Cross-tab broadcast** — `broadcast_append_to` / `broadcast_remove_to` / `broadcast_replace_to` | every mutating action |
+              | **`on_client` menu** — the ⋯ kebab toggles with zero round trips | the row |
+              | **`error_flash` + `dismiss_after:`** — a self-dismissing confirmation / error toast | the reply |
+            MD
+          end
+        end
+
+        def the_container
+          DocsUI::Section('The container') do
+            md <<~MD
+              `TeamInboxComponent` declares the collection once and drives three
+              actions. `archive` removes the row + count + empty-state in one
+              `reply.remove`, broadcasts the removal to teammates, and chains a
+              `.flash(dismiss_after: 2000)`. `mark_read` persists + broadcasts the
+              updated row. `simulate_incoming` creates a message and
+              `broadcast_append_to`s it (excluding the actor, who gets it from their
+              own `reply.append`).
+            MD
+            DocsUI::Code(read_component('team_inbox_component.rb'),
+                         lexer: :ruby, filename: 'app/components/team_inbox_component.rb')
+          end
+        end
+
+        def the_row
+          DocsUI::Section('The row (tokenless — client menu + container dispatch)') do
+            md <<~MD
+              `InboxMessageComponent` carries **no token of its own**. Its ⋯ kebab is
+              a pure `on_client(:click, js.toggle(...))` — zero round trips. The
+              Archive / Mark-read buttons inside dispatch the *container's* actions
+              keyed by message id. Archive's `optimistic:` hint targets **this
+              row's** own id (`to: "#" + dom_id`) — not `:root`, because a tokenless
+              row's `:root` would hide the whole inbox — so only the archived row hides.
+            MD
+            DocsUI::Code(read_component('inbox_message_component.rb'),
+                         lexer: :ruby, filename: 'app/components/inbox_message_component.rb')
+          end
+        end
+
+        def revert
+          DocsUI::Section('Optimistic revert on failure') do
+            md <<~MD
+              The optimistic hint is **cosmetic and always reversible**. When the
+              archive of the locked message denies (a registered authorization error
+              → 403), the client replays the inverse: the row that was optimistically
+              hidden **snaps back**, and `error_flash` surfaces the reason. Nothing
+              was persisted, and the inbox is exactly as it was — the whole point of
+              an optimistic hint that can't drift from server truth.
+            MD
+            DocsUI::Callout(:tip) do
+              md <<~MD
+                This is the discipline that makes optimistic UI safe here: the hint
+                is a *guess* the server confirms or reverts. You never ship state to
+                the client and trust it back — the signed identity re-finds the
+                record, the action authorizes, and the reply is the source of truth.
+              MD
+            end
+          end
+        end
+
+        def notes
+          DocsUI::Section('Notes') do
+            md <<~MD
+              Open this page in **two tabs** and archive or mark-read in one — the
+              other updates live over the shared inbox stream
+              (`exclude: reactive_connection_id` keeps the actor from doubling). On
+              the deployed docs site this rides pgbus SSE; in dev/CI it's Action
+              Cable. The component is identical either way — the transport is a
+              config detail, not a code path.
+            MD
+          end
+        end
+
+        def read_component(basename)
+          Rails.root.join('app/reactive_components', basename).read.strip
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_todo_list.rb
+++ b/docs/app/views/docs/pages/example_todo_list.rb
@@ -8,17 +8,16 @@ module Views
         eyebrow 'Examples'
 
         def lead
-          'Per-row reactive components with add / toggle / rename / delete — optimistic delete, ' \
-            'Enter-to-add, morph-preserved inline rename, and a broadcast on change so the list ' \
-            'stays in sync across tabs and users. The canonical "list of records" pattern.'
+          'Per-row reactive components with add / toggle / rename / archive — ' \
+            'optimistic toggle and delete, Enter-to-add, a morph-preserved inline ' \
+            'rename, a client-only tips toggle, and a broadcast on every change so ' \
+            'the list stays in sync across tabs. The canonical "list of records" pattern.'
         end
 
         def content
-          live
-          model
-          row
-          list
-          collections
+          try_it
+          the_row
+          the_list
           broadcasting
           what_you_get
           keyed_lists
@@ -26,7 +25,7 @@ module Views
 
         private
 
-        def live
+        def try_it
           DocsUI::Section('Try it') do
             md <<~MD
               This is a **real** reactive list rendered right here — not a
@@ -34,258 +33,74 @@ module Views
               inline, or archive it. Each interaction POSTs to `/reactive/actions`,
               the server rebuilds the component from its signed token, runs the
               action, and re-renders in place — no Stimulus controller and no
-              `.turbo_stream.erb` anywhere.
+              `.turbo_stream.erb` anywhere. Turn on the latency toggle to watch the
+              optimistic toggle/hide and the `disable_with:` guard.
             MD
-            render TodoListComponent.new
+            render Views::Examples::LatencyToggle.new(delay_ms: 600)
+            render Views::Examples::LiveExample.new(
+              component: TodoListComponent.new,
+              filename: 'app/components/todo_list_component.rb'
+            )
           end
         end
 
-        def model
-          DocsUI::Section('Model') do
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/models/todo.rb')
-              class Todo < ApplicationRecord
-                belongs_to :list
-                validates :title, presence: true
-                # Live cross-client sync over pgbus SSE — transactional, reconnect-safe.
-                broadcasts_to ->(t) { [t.list, :todos] }, durable: true
-              end
-            RUBY
-            md <<~MD
-              `broadcasts_to` here only fires Turbo's default per-record
-              broadcasts. We drive the precise UI updates from the reactive
-              actions below (clearer for a component-rendered list), so you can
-              also omit `broadcasts_to` and broadcast explicitly — shown inline.
-            MD
-          end
-        end
-
-        def row
+        def the_row
           DocsUI::Section('One row (record-backed, all the actions)') do
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/todos/item.rb')
-              class Todos::Item < ApplicationComponent
-                include Phlex::Reactive::Component
-
-                reactive_record :todo                    # identity AND the default #id: dom_id(@todo)
-                action :toggle
-                action :rename, params: { title: :string }
-                action :cancel
-                action :destroy
-
-                def initialize(todo:) = @todo = todo
-                # no `def id` needed: reactive_record :todo defaults it to dom_id(@todo)
-
-                def toggle
-                  authorize! @todo, :update?
-                  @todo.update!(done: !@todo.done?)
-                  broadcast
-                end
-
-                # Escape discards the in-progress edit — just re-render the row
-                # from the persisted title (reply.morph keeps the caret, then the
-                # server value overwrites the input's live text).
-                def cancel = reply.morph
-
-                # Morph in place so the focused rename <input> + caret survive the
-                # re-render — the point of an inline editor (issue #28).
-                def rename(title:)
-                  authorize! @todo, :update?
-                  @todo.update!(title:) if title.present?
-                  broadcast
-                  reply.morph
-                end
-
-                def destroy
-                  authorize! @todo, :destroy?
-                  list = @todo.list
-                  @todo.destroy!
-                  # Suppress the actor's own echo — they already handled it via reply.remove.
-                  Todos::Item.broadcast_remove_to(list, :todos, model: @todo,
-                                                  exclude: reactive_connection_id)
-                  reply.remove                           # remove this tab's element in place
-                end
-
-                def view_template
-                  li(**reactive_root(class: ("done" if @todo.done?))) do
-                    # A checkbox that flips the INSTANT you click (optimistic: checked: :keep),
-                    # before the round trip; the morph reconciles from server truth, a failure snaps it back.
-                    input(type: "checkbox", checked: @todo.done?,
-                      **mix(on(:toggle, event: "change", optimistic: { checked: :keep }), name: "done"))
-
-                    # Enter saves the rename; Escape cancels (one action per element,
-                    # so cancel lives on its own control). event: is Stimulus's native
-                    # keyboard filter — the action fires only on that key, no custom JS.
-                    reactive_input(:title, value: @todo.title, **on(:rename, event: "keydown.enter"))
-                    button(**on(:cancel, event: "keydown.esc")) { "esc" }
-
-                    # Instant delete: hide the row NOW, remove it on the reply.
-                    button(**on(:destroy, confirm: "Delete?", disable_with: "…",
-                                optimistic: { hide: true, to: :root })) { "✕" }
-                  end
-                end
-
-                private
-
-                # Re-render this row into every OTHER subscribed tab — exclude the
-                # actor, whose own reply.morph / self-replace already updated them.
-                def broadcast
-                  Todos::Item.broadcast_replace_to(@todo.list, :todos, model: @todo,
-                                                   exclude: reactive_connection_id)
-                end
-              end
-            RUBY
             md <<~MD
-              **`reactive_input(:title, …)`** drops the magic `name:` — it emits
-              `<input name="title" …>` bound to the `rename` action's `title`
-              param, so the field's value always travels with the action.
+              Each row is `TodoItemComponent` — record-backed via
+              `reactive_record :todo`, so its identity is the Todo's GlobalID and
+              the token re-finds the record server-side (never trusts client
+              state). Its `#id` is `dom_id(@todo)`, the single source of truth for
+              the row: the morph target for its own actions AND for broadcasts.
 
-              **`optimistic: { checked: :keep }`** flips the checkbox client-side
-              the instant you click — without it the reactive controller's
-              `preventDefault` would leave the box unflipped until the morph
-              arrives. `optimistic: { hide: true, to: :root }` on delete hides the
-              row immediately; `reply.remove` then removes it, so it never flashes
-              back. Hints are cosmetic and always-reversible — a failed round trip
-              replays the inverse.
-
-              **`disable_with: "…"`** disables the delete button while the action
-              is in flight, so a rapid double-click fires the destroy exactly once.
-
-              **`reply.morph`** (rename) re-renders via Idiomorph, preserving the
-              focused input + caret — a plain `replace` would tear the field out
-              from under the typist. **`reply.remove`** (destroy) drops the actor's
-              own row with no doomed self re-render.
+              - **`optimistic: { checked: :keep }`** on the toggle flips the
+                checkbox the instant you click — without it the reactive
+                controller's `preventDefault` would leave the box unticked until
+                the morph arrives. `optimistic: { hide: true, to: :root }` on
+                archive hides the row immediately; `reply.remove` then drops it, so
+                it never flashes back. Hints are cosmetic and always reversible — a
+                failed round trip replays the inverse.
+              - **`reply.morph`** (rename) re-renders via Idiomorph, preserving the
+                focused input + caret — a plain `replace` would tear the field out
+                from under the typist. **`reply.remove`** (archive) drops the
+                actor's own row with no doomed self re-render.
+              - **`disable_with: "…"`** disables the archive button while the action
+                is in flight, so a rapid double-click fires archive exactly once.
             MD
+            DocsUI::Code(read_component('todo_item_component.rb'),
+                         lexer: :ruby, filename: 'app/components/todo_item_component.rb')
           end
         end
 
-        def list
+        def the_list
           DocsUI::Section('The list + composer') do
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/todos/list.rb')
-              class Todos::List < ApplicationComponent
-                include Phlex::Reactive::Component
-
-                reactive_record :list
-                action :add, params: { title: :string }
-
-                def initialize(list:) = @list = list
-                def id = dom_id(@list, :todos_panel)
-
-                def add(title:)
-                  authorize! @list, :update?
-                  title = title.to_s.strip
-                  return if title.blank?
-
-                  todo = @list.todos.create!(title:)
-                  # Append the new row into every OTHER subscribed tab. An append INSERTS
-                  # a child (not id-deduped like a replace), so without exclude: the actor
-                  # would get the row a second time on top of their own HTTP reply.
-                  Todos::Item.broadcast_append_to(@list, :todos, target: dom_id(@list, :todos),
-                                                  model: todo, exclude: reactive_connection_id)
-                end
-
-                def view_template
-                  div(**reactive_root) do
-                    turbo_stream_from @list, :todos                       # subscribe to live updates
-
-                    ul(id: dom_id(@list, :todos)) do
-                      @list.todos.order(:created_at).each { |t| render Todos::Item.new(todo: t) }
-                    end
-
-                    div do
-                      # Enter in the field adds the todo — the same :add action the
-                      # button fires on click. event: "keydown.enter" is Stimulus's
-                      # native keyboard filter, so only Enter dispatches.
-                      reactive_input(:title, placeholder: "New todo…", autocomplete: "off",
-                        **on(:add, event: "keydown.enter"))
-                      button(**on(:add, disable_with: "Adding…")) { "Add" }
-
-                      # Client-only reset: clear the composer with ZERO round trip —
-                      # no token, no POST, ever. Pure UX polish on its own trigger.
-                      button(**on_client(:click, js.set_attr("[name=title]", "value", ""))) { "Clear" }
-                    end
-                  end
-                end
-              end
-            RUBY
             md <<~MD
-              **`broadcast_append_to(..., exclude: reactive_connection_id)`** is
-              the load-bearing detail for a list. An `append` *inserts* a child —
-              it is not id-deduped the way a `replace`/`morph` of an existing
-              element is. Without `exclude:`, the actor's own subscribed tab would
-              receive the broadcast and append the new row a **second** time, on
-              top of the copy the action reply already rendered. (Toggle/rename use
-              `broadcast_replace_to`, which idiomorph *does* dedupe by dom id — so
-              the actor there is silently fine — but `exclude:` is still the
-              correct, consistent pattern.)
+              `TodoListComponent` renders one `TodoItemComponent` per row plus the
+              composer. Its `add` action creates the Todo, **broadcasts the new
+              row's component to every OTHER subscribed tab**, and re-renders self
+              so the actor sees the row and the empty-state clears.
 
-              **`disable_with: "Adding…"`** stops a rapid double-click on **Add**
-              from creating two todos; the button re-enables when the round trip
-              settles. **`on_client(:click, js.set_attr(...))`** on the Clear
-              button empties the field client-side with no token, no POST — a
-              zero-round-trip DOM op the one generic controller applies locally.
+              - **`broadcast_append_to(..., exclude: reactive_connection_id)`** is
+                the load-bearing detail. An `append` *inserts* a child — it is not
+                id-deduped the way a `replace`/`morph` of an existing element is.
+                Without `exclude:`, the actor's own subscribed tab would receive the
+                broadcast and append the row a **second** time, on top of the copy
+                the self re-render already rendered.
+              - **`disable_with: "Adding…"`** stops a rapid double-click on **Add**
+                from creating two todos.
+              - **`on_client(:click, js.toggle("#todo-tips"))`** on the Tips button
+                shows/hides the hint client-side with no token, no POST — a
+                zero-round-trip DOM op the one generic controller applies locally.
             MD
-          end
-        end
-
-        def collections
-          DocsUI::Section('One-call add/remove: reactive_collection') do
-            md <<~MD
-              Hand-deriving the container id, the count badge, and the empty-state
-              in every action gets repetitive. `reactive_collection` declares the
-              list contract **once**; an action then appends or removes a row with
-              a single `reply.append` / `reply.remove` that emits the row stream,
-              the count companion, and the empty-state toggle as ONE reply.
-            MD
-            DocsUI::Code(<<~RUBY, lexer: :ruby, filename: 'app/components/todos/list.rb')
-              class Todos::List < ApplicationComponent
-                include Phlex::Reactive::Component
-
-                reactive_record :list
-                action :add, params: { title: :string }
-                action :remove_todo, params: { id: :integer }
-
-                # Declare the row list once: the row component, the container id
-                # (a plain DOM id string), an optional count badge id, an optional
-                # empty-state component, and the live size resolver (a proc,
-                # instance_exec'd against the component).
-                reactive_collection :todos,
-                  item:      Todos::Item,
-                  container: "todos",
-                  count:     "todos-count",
-                  empty:     Todos::Empty,
-                  size:      -> { @list.todos.size }
-
-                def initialize(list:) = @list = list
-                def id = dom_id(@list, :todos_panel)
-
-                def add(title:)
-                  authorize! @list, :update?
-                  title = title.to_s.strip
-                  return if title.blank?
-
-                  todo = @list.todos.create!(title:)
-                  reply.append(:todos, todo)   # row + count + clears the empty-state, in one reply
-                end
-
-                def remove_todo(id:)
-                  authorize! @list, :update?
-                  @list.todos.find(id).destroy!
-                  reply.remove(:todos, id)     # row remove + count + restores the empty-state
-                end
-              end
-            RUBY
-            md <<~MD
-              `count:` and `empty:` are optional — a list with just rows omits them
-              and those streams simply aren't emitted. The row component
-              (`Todos::Item`) still owns its own toggle/rename/destroy actions; the
-              collection is only about the container-level add/remove reply.
-            MD
+            DocsUI::Code(read_component('todo_list_component.rb'),
+                         lexer: :ruby, filename: 'app/components/todo_list_component.rb')
           end
         end
 
         def broadcasting
           DocsUI::Section('Broadcasting: suppress the actor echo') do
             md <<~MD
-              Every mutating action above ends the same way: update the record,
+              Every mutating action ends the same way: update the record,
               **broadcast to the other tabs, and reconcile the actor via the HTTP
               reply.** The one rule that keeps it correct is
               `exclude: reactive_connection_id` on the broadcast:
@@ -297,7 +112,7 @@ module Views
                 is keyed by dom id, so idiomorph dedupes it for the actor even
                 without `exclude:`. Passing `exclude:` anyway keeps every action on
                 one consistent pattern and avoids a redundant echo.
-              - **`destroy` → `broadcast_remove_to`** — remove is idempotent, so a
+              - **`archive` → `broadcast_remove_to`** — remove is idempotent, so a
                 double remove is invisible; `exclude:` still spares the actor a
                 redundant echo they already handled via `reply.remove`.
             MD
@@ -316,25 +131,23 @@ module Views
         def what_you_get
           DocsUI::Section('What you get') do
             md <<~MD
-              - Toggle, rename, add, delete — all without a Stimulus controller or a
-                `.turbo_stream.erb`.
+              - Toggle, rename, add, archive — all without a Stimulus controller or
+                a `.turbo_stream.erb`.
               - **Optimistic delete + instant toggle** via
                 `optimistic: { hide: true }` / `optimistic: { checked: :keep }` — the
-                UI reacts in the same gesture, the morph reconciles from server truth,
-                and a failure snaps it back.
-              - **Enter-to-add and Enter-to-save** via `on(:add, event:
-                "keydown.enter")`, **Escape-to-cancel** via `event: "keydown.esc"` —
-                Stimulus's native keyboard filter, no custom JavaScript.
-              - **No double-submit:** `disable_with:` disables the Add / delete
+                UI reacts in the same gesture, the morph reconciles from server
+                truth, and a failure snaps it back.
+              - **Enter-to-add and Enter-to-save** via
+                `on(:add, event: "keydown.enter")` — Stimulus's native keyboard
+                filter, no custom JavaScript.
+              - **No double-submit:** `disable_with:` disables the Add / archive
                 buttons while their action is in flight.
-              - **Focus-preserving inline rename** via `reply.morph` (Idiomorph keeps
-                the caret in the field), and a client-cleared composer via
+              - **Focus-preserving inline rename** via `reply.morph` (Idiomorph
+                keeps the caret in the field), and a client-only tips toggle via
                 `on_client` + `js` — zero round trip.
-              - Every change broadcasts the affected **row** (not the whole list) over
-                pgbus SSE with `exclude: reactive_connection_id`, so other tabs/users
-                update with a minimal payload and the actor never doubles.
-              - `dom_id(@todo)` is the single source of truth for the row's identity:
-                the morph target for actions AND broadcasts.
+              - Every change broadcasts the affected **row** (not the whole list)
+                with `exclude: reactive_connection_id`, so other tabs update with a
+                minimal payload and the actor never doubles.
             MD
           end
         end
@@ -357,6 +170,12 @@ module Views
               MD
             end
           end
+        end
+
+        # Read a reactive component's own source off disk so the code shown on the
+        # page can never drift from the component the demo renders.
+        def read_component(basename)
+          Rails.root.join('app/reactive_components', basename).read.strip
         end
       end
     end

--- a/docs/app/views/docs/pages/examples_overview.rb
+++ b/docs/app/views/docs/pages/examples_overview.rb
@@ -10,7 +10,8 @@ module Views
         def lead
           'Concrete, copy-pasteable examples covering the common patterns. ' \
             'Each is a complete, working feature — with the live reactive ' \
-            'component rendered on its page, not a screenshot.'
+            'component rendered on its page and its source read straight off the ' \
+            'file, so the demo and the code can never drift.'
         end
 
         # One section only — an overview index stays scannable, and the auto-TOC
@@ -20,49 +21,50 @@ module Views
         def content
           DocsUI::Section('The examples') do
             md <<~MD
-              Each page below is a complete, working feature you can copy and
-              paste. They build from the smallest reactive component up to
-              record-backed actions, live broadcasts, and declared-once
-              collections — and each renders its **real** reactive component
-              inline so you can click it.
+              Each page below renders its **real** reactive component inline — click
+              it, it round-trips. They build from the smallest reactive component up
+              to record-backed actions, live broadcasts, declared-once collections,
+              and the flagship inbox that composes everything.
 
               | Example | What it shows |
               |---|---|
               | [Counter](/docs/example-counter) | State-backed — the smallest reactive component. Click → server → re-render, no DB row. |
-              | [Payment split](/docs/example-payment-split) | Live sum-to-total rebalancer: nested bracketed params, auto-collected siblings, a client-side `reactive_compute` total that paints before the debounced save. |
-              | [Cross-tab chat](/docs/example-chat) | Record-backed action **and broadcast** → live cross-tab sync in ~60 lines of Ruby, zero JS. |
-              | [Live todo list](/docs/example-todo-list) | Per-row record-backed components: add / toggle / rename / archive, Enter-to-add, morph-in-place, broadcast on change. |
-              | [Inline edit](/docs/example-inline-edit) | Show ↔ edit toggle: Enter saves, Escape cancels — replacing a Stimulus controller plus three routes. |
-              | [Notifications / badges](/docs/example-notifications) | Pure broadcast (no client action) — a job pushes a live re-render. |
-              | [Reactive collections](/docs/example-collections) | Add / remove rows + a running count + an empty state, declared **once** with `reactive_collection`. |
+              | [Payment split](/docs/example-payment-split) | Nested bracketed params, auto-collected siblings, and a live `reactive_compute` + `reactive_text` preview that paints before the debounced save. |
+              | [Cross-tab chat](/docs/example-chat) | Record-backed action **and broadcast** → live cross-tab sync, zero JS. |
+              | [Live todo list](/docs/example-todo-list) | Per-row record-backed components: add / toggle / rename / archive, optimistic toggle + delete, Enter-to-add, morph-in-place, broadcast on change. |
+              | [Inline edit + dirty tracking](/docs/example-inline-edit) | Show ↔ edit (Enter saves, Escape cancels) plus an “Unsaved” badge + leave-guard with zero shipped state. |
+              | [Notifications / badges](/docs/example-notifications) | Pure broadcast — a background event pushes a live re-render, plus a `broadcast_js_to` cross-tab pulse. |
+              | [Reactive collections](/docs/example-collections) | Add / remove rows + a running count + an empty state, declared **once** with `reactive_collection`, optimistic dismiss + a self-dismissing flash. |
+              | [Loading states](/docs/example-loading-states) | `disable_with:` + `busy_on` + the always-on `aria-busy`, with a latency toggle to make the pending window visible. |
+              | [Client-only ops](/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS. |
+              | [Failure surface](/docs/example-failure) | `error_flash` + `data-reactive-error` + `dismiss_after:` — what an adopter gets for free when an action fails. |
+              | [Team inbox (flagship)](/docs/example-team-inbox) | The whole toolkit in one UI: collection rows, optimistic archive that **reverts on failure**, cross-tab broadcast, an `on_client` kebab, and error flashes. |
 
-              **Scanning for a specific capability** — each headline feature is
-              showcased inside one of the examples above (or, for the combobox, a
-              live demo). The reference docs for each live in the
-              [README](https://github.com/mhenrixon/phlex-reactive#readme).
+              **Every headline feature now has a live page.** Pick a capability:
 
-              | Feature | Where it's shown |
+              | Feature | Where it's shown (live) |
               |---|---|
-              | **Client-only ops** — `on_client` + `js` (`show`/`hide`/`toggle`, `set_attr`/`toggle_attr`, `focus`, `dispatch`, transitions): zero round trips | [Todo list](/docs/example-todo-list), [Notifications](/docs/example-notifications) |
-              | **Client-side computes** — `reactive_compute` + `reactive_text` (a running total / live preview / char counter that paints with no round trip) | [Payment split](/docs/example-payment-split) |
-              | **Declarative loading states** — `loading:` / `disable_with:` / `busy_on` (+ the always-on `aria-busy` / `data-reactive-busy` you style with CSS) | [Payment split](/docs/example-payment-split), [Inline edit](/docs/example-inline-edit), [Collections](/docs/example-collections) |
+              | **Client-only ops** — `on_client` + `js` (`show`/`hide`/`toggle`, `set_attr`/`toggle_attr`, `focus`, `dispatch`, transitions): zero round trips | [Client-only ops](/docs/example-client-ops), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
+              | **Client-side computes** — `reactive_compute` + `reactive_text` (a live preview / char counter that paints with no round trip) | [Payment split](/docs/example-payment-split) |
+              | **Declarative loading states** — `loading:` / `disable_with:` / `busy_on` (+ the always-on `aria-busy` / `data-reactive-busy`) | [Loading states](/docs/example-loading-states), [Todo list](/docs/example-todo-list), [Collections](/docs/example-collections), [Team inbox](/docs/example-team-inbox) |
               | **Dirty-field tracking** — `dirty:` / `track_dirty:` / `warn_unsaved:` (enable Save only on change; warn before leaving) | [Inline edit](/docs/example-inline-edit) |
-              | **Optimistic visual hints** — `optimistic:` (flip a checkbox / hide a row the instant you click; revert on failure) | [Todo list](/docs/example-todo-list), [Collections](/docs/example-collections) |
+              | **Optimistic visual hints** — `optimistic:` (flip a checkbox / hide a row instantly; revert on failure) | [Todo list](/docs/example-todo-list), [Collections](/docs/example-collections), [Team inbox](/docs/example-team-inbox) |
               | **Keyboard triggers** — `event: "keydown.enter"` / `"keydown.esc"` (Enter-to-add, Escape-to-cancel) | [Todo list](/docs/example-todo-list), [Inline edit](/docs/example-inline-edit) |
-              | **Debounced / morph editing** — `debounce:` live-as-you-type + `reply.morph` to keep the focused field's caret | [Payment split](/docs/example-payment-split), [Inline edit](/docs/example-inline-edit) |
-              | **Live broadcasts** — `broadcast_replace_to` / `broadcast_append_to` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list) |
+              | **Debounced / morph editing** — `debounce:` live-as-you-type + `reply.morph` to keep the caret | [Payment split](/docs/example-payment-split), [Inline edit](/docs/example-inline-edit) |
+              | **Live broadcasts** — `broadcast_replace_to` / `broadcast_append_to` / `broadcast_js_to` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
+              | **Failure surface** — `error_flash` / `data-reactive-error` / `dismiss_after:` / timeout + offline | [Failure surface](/docs/example-failure), [Team inbox](/docs/example-team-inbox) |
               | **Combobox keyboard navigation** — `listnav:` (Arrow keys move a client highlight, Enter picks) | [Searchable combobox demo](/demos/searchable-combobox) |
             MD
 
             DocsUI::Callout(:note) do
               md <<~MD
                 **File uploads** (`:file` params / multipart `FormData`) and
-                **custom param types** (`Phlex::Reactive.param_type`) don't yet
-                have a worked example page — see the
-                [README](https://github.com/mhenrixon/phlex-reactive#readme) for
-                the reference. The [payment split](/docs/example-payment-split)
-                is the closest cousin: it's the nested-params / auto-collected
-                sibling-fields example that a `FormData` upload extends.
+                **custom param types** (`Phlex::Reactive.param_type`) don't yet have
+                a dedicated live example page — see the
+                [README](https://github.com/mhenrixon/phlex-reactive#readme) for the
+                reference. The [payment split](/docs/example-payment-split) is the
+                closest cousin: it's the nested-params / auto-collected sibling-fields
+                example that a `FormData` upload extends.
               MD
             end
           end

--- a/docs/app/views/examples/latency_toggle.rb
+++ b/docs/app/views/examples/latency_toggle.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Views
+  module Examples
+    # A labelled checkbox that turns the client latency simulator on/off for the
+    # whole tab. On a localhost round trip (~5 ms) the loading/optimistic
+    # affordances — `disable_with:` label swaps, the `busy_on` spinner, an
+    # `optimistic:` flip-then-reconcile — flash by too fast to see. Flip this on
+    # and every reactive action is delayed client-side, so those affordances
+    # become observable. It's a pure client concern: no reactive token, no POST.
+    #
+    # Drop it above any live example that demonstrates a pending/optimistic state.
+    #
+    #   render Views::Examples::LatencyToggle.new                # 400 ms default
+    #   render Views::Examples::LatencyToggle.new(delay_ms: 800) # slower, for a longer look
+    class LatencyToggle < Phlex::HTML
+      def initialize(delay_ms: 400)
+        @delay_ms = delay_ms
+      end
+
+      def view_template
+        label(class: 'not-prose my-4 flex w-fit cursor-pointer items-center gap-3 ' \
+                     'rounded-box border border-base-300 bg-base-200 px-4 py-2',
+              data: { testid: 'latency-toggle' }) do
+          input(
+            type: 'checkbox',
+            class: 'toggle toggle-sm toggle-primary',
+            data: {
+              testid: 'latency-toggle-input',
+              controller: 'latency-toggle',
+              latency_toggle_ms_value: @delay_ms,
+              action: 'change->latency-toggle#toggle'
+            }
+          )
+          span(class: 'flex flex-col') do
+            span(class: 'text-sm font-medium') { 'Simulate network latency' }
+            span(class: 'text-xs opacity-60') do
+              plain "Delay every action by #{@delay_ms} ms so the loading states are visible."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/examples/live_example.rb
+++ b/docs/app/views/examples/live_example.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Views
+  module Examples
+    # A drift-proof inline embed for an example DOC PAGE: render a REAL reactive
+    # component live AND show that same component's own source, read live off its
+    # file. Because the demo and the code come from ONE class, they can never
+    # diverge — the exact drift the docs are meant to warn adopters about.
+    #
+    # This is the docs-page cousin of Views::Examples::DemoPanel (the CSS-tab
+    # panel behind the /demos/* gallery): same "read the source you render"
+    # guarantee, but laid out inline for a prose page — the live component in a
+    # bordered box, then its source in a highlighted block.
+    #
+    #   render Views::Examples::LiveExample.new(
+    #     component: TodoListComponent.new,
+    #     filename: "app/components/todo_list_component.rb"
+    #   )
+    class LiveExample < Phlex::HTML
+      def initialize(component:, filename: nil, source: nil)
+        @component = component
+        @filename = filename
+        @source = source
+      end
+
+      def view_template
+        div(class: 'not-prose my-6 flex flex-col gap-4') do
+          live_demo
+          component_source_block
+        end
+      end
+
+      private
+
+      # The live component, rendered into a bordered box so it reads as "the demo"
+      # on a prose page. It self-targets its own #id and round-trips like anywhere.
+      def live_demo
+        div(class: 'rounded-box border border-base-300 bg-base-100 p-6',
+            data: { testid: 'live-example-demo' }) do
+          render @component
+        end
+      end
+
+      def component_source_block
+        DocsUI::Code(component_source, lexer: :ruby, filename: @filename)
+      end
+
+      # The component's own source. Prefer an explicit `source:` (for a source
+      # that isn't a single file — e.g. a trio of collaborating classes), else
+      # read the file backing this component's view_template. Falls back to the
+      # whole file, matching DemoPanel#component_source.
+      def component_source
+        return @source if @source
+
+        path = @component.class.instance_method(:view_template).source_location&.first
+        path ? File.read(path).strip : '# source unavailable'
+      end
+    end
+  end
+end

--- a/docs/config/importmap.rb
+++ b/docs/config/importmap.rb
@@ -5,3 +5,6 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+# Client-side compute reducers (reactive_compute). Registered on load in
+# application.js via setComputeReducer.
+pin_all_from "app/javascript/reducers", under: "reducers"

--- a/docs/config/initializers/phlex_reactive.rb
+++ b/docs/config/initializers/phlex_reactive.rb
@@ -10,6 +10,10 @@ Rails.application.config.after_initialize do
   # render-time undeclared-action guard because `boom` IS declared.
   Phlex::Reactive.authorization_errors << FailureSurfaceComponent::Denied
 
+  # The flagship Team inbox: a locked message refuses to archive. Registering the
+  # error maps the denial to a clean 403 so the client reverts the optimistic hide.
+  Phlex::Reactive.authorization_errors << TeamInboxComponent::Locked
+
   # With error_flash set, the endpoint renders a turbo-stream flash the browser
   # SHOWS on a failed action, and the client marks the root data-reactive-error.
   Phlex::Reactive.error_flash = ->(kind) { "Something went wrong (#{kind})." }

--- a/docs/config/initializers/phlex_reactive.rb
+++ b/docs/config/initializers/phlex_reactive.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# phlex-reactive config for the docs app. The defaults (renderer =
+# ActionController::Base, base_controller = ActionController::Base) already make
+# the record-backed demos work; this only wires the failure-surface example.
+Rails.application.config.after_initialize do
+  # Register the failure-surface demo's authorization error so a DECLARED action
+  # that denies returns a clean 403 (client kind=http) — mirroring how a real app
+  # registers Pundit::NotAuthorizedError. The page still renders under the
+  # render-time undeclared-action guard because `boom` IS declared.
+  Phlex::Reactive.authorization_errors << FailureSurfaceComponent::Denied
+
+  # With error_flash set, the endpoint renders a turbo-stream flash the browser
+  # SHOWS on a failed action, and the client marks the root data-reactive-error.
+  Phlex::Reactive.error_flash = ->(kind) { "Something went wrong (#{kind})." }
+end

--- a/docs/db/migrate/20260703202841_create_notifications.rb
+++ b/docs/db/migrate/20260703202841_create_notifications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notifications do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/docs/db/migrate/20260703210005_create_inbox_messages.rb
+++ b/docs/db/migrate/20260703210005_create_inbox_messages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateInboxMessages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :inbox_messages do |t|
+      t.string :subject, null: false
+      t.string :sender, null: false, default: 'system'
+      t.boolean :read, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/docs/db/schema.rb
+++ b/docs/db/schema.rb
@@ -10,12 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_190905) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_202841) do
   create_table "chat_messages", force: :cascade do |t|
     t.string "author", default: "anon", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.string "room", default: "lobby", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "title", null: false
     t.datetime "updated_at", null: false
   end
 

--- a/docs/db/schema.rb
+++ b/docs/db/schema.rb
@@ -10,12 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_202841) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_210005) do
   create_table "chat_messages", force: :cascade do |t|
     t.string "author", default: "anon", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.string "room", default: "lobby", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "inbox_messages", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "read", default: false, null: false
+    t.string "sender", default: "system", null: false
+    t.string "subject", null: false
     t.datetime "updated_at", null: false
   end
 

--- a/docs/db/seeds.rb
+++ b/docs/db/seeds.rb
@@ -14,6 +14,15 @@ if Notification.none?
   end
 end
 
+if InboxMessage.none?
+  [
+    { subject: 'Deploy to production finished', sender: 'ci' },
+    { subject: 'New signup: acme.co', sender: 'billing' },
+    { subject: 'Locked: compliance hold', sender: 'locked' }, # archive denies → optimistic revert demo
+    { subject: 'Weekly digest', sender: 'system', read: true }
+  ].each { |attrs| InboxMessage.create!(**attrs) }
+end
+
 if ChatMessage.where(room: 'lobby').none?
   [
     { author: 'ruby', body: 'Welcome to the phlex-reactive chat demo!' },

--- a/docs/db/seeds.rb
+++ b/docs/db/seeds.rb
@@ -2,15 +2,21 @@
 
 # Idempotent demo seed data so the deployed docs site has something to show in
 # the record-backed demos (Todos, Chat). Safe to run on every boot.
-if Todo.count.zero?
-  ["Try the searchable combobox", "Toggle me done", "Rename me inline"].each do |title|
+if Todo.none?
+  ['Try the searchable combobox', 'Toggle me done', 'Rename me inline'].each do |title|
     Todo.create!(title:)
   end
 end
 
-if ChatMessage.where(room: "lobby").none?
+if Notification.none?
+  ['Your build passed', 'New comment on your PR', 'Deploy to staging finished'].each do |title|
+    Notification.create!(title:)
+  end
+end
+
+if ChatMessage.where(room: 'lobby').none?
   [
-    { author: "ruby", body: "Welcome to the phlex-reactive chat demo!" },
-    { author: "you", body: "Send a message — it broadcasts with zero custom JS." }
-  ].each { |attrs| ChatMessage.create!(room: "lobby", **attrs) }
+    { author: 'ruby', body: 'Welcome to the phlex-reactive chat demo!' },
+    { author: 'you', body: 'Send a message — it broadcasts with zero custom JS.' }
+  ].each { |attrs| ChatMessage.create!(room: 'lobby', **attrs) }
 end

--- a/docs/spec/requests/dirty_form_spec.rb
+++ b/docs/spec/requests/dirty_form_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Dirty tracking: the signed root carries track_dirty:/warn_unsaved: descriptors,
+# and save morphs so the field re-renders with a fresh default (badge clears). The
+# dirty detection itself is client-side (defaultValue vs value) — the endpoint
+# contract is the persist + morph reply + the descriptors on the root.
+RSpec.describe 'DirtyForm actions', type: :request do
+  let!(:todo) { Todo.create!(title: 'original') }
+
+  it 'renders the track_dirty / warn_unsaved descriptors on the root' do
+    post_action(DirtyFormComponent, payload: { 'gid' => todo.to_gid.to_s },
+                                    act: 'save', params: { title: 'edited' })
+
+    # The root wires trackDirty on input and arms the unsaved-navigation guard.
+    expect(response.body).to include('trackDirty')
+    expect(response.body).to include('reactive-warn-unsaved')
+  end
+
+  it 'saves the title and morphs so the field default resets (badge clears)' do
+    post_action(DirtyFormComponent, payload: { 'gid' => todo.to_gid.to_s },
+                                    act: 'save', params: { title: 'edited' })
+
+    expect(todo.reload.title).to eq('edited')
+    expect(response.body).to include('method="morph"')
+    expect(response.body).to include('edited')
+  end
+
+  it 'ignores a blank title (presence guard)' do
+    post_action(DirtyFormComponent, payload: { 'gid' => todo.to_gid.to_s },
+                                    act: 'save', params: { title: '' })
+    expect(todo.reload.title).to eq('original')
+  end
+
+  it 'forbids an undeclared action' do
+    post_action(DirtyFormComponent, payload: { 'gid' => todo.to_gid.to_s }, act: 'wipe')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/failure_surface_spec.rb
+++ b/docs/spec/requests/failure_surface_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The failure surface (issue #100): a declared action that denies returns a clean
+# 403 (error registered in the initializer), the endpoint renders an error_flash,
+# and a normal action succeeds. flash_now emits a self-dismissing toast.
+RSpec.describe 'FailureSurface actions', type: :request do
+  it 'returns 403 and an error flash when the action denies' do
+    post_action(FailureSurfaceComponent, payload: { 's' => { 'count' => 0 } }, act: 'boom')
+
+    expect(response).to have_http_status(:forbidden)
+    # error_flash renders the configured message into the flash target.
+    expect(response.body).to include('Something went wrong')
+  end
+
+  it 'succeeds on a normal action and re-renders' do
+    post_action(FailureSurfaceComponent, payload: { 's' => { 'count' => 2 } }, act: 'succeed')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('target="failure-surface"')
+    expect(response.body).to match(/>\s*3\s*</)
+  end
+
+  it 'emits a self-dismissing flash on flash_now' do
+    post_action(FailureSurfaceComponent, payload: { 's' => { 'count' => 0 } }, act: 'flash_now')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('self-dismisses')
+    expect(response.body).to include('data-reactive-dismiss-after="2500"')
+  end
+
+  it 'forbids an undeclared action (default-deny)' do
+    post_action(FailureSurfaceComponent, payload: { 's' => { 'count' => 0 } }, act: 'nuke')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/inline_edit_spec.rb
+++ b/docs/spec/requests/inline_edit_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Inline edit: record-backed identity (GlobalID) + transient mode as signed state
+# (attribute/editing). The endpoint contract — enter edit, save through the schema,
+# cancel back to display, default-deny.
+RSpec.describe 'InlineEdit actions', type: :request do
+  let!(:todo) { Todo.create!(title: 'draft title') }
+
+  def payload = { 'gid' => todo.to_gid.to_s, 's' => { 'attribute' => 'title', 'editing' => false } }
+
+  it 'enters edit mode (renders the field + Save/Cancel)' do
+    post_action(InlineEditComponent, payload:, act: 'edit')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('data-testid="field"')
+    expect(response.body).to include('data-testid="save"')
+    expect(response.body).to include('data-testid="cancel"')
+  end
+
+  it 'saves the value through the declared schema and returns to display' do
+    editing = { 'gid' => todo.to_gid.to_s, 's' => { 'attribute' => 'title', 'editing' => true } }
+    post_action(InlineEditComponent, payload: editing, act: 'save', params: { value: 'final title' })
+
+    expect(todo.reload.title).to eq('final title')
+    expect(response.body).to include('data-testid="display"')
+    expect(response.body).to include('final title')
+  end
+
+  it 'cancels back to the display without changing the record' do
+    editing = { 'gid' => todo.to_gid.to_s, 's' => { 'attribute' => 'title', 'editing' => true } }
+    post_action(InlineEditComponent, payload: editing, act: 'cancel')
+
+    expect(todo.reload.title).to eq('draft title')
+    expect(response.body).to include('data-testid="display"')
+  end
+
+  it 'forbids an undeclared action' do
+    post_action(InlineEditComponent, payload:, act: 'delete_everything')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/loading_button_spec.rb
+++ b/docs/spec/requests/loading_button_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# State-backed loading-states demo: save bumps the signed count and re-renders.
+# The disable_with: / busy_on affordances are client-side, so the endpoint
+# contract is just the increment + default-deny.
+RSpec.describe 'LoadingButton actions', type: :request do
+  it 'increments the signed count on save' do
+    post_action(LoadingButtonComponent, payload: { 's' => { 'count' => 0 } }, act: 'save')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('target="loading-button"')
+    expect(response.body).to include('data-testid="save"')
+  end
+
+  it 'forbids an undeclared action (default-deny)' do
+    post_action(LoadingButtonComponent, payload: { 's' => { 'count' => 0 } }, act: 'nuke')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/notification_bell_spec.rb
+++ b/docs/spec/requests/notification_bell_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'turbo/broadcastable/test_helper'
+
+# The live notification bell: a simulate_event action bumps the unread count,
+# re-renders the bell, and broadcasts both the replaced bell and a broadcast_js_to
+# pulse to the other tabs.
+RSpec.describe 'Notification bell actions', type: :request do
+  include ActiveSupport::Testing::Assertions
+  include Turbo::Broadcastable::TestHelper
+
+  def simulate(unread: 0)
+    post_action(NotificationBellComponent, payload: { 's' => { 'unread' => unread } }, act: 'simulate_event')
+  end
+
+  it 'bumps the unread count and re-renders the bell' do
+    post_action(NotificationBellComponent, payload: { 's' => { 'unread' => 0 } }, act: 'simulate_event')
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('target="notification-bell"')
+    expect(response.body).to include('data-testid="bell-count"')
+    expect(response.body).to match(/>\s*1\s*</)
+  end
+
+  it 'broadcasts the replaced bell + a reactive:js pulse to the stream' do
+    broadcasts = capture_turbo_stream_broadcasts(NotificationBellComponent::STREAM) do
+      simulate(unread: 2)
+    end
+
+    html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+    # The replace carries the bumped count to every subscribed tab.
+    expect(html).to include('action="replace"')
+    expect(html).to include('target="notification-bell"')
+    # The broadcast_js_to nudge ships a whitelisted DOM op (no HTML re-render).
+    expect(html).to include('reactive:js')
+    expect(html).to include('animate-bounce')
+  end
+
+  it 'forbids an undeclared action (default-deny)' do
+    post_action(NotificationBellComponent, payload: { 's' => { 'unread' => 0 } }, act: 'spam')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/notifications_spec.rb
+++ b/docs/spec/requests/notifications_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# reactive_collection (issue #35): the list declares the contract once, and add /
+# dismiss emit the row + count + empty-state toggle as ONE reply each. State-backed
+# — the size resolver reads the live DB count.
+RSpec.describe 'Notifications collection', type: :request do
+  def list_payload = { 's' => {} }
+
+  describe '#add' do
+    it 'creates a notification and appends the row + count + clears empty' do
+      expect do
+        post_action(NotificationsListComponent, payload: list_payload,
+                                                act: 'add', params: { title: 'Build finished' })
+      end.to change(Notification, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Build finished')
+      # The collection reply targets the container + the count companion.
+      expect(response.body).to include('target="notifications"')
+      expect(response.body).to include('notifications-count')
+    end
+
+    it 'ignores a blank title' do
+      expect do
+        post_action(NotificationsListComponent, payload: list_payload, act: 'add', params: { title: '  ' })
+      end.not_to change(Notification, :count)
+    end
+  end
+
+  describe '#dismiss' do
+    let!(:notification) { Notification.create!(title: 'Dismiss me') }
+
+    it 'removes the row + count + restores empty, with a self-dismissing flash' do
+      expect do
+        post_action(NotificationsListComponent, payload: list_payload,
+                                                act: 'dismiss', params: { id: notification.id })
+      end.to change(Notification, :count).by(-1)
+
+      expect(response.body).to include('action="remove"')
+      # The dismiss_after: flash carries the self-dismiss schedule attribute.
+      expect(response.body).to include('Notification dismissed')
+      expect(response.body).to include('data-reactive-dismiss-after="3000"')
+    end
+  end
+
+  it 'forbids an undeclared action (default-deny)' do
+    post_action(NotificationsListComponent, payload: list_payload, act: 'purge', params: { title: 'x' })
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/post_preview_spec.rb
+++ b/docs/spec/requests/post_preview_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# reactive_compute + reactive_text (issue #104): the client mirrors the title and
+# recomputes the char counter with no round trip; save reconciles server-side. The
+# endpoint contract is the persist + the seeded derived text on re-render.
+RSpec.describe 'PostPreview actions', type: :request do
+  let!(:todo) { Todo.create!(title: 'hello') }
+
+  it 'saves the title and seeds the derived preview + counter on re-render' do
+    post_action(PostPreviewComponent, payload: { 'gid' => todo.to_gid.to_s },
+                                      act: 'save', params: { title: 'a longer title' })
+
+    expect(todo.reload.title).to eq('a longer title')
+    # The identity mirror + the reducer output are both seeded server-side.
+    expect(response.body).to include('data-reactive-text="title"')
+    expect(response.body).to include('data-reactive-text="char_count"')
+    # The seeded counter matches the Ruby twin ("<len>/80").
+    expect(response.body).to include('14/80')
+    # The server-only echo confirms the persisted value.
+    expect(response.body).to include('a longer title')
+  end
+
+  it 'carries the compute binding on the root so the client reducer can find it' do
+    post_action(PostPreviewComponent, payload: { 'gid' => todo.to_gid.to_s },
+                                      act: 'save', params: { title: 'x' })
+    expect(response.body).to include('data-reactive-compute')
+  end
+
+  it 'forbids an undeclared action' do
+    post_action(PostPreviewComponent, payload: { 'gid' => todo.to_gid.to_s }, act: 'nuke')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/team_inbox_spec.rb
+++ b/docs/spec/requests/team_inbox_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'turbo/broadcastable/test_helper'
+
+# The flagship Team inbox: reactive_collection archive/mark-read/simulate, cross-tab
+# broadcasts, and a denied archive of a locked message (optimistic revert).
+RSpec.describe 'Team inbox actions', type: :request do
+  include ActiveSupport::Testing::Assertions
+  include Turbo::Broadcastable::TestHelper
+
+  def inbox_payload = { 's' => {} }
+
+  describe '#archive' do
+    let!(:message) { InboxMessage.create!(subject: 'Deploy finished', sender: 'ci') }
+
+    it 'removes the row + count + empty and confirms with a self-dismissing flash' do
+      expect do
+        post_action(TeamInboxComponent, payload: inbox_payload, act: 'archive', params: { id: message.id })
+      end.to change(InboxMessage, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="remove"')
+      expect(response.body).to include('inbox-count')
+      expect(response.body).to include('data-reactive-dismiss-after="2000"')
+    end
+
+    it 'broadcasts the removal to teammates' do
+      broadcasts = capture_turbo_stream_broadcasts(InboxMessage.stream_key) do
+        post_action(TeamInboxComponent, payload: inbox_payload, act: 'archive', params: { id: message.id })
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="remove"')
+    end
+  end
+
+  describe '#archive on a locked message (optimistic revert)' do
+    let!(:locked) { InboxMessage.create!(subject: 'Compliance hold', sender: 'locked') }
+
+    it 'denies with a 403 and does NOT destroy the record' do
+      expect do
+        post_action(TeamInboxComponent, payload: inbox_payload, act: 'archive', params: { id: locked.id })
+      end.not_to change(InboxMessage, :count)
+
+      expect(response).to have_http_status(:forbidden)
+      # error_flash surfaces the reason; the client reverts the optimistic hide.
+      expect(response.body).to include('Something went wrong')
+    end
+  end
+
+  describe '#mark_read' do
+    let!(:message) { InboxMessage.create!(subject: 'New signup', sender: 'billing', read: false) }
+
+    it 'marks the message read and re-renders' do
+      post_action(TeamInboxComponent, payload: inbox_payload, act: 'mark_read', params: { id: message.id })
+      expect(message.reload.read?).to be(true)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#simulate_incoming' do
+    it 'creates a message and appends the row + count' do
+      expect do
+        post_action(TeamInboxComponent, payload: inbox_payload, act: 'simulate_incoming')
+      end.to change(InboxMessage, :count).by(1)
+
+      expect(response.body).to include('target="inbox-messages"')
+    end
+  end
+
+  it 'forbids an undeclared action (default-deny)' do
+    post_action(TeamInboxComponent, payload: inbox_payload, act: 'delete_all')
+    expect(response).to have_http_status(:forbidden)
+  end
+end

--- a/docs/spec/requests/todos_spec.rb
+++ b/docs/spec/requests/todos_spec.rb
@@ -2,12 +2,13 @@
 
 require 'rails_helper'
 
-# Record-backed todos: the list adds, and each row toggles / renames / archives.
+# Record-backed todos: the list adds (broadcasting the new row to other tabs),
+# and each row toggles / renames / archives with optimistic hints + a broadcast.
 # Row identity is the Todo's GlobalID (reactive_record) — the record is re-found
 # server-side, never trusted from the client.
 RSpec.describe 'Todo actions', type: :request do
   describe 'TodoListComponent#add' do
-    it 'creates a todo from the declared title param' do
+    it 'creates a todo from the declared title param and re-renders the list' do
       expect do
         post_action(TodoListComponent, payload: { 's' => { 'build_token' => 'list' } },
                                        act: 'add', params: { title: 'write specs' })
@@ -15,6 +16,7 @@ RSpec.describe 'Todo actions', type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('write specs')
+      expect(response.body).to include('target="todo-list"')
     end
 
     it 'ignores a blank title' do
@@ -22,6 +24,21 @@ RSpec.describe 'Todo actions', type: :request do
         post_action(TodoListComponent, payload: { 's' => { 'build_token' => 'list' } },
                                        act: 'add', params: { title: '   ' })
       end.not_to change(Todo, :count)
+    end
+
+    it 'renders the empty-state when there are no rows' do
+      post_action(TodoListComponent, payload: { 's' => { 'build_token' => 'list' } },
+                                     act: 'add', params: { title: '' })
+      expect(response.body).to include('data-testid="todos-empty"')
+    end
+
+    it 'guards Add against a double-submit with disable_with:' do
+      # The signed root carries the loading hint so the client disables the button
+      # in flight. Assert it renders on the composed page (a fresh add re-render).
+      post_action(TodoListComponent, payload: { 's' => { 'build_token' => 'list' } },
+                                     act: 'add', params: { title: 'first' })
+      expect(response.body).to include('reactive-loading-param')
+      expect(response.body).to include('Adding…')
     end
   end
 
@@ -32,6 +49,12 @@ RSpec.describe 'Todo actions', type: :request do
       post_action(TodoItemComponent, payload: { 'gid' => todo.to_gid.to_s }, act: 'toggle')
       expect(response).to have_http_status(:ok)
       expect(todo.reload.done?).to be(true)
+    end
+
+    it 'renders the optimistic checkbox hint so the box flips before the round trip' do
+      post_action(TodoItemComponent, payload: { 'gid' => todo.to_gid.to_s }, act: 'toggle')
+      # checked: :keep emits the optimistic descriptor on the toggle control.
+      expect(response.body).to include('reactive-optimistic-param')
     end
 
     it 'renames through the declared schema and morphs so the field keeps focus' do

--- a/docs/spec/system/chat_example_spec.rb
+++ b/docs/spec/system/chat_example_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The live chat room embedded on the example page: sending a message creates it
+# and broadcasts it to the room stream — the same reactive round trip proven on
+# /demos/chat, now dogfooded inline on the docs page. (Delivery to the SENDER's
+# own tab needs a real pub/sub backend — pgbus in production; the in-process async
+# cable this demo runs on fans out cross-CLIENT, so a single session asserts the
+# create + the round trip, not a same-tab echo. See the component's own note.)
+RSpec.describe 'Chat example page', type: :system do
+  before { ChatMessage.delete_all }
+
+  it 'renders the live chat room and sends a message (created + composer clears)' do
+    visit '/docs/example-chat'
+    page.execute_script("window.__noReload = 'alive'")
+
+    within first("[data-testid='live-example-demo']") do
+      expect(page).to have_css("[data-testid='chat-messages']")
+      find("[data-testid='chat-input']").set('hello from the docs page')
+      find("[data-testid='chat-send']").click
+
+      # The reactive action creates the record and re-renders the composer clear.
+      expect(page).to have_field('body', with: '')
+    end
+
+    # The message was created and broadcast over the room stream — no full reload.
+    expect(page).to have_css("[data-testid='chat-messages']") # still on the page
+    expect(ChatMessage.where(body: 'hello from the docs page')).to exist
+    expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+end

--- a/docs/spec/system/client_ops_spec.rb
+++ b/docs/spec/system/client_ops_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# Issue #95: a component whose entire interactivity is on_client ops. The contract
+# is ZERO fetches — a fetch spy proves no click ever posts to the action endpoint.
+RSpec.describe 'Client-only ops', type: :system do
+  def install_fetch_spy
+    page.execute_script(<<~JS)
+      window.__fetches = 0
+      const original = window.fetch
+      window.fetch = function () { window.__fetches++; return original.apply(this, arguments) }
+    JS
+  end
+
+  it 'switches tabs, toggles a menu, and opens a drawer with ZERO fetches' do
+    visit '/docs/example-client-ops'
+    install_fetch_spy
+
+    within first("[data-testid='live-example-demo']") do
+      # Tabs: panel 1 shown by default, panel 2 hidden.
+      expect(page).to have_css("[data-testid='panel-1']", visible: :visible)
+      expect(page).to have_no_css("[data-testid='panel-2']", visible: :visible)
+
+      find("[data-testid='tab-2']").click
+      expect(page).to have_css("[data-testid='panel-2']", visible: :visible)
+      expect(page).to have_no_css("[data-testid='panel-1']", visible: :visible)
+
+      # Menu: open it with a client op.
+      find("[data-testid='menu-open']").click
+      expect(page).to have_css("[data-testid='menu']", visible: :visible)
+
+      # Drawer: opens (fade) and its first button receives focus.
+      find("[data-testid='drawer-open']").click
+      expect(page).to have_css("[data-testid='drawer']", visible: :visible)
+    end
+
+    # Click clearly OUTSIDE the component (the page heading) — the root's
+    # outside-close op hides the menu with no round trip.
+    find('h1').click
+    expect(page).to have_no_css("[data-testid='menu']", visible: :visible)
+
+    # The #95 contract: not a single fetch fired across all those interactions.
+    expect(page.evaluate_script('window.__fetches')).to eq(0)
+  end
+end

--- a/docs/spec/system/failure_surface_spec.rb
+++ b/docs/spec/system/failure_surface_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The failure surface (issue #100) in a real browser: a failed action reveals the
+# error banner (data-reactive-error) and shows an error flash; a successful action
+# clears it; flash_now shows a self-dismissing toast.
+RSpec.describe 'Failure surface', type: :system do
+  it 'reveals the error banner on a failed action and clears it on success' do
+    visit '/docs/example-failure'
+
+    within first("[data-testid='live-example-demo']") do
+      # The banner is hidden until an action fails.
+      expect(page).to have_no_css("[data-testid='error-banner']", visible: :visible)
+
+      find("[data-testid='boom']").click
+      # data-reactive-error is set on the root → the banner reveals via CSS.
+      expect(page).to have_css("[data-testid='error-banner']", visible: :visible)
+
+      # A successful action re-renders and clears the error.
+      find("[data-testid='succeed']").click
+      expect(page).to have_css("[data-testid='count']", text: '1')
+      expect(page).to have_no_css("[data-testid='error-banner']", visible: :visible)
+    end
+  end
+
+  it 'shows a self-dismissing flash on flash_now' do
+    visit '/docs/example-failure'
+
+    within first("[data-testid='live-example-demo']") do
+      find("[data-testid='flash-now']").click
+    end
+
+    # The toast appears (visible: :all — the flash toast layout is finicky under
+    # Capybara's strict visibility) then clears itself after dismiss_after: (2.5 s).
+    expect(page).to have_css("[data-testid='flash']", text: 'self-dismisses', visible: :all)
+    expect(page).to have_no_css("[data-testid='flash']", text: 'self-dismisses', visible: :all, wait: 5)
+  end
+end

--- a/docs/spec/system/inline_edit_spec.rb
+++ b/docs/spec/system/inline_edit_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# Inline edit + dirty tracking in a real browser: click-to-edit shows the field,
+# Save persists and returns to display, and the "Unsaved" badge appears on the
+# first keystroke and clears after a save — all without a full-page reload.
+RSpec.describe 'Inline edit + dirty tracking', type: :system do
+  before { Todo.delete_all }
+
+  it 'clicks to edit, saves, and returns to the display value' do
+    visit '/docs/example-inline-edit'
+    page.execute_script("window.__noReload = 'alive'")
+
+    within first("[data-testid='live-example-demo']") do
+      find("[data-testid='display']").click
+      field = find("[data-testid='field']")
+      field.set('Renamed in place')
+      find("[data-testid='save']").click
+
+      # Back to display mode, showing the persisted value (no field visible).
+      expect(page).to have_css("[data-testid='display']", text: 'Renamed in place')
+      expect(page).to have_no_css("[data-testid='field']")
+    end
+
+    expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+
+  it 'cancels an edit back to display mode without persisting' do
+    visit '/docs/example-inline-edit'
+
+    within first("[data-testid='live-example-demo']") do
+      find("[data-testid='display']").click
+      find("[data-testid='field']").set('discard this')
+      find("[data-testid='cancel']").click
+
+      # Back in display mode (field gone) and the discarded text was not saved.
+      expect(page).to have_css("[data-testid='display']")
+      expect(page).to have_no_css("[data-testid='field']")
+      expect(page).to have_no_text('discard this')
+    end
+  end
+
+  it 'shows the Unsaved badge on edit and clears it after save' do
+    visit '/docs/example-inline-edit'
+
+    # The dirty-form demo is the SECOND live example on the page.
+    within all("[data-testid='live-example-demo']")[1] do
+      expect(page).to have_no_css("[data-testid='dirty-badge']", visible: :visible)
+
+      find("[data-testid='title']").set('changed value')
+      expect(page).to have_css("[data-testid='dirty-badge']", visible: :visible, text: 'Unsaved')
+
+      find("[data-testid='save']").click
+      # After the morph the field's default resets to the saved value → clean.
+      expect(page).to have_no_css("[data-testid='dirty-badge']", visible: :visible)
+      expect(page).to have_css("[data-testid='current']", text: 'changed value')
+    end
+  end
+end

--- a/docs/spec/system/latency_toggle_spec.rb
+++ b/docs/spec/system/latency_toggle_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The docs-owned latency toggle (issue #149 step 2). The loading-states page ships
+# a FAST server action (LoadingButtonComponent#save has no sleep), so the busy
+# window is unobservable on localhost. Flipping the toggle injects a client-side
+# delay via the gem's enableLatencySim, making disable_with: + busy_on observable.
+RSpec.describe 'Latency toggle', type: :system do
+  it 'makes the disable_with: label + busy spinner observable when the sim is on' do
+    visit '/docs/example-loading-states'
+
+    # Baseline: the button reads "Save" and is enabled.
+    expect(page).to have_css("[data-testid='save']", text: 'Save')
+
+    # Flip the simulator on (500 ms delay, per the page).
+    find("[data-testid='latency-toggle-input']").click
+
+    # Click Save: during the injected delay the button label swaps to "Saving…",
+    # the button is disabled, and the scoped spinner carries data-reactive-busy.
+    find("[data-testid='save']").click
+
+    expect(page).to have_css("[data-testid='save'][disabled]", text: 'Saving…')
+    expect(page).to have_css("[data-testid='spinner'][data-reactive-busy]")
+
+    # After the round trip settles the button reverts and the count advanced once.
+    expect(page).to have_css("[data-testid='save']:not([disabled])", text: 'Save')
+    expect(page).to have_css("[data-testid='saved-count']", text: 'Saved 1 times')
+  end
+
+  it 'dedups a rapid double-click to a single POST (the disable IS the dedup)' do
+    visit '/docs/example-loading-states'
+    expect(page).to have_css("[data-testid='saved-count']", text: 'Saved 0 times')
+
+    # Fire two native clicks back-to-back via execute_script — Capybara's own
+    # click auto-waits for the button to re-enable, which would defeat the test.
+    # The first click enqueues the POST and disables the button (disable_with)
+    # before the second lands, so a disabled button swallows the second click.
+    page.execute_script(<<~JS)
+      const btn = document.querySelector("[data-testid='save']")
+      btn.click()
+      btn.click()
+    JS
+
+    # Exactly one increment landed — the second click hit a dead control.
+    expect(page).to have_css("[data-testid='saved-count']", text: 'Saved 1 times')
+    expect(page).to have_no_css("[data-testid='saved-count']", text: 'Saved 2 times')
+
+    # A THIRD click after the settle still works — the dedup is per pending
+    # window, not a permanent lock.
+    find("[data-testid='save']").click
+    expect(page).to have_css("[data-testid='saved-count']", text: 'Saved 2 times')
+  end
+
+  it 'stays instant with the simulator off (no observable busy window)' do
+    visit '/docs/example-loading-states'
+
+    # No toggle: the fast action settles immediately; the count advances with no
+    # lingering disabled/"Saving…" state to trip over.
+    find("[data-testid='save']").click
+    expect(page).to have_css("[data-testid='saved-count']", text: 'Saved 1 times')
+    expect(page).to have_css("[data-testid='save']:not([disabled])", text: 'Save')
+  end
+end

--- a/docs/spec/system/notification_bell_spec.rb
+++ b/docs/spec/system/notification_bell_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The live notification bell in a real browser: clicking "Simulate a background
+# event" bumps the unread count in place (the actor's own HTTP reply), proving the
+# pure-broadcast bell round-trips. (The cross-tab pulse needs a second tab, out of
+# scope for a single-session spec — its wire form is covered in the request spec.)
+RSpec.describe 'Notification bell', type: :system do
+  it 'bumps the unread count when a background event is simulated' do
+    visit '/docs/example-notifications'
+    page.execute_script("window.__noReload = 'alive'")
+
+    within first("[data-testid='live-example-demo']") do
+      expect(page).to have_no_css("[data-testid='bell-count']")
+
+      find("[data-testid='simulate']").click
+      expect(page).to have_css("[data-testid='bell-count']", text: '1')
+
+      find("[data-testid='simulate']").click
+      expect(page).to have_css("[data-testid='bell-count']", text: '2')
+    end
+
+    expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+end

--- a/docs/spec/system/notifications_collection_spec.rb
+++ b/docs/spec/system/notifications_collection_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# reactive_collection in a real browser: add appends a row + bumps the count +
+# clears the empty-state; dismiss removes it optimistically + restores the empty
+# state + shows a self-dismissing flash — all as single reply calls.
+RSpec.describe 'Reactive collections', type: :system do
+  before { Notification.delete_all }
+
+  it 'adds a row and bumps the running count' do
+    visit '/docs/example-collections'
+    expect(page).to have_css("[data-testid='empty-state']")
+    expect(page).to have_css("[data-testid='count']", text: '0')
+
+    find("[data-testid='new-notification']").set('Build finished')
+    find("[data-testid='add']").click
+
+    expect(page).to have_css("[data-testid='notification']", count: 1, text: 'Build finished')
+    expect(page).to have_css("[data-testid='count']", text: '1')
+    expect(page).to have_no_css("[data-testid='empty-state']")
+  end
+
+  it 'dismisses a row, restores the empty-state, and shows a self-dismissing flash' do
+    visit '/docs/example-collections'
+    find("[data-testid='new-notification']").set('Dismiss me')
+    find("[data-testid='add']").click
+    expect(page).to have_css("[data-testid='notification']", count: 1)
+
+    find("[data-testid='dismiss']").click
+
+    # The row is gone, the count is back to zero, and the empty-state returns.
+    expect(page).to have_no_css("[data-testid='notification']")
+    expect(page).to have_css("[data-testid='count']", text: '0')
+    expect(page).to have_css("[data-testid='empty-state']")
+
+    # The self-dismissing flash appeared, then clears itself (dismiss_after: 3 s).
+    expect(page).to have_css("[data-testid='flash']", text: 'Notification dismissed')
+    expect(page).to have_no_css("[data-testid='flash']", text: 'Notification dismissed', wait: 5)
+  end
+end

--- a/docs/spec/system/post_preview_spec.rb
+++ b/docs/spec/system/post_preview_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# reactive_compute + reactive_text in a real browser: the title heading mirrors
+# the field and the char counter recomputes IN-BROWSER on input (the "preview" JS
+# reducer, no round trip); Save reconciles through the server.
+RSpec.describe 'Live compute preview', type: :system do
+  before { Todo.delete_all }
+
+  it 'mirrors the title and recomputes the counter with no round trip' do
+    visit '/docs/example-payment-split'
+    page.execute_script(<<~JS)
+      window.__fetches = 0
+      const original = window.fetch
+      window.fetch = function () { window.__fetches++; return original.apply(this, arguments) }
+    JS
+
+    within first("[data-testid='live-example-demo']") do
+      field = find("[data-testid='title']")
+      field.set('Reactive compute')
+
+      # The identity mirror and the reducer output both update client-side.
+      expect(page).to have_css("[data-testid='preview']", text: 'Reactive compute')
+      expect(page).to have_css("[data-testid='counter']", text: '16/80')
+    end
+
+    # No POST happened for the live preview — it's a pure client compute.
+    expect(page.evaluate_script('window.__fetches')).to eq(0)
+  end
+
+  it 'reconciles through the server on Save' do
+    visit '/docs/example-payment-split'
+
+    within first("[data-testid='live-example-demo']") do
+      find("[data-testid='title']").set('Saved value')
+      find("[data-testid='save']").click
+
+      # The server-only echo confirms the round trip persisted + reconciled.
+      expect(page).to have_css("[data-testid='saved']", text: 'Saved value')
+    end
+  end
+end

--- a/docs/spec/system/team_inbox_spec.rb
+++ b/docs/spec/system/team_inbox_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The flagship Team inbox in a real browser: the happy path (kebab → archive
+# removes the row optimistically + count drops) AND the optimistic-revert path (a
+# locked message's archive denies, so the row snaps back).
+RSpec.describe 'Team inbox', type: :system do
+  before { InboxMessage.delete_all }
+
+  it 'archives a message via the kebab menu and drops the count' do
+    InboxMessage.create!(subject: 'Deploy finished', sender: 'ci')
+    visit '/docs/example-team-inbox'
+
+    within first("[data-testid='live-example-demo']") do
+      expect(page).to have_css("[data-testid='inbox-row']", count: 1)
+      expect(page).to have_css("[data-testid='inbox-count']", text: '1')
+
+      # The kebab is a pure client op — open it, then Archive.
+      within first("[data-testid='inbox-row']") do
+        find("[data-testid='kebab']").click
+        find("[data-testid='archive']").click
+      end
+
+      expect(page).to have_no_css("[data-testid='inbox-row']")
+      expect(page).to have_css("[data-testid='inbox-count']", text: '0')
+      expect(page).to have_css("[data-testid='inbox-empty']")
+    end
+  end
+
+  it 'reverts the optimistic hide when archiving a locked message is denied' do
+    InboxMessage.create!(subject: 'Compliance hold', sender: 'locked')
+    visit '/docs/example-team-inbox'
+
+    within first("[data-testid='live-example-demo']") do
+      expect(page).to have_css("[data-testid='inbox-row']", count: 1)
+
+      within first("[data-testid='inbox-row']") do
+        find("[data-testid='kebab']").click
+        find("[data-testid='archive']").click
+      end
+
+      # The archive denies (403), so the optimistically-hidden row SNAPS BACK and
+      # the count is unchanged — the record was never destroyed.
+      expect(page).to have_css("[data-testid='inbox-row']", count: 1, text: 'Compliance hold')
+      expect(page).to have_css("[data-testid='inbox-count']", text: '1')
+    end
+
+    expect(InboxMessage.where(subject: 'Compliance hold')).to exist
+  end
+
+  it 'pushes a new message with Simulate incoming' do
+    visit '/docs/example-team-inbox'
+
+    within first("[data-testid='live-example-demo']") do
+      expect(page).to have_css("[data-testid='inbox-empty']")
+      find("[data-testid='simulate-incoming']").click
+
+      expect(page).to have_css("[data-testid='inbox-row']", count: 1)
+      expect(page).to have_no_css("[data-testid='inbox-empty']")
+      expect(page).to have_css("[data-testid='inbox-count']", text: '1')
+    end
+  end
+end

--- a/docs/spec/system/todos_spec.rb
+++ b/docs/spec/system/todos_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The live todo list in a real browser: optimistic archive, the client-only Clear
+# button (zero fetch), and the empty-state — the richer behavior the example page
+# documents, now proven end-to-end.
+RSpec.describe 'Live todo list', type: :system do
+  # System specs drive a real server on a separate connection, so
+  # use_transactional_fixtures does NOT roll back rows the server created.
+  before { Todo.delete_all }
+
+  it 'shows the empty-state until the first todo is added' do
+    visit '/docs/example-todo-list'
+    expect(page).to have_css("[data-testid='todos-empty']")
+
+    find("[data-testid='new-todo']").set('first thing')
+    find("[data-testid='add']").click
+
+    expect(page).to have_css("[data-testid='todo']", count: 1)
+    expect(page).to have_no_css("[data-testid='todos-empty']")
+  end
+
+  it 'archives a row optimistically (it hides in the same gesture)' do
+    visit '/docs/example-todo-list'
+    find("[data-testid='new-todo']").set('archive me')
+    find("[data-testid='add']").click
+    expect(page).to have_css("[data-testid='todo']", count: 1)
+
+    within first("[data-testid='todo']") do
+      find("[data-testid='archive']").click
+    end
+
+    # reply.remove drops the row; the optimistic hide meant it disappeared the
+    # instant the button was clicked.
+    expect(page).to have_no_css("[data-testid='todo']")
+  end
+
+  it 'toggles the tips hint client-side with ZERO round trip' do
+    visit '/docs/example-todo-list'
+    page.execute_script("window.__noReload = 'alive'")
+
+    # The hint starts hidden; a client-only op flips it with no token, no POST.
+    expect(page).to have_no_css("[data-testid='todo-tips']", visible: :visible)
+    find("[data-testid='tips-toggle']").click
+    expect(page).to have_css("[data-testid='todo-tips']", visible: :visible, text: 'Press Enter')
+
+    # No todo was created and no full-page reload happened — pure client op.
+    expect(page).to have_no_css("[data-testid='todo']")
+    expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+
+  it 'toggles a row done and marks it via the re-render' do
+    visit '/docs/example-todo-list'
+    find("[data-testid='new-todo']").set('toggle me')
+    find("[data-testid='add']").click
+    expect(page).to have_css("[data-testid='todo']", count: 1)
+
+    within first("[data-testid='todo']") do
+      find("[data-testid='toggle']").click
+    end
+
+    expect(page).to have_css("[data-testid='todo'][data-done='true']")
+  end
+end

--- a/docs/spec/views/examples/live_example_spec.rb
+++ b/docs/spec/views/examples/live_example_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The drift-proof embed wrapper for the example pages: it renders a REAL reactive
+# component live AND reads that same component's own source file for the code
+# block, so the demo and the shown code can never diverge (the #148/DemoPanel
+# pattern, made reusable on a docs page).
+RSpec.describe Views::Examples::LiveExample, type: :request do
+  # Render the Phlex wrapper the way a docs page does — through the configured
+  # renderer's view context so dom_id/url_for/csrf work during the reactive
+  # component's render.
+  def render_wrapper(**)
+    Phlex::Reactive.renderer.render(described_class.new(**))
+  end
+
+  it 'renders the live component (the demo round-trips)' do
+    html = render_wrapper(component: CounterComponent.new(count: 0))
+
+    # The live demo box wraps the real component, which self-targets its own id.
+    expect(html).to include('data-testid="live-example-demo"')
+    expect(html).to include('id="counter"')
+    expect(html).to include('data-testid="inc"')
+  end
+
+  it 'reads the component source live from its own file (drift-proof)' do
+    html = render_wrapper(component: CounterComponent.new(count: 0))
+
+    # The code block shows the ACTUAL class source read off disk — not a
+    # hand-copied snippet — so a change to the component updates the docs too.
+    # (Rouge wraps each token in a <span>, so assert on identifiers that survive
+    # highlighting as a single token, not multi-token phrases.)
+    expect(html).to include('CounterComponent')
+    expect(html).to include('reactive_state')
+    expect(html).to include('bump_via_morph')
+  end
+
+  it 'passes an explicit source through verbatim when given (multi-class port)' do
+    html = render_wrapper(component: CounterComponent.new(count: 0),
+                          source: '# THREE collaborating classes shown together')
+
+    expect(html).to include('THREE collaborating classes')
+    # The explicit source wins — the file is not read.
+    expect(html).not_to include('reactive_state')
+  end
+
+  it 'labels the source with a copy-pasteable filename' do
+    html = render_wrapper(component: CounterComponent.new(count: 0),
+                          filename: 'app/components/counter_component.rb')
+
+    expect(html).to include('app/components/counter_component.rb')
+  end
+end


### PR DESCRIPTION
## Summary

Closes #149. The docs site's example pages had drifted from reality — 5 of 8 were prose + static code referencing components that don't exist, and the one live demo (todos) was a stub next to documentation of features it didn't implement. This makes **every example page run the live component it teaches**, with the source shown on the page **read straight off the real component file**, so code and demo can never drift again.

The whole `#95–#104` UX wave now has a live presence, plus a new flagship **Team inbox** that composes it all.

## What changed

**New drift-proof primitive**
- `Views::Examples::LiveExample` — renders a REAL reactive component live AND reads that same component's source off disk (the DemoPanel pattern, reusable on a prose page).
- A docs-owned **latency toggle** (`enableLatencySim`/`disableLatencySim` imported directly from the gem's client runtime — no gem gating change, works on the deployed demo site) that makes the loading/optimistic affordances observable on localhost.

**Fixed the todo drift**
- `TodoListComponent`/`TodoItemComponent` now implement the documented behavior: optimistic toggle + archive, `disable_with:`, `broadcast_*_to`, an `on_client` client-only op. The page reads their real source.

**Ported the spec-covered dummy fixtures → live pages**
- Inline edit + dirty tracking (`track_dirty:` / `warn_unsaved:`)
- Reactive collections (notifications trio: `reactive_collection`, optimistic dismiss, `dismiss_after:`)
- Live notification bell + `broadcast_js_to` cross-tab pulse
- `reactive_compute` + `reactive_text` variant on payment-split (new `preview` JS reducer)
- The existing chat room, now embedded on its example page
- Loading states (`disable_with:` / `busy_on`)
- Client-only ops (`on_client`, **zero fetches** — the #95 contract)
- Failure surface (`error_flash` + `data-reactive-error` + `dismiss_after:`)

**Flagship: Team inbox**
- `reactive_collection` rows + optimistic archive that **reverts on failure** (a locked message denies → the row snaps back) + `disable_with:` + cross-tab broadcast + an `on_client` kebab menu + `error_flash`. New `/demos/team-inbox` entry.

**Wiring & registries**
- New models: `Notification`, `InboxMessage` (with migrations); a `config/initializers/phlex_reactive.rb` registering the failure-surface + inbox authorization errors and `error_flash`.
- `examples_overview` rewritten so every feature maps to a LIVE page; README examples table + footer updated. The landing grid and docs links are data-driven, so they pick up the new demos automatically.

## Test coverage

Every page/demo has request + system specs (TDD, written before the port):
- Endpoint contracts: append/remove collection replies, optimistic descriptors, morph, `disable_with`, `error_flash` 403s, `dismiss_after`, broadcasts, default-deny.
- Browser loop: click → morph, the #95 **zero-fetch** assertion, the optimistic-revert-on-failure path, self-dismissing flashes, dirty badge, live compute with **zero fetches**.

## Verification

- `cd docs && bundle exec rubocop` — clean (110 app+spec files)
- docs request specs — **80 examples, 0 failures**
- docs system specs — **47 examples, 0 failures under Puma AND Falcon**
- gem suite (`spec/phlex spec/requests`) — **696 examples, 0 failures** (no gem code touched)
- Seeds run idempotently

## Scope

No gem code changes (`lib/`, `app/`) — pure docs work, as the issue required. The 48 pre-existing `Style/ItBlockParameter` offenses in the gem root exist identically on `main` and are out of scope. A live timeout/offline demo (which needs a page-level timeout meta that would affect other demos) is documented in prose + covered by the gem's own browser suite; the failure-surface page demos the 403 → `error_flash` path that shares the exact same client surface.

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
