### PR TITLE
docs: Actions & events guide, uploads example, README token-versioning (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1599,6 +1599,29 @@ real, so read this once.
   but if you have *public* reactive components, ensure the action path isn't
   force-redirected to a login page for logged-out users.
 
+### Token payload versioning
+
+The signed identity payload carries a version (`"v"`,
+`Phlex::Reactive::TOKEN_VERSION`) so a future change to the token *shape* can
+**upgrade tokens already in flight** instead of breaking every open page at
+deploy. When you change the shape, bump `TOKEN_VERSION` and register an upgrader:
+
+```ruby
+# config/initializers/phlex_reactive.rb
+Phlex::Reactive.register_token_upgrader(0) do |payload|
+  payload.merge("gid" => rewrite_old_gid(payload["gid"]))
+end
+```
+
+On verify, the payload runs through the upgrader chain (oldest → current) before
+your component rebuilds from it. A pre-versioning token (no `"v"`) is read as-is
+— introducing versioning invalidated nothing. It **fails closed**: a token signed
+by a *newer* deploy than the running code (a rollback) verifies its signature but
+carries an unknown version, so `Phlex::Reactive.verify` returns `nil` and the
+endpoint answers 400 — never guessing a shape it doesn't understand. See
+[the security guide](https://phlex-reactive.zoolutions.llc/docs/security#token-lifetime-rotation)
+for depth.
+
 ### Debugging endpoint failures (`verbose_errors`)
 
 Every endpoint failure is warn-logged as `[phlex-reactive] …` in **every**
@@ -1863,6 +1886,7 @@ the full layer-by-layer walkthrough.
 
 - [Installation & bundler setups](https://phlex-reactive.zoolutions.llc/docs/installation)
 - [Mental model & architecture](https://phlex-reactive.zoolutions.llc/docs/architecture)
+- [Actions & events (the `on(...)` API)](https://phlex-reactive.zoolutions.llc/docs/actions-events)
 - [Security & threat model](https://phlex-reactive.zoolutions.llc/docs/security)
 - [Broadcasting & live updates](https://phlex-reactive.zoolutions.llc/docs/broadcasting)
 - [Transport: pgbus vs Action Cable](https://phlex-reactive.zoolutions.llc/docs/transport-pgbus)
@@ -1874,6 +1898,7 @@ the full layer-by-layer walkthrough.
   [inline edit](https://phlex-reactive.zoolutions.llc/docs/example-inline-edit) ·
   [notifications](https://phlex-reactive.zoolutions.llc/docs/example-notifications) ·
   [collections](https://phlex-reactive.zoolutions.llc/docs/example-collections) ·
+  [file uploads & custom types](https://phlex-reactive.zoolutions.llc/docs/example-uploads) ·
   [loading states](https://phlex-reactive.zoolutions.llc/docs/example-loading-states) ·
   [client-only ops](https://phlex-reactive.zoolutions.llc/docs/example-client-ops) ·
   [failure surface](https://phlex-reactive.zoolutions.llc/docs/example-failure) ·

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -8,6 +8,7 @@ class Doc
   REGISTRY = [
     { slug: 'installation',          title: 'Installation',            group: 'Guide',    view: 'Installation' },
     { slug: 'architecture',          title: 'Architecture',            group: 'Guide',    view: 'Architecture' },
+    { slug: 'actions-events',        title: 'Actions & events',        group: 'Guide',    view: 'ActionsEvents' },
     { slug: 'security',              title: 'Security & threat model', group: 'Guide',    view: 'Security' },
     { slug: 'broadcasting',          title: 'Broadcasting',            group: 'Guide',    view: 'Broadcasting' },
     { slug: 'transport-pgbus',       title: 'Transport: pgbus',        group: 'Guide',    view: 'TransportPgbus' },
@@ -20,6 +21,8 @@ class Doc
     { slug: 'example-todo-list',     title: 'Todo list',               group: 'Examples', view: 'ExampleTodoList' },
     { slug: 'example-inline-edit',   title: 'Inline edit',             group: 'Examples', view: 'ExampleInlineEdit' },
     { slug: 'example-collections',   title: 'Collections',             group: 'Examples', view: 'ExampleCollections' },
+    { slug: 'example-uploads',       title: 'File uploads & custom types', group: 'Examples',
+      view: 'ExampleUploads' },
     { slug: 'example-notifications', title: 'Notifications',           group: 'Examples',
       view: 'ExampleNotifications' },
     { slug: 'example-chat',          title: 'Cross-tab chat',          group: 'Examples', view: 'ExampleChat' },

--- a/docs/app/views/docs/pages/actions_events.rb
+++ b/docs/app/views/docs/pages/actions_events.rb
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      # The reference home for the `on(...)` API — declaration, the param schema,
+      # event triggers, timing modifiers, and the page-level modifiers from #80.
+      # The param-types table mirrors the README (:355–385) so there is one source
+      # of truth for the names and semantics.
+      class ActionsEvents < DocsUI::Page
+        title 'Actions & events'
+        eyebrow 'Guide'
+
+        def lead
+          'How a DOM event becomes a server action: `action` declares what the ' \
+            'client may invoke, `on(...)` wires an element to it, a param schema ' \
+            'coerces the input, and event/timing modifiers cover the page-level ' \
+            'patterns that would otherwise need a hand-written Stimulus controller.'
+        end
+
+        def content
+          declaring
+          param_schema
+          custom_types
+          keyboard
+          timing
+          modifiers
+          reserved
+          client_only
+        end
+
+        private
+
+        def declaring
+          DocsUI::Section('Declaring an action, binding an event') do
+            md <<~MD
+              A reactive action is a two-step contract. `action :name` on the class
+              declares the method the client may invoke — **default-deny**, so a
+              public method with no `action` line is unreachable. `on(:name)` on an
+              element wires a DOM event to that action: it emits the signed
+              `data-reactive-*` attributes the one generic Stimulus controller reads.
+
+              ```ruby
+              class Counter < ApplicationComponent
+                include Phlex::Reactive::Component
+
+                reactive_record :counter
+                action :increment            # declared → invokable
+                action :decrement
+
+                def increment = @counter.increment!(:value)
+                def decrement = @counter.decrement!(:value)
+
+                def view_template
+                  div(**reactive_root) do
+                    button(**on(:decrement)) { "−" }
+                    span { @counter.value }
+                    button(**on(:increment)) { "+" }
+                  end
+                end
+              end
+              ```
+
+              `on(:action, event: "click")` defaults to a click and adds
+              `type="button"` (so a bare button inside a `<form>` can't submit it).
+              The event flows **client → endpoint → action → re-render**: the click
+              POSTs the signed token, the endpoint verifies it and runs the declared
+              method, and the component re-renders into its own `#id`. No routes, no
+              partial, no hand-picked Turbo target.
+            MD
+
+            DocsUI::Callout(:note, title: 'Combining on(...) with other attributes') do
+              md <<~MD
+                `on(...)` returns a `data:` hash. Merging it with another `data:`/
+                `class:` with a bare `**` **clobbers** the `data-action` the
+                descriptor rides on. Use Phlex's `mix` to deep-merge:
+
+                ```ruby
+                button(**mix(on(:increment), class: "btn", data: { testid: "inc" })) { "+" }
+                ```
+              MD
+            end
+          end
+        end
+
+        def param_schema
+          DocsUI::Section('Passing input — the param schema') do
+            md <<~MD
+              An action that takes input declares its params. Only declared keys
+              reach the method, each **coerced to its declared type**; anything not
+              in the schema is dropped before your method runs (no raw mass
+              assignment). The schema is **compiled once at declaration** — a typo'd
+              type symbol raises `Phlex::Reactive::UnknownParamType` at class load,
+              not silently at click time.
+
+              ```ruby
+              action :rename, params: { title: :string }
+              def rename(title:)
+                authorize! @todo, :update?      # the signature is not authorization
+                @todo.update!(title:)
+              end
+              ```
+
+              | Type | Coercion | Dropped when |
+              |---|---|---|
+              | `:string` | the default; used raw | — |
+              | `:integer` | `Integer(value)` | non-numeric |
+              | `:float` | `Float(value)` | non-numeric |
+              | `:boolean` | truthy string → `true`/`false` | — |
+              | `:date` | ISO8601 → `Date` | won't parse |
+              | `:datetime` | ISO8601 → `Time` | won't parse |
+              | `:decimal` | `BigDecimal(value)` | non-numeric |
+              | `:file` | `ActionDispatch::Http::UploadedFile`, untouched | a non-file value |
+
+              **Drop, don't fabricate.** A value that won't coerce is dropped, so the
+              method receives its keyword default — never a fabricated zero or a
+              coerced-to-string surprise. Give every declared param a default
+              (`def rename(title: nil)`) so a dropped value has somewhere to land.
+
+              Nested and array params compose. A `params: { invoice: { date: :string } }`
+              matches bracketed field names (`invoice[date]`) after the endpoint
+              expands the brackets — so the schema must mirror the field **names**,
+              not the conceptual params. A flat `{ date: :string }` against
+              `invoice[date]` inputs matches nothing and the value is silently
+              dropped.
+            MD
+
+            DocsUI::Callout(:tip, title: 'Files & multipart') do
+              md <<~MD
+                Declare `:file` (or `[:file]` for multiple) to accept an upload in a
+                reactive action. When the root holds a populated `<input type="file">`,
+                the client sends the action as multipart `FormData` instead of JSON —
+                same bracket-expanded field shape, so both bodies coerce identically.
+                See the [uploads example](/docs/example-uploads) for the full
+                walkthrough.
+              MD
+            end
+          end
+        end
+
+        def custom_types
+          DocsUI::Section('Custom param types (Phlex::Reactive.param_type)') do
+            md <<~'MD'
+              Register your own type in an initializer. The block receives the raw
+              client value and returns the coerced value, or
+              `Phlex::Reactive::ParamSchema::DROP` to reject it (the keyword default
+              then applies — the same drop-don't-fabricate contract as the built-ins).
+
+              ```ruby
+              # config/initializers/phlex_reactive.rb
+              Phlex::Reactive.param_type(:money) do |value|
+                if /\A\d+(\.\d{1,2})?\z/.match?(value.to_s)
+                  BigDecimal(value)
+                else
+                  Phlex::Reactive::ParamSchema::DROP
+                end
+              end
+
+              # then, in any component:
+              action :charge, params: { amount: :money }
+              def charge(amount:) = @invoice.charge!(amount)   # a BigDecimal, or unset
+              ```
+
+              A schema referencing a registered type is validated at declaration like
+              any built-in.
+            MD
+
+            DocsUI::Callout(:warning, title: 'Register during boot only') do
+              md <<~MD
+                The type registry is **frozen after initialization**. A runtime
+                `param_type` call raises — register every custom type from an
+                initializer, never lazily from a component.
+              MD
+            end
+          end
+        end
+
+        def keyboard
+          DocsUI::Section('Keyboard triggers (event:)') do
+            md <<~MD
+              `event:` is interpolated straight into the Stimulus action descriptor,
+              so any Stimulus event string works — including its native **keyboard
+              filters**. Pass `event: "keydown.enter"` to fire only on Enter,
+              `event: "keydown.esc"` for Escape — the classic "Enter adds the row",
+              "Escape cancels the edit" interactions, with no `event.key` check of
+              your own.
+
+              ```ruby
+              # Enter in the composer adds the todo (same action as the Add button).
+              input(**mix(on(:add, event: "keydown.enter"), name: "title", placeholder: "New todo…"))
+
+              # Inline editor: Enter saves; a separate control cancels on Escape.
+              input(**mix(on(:save, event: "keydown.enter"), name: "title", value: @todo.title))
+              button(**on(:cancel, event: "keydown.esc")) { "Cancel" }
+              ```
+
+              The filter tokens are Stimulus's own (`enter`, `esc`, `space`, `up`,
+              `down`, a bare letter, …). A keyboard trigger isn't a click, so it gets
+              **no** forced `type="button"`. Folding the key into `event:` keeps `key`
+              free as an ordinary action-param name.
+            MD
+
+            DocsUI::Callout(:note, title: 'One action per element') do
+              md <<~MD
+                Each trigger element carries a **single** reactive action, so you
+                can't put `on(:save, event: "keydown.enter")` and
+                `on(:cancel, event: "keydown.esc")` on the same input — the second
+                overwrites the first. Bind each key trigger to its own element.
+              MD
+            end
+          end
+        end
+
+        def timing
+          DocsUI::Section('Timing — debounce: and throttle:') do
+            md <<~MD
+              Two mutually-exclusive rate limiters shape how rapid events reach the
+              server. Passing both raises `ArgumentError`.
+
+              - **`debounce: 300` (trailing-edge)** coalesces rapid events into one
+                round trip fired after the quiet period — live-as-you-type without a
+                POST per keystroke. A blur flushes a pending dispatch so the last
+                edit is never dropped.
+              - **`throttle: 250` (leading-edge)** fires the first event immediately,
+                then drops further events until the window elapses — for a hot
+                trigger like `scroll` or `mousemove`.
+
+              ```ruby
+              # Recompute a total live as the user types, without hammering the endpoint.
+              input(**mix(on(:update, event: "input", debounce: 300), name: "quantity", value: @item.quantity))
+              ```
+            MD
+          end
+        end
+
+        def modifiers
+          DocsUI::Section('Page-level modifiers — window:, outside:, once:') do
+            md <<~MD
+              Three modifiers (issue #80) cover the page-level trigger patterns that
+              otherwise need a hand-written Stimulus controller:
+
+              - **`window: true`** binds the trigger to the window (Stimulus's native
+                `@window`) for page-level events like `scroll`/`resize`. A
+                window-bound trigger is **never `preventDefault`-ed** — a mounted
+                dropdown must not kill link clicks elsewhere — and skips the forced
+                `type="button"`.
+              - **`outside: true`** fires the action only for events whose target is
+                **outside** this component's root — the close-a-dropdown-on-outside-click
+                pattern. An event inside the root is a complete client-side no-op.
+                Implies `window: true`.
+              - **`once: true`** fires at most once, then unbinds (Stimulus's
+                `:once`).
+
+              ```ruby
+              # A dropdown that closes itself on any click outside — no Stimulus controller.
+              div(**mix(reactive_root, on(:close_menu, outside: true))) do
+                button(**on(:toggle_menu)) { "Menu" }
+                ul { menu_items } if @open
+              end
+
+              # Throttled page-scroll tracking.
+              div(**mix(reactive_root, on(:track, event: "scroll", window: true, throttle: 500)))
+              ```
+            MD
+          end
+        end
+
+        def reserved
+          DocsUI::Section('Reserved keyword names') do
+            md <<~MD
+              These keywords on `on(...)` are **reserved** — they configure the
+              trigger and are no longer usable as free action-param names. Everything
+              **not** on this list flows through as an action param (so
+              `on(:switch, key: "pgbus")` still passes `key` as a param):
+
+              | Keyword | Purpose |
+              |---|---|
+              | `event:` | the DOM event / Stimulus keyboard filter (`"click"`, `"keydown.enter"`, …) |
+              | `debounce:` | trailing-edge coalescing (ms) |
+              | `throttle:` | leading-edge rate limit (ms) |
+              | `window:` | bind to the window |
+              | `outside:` | fire only outside the root (implies `window:`) |
+              | `once:` | fire at most once |
+              | `confirm:` | gate behind a confirmation dialog |
+              | `listnav:` | combobox keyboard navigation |
+              | `optimistic:` | reversible cosmetic hint applied before the round trip |
+              | `loading:` / `disable_with:` | declarative pending state on the trigger |
+
+              A misspelled action surfaces early: with `Phlex::Reactive.verbose_errors`
+              on (the default in development and test), `on(:typo)` **raises at render
+              time** listing the declared actions, instead of an opaque 403 on click.
+              Production keeps the permissive emit so a stale page after a deploy that
+              removed an action never 500s on render.
+            MD
+          end
+        end
+
+        def client_only
+          DocsUI::Section('on_client — the same modifiers, zero round trips') do
+            md <<~MD
+              `on_client(:event, ops)` binds a DOM event to a chain of declared DOM
+              operations the controller applies **locally** — no token, no params, no
+              POST, ever. It's the zero-round-trip sibling of `on(...)`, for purely
+              presentational state (tabs, a dropdown, an accordion).
+
+              ```ruby
+              div(**mix(reactive_root, on_client(:click, js.hide("#menu"), outside: true))) do
+                button(**on_client(:click, js.show("#menu"))) { "Menu" }
+                div(id: "menu", hidden: true) { menu_items }
+              end
+              ```
+
+              `window:`, `once:`, and `outside:` compose **exactly** as they do on
+              `on(...)`: the menu above closes on any outside click, and the
+              window-bound trigger never `preventDefault`s. Reach for `on_client` when
+              the interaction is presentational; reach for a signed `action` (a token
+              + POST) only when the server must **decide** or **persist** something.
+              See the [client-only ops example](/docs/example-client-ops) for the live
+              version.
+            MD
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_uploads.rb
+++ b/docs/app/views/docs/pages/example_uploads.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      # A code-first walkthrough of file/multipart params and custom param types.
+      # Deliberately NOT a live demo — a public upload endpoint is a storage/abuse
+      # surface, and the docs app carries no ActiveStorage. The component shown is
+      # the dummy DocumentUploadComponent (#34/#39) reproduced inline as reference
+      # code (the docs are self-contained: the gem's spec/dummy is gone at deploy).
+      class ExampleUploads < DocsUI::Page
+        title 'File uploads & custom types'
+        eyebrow 'Examples'
+
+        def lead
+          'Accept a file in a reactive action — attach a document, receipt, or ' \
+            'image to a record without dropping out to a bespoke controller — and ' \
+            'register your own coerced param type. A code-first walkthrough; there ' \
+            'is no live upload demo (a public upload endpoint is a storage/abuse surface).'
+        end
+
+        def content
+          the_component
+          how_multipart
+          nested_and_meta
+          custom_types
+          checklist
+        end
+
+        private
+
+        def the_component
+          DocsUI::Section('A component that accepts a file') do
+            md <<~MD
+              Declare `:file` (or `[:file]` for multiple) in the action's param
+              schema. When the reactive root holds a populated `<input type="file">`,
+              the client sends the action as multipart `FormData` instead of JSON;
+              the endpoint coerces the declared `:file` param to the
+              `ActionDispatch::Http::UploadedFile` and passes it through untouched.
+              The action attaches it — the rest of the reactive flow (token
+              threading, re-render/morph) is identical.
+
+              ```ruby
+              class DocumentUploadComponent < ApplicationComponent
+                include Phlex::Reactive::Streamable
+                include Phlex::Reactive::Component
+
+                reactive_record :document
+
+                # Single-file path (has_one_attached). A caption rides alongside as a
+                # scalar field to prove multipart carries scalar params + the file.
+                action :upload, params: { file: :file, caption: :string }
+                # Multiple-file path (has_many_attached): [:file] coerces an array.
+                action :upload_pages, params: { pages: [:file] }
+
+                def initialize(document:) = @document = document
+
+                def id = dom_id(@document)
+
+                def upload(file: nil, caption: nil)
+                  @document.file.attach(file) if file
+                  @document.update!(title: caption) if caption.present?
+                end
+
+                def upload_pages(pages: nil)
+                  @document.pages.attach(pages) if pages.present?
+                end
+
+                def view_template
+                  div(**mix(reactive_attrs, id:)) do
+                    span { @document.title }
+                    form(**on(:upload, event: "submit")) do
+                      input(type: "file", name: "file")
+                      input(name: "caption")
+                      button(type: "submit") { "Upload" }
+                    end
+                  end
+                end
+              end
+              ```
+            MD
+          end
+        end
+
+        def how_multipart
+          DocsUI::Section('How the multipart path works') do
+            md <<~MD
+              Only the request **encoding** changes when a file is present — the
+              action never sees the difference:
+
+              - When a populated `<input type="file">` is in the root, the client
+                switches from a JSON body to multipart `FormData`.
+              - `token` and `act` ride as fields; scalar params (`caption`) ride as
+                fields; the file(s) are appended.
+              - The endpoint coerces `:file` to the uploaded file, passed through
+                untouched. A **non-file** value sent to a `:file` param is dropped
+                (the keyword default applies — never a fabricated file), the same
+                drop-don't-fabricate contract as every built-in type.
+              - `[:file]` coerces an **array** of uploads for a `has_many_attached`
+                target.
+
+              ```ruby
+              action :upload,       params: { file: :file, caption: :string }
+              action :upload_pages, params: { pages: [:file] }
+              ```
+            MD
+          end
+        end
+
+        def nested_and_meta
+          DocsUI::Section('A file alongside nested params (#39)') do
+            md <<~'MD'
+              A `:file` param can sit next to an explicit **nested-hash** param. On
+              the multipart path, nested and array params are **bracket-expanded**
+              into `params[key][sub]` / `params[key][index]` fields — the same
+              Rails-form shape a JSON body produces — so a JSON body and a multipart
+              body coerce **identically**. The nested `meta` used to be dropped on
+              the multipart path (issue #39); it now survives next to the file:
+
+              ```ruby
+              action :upload_with_meta,
+                params: { file: :file, meta: { tag: :string, year: :integer } }
+
+              def upload_with_meta(file: nil, meta: nil)
+                @document.file.attach(file) if file
+                @document.update!(title: "#{meta[:tag]} #{meta[:year]}") if meta
+              end
+              ```
+
+              The schema mirrors the field **names**, not the conceptual params — a
+              flat `{ tag: :string }` against `meta[tag]` inputs would match nothing
+              and drop silently. When in doubt, read a field's real `name` attribute
+              and shape the schema to it.
+            MD
+          end
+        end
+
+        def custom_types
+          DocsUI::Section('Registering a custom param type (:money)') do
+            md <<~'MD'
+              File params are one built-in type; you can register your own. In an
+              initializer, `Phlex::Reactive.param_type` takes a block that receives
+              the raw client value and returns the coerced value — or
+              `Phlex::Reactive::ParamSchema::DROP` to reject it, so the keyword
+              default applies (the same drop-don't-fabricate contract):
+
+              ```ruby
+              # config/initializers/phlex_reactive.rb
+              Phlex::Reactive.param_type(:money) do |value|
+                if /\A\d+(\.\d{1,2})?\z/.match?(value.to_s)
+                  BigDecimal(value)
+                else
+                  Phlex::Reactive::ParamSchema::DROP
+                end
+              end
+
+              # then, in any component:
+              action :charge, params: { amount: :money }
+              def charge(amount:) = @invoice.charge!(amount)   # a BigDecimal, or unset
+              ```
+            MD
+
+            DocsUI::Callout(:warning, title: 'Register during boot only') do
+              md <<~MD
+                The type registry is **frozen after initialization**, so a runtime
+                `param_type` call raises. A schema that references a registered type
+                is validated at declaration like any built-in — a typo raises
+                `Phlex::Reactive::UnknownParamType` at class load, not at click time.
+              MD
+            end
+          end
+        end
+
+        def checklist
+          DocsUI::Section('What this example proves') do
+            md <<~MD
+              - `:file` and `[:file]` accept single and multiple uploads in a
+                reactive action, coerced to `ActionDispatch::Http::UploadedFile`.
+              - Scalar params (`caption`) ride alongside the file through multipart.
+              - A nested-hash param (`meta`) survives next to the file (#39).
+              - A custom `param_type(:money)` coerces or drops, and is validated at
+                declaration.
+
+              For the reference detail, see
+              [Actions & events](/docs/actions-events) (the `on(...)` API and the
+              full param-types table) and the file-params note in
+              [Security](/docs/security).
+            MD
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/examples_overview.rb
+++ b/docs/app/views/docs/pages/examples_overview.rb
@@ -35,6 +35,7 @@ module Views
               | [Inline edit + dirty tracking](/docs/example-inline-edit) | Show ↔ edit (Enter saves, Escape cancels) plus an “Unsaved” badge + leave-guard with zero shipped state. |
               | [Notifications / badges](/docs/example-notifications) | Pure broadcast — a background event pushes a live re-render, plus a `broadcast_js_to` cross-tab pulse. |
               | [Reactive collections](/docs/example-collections) | Add / remove rows + a running count + an empty state, declared **once** with `reactive_collection`, optimistic dismiss + a self-dismissing flash. |
+              | [File uploads & custom types](/docs/example-uploads) | `:file` / `[:file]` params (multipart `FormData`), a nested-hash param alongside the file (#39), and a custom `Phlex::Reactive.param_type`. Code-first — no live demo. |
               | [Loading states](/docs/example-loading-states) | `disable_with:` + `busy_on` + the always-on `aria-busy`, with a latency toggle to make the pending window visible. |
               | [Client-only ops](/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS. |
               | [Failure surface](/docs/example-failure) | `error_flash` + `data-reactive-error` + `dismiss_after:` — what an adopter gets for free when an action fails. |
@@ -54,17 +55,18 @@ module Views
               | **Live broadcasts** — `broadcast_replace_to` / `broadcast_append_to` / `broadcast_js_to` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
               | **Failure surface** — `error_flash` / `data-reactive-error` / `dismiss_after:` / timeout + offline | [Failure surface](/docs/example-failure), [Team inbox](/docs/example-team-inbox) |
               | **Combobox keyboard navigation** — `listnav:` (Arrow keys move a client highlight, Enter picks) | [Searchable combobox demo](/demos/searchable-combobox) |
+              | **File uploads & custom param types** — `:file` / `[:file]` (multipart `FormData`), `Phlex::Reactive.param_type` | [File uploads & custom types](/docs/example-uploads) (code-first) |
             MD
 
             DocsUI::Callout(:note) do
               md <<~MD
-                **File uploads** (`:file` params / multipart `FormData`) and
-                **custom param types** (`Phlex::Reactive.param_type`) don't yet have
-                a dedicated live example page — see the
-                [README](https://github.com/mhenrixon/phlex-reactive#readme) for the
-                reference. The [payment split](/docs/example-payment-split) is the
-                closest cousin: it's the nested-params / auto-collected sibling-fields
-                example that a `FormData` upload extends.
+                **File uploads** (`:file` / `[:file]` params, multipart `FormData`)
+                and **custom param types** (`Phlex::Reactive.param_type`) have a
+                dedicated [code-first walkthrough](/docs/example-uploads) — no live
+                demo, because a public upload endpoint is a storage/abuse surface.
+                The [payment split](/docs/example-payment-split) is the closest live
+                cousin: the nested-params / auto-collected sibling-fields example that
+                a `FormData` upload extends.
               MD
             end
           end


### PR DESCRIPTION
Closes #150.

Closes the documentation coverage gaps found in the #79–#120 feature audit — without restructuring the README while the API is still settling (per the issue's decision to re-evaluate the split at 1.0).

## What changed

**New Guide page — Actions & events** (`docs/app/views/docs/pages/actions_events.rb`)

The reference home for the `on(...)` API, which the docs site's Guide group didn't own anywhere before:

- Action declaration + default-deny
- The param schema — built-in types (incl. `:date` / `:datetime` / `:decimal` / `:file`), custom `Phlex::Reactive.param_type`, and the boot-time `UnknownParamType` raise
- `event:` keyboard triggers (Enter-to-submit / Escape-to-cancel)
- `debounce:` (trailing) / `throttle:` (leading)
- The #80 modifiers — `window:` / `outside:` / `once:`
- The reserved-keyword list
- How `on_client` composes the same modifiers, zero round trips

Registered in the Guide group, right after Architecture.

**New example page — File uploads & custom types** (`example_uploads.rb`)

A code-first walkthrough (no live demo — a public upload endpoint is a storage/abuse surface, and the docs app carries no ActiveStorage):

- `:file` / `[:file]` multipart params
- A nested-hash param riding alongside a file (#39)
- A custom `:money` `param_type` recipe

Registered in the Examples group, after Collections.

**examples_overview.rb**

- Resolves the "no worked example yet" callout for uploads / custom types (they now have a page)
- Adds the uploads row to the examples table and the by-feature map

**README**

- New **Token payload versioning** subsection under Security (#111 was docs-site-only): `TOKEN_VERSION`, `register_token_upgrader`, upgrader chain, fails-closed on a rollback, links to the security page
- Adds the two new pages to the Documentation section

Docs-only. No gem code changes, no live upload demo, no README restructure. (The Concrete-examples-table collections row and the collections docs-link were already present on main, so those two audit items needed no change.)

## Test plan

- The docs request suite renders every registered page (iterates `Doc.all`), so both new pages are covered automatically — **23** page-render specs green (was 21 + 2 new); full docs request suite **82** examples green.
- Verified rendered content with a temporary spec (since removed): the reserved-keyword table, `UnknownParamType`, `param_type`, both cross-links, ≥6 TOC sections, code highlighting, `DocumentUploadComponent`, the `:money` recipe, and `FormData` all appear in the HTML.

## Verification gates

- [x] `cd docs && bundle exec rubocop` — no offenses (new pages autocorrected to the repo's unquoted-heredoc house style; the interpolation/regex blocks correctly kept `<<~'MD'`)
- [x] docs request specs green (every registered page renders, including the two new ones)
- [x] `bundle exec rubocop` (gem root) — no offenses (174 files); gem suite untouched
- [x] Nav shows the new pages in the intended order; all cross-linked slugs resolve

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
