### PR TITLE
docs: enable the docs-kit MCP server + rate-limit the AI endpoints

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -38,6 +38,17 @@ gem "daisyui", github: "mhenrixon/daisyui", require: "daisy_ui"
 # resolve it; the gem lives in a sibling repo, outside the build context.
 gem "docs-kit", github: "mhenrixon/docs-kit", tag: "v1.0.2", require: "docs_kit"
 
+# MCP — docs-kit's optional Model Context Protocol server (read-only, stateless).
+# Not a docs-kit gemspec dependency; present here so the /mcp endpoint (routes in
+# config/routes.rb) goes live and an agent can query these docs as native tools.
+gem "mcp"
+
+# Rack::Attack — throttle the public, unauthenticated AI endpoints (/mcp, /llms*,
+# /docs/search). Those are bare ActionController::Base controllers in the gem, so
+# a controller-level rate_limit can't reach them; a Rack middleware throttles them
+# by IP regardless. See config/initializers/rack_attack.rb.
+gem "rack-attack"
+
 # Icons — lucide via rails_icons (SVGs synced into app/assets/svg/icons).
 gem "rails_icons", "~> 1.1"
 

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 PATH
   remote: ..
   specs:
-    phlex-reactive (0.4.8)
+    phlex-reactive (0.9.0)
       globalid (~> 1.0)
       phlex-rails (>= 2.0, < 3)
       railties (>= 7.1, < 9.0)
@@ -207,6 +207,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.4.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     icons (0.9.0)
@@ -225,6 +226,11 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.20.0)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     localhost (1.8.0)
@@ -241,6 +247,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
+    mcp (0.22.0)
+      json_schemer (>= 2.4)
     method_source (1.1.0)
     metrics (0.15.0)
     mime-types (3.7.0)
@@ -338,6 +346,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -455,6 +465,7 @@ GEM
     samovar (2.5.1)
       console (~> 1.0)
     securerandom (0.4.1)
+    simpleidn (0.2.3)
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-aarch64-linux-musl)
     sqlite3 (2.9.5-arm-linux-gnu)
@@ -518,6 +529,7 @@ DEPENDENCIES
   docs-kit!
   falcon
   importmap-rails
+  mcp
   method_source
   pg (~> 1.5)
   pgbus
@@ -527,6 +539,7 @@ DEPENDENCIES
   propshaft
   protocol-rack
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.3)
   rails_icons (~> 1.1)
   rouge
@@ -601,6 +614,7 @@ CHECKSUMS
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   icons (0.9.0) sha256=128365c3414a1b76de4ea1913ef9190163fec1f8c701fa9a37fa301c04f4c9dc
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -610,6 +624,7 @@ CHECKSUMS
   io-stream (0.13.1) sha256=570d7c4dfb0fbd767480b4a222048a2be6d9b78febc1ec68258d0e0a4cde20de
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   localhost (1.8.0) sha256=df7ea825b4f64949c588c17efac86bc47ddc4460d723778abe933b71759b2701
@@ -618,6 +633,7 @@ CHECKSUMS
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mcp (0.22.0) sha256=e2ef603207c7e2c691bef4d8d8ab35d9740bedf315949fdb6d9a25318d1a7025
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   metrics (0.15.0) sha256=61ded5bac95118e995b1bc9ed4a5f19bc9814928a312a85b200abbdac9039072
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
@@ -652,7 +668,7 @@ CHECKSUMS
   pgmq-ruby (0.7.0) sha256=018a33e304b0c4513d3dc8cd06322ac767ebc0b475422738a71c198f066f2a76
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
-  phlex-reactive (0.4.8)
+  phlex-reactive (0.9.0)
   playwright-ruby-client (1.60.0) sha256=942242d6130e797b21213d9c49dc09d31235cab429a9edae73401ed112c94853
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
@@ -669,6 +685,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
@@ -701,6 +718,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   samovar (2.5.1) sha256=8a9fc41eb8868084f0321eb41678c485cfbc7d282fb306c0be67c3284b1d2394
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,31 @@ bundle exec rubocop
 The reactive round trip is proven under **both** real servers — Puma (sync) and
 Falcon (async) — exactly as the gem's own suite requires.
 
+## AI & tooling surfaces (docs-kit)
+
+Every reference page is machine-readable, not just human-readable — the docs-kit
+chrome exposes the whole site to agents with no extra authoring:
+
+- **`/llms.txt`** + **`/llms-full.txt`** — the [llmstxt.org](https://llmstxt.org)
+  index and the full concatenation, built from each page's Markdown twin.
+- **`<page>.md`** — every doc page has a Markdown twin (e.g.
+  `/docs/architecture.md`), derived from its own render so it can't drift. The
+  masthead **"Markdown"** action copies the page to the clipboard for pasting
+  into an LLM.
+- **`/docs/search`** — full-text search over the same twins, no external service.
+- **`/mcp`** — a read-only, stateless [MCP](https://modelcontextprotocol.io)
+  server exposing `list_pages`, `get_page`, and `search_docs` over the live
+  registry. Add it to an agent:
+
+  ```bash
+  claude mcp add --transport http docs https://phlex-reactive.zoolutions.llc/mcp
+  ```
+
+  It needs `gem "mcp"` (bundled here) and the `/mcp` route (drawn in
+  `config/routes.rb`); `c.mcp` defaults to on. The public AI endpoints
+  (`/mcp`, `/llms*`, `/docs/search`) are rate-limited per IP by Rack::Attack
+  (`config/initializers/rack_attack.rb`).
+
 ## How it dogfoods the gem
 
 The phlex-reactive engine auto-mounts `POST /reactive/actions` and auto-pins the

--- a/docs/config/initializers/rack_attack.rb
+++ b/docs/config/initializers/rack_attack.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Throttle the public, unauthenticated AI/tooling endpoints docs-kit exposes:
+#   POST /mcp            — the Model Context Protocol server (JSON-RPC)
+#   GET  /llms.txt       — the llmstxt.org index
+#   GET  /llms-full.txt  — every page concatenated
+#   GET  /docs/search    — the search index (html + json)
+#
+# These are read-only over already-public content, but they're outward-facing and
+# cheap to hammer (llms-full.txt concatenates every page; search scans the index),
+# so a per-IP cap keeps a scraper or a runaway agent from dominating a single
+# server. The docs-kit controllers are bare ActionController::Base subclasses, so
+# a controller-level `rate_limit` can't reach them — a Rack middleware can.
+#
+# Rack::Attack counts in its own cache. Rails.cache is a MemoryStore in dev and a
+# per-server FileStore in production (both fine for a per-server throttle); it's a
+# NullStore in test, so give Rack::Attack an explicit MemoryStore there so the
+# throttle is exercisable in specs and never silently a no-op.
+Rack::Attack.cache.store =
+  if Rails.env.test?
+    ActiveSupport::Cache::MemoryStore.new
+  else
+    Rails.cache
+  end
+
+# 60 requests/minute per IP across the AI endpoints — generous for a human or a
+# well-behaved agent, a wall for a scraper. Over the limit → 429.
+Rack::Attack.throttle('ai-endpoints/ip', limit: 60, period: 60) do |request|
+  path = request.path
+  ai_path =
+    path == '/mcp' ||
+    path == '/llms.txt' ||
+    path == '/llms-full.txt' ||
+    path == '/docs/search' ||
+    path.start_with?('/docs/search.')
+
+  request.ip if ai_path
+end
+
+# A small, honest 429 (plus Retry-After) instead of Rack::Attack's blank default.
+Rack::Attack.throttled_responder = lambda do |request|
+  match_data = request.env['rack.attack.match_data'] || {}
+  retry_after = (match_data[:period] || 60).to_i
+  [
+    429,
+    { 'Content-Type' => 'text/plain', 'Retry-After' => retry_after.to_s },
+    ["Rate limit exceeded. Retry in #{retry_after}s.\n"]
+  ]
+end

--- a/docs/config/routes.rb
+++ b/docs/config/routes.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Add your docs to an agent over MCP (needs `gem "mcp"`):
-  # post "/mcp" => "docs_kit/mcp#create"
-  # match "/mcp" => "docs_kit/mcp#method_not_allowed", via: %i[get delete]
+  # Add your docs to an agent over MCP (read-only, stateless — needs `gem "mcp"`).
+  # An agent connects with:  claude mcp add --transport http docs <site>/mcp
+  post "/mcp" => "docs_kit/mcp#create", as: :mcp
+  match "/mcp" => "docs_kit/mcp#method_not_allowed", via: %i[get delete]
   get "/llms-full.txt" => "docs_kit/llms#full", as: :llms_full
   get "/llms.txt" => "docs_kit/llms#index", as: :llms
   get "/docs/search" => "docs_kit/search#index", as: :docs_search

--- a/docs/spec/requests/ai_rate_limit_spec.rb
+++ b/docs/spec/requests/ai_rate_limit_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The public, unauthenticated AI endpoints (/mcp, /llms*, /docs/search) are
+# throttled per-IP by Rack::Attack (config/initializers/rack_attack.rb) so a
+# scraper or runaway agent can't dominate a server. In test the throttle counts
+# in a real MemoryStore (Rails.cache is NullStore there), so the limit is
+# exercisable. 60 req/min/IP → the 61st in a window is a 429 with Retry-After.
+RSpec.describe 'AI endpoint rate limiting', type: :request do
+  before { Rack::Attack.cache.store.clear }
+  after { Rack::Attack.cache.store.clear }
+
+  it 'lets a normal burst through and 429s past the per-IP limit' do
+    60.times do
+      get '/llms.txt'
+      expect(response).to have_http_status(:ok)
+    end
+
+    get '/llms.txt'
+    expect(response).to have_http_status(:too_many_requests)
+    expect(response.headers['Retry-After']).to be_present
+  end
+
+  it 'throttles the /mcp endpoint on the same per-IP budget' do
+    60.times { get '/llms.txt' } # consume the shared AI budget
+    post '/mcp',
+         params: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }.to_json,
+         headers: { 'CONTENT_TYPE' => 'application/json' }
+    expect(response).to have_http_status(:too_many_requests)
+  end
+
+  it 'does not throttle ordinary doc pages' do
+    70.times do
+      get '/docs/architecture'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/docs/spec/requests/mcp_spec.rb
+++ b/docs/spec/requests/mcp_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The docs-kit MCP server (read-only, stateless JSON-RPC over POST) exposes this
+# site's docs as agent tools. It's live because the `mcp` gem is bundled, the
+# /mcp route is drawn, and c.mcp defaults to true. These specs lock in that the
+# three tools respond, that GET/DELETE are rejected, and that enabling MCP makes
+# /llms.txt advertise the endpoint — so a regression (gem dropped, route
+# recommented, c.mcp flipped) fails loudly.
+RSpec.describe 'MCP endpoint', type: :request do
+  def rpc(method, params = {})
+    post '/mcp',
+         params: { jsonrpc: '2.0', id: 1, method:, params: }.to_json,
+         headers: { 'CONTENT_TYPE' => 'application/json' }
+    response.parsed_body
+  end
+
+  def tool_text(name, arguments = {})
+    result = rpc('tools/call', { name:, arguments: }).fetch('result')
+    expect(result['isError']).to be_falsey
+    result.dig('content', 0, 'text').to_s
+  end
+
+  describe 'tools/list' do
+    it 'advertises the three read-only docs tools' do
+      names = rpc('tools/list').dig('result', 'tools').pluck('name')
+      expect(names).to contain_exactly('list_pages', 'get_page', 'search_docs')
+    end
+  end
+
+  describe 'tools/call' do
+    it 'list_pages returns the authored pages with their slugs and urls' do
+      text = tool_text('list_pages')
+      expect(text).to include('architecture').and include('/docs/architecture')
+    end
+
+    it 'get_page returns one page as Markdown by slug' do
+      text = tool_text('get_page', { slug: 'architecture' })
+      expect(text).to include('/docs/architecture')
+      expect(text).to include('Architecture').or include('re-render')
+    end
+
+    it 'search_docs ranks hits for a query' do
+      text = tool_text('search_docs', { query: 'broadcast' })
+      expect(text).to include('/docs/broadcasting')
+    end
+  end
+
+  describe 'method handling' do
+    it 'rejects GET with 405 (POST-only, stateless — no SSE session)' do
+      get '/mcp'
+      expect(response).to have_http_status(:method_not_allowed)
+    end
+
+    it 'rejects DELETE with 405 (no session to terminate)' do
+      delete '/mcp'
+      expect(response).to have_http_status(:method_not_allowed)
+    end
+  end
+
+  describe '/llms.txt advertises the endpoint' do
+    it 'grows a ## MCP section when the endpoint is live' do
+      get '/llms.txt'
+      expect(response.body).to include('## MCP')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Turns on the **one docs-kit 1.0.2 AI feature this site wasn't using yet — MCP** — and rate-limits the public AI endpoints.

An audit of docs-kit 1.0.2's AI/tooling surfaces found almost everything was already live on this site:

| Feature | Before this PR |
|---|---|
| `/llms.txt` + `/llms-full.txt` | ✅ live |
| Per-page Markdown twins (`/docs/x.md`) + "Markdown" masthead action | ✅ live |
| Full-text `/docs/search` | ✅ live |
| `AGENTS.md` + `write-docs-page` skill | ✅ live |
| **MCP server (`/mcp`)** | ❌ **off** (routes commented, gem absent) |
| API-docs helpers (`RequestExample`/`OpenApiOperation`) | N/A — phlex-reactive is a Ruby lib, not an HTTP API |

So this PR is small and targeted: enable MCP + protect the endpoints.

## What changed

### 🤖 MCP (Model Context Protocol)
- Add `gem "mcp"` — docs-kit's **optional, non-gemspec** dependency; the endpoint stays off byte-for-byte until it's present.
- Uncomment the `/mcp` routes (`POST` → create, `GET`/`DELETE` → **405**). `c.mcp` defaults to `true`, so no config change.
- The server exposes three read-only tools over the **same registry the docs render from** (an agent queries live docs, never a stale copy):
  - `list_pages` — every page's slug/title/group/url
  - `get_page(slug:)` — one page's Markdown twin
  - `search_docs(query:)` — ranked hits
- When enabled, `/llms.txt` grows a `## MCP` line advertising the endpoint. Readers connect with:
  ```bash
  claude mcp add --transport http docs https://phlex-reactive.zoolutions.llc/mcp
  ```

### 🛡️ Rate limiting
- The public, unauthenticated AI endpoints (`/mcp`, `/llms*`, `/docs/search`) are cheap to hammer and outward-facing. docs-kit's controllers are bare `ActionController::Base` subclasses, so a controller-level `rate_limit` **can't reach them** — added **Rack::Attack** (a Rack middleware, sees every request) throttling those paths to **60 req/min per IP** → `429` + `Retry-After`.
- Rack::Attack counts in its own store: `Rails.cache` in dev/prod, an explicit `MemoryStore` in test (where `Rails.cache` is `NullStore`) so the throttle is actually exercisable in specs.

## Test plan

- `spec/requests/mcp_spec.rb` — `tools/list` returns the three tools; live `get_page` + `search_docs` calls; `GET`/`DELETE` → 405; `/llms.txt` includes `## MCP`.
- `spec/requests/ai_rate_limit_spec.rb` — 60 requests through, the 61st is a 429 with `Retry-After`; `/mcp` shares the per-IP budget; ordinary doc pages stay unthrottled.
- ✅ `rake lint` — 122 files, clean
- ✅ `bundle exec rspec spec/requests` — **98 green** (88 + 10 new)
- ✅ Live booted server: `tools/list` answers, `GET /mcp` → 405, `/llms.txt` advertises `## MCP`

## Notes
- Read-only over already-public content; writing docs is still git, and private-docs auth is a host concern (there's no auth on this public site).
- Docs-site-only change; the phlex-reactive gem is untouched.

https://claude.ai/code/session_012wq1sjyeXMG1TiUyTBMhg1
