### PR TITLE
chore(release): v0.9.0 release-prep — security + perf gates, changelog cut, upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-03
+
+Consolidates everything since 0.2.6; tags 0.2.7–0.4.8 shipped without changelog
+sections, so this section spans the whole run to 0.9.0. The jump from 0.4.8 to
+0.9.0 signals the Tier-2 API wave (#79–#120) and the run-up to 1.0, leaving 0.9.x
+room for dogfood fixes.
+
+### Upgrading from 0.4.x
+
+- **BREAKING — an unknown param-type symbol now raises at boot, not at click
+  time (#109).** A `params:` schema declared with a type the library doesn't know
+  (a typo like `:strng`, or a type you meant to register) raises
+  `Phlex::Reactive::UnknownParamType` when the component class loads — the schema
+  is compiled once at declaration. Fix the typo or register the type. Previously a
+  bad type symbol slipped through to the request and failed obscurely per click.
+- **Minimum Ruby is now 3.4** (was 3.2). Enabling the `it` block parameter
+  requires 3.4, so `required_ruby_version` is `>= 3.4.0`. Stay on the 0.3.x line
+  if you need Ruby 3.2/3.3.
+- **`optimistic:` / `loading:` / `disable_with:` are now RESERVED `on(...)`
+  keywords** (#98, #99), joining `window:` / `once:` / `outside:` / `throttle:`
+  from #80. If an action of yours took a free param literally named `optimistic`,
+  `loading`, or `disable_with`, rename it — those names now configure the
+  client-side hint/loading behavior instead of passing through as an action param.
+- **`flash_builder` → `stream_builder` rename (#113) — no action needed.** The
+  builder does far more than flashes, so it was renamed;
+  `Phlex::Reactive.flash_builder` and `reset_flash_builder!` remain **permanent
+  aliases** (no deprecation). Listed only for grep-ability if you referenced the
+  old names.
+- **The client runtime now ships pre-minified (#148) — zero change for importmap
+  consumers.** The engine pins the `.min.js` build (106 KB → 22 KB, ~7.7 KB
+  gzipped) with a linked sourcemap, so devtools still shows readable source. If
+  you vendor the client file by hand, re-vendor from the minified build (the
+  dummy app's `spec/dummy/public/vendor/reactive_controller.js` is that build).
+
+### Security
+
+- **The signed-token version (`v`) now fails closed on a malformed value.**
+  `upgrade_token` type-guards `v` before comparing it: a non-integer or negative
+  `v` (only producible with the signing key, or by operator error — `v` lives
+  inside the signed blob) now returns `nil` → `400` through the endpoint's
+  `|| raise(InvalidToken)`, instead of a 500 on the `v > TOKEN_VERSION`
+  comparison or silently treating a negative `v` as a legacy passthrough. The
+  fail-closed-on-rollback contract (a `v` newer than this code understands → 400)
+  is unchanged.
+- **The raw-array `js([...])` / `broadcast_js_to([...])` escape hatch now
+  re-applies the attribute-name allowlist server-side.** The `JS` builder rejects
+  event-handler (`on*`), URL-bearing, and `style` attribute names at build time;
+  the raw `[[op, args], …]` form skipped that Ruby-side check and relied on the
+  client interpreter alone. `Phlex::Reactive::JS.assert_ops_allowed!` restores
+  full server-side parity (defense in depth — the client still enforces it too),
+  so a hand-built ops array can't emit an `onclick`/`href`/`style` attr op.
+
 ### Changed
 
 - **One inheritance-aware registry behind the Component DSL; `component.rb` split
@@ -1552,7 +1604,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   scaffolds a reactive component (and an RSpec spec when the app uses RSpec),
   state-backed by default or record-backed with `--record`.
 
-[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/mhenrixon/phlex-reactive/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.6...v0.9.0
+[0.2.6]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.5...v0.2.6
+[0.2.5]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/mhenrixon/phlex-reactive/compare/v0.2.1...v0.2.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,27 @@ bundle exec rubocop                          # Lint (rubocop -A to autocorrect)
 bundle exec rake                             # spec + rubocop
 bundle exec rake bench                        # Performance micro-benches (render, token, coerce_params)
 bundle exec rake bench:request                # End-to-end request-cycle bench (derailed)
+rake build:js                                 # Rebuild the minified client (.min.js + .map) after editing reactive_controller.js
+rake build:js_check                           # CI drift guard: committed .min.js must match a fresh build
 ```
+
+### Editing the client runtime (`reactive_controller.js` / `confirm.js` / `compute.js`)
+
+The gem ships the **minified** build, and the browser suite runs that same
+minified build (the dummy vendors it). So a source edit is a THREE-file change:
+
+```bash
+rake build:js                                 # regenerate the .min.js + .map from source
+cp app/javascript/phlex/reactive/reactive_controller.min.js \
+   spec/dummy/public/vendor/reactive_controller.js   # re-sync the vendored copy (same for confirm/compute)
+bun test spec/javascript                      # JS unit suite
+```
+
+Commit the source, the rebuilt `.min.js`/`.map`, AND the re-synced vendored copy
+together. Two guards enforce it: `rake build:js_check` (committed min build matches
+a fresh build) and `spec/phlex/vendored_controller_sync_spec.rb` (vendored copy is
+byte-identical to the shipped `.min.js`). Its failure message prints the exact
+re-sync command.
 
 ## Slash Commands
 

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -446,6 +446,10 @@ module Phlex
       #     through the endpoint's existing `|| raise(InvalidToken)` → 400.
       def upgrade_token(payload)
         version = payload.fetch("v", 0)
+        # "v" is inside the signed blob, so only our own key could produce a
+        # malformed one — but fail closed rather than 500 on the comparison
+        # (String vs Integer) or silently treat a negative "v" as legacy.
+        return nil unless version.is_a?(::Integer) && version >= 0
         return payload if version == TOKEN_VERSION
         return nil if version > TOKEN_VERSION
 

--- a/lib/phlex/reactive/js.rb
+++ b/lib/phlex/reactive/js.rb
@@ -44,6 +44,44 @@ module Phlex
       URL_BEARING_ATTRS = %w[href src srcdoc action formaction xlink:href].freeze
       EVENT_HANDLER_ATTR = /\Aon/i
 
+      # The attr ops whose args carry a "name" the allowlist must gate. Used to
+      # re-validate a RAW [op, args] list (the js([...]) / broadcast_js_to([...])
+      # escape hatch) that skips the builder's build-time attr_args check.
+      ATTR_NAME_OPS = %w[set_attr remove_attr toggle_attr].freeze
+
+      # Validate a raw ops list ([[op, args], ...] as passed to js/broadcast_js_to
+      # without the builder) against the attribute allowlist, so the escape hatch
+      # gets the SAME server-side default-deny as the JS chain (defense in depth;
+      # the client also enforces it). Non-attr ops and malformed entries pass
+      # through untouched — the client interpreter default-denies unknown ops.
+      def self.assert_ops_allowed!(list)
+        Array(list).each do |op, args|
+          next unless ATTR_NAME_OPS.include?(op.to_s) && args.is_a?(::Hash)
+
+          name = args["name"] || args[:name]
+          assert_allowed_attr(name.to_s) if name
+        end
+      end
+
+      # The attribute-name allowlist (issue #96), case-insensitive. Refuses
+      # event-handler (on*), URL-bearing, and style attributes. Enforced at build
+      # time by the instance builder AND on the raw-list escape hatch — two-sided
+      # default-deny with the client interpreter.
+      def self.assert_allowed_attr(name)
+        lower = name.downcase
+        if name.match?(EVENT_HANDLER_ATTR)
+          raise ArgumentError,
+            "#{self}: attribute #{name.inspect} is an event handler (on*) — refused (XSS). " \
+            "Client attr ops target hidden/disabled/open/selected/aria-*/data-* and classes."
+        end
+        return unless URL_BEARING_ATTRS.include?(lower) || lower == "style"
+
+        raise ArgumentError,
+          "#{self}: attribute #{name.inspect} is refused — URL-bearing attributes " \
+          "(#{URL_BEARING_ATTRS.join(", ")}) and `style` can't be set from client ops " \
+          "(injection surface). Use classes for styling; target aria-*/data-*/boolean attrs."
+      end
+
       # The accumulated [name, args] op pairs, oldest first. Frozen.
       attr_reader :ops
 
@@ -169,21 +207,10 @@ module Phlex
         args.freeze
       end
 
-      # The attribute-name allowlist (issue #96), case-insensitive. Enforced here
-      # AND in the client interpreter — two-sided default-deny.
+      # Build-time attr-name allowlist for the instance builder — delegates to the
+      # shared class-method check (also used by the raw-list escape hatch).
       def assert_allowed_attr(name)
-        lower = name.downcase
-        if name.match?(EVENT_HANDLER_ATTR)
-          raise ArgumentError,
-            "#{self.class}: attribute #{name.inspect} is an event handler (on*) — refused (XSS). " \
-            "Client attr ops target hidden/disabled/open/selected/aria-*/data-* and classes."
-        end
-        return unless URL_BEARING_ATTRS.include?(lower) || lower == "style"
-
-        raise ArgumentError,
-          "#{self.class}: attribute #{name.inspect} is refused — URL-bearing attributes " \
-          "(#{URL_BEARING_ATTRS.join(", ")}) and `style` can't be set from client ops " \
-          "(injection surface). Use classes for styling; target aria-*/data-*/boolean attrs."
+        self.class.assert_allowed_attr(name)
       end
 
       # A transition must be exactly [during, from, to] class lists (strings).

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -275,6 +275,10 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
             list = Array(ops)
             raise ArgumentError, "js(...) got no ops — a dead reactive:js stream" if list.empty?
 
+            # The builder validates attr names at build time; a raw [op, args]
+            # list skips that, so re-apply the allowlist here (defense in depth —
+            # the client interpreter also refuses on*/URL/style attrs).
+            Phlex::Reactive::JS.assert_ops_allowed!(list)
             list.to_json
           end
         end

--- a/spec/phlex/reactive/js_spec.rb
+++ b/spec/phlex/reactive/js_spec.rb
@@ -133,6 +133,41 @@ RSpec.describe Phlex::Reactive::JS do
     # rubocop:enable Style/ItBlockParameter
   end
 
+  # The raw [op, args] escape hatch (js([...]) / broadcast_js_to([...])) skips the
+  # builder, so the allowlist is re-applied via .assert_ops_allowed! — full
+  # server-side parity with the JS chain (defense in depth; the client also refuses).
+  describe ".assert_ops_allowed! (raw-list escape hatch)" do
+    it "rejects a raw set_attr op with an event-handler name" do
+      list = [["set_attr", { "to" => "#x", "name" => "onclick", "value" => "alert(1)" }]]
+      expect { described_class.assert_ops_allowed!(list) }.to raise_error(ArgumentError, /onclick/)
+    end
+
+    it "rejects a raw op with a URL-bearing name (case-insensitive)" do
+      list = [["set_attr", { "to" => "#x", "name" => "HREF", "value" => "javascript:evil()" }]]
+      expect { described_class.assert_ops_allowed!(list) }.to raise_error(ArgumentError, /href/i)
+    end
+
+    it "rejects a raw remove_attr/toggle_attr op with a style name" do
+      expect { described_class.assert_ops_allowed!([["toggle_attr", { "name" => "style" }]]) }
+        .to raise_error(ArgumentError, /style/)
+    end
+
+    it "accepts symbol-keyed args (name: ...) too" do
+      expect { described_class.assert_ops_allowed!([["set_attr", { name: "onmouseover" }]]) }
+        .to raise_error(ArgumentError, /onmouseover/)
+    end
+
+    it "leaves allowed attr ops and non-attr ops untouched" do
+      expect do
+        described_class.assert_ops_allowed!([
+          ["set_attr", { "to" => "#x", "name" => "aria-expanded", "value" => "true" }],
+          ["add_class", { "to" => "#x", "classes" => ["open"] }],
+          ["show", { "to" => "#x" }]
+        ])
+      end.not_to raise_error
+    end
+  end
+
   # --- Issue #96: focus ops ---
 
   describe "focus ops (#focus / #focus_first)" do

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -382,6 +382,11 @@ RSpec.describe Phlex::Reactive::Response do
       expect(stream).to include("&quot;focus&quot;")
     end
 
+    it "enforces the attr allowlist on a raw op array (escape hatch can't bypass it)" do
+      hostile = [["set_attr", { "to" => "#x", "name" => "onclick", "value" => "alert(1)" }]]
+      expect { described_class.with.js(hostile) }.to raise_error(ArgumentError, /onclick/)
+    end
+
     it "rejects an empty op chain (a dead reactive:js stream is a mistake)" do
       empty = CounterComponent.new(count: 0).js
       expect { described_class.with.js(empty) }.to raise_error(ArgumentError, /no ops/)

--- a/spec/phlex/reactive_spec.rb
+++ b/spec/phlex/reactive_spec.rb
@@ -67,6 +67,21 @@ RSpec.describe Phlex::Reactive do
       expect(described_class.verify(future)).to be_nil
     end
 
+    it "fails closed on a signed token whose \"v\" is not an integer" do
+      # "v" lives inside the signed blob, so only our own signing key (or an
+      # operator error) could produce a non-integer "v". Rather than 500 on the
+      # `version > TOKEN_VERSION` comparison (String vs Integer), reject → 400.
+      malformed = raw_sign({ "c" => "X", "v" => "1" })
+      expect(described_class.verify(malformed)).to be_nil
+    end
+
+    it "fails closed on a signed token whose \"v\" is negative" do
+      # A negative "v" is not a shape we ever minted; treat it as unrecognized and
+      # reject rather than silently passing it through the legacy path.
+      malformed = raw_sign({ "c" => "X", "v" => -1 })
+      expect(described_class.verify(malformed)).to be_nil
+    end
+
     it "still returns nil for a genuinely invalid signature (versioning didn't change this)" do
       expect(described_class.verify("not-a-real-token")).to be_nil
     end


### PR DESCRIPTION
## Summary

Release-prep for **v0.9.0** — issue #151, steps 2, 3, and 5 (the parts `/lfg` owns). Steps 1, 6–8 (merge #148, tag, verify, dogfood) are deliberate user actions and are **not** in this PR.

Prerequisites are all landed: #148 (minified client), #149 (living showcase), #150 (coverage gaps) are merged.

## What's in this PR

### 🔒 Security gate (step 2) — all 7 surfaces SAFE; 2 hardenings applied

A three-agent audit of the new 0.9.0 surfaces found every one **SAFE**:

| Surface | Verdict |
|---|---|
| `js` attr-op allowlist parity (source vs **minified**) | SAFE — full parity, case-insensitive refusals both sides; vendored client byte-identical to shipped `.min.js` |
| `reply.js` / `broadcast_js_to` trust plane | SAFE — server-originated ops only, two-sided default-deny, escaped values |
| `error_flash` / error-body escaping | SAFE — `ERB::Util.html_escape` / `CGI.escapeHTML`; verbose body is `text/plain` |
| `verbose_errors` / debug-mode leak | SAFE — production-opaque defaults; names-never-values contract upheld |
| `around_action` context immutability | SAFE — frozen `Data` object; params a frozen dup distinct from the action's inputs |
| token versioning fail-closed | SAFE — `v > current` → 400, signature primary, `v` inside the signed blob |
| Notifications payload hygiene | SAFE — names / outcomes / sizes only |

Two **defense-in-depth** findings surfaced (neither exploitable without the signing key or an app-authored ops array) and were fixed with TDD:

1. **Token `v` fails closed on a malformed value.** `upgrade_token` now type-guards `v`: a non-integer or negative `v` (only producible with `secret_key_base`, or operator error — `v` is inside the signed blob) returns `nil` → **400**, instead of a 500 on the `v > TOKEN_VERSION` comparison or silently treating a negative `v` as a legacy passthrough.
2. **Raw-array `js([...])` / `broadcast_js_to([...])` re-applies the attr allowlist server-side.** The raw `[[op, args], …]` escape hatch skipped the builder's build-time `on*`/URL/`style` refusal and relied on the client alone. New `Phlex::Reactive::JS.assert_ops_allowed!` restores full server-side parity (the client still enforces it too).

### ⚡ Perf gate (step 3) — bench trio green, no regression

Captured on the post-#148 baseline (same machine):

| Bench | Result |
|---|---|
| `rake bench` (micro: render / sign / verify) | retained **0 objects** everywhere (no leak); sign ~180k i/s, verify ~135k i/s |
| `rake bench:client` (extractToken / collectFields / recompute) | in the perf-page ranges (extractToken 4.62 µs / 9.83 µs) |
| `rake bench:request` (full Rack stack) | state 1168 i/s, record 821 i/s |

No representative number moved vs the #148 numbers, so the performance page and CHANGELOG need no perf edit. (The page already carries #148's client-size table.)

### 📝 Release-prep docs (step 5)

- **CHANGELOG cut:** the entire `[Unreleased]` block (uncut since 0.2.6, ~1,370 lines) moved into `## [0.9.0] - 2026-07-03` with a one-line preamble; a fresh empty `[Unreleased]` left for the next cycle.
- **Upgrade notes:** a `### Upgrading from 0.4.x` block at the top of 0.9.0 — `UnknownParamType` at boot (#109), Ruby ≥ 3.4 floor, `optimistic:`/`loading:`/`disable_with:` reserved `on(...)` keywords, `flash_builder`→`stream_builder` (permanent alias, grep-only), minified-client pin (#148). Each claim verified against the code.
- **Footer compare-links** repaired: `[Unreleased]: v0.9.0...HEAD`, `[0.9.0]: v0.2.6...v0.9.0`, plus the previously-missing `[0.2.6]`/`[0.2.5]` links so every body header resolves.
- **Contributor workflow:** CLAUDE.md now documents the client-runtime build (`rake build:js` + the vendored re-sync `cp` + `bun test`) and the two guards that enforce it (`build:js_check`, `vendored_controller_sync_spec`).
- **README link check:** every Documentation-section slug maps to a `docs/app/views/docs/pages/*.rb` page. Token-versioning and the minified client are already documented (from #150/#148).

## Deliberately NOT in this PR

- **Version bump.** `rake release[0.9.0]` bumps `version.rb` and commits it (`Rakefile:212–221`) — touching it here would collide.
- **`docs/Gemfile.lock` refresh.** It records the path-gem version string (still `0.4.8`); refreshing it *before* the bump is a no-op. **Post-release step:** after `rake release[0.9.0]`, run `cd docs && bundle install` to record `0.9.0`.
- Steps 1, 6–8 (merge #148, tag, verify on RubyGems/docs deploy, dogfood in cosmos).

## Test Coverage

- `reactive_spec`: a signed token with a string `v` → nil; a negative `v` → nil (both RED-verified before the fix)
- `js_spec`: `.assert_ops_allowed!` rejects raw `on*`/URL/`style` ops (symbol- and string-keyed args); leaves allowed attr ops and non-attr ops untouched
- `response_spec`: the raw `js([...])` escape hatch raises on an `onclick` attr op

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests` — **704 green** (696 baseline + 8 new)
- [x] `bundle exec rubocop` — 174 files, no offenses
- [x] `bun test spec/javascript` — 255 pass
- [x] `rake build:js_check` — no drift
- [x] `gem build phlex-reactive.gemspec --strict` — clean; the built gem contains the `.min.js` + `.map` files
- [x] Bench trio captured; no regression vs #148
- [x] `.js` client source untouched → browser suite not required for this change

Refs #151

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened validation for signed tokens and dynamic JavaScript operations, rejecting malformed or unsafe inputs earlier.
  * Added extra safeguards to block unsafe attribute usage, including event handlers and URL/style-related attributes.

* **Bug Fixes**
  * Improved handling of invalid token version values so they fail safely instead of being processed.

* **Documentation**
  * Updated release notes and developer guidance for the latest release workflow.

* **Tests**
  * Added coverage for malformed tokens and unsafe operation inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->