### PR TITLE
feat(authorization): verify_authorized fail-closed runtime guard (#168 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,38 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: `verify_authorized` is ON by default (#168).** A reactive action
+  that completes **without any authorization call now raises**
+  `Phlex::Reactive::AuthorizationNotVerified` — **rolling back the transaction**
+  (fail-closed, stronger than Pundit's after-the-fact check). This is the
+  presence-side complement to `authorization_errors`: a forgotten `authorize!`
+  becomes a loud 500 your error tracker sees, not a silent hole. The guard
+  detects a call to any `Phlex::Reactive.authorization_methods` name
+  (default `%i[authorize! authorize allowed_to?]` — Pundit/CanCanCan/ActionPolicy)
+  **or** `mark_authorized!`, made anywhere during the action (a helper the action
+  calls counts too). **Three remedies** for each action:
+  1. call your authorization method (`authorize! @record, :update?`);
+  2. call `mark_authorized!` after a bespoke check the interceptor can't see;
+  3. declare `skip_verify_authorized` (whole component) or
+     `skip_verify_authorized :action_name` (specific actions) for an
+     intentionally public action.
+  Turn it off globally with `Phlex::Reactive.verify_authorized = false` (the
+  install-generator initializer documents the knob). The `action.phlex_reactive`
+  instrumentation event gains a new `:unverified` outcome. A new **advisory**
+  doctor check flags mutating actions with no detected authorization call
+  (heuristic — a helper may authorize indirectly; never a hard fail).
+
 ### Added
+
+- **verify_authorized runtime guard (#168).** New
+  `Phlex::Reactive::Authorization` (fiber-local tracking window, method
+  interception, the enforcement decision), `mark_authorized!` instance helper,
+  the `skip_verify_authorized` DSL (registry #6, inherits like the other five),
+  and `Phlex::Reactive.verify_authorized` / `authorization_methods` config
+  (`defined?`-guarded so an explicit override sticks). See the breaking note
+  above for the behavior and remedies.
 
 - **Action inventory — `Phlex::Reactive::Inspector` + rake tasks (#168).** A new
   read-only introspection layer that answers "what reactive actions exist in this

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -60,10 +60,21 @@ module Phlex
         component = component_class.from_identity(payload)
         coerced = coerce_params(action_def, component_class:, action_name: action_def.name)
 
+        # verify_authorized (issue #168): instrument the class ONCE (idempotent,
+        # per class object) so its authorization methods mark the tracking cell.
+        # Only when the feature is on — zero cost otherwise.
+        Phlex::Reactive::Authorization.instrument!(component_class) if Phlex::Reactive.verify_authorized
+
         result = run_action(component, action_def, coerced)
 
         event[:outcome] = :ok
         render turbo_stream: response_streams(result, component)
+      rescue Phlex::Reactive::AuthorizationNotVerified
+        # A developer error (a forgotten authorize!), NOT a client fault — it
+        # bubbles as a 500 so error trackers fire, but we tag the event first so
+        # the action.phlex_reactive outcome stays accurate, then re-raise.
+        event[:outcome] = :unverified
+        raise
       rescue Phlex::Reactive::InvalidToken => e
         # The component name here came from an UNVERIFIED token — do NOT report it
         # as trusted. Leave event[:component] nil.
@@ -153,10 +164,21 @@ module Phlex
         Phlex::Reactive.with_connection_id(request.headers["X-Pgbus-Connection"]) do
           with_around_actions(component, action_def, coerced) do
             transaction_wrapper do
-              if coerced.any?
-                component.public_send(action_def.name, **coerced)
-              else
-                component.public_send(action_def.name)
+              # verify_authorized (issue #168): open the tracking window, run the
+              # action, then verify INSIDE the transaction so an unverified action
+              # rolls its mutation back (fail-closed). with_tracking is a bare
+              # yield's-worth of overhead; verify! is a no-op when the feature is
+              # off / the action is skipped / something marked. The interceptor
+              # (create_action's instrument!) marks the window on a real
+              # authorization call.
+              Phlex::Reactive::Authorization.with_tracking do
+                result = if coerced.any?
+                           component.public_send(action_def.name, **coerced)
+                         else
+                           component.public_send(action_def.name)
+                         end
+                Phlex::Reactive::Authorization.verify!(component.class, action_def)
+                result
               end
             end
           end

--- a/docs/config/initializers/phlex_reactive.rb
+++ b/docs/config/initializers/phlex_reactive.rb
@@ -4,6 +4,12 @@
 # ActionController::Base, base_controller = ActionController::Base) already make
 # the record-backed demos work; this only wires the failure-surface example.
 Rails.application.config.after_initialize do
+  # The docs app's demo components (chat, counters, the team inbox) are showcases
+  # with no authorization layer, so the default-ON verify_authorized guard (#168)
+  # would raise on every unauthorized demo action. Disable it here — the same
+  # posture as the gem's dummy app; a real app leaves it on and authorizes.
+  Phlex::Reactive.verify_authorized = false
+
   # Register the failure-surface demo's authorization error so a DECLARED action
   # that denies returns a clean 403 (client kind=http) — mirroring how a real app
   # registers Pundit::NotAuthorizedError. The page still renders under the

--- a/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
+++ b/lib/generators/phlex/reactive/install/templates/phlex_reactive.rb.erb
@@ -15,6 +15,16 @@
 # Phlex::Reactive.authorization_errors = [Pundit::NotAuthorizedError]
 # Phlex::Reactive.authorization_errors = [ActionPolicy::Unauthorized]
 
+# verify_authorized (ON by default): an action that completes WITHOUT any
+# authorization call raises Phlex::Reactive::AuthorizationNotVerified inside the
+# transaction — the mutation rolls back (fail-closed). Satisfy it by calling one
+# of authorization_methods, calling `mark_authorized!` after a bespoke check, or
+# declaring `skip_verify_authorized` on a genuinely public component/action.
+# Set the method names to match your authorization library:
+# Phlex::Reactive.authorization_methods = %i[authorize! authorize allowed_to?]
+# Turn the guard off entirely (not recommended — you lose the fail-closed net):
+# Phlex::Reactive.verify_authorized = false
+
 # Diagnostic endpoint error bodies + dropped-param logging (statuses never
 # change). Defaults to Rails.env.local? — on in development AND test, off in production.
 # Phlex::Reactive.verbose_errors = true

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -56,6 +56,16 @@ module Phlex
     # the stdlib one an app catches.
     class UnknownParamType < ::ArgumentError; end
 
+    # Raised when the default-ON verify_authorized guard (issue #168) finds an
+    # action completed WITHOUT any authorization call — the fail-closed
+    # presence-side complement to authorization_errors. It fires INSIDE the
+    # action's transaction, so the mutation rolls back, and it is NOT rescued
+    # into a 4xx: it bubbles as a developer error (a 500 your error tracker
+    # must see) because a missing authorize! is a bug, not a client fault. The
+    # message names the component#action and all three remedies (call an
+    # authorization method / mark_authorized! / declare skip_verify_authorized).
+    class AuthorizationNotVerified < Error; end
+
     # Purpose string bound into every identity token's signature so a token
     # minted for phlex-reactive can't be replayed against another verifier use.
     IDENTITY_PURPOSE = "phlex-reactive/identity"
@@ -165,6 +175,37 @@ module Phlex
         return @debug if defined?(@debug)
 
         false
+      end
+
+      # verify_authorized (issue #168): the default-ON runtime guard. When true,
+      # an action that completes without any authorization call raises
+      # AuthorizationNotVerified inside its transaction (fail-closed — the
+      # mutation rolls back). Default ON is a deliberate, pre-1.0 breaking change:
+      # a forgotten authorize! becomes a loud 500, not a silent hole. Opt out per
+      # component with `skip_verify_authorized`, mark a bespoke check with
+      # `mark_authorized!`, or turn it off globally here. The `defined?` guard
+      # (not `||=`) makes an explicit `= false` stick.
+      attr_writer :verify_authorized
+
+      def verify_authorized
+        return @verify_authorized if defined?(@verify_authorized)
+
+        true
+      end
+
+      # The method names verify_authorized's interceptor wraps to detect an
+      # authorization call (issue #168). Defaults to the common set across
+      # authorization libraries — Pundit (`authorize`), CanCanCan (`authorize!`),
+      # ActionPolicy (`authorize!`/`allowed_to?`). Set in an initializer to match
+      # your app's helper. `mark_authorized!` always counts, regardless of this
+      # list. The `defined?` guard makes an explicit override (including a
+      # narrower list) stick.
+      attr_writer :authorization_methods
+
+      def authorization_methods
+        return @authorization_methods if defined?(@authorization_methods)
+
+        %i[authorize! authorize allowed_to?]
       end
 
       # Register an app-defined param type (issue #109). The block receives the

--- a/lib/phlex/reactive/authorization.rb
+++ b/lib/phlex/reactive/authorization.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Phlex
+  module Reactive
+    # The runtime machinery behind verify_authorized (issue #168): a time-window
+    # tracking cell, an interceptor that marks it when a configured authorization
+    # method returns, and the enforcement decision the endpoint calls after an
+    # action runs.
+    #
+    # The design mirrors Phlex::Reactive.with_connection_id: a fiber-local cell
+    # (Thread.current, which is fiber-local in Ruby, so Falcon's fiber-per-request
+    # model is safe) saved and restored around the action. Because tracking is a
+    # WINDOW — anything marking during the action counts — authorization performed
+    # in a HELPER the action calls is detected too, not just a top-level call.
+    module Authorization
+      # The fiber-local key holding the tracking cell during an action. A truthy
+      # value means "some authorization method has been called (and returned)
+      # during this window".
+      CELL = :phlex_reactive_authorized
+
+      # Streamable defines a CLASS method `prepend(target:, model:)` (the Turbo
+      # Stream verb), which shadows Ruby's Module#prepend on a component class.
+      # Bind the real Module#prepend so instrument! can prepend the interceptor
+      # module without dispatching to the stream helper (and its keyword arity).
+      MODULE_PREPEND = ::Module.instance_method(:prepend)
+      private_constant :MODULE_PREPEND
+
+      class << self
+        # Open a fresh tracking window, run the block, and restore the previous
+        # cell — exactly the with_connection_id save/restore shape, so nesting is
+        # correct and a raise still restores. The inner window starts UNMARKED
+        # regardless of an outer mark (a fresh action authorizes for itself).
+        def with_tracking
+          previous = Thread.current[CELL]
+          Thread.current[CELL] = false
+          yield
+        ensure
+          Thread.current[CELL] = previous
+        end
+
+        # Mark the current window authorized. Called by the interceptor (on a
+        # non-raising authorization-method return) and by Component#mark_authorized!
+        # for a bespoke check. A no-op semantically outside a window (the cell is
+        # simply overwritten and restored by the nearest with_tracking).
+        def mark!
+          Thread.current[CELL] = true
+        end
+
+        # Has anything marked the current window?
+        def marked?
+          Thread.current[CELL] == true
+        end
+
+        # The enforcement decision, called by the endpoint AFTER the action runs,
+        # INSIDE the transaction (so a raise rolls the mutation back). A no-op
+        # unless verify_authorized is on, the action isn't skipped, and nothing
+        # marked the window. Otherwise raises AuthorizationNotVerified naming the
+        # component#action and the three remedies.
+        def verify!(component_class, action_def)
+          return unless Phlex::Reactive.verify_authorized
+          return if skipped?(component_class, action_def.name)
+          return if marked?
+
+          raise Phlex::Reactive::AuthorizationNotVerified, violation_message(component_class, action_def)
+        end
+
+        # Wrap each configured authorization method the class defines (public OR
+        # private, own OR inherited) with a prepended module that calls super and
+        # then mark! on a NON-RAISING return — so a denial (which raises) never
+        # marks and still propagates to the endpoint's authorization_errors → 403.
+        #
+        # Idempotent per class OBJECT (memoized on an ivar the class carries), so
+        # a Zeitwerk reload's fresh class re-instruments naturally and a repeated
+        # call in one process is a no-op. Re-reads authorization_methods each first
+        # call, so an initializer that widened the list is honored.
+        def instrument!(component_class)
+          return if component_class.instance_variable_get(:@reactive_authorization_instrumented)
+
+          names = Phlex::Reactive.authorization_methods.select do
+            component_class.method_defined?(it) || component_class.private_method_defined?(it)
+          end
+          MODULE_PREPEND.bind_call(component_class, interceptor_for(names)) if names.any?
+          component_class.instance_variable_set(:@reactive_authorization_instrumented, true)
+        end
+
+        private
+
+        def skipped?(component_class, action_name)
+          component_class.respond_to?(:skip_verify_authorized?) &&
+            component_class.skip_verify_authorized?(action_name)
+        end
+
+        # Build the prepend module: one wrapper per authorization method name,
+        # each `super(...)` then mark! (only reached when super didn't raise).
+        def interceptor_for(names)
+          Module.new do
+            names.each do
+              define_method(it) do |*args, **kwargs, &block|
+                result = super(*args, **kwargs, &block)
+                Phlex::Reactive::Authorization.mark!
+                result
+              end
+            end
+          end
+        end
+
+        def violation_message(component_class, action_def)
+          where = [component_class&.name, action_def&.name].compact.join("#")
+          methods = Phlex::Reactive.authorization_methods.map { ":#{it}" }.join(", ")
+          "#{where} completed without any authorization call — verify_authorized is on. " \
+            "Either call one of your authorization methods (#{methods}), call mark_authorized! " \
+            "for a bespoke check, or declare `skip_verify_authorized` (whole component) / " \
+            "`skip_verify_authorized :#{action_def&.name}` (this action) if it is intentionally public."
+        end
+      end
+    end
+  end
+end

--- a/lib/phlex/reactive/component/dsl.rb
+++ b/lib/phlex/reactive/component/dsl.rb
@@ -100,6 +100,41 @@ module Phlex
             reactive_actions.key?(name.to_sym)
           end
 
+          # Opt out of the default-ON verify_authorized guard (issue #168).
+          # Bare skips the WHOLE component (a public counter, a client-only
+          # filter); with names skips just those actions:
+          #
+          #   skip_verify_authorized                 # every action
+          #   skip_verify_authorized :filter, :page  # only these
+          #
+          # Registry #6 — resolves through the superclass at read time like the
+          # other five, so a child inherits a parent's skips (and a child's bare
+          # skip covers everything). Marks nothing else; a non-skipped action
+          # still needs a real authorization call or mark_authorized!.
+          def skip_verify_authorized(*names)
+            if names.empty?
+              Registry.write_scalar(self, :skip_all, true)
+            else
+              Registry.append(self, :skip_actions, names.map(&:to_sym))
+            end
+          end
+
+          def reactive_skip_all_authorization?
+            Registry.resolve_scalar(self, :skip_all, :reactive_skip_all_authorization?) == true
+          end
+
+          def reactive_skip_authorization_actions
+            Registry.resolve_list(self, :skip_actions, :reactive_skip_authorization_actions)
+          end
+
+          # Is verify_authorized skipped for `action_name`? True under a bare
+          # component skip OR when the action is in the named list — resolved
+          # through Registry so inheritance matches every other declaration.
+          def skip_verify_authorized?(action_name)
+            reactive_skip_all_authorization? ||
+              reactive_skip_authorization_actions.include?(action_name.to_sym)
+          end
+
           # Declare an add/remove-row collection (issue #35) — the list contract
           # in one place, so actions append/prepend/remove a row WITHOUT
           # re-deriving the container id, count, and empty-state in every action:

--- a/lib/phlex/reactive/component/helpers.rb
+++ b/lib/phlex/reactive/component/helpers.rb
@@ -28,6 +28,23 @@ module Phlex
           Phlex::Reactive.current_connection_id
         end
 
+        # Manually satisfy the verify_authorized guard (issue #168) for a bespoke
+        # authorization check the interceptor can't see — a hand-rolled policy, a
+        # feature flag, an ownership comparison that doesn't go through one of
+        # Phlex::Reactive.authorization_methods:
+        #
+        #   def publish
+        #     raise NotAllowed unless @post.author == Current.user
+        #     mark_authorized!
+        #     @post.update!(published: true)
+        #   end
+        #
+        # Call it only AFTER your check passes — it asserts "I have authorized
+        # this action." A no-op when verify_authorized is off.
+        def mark_authorized!
+          Phlex::Reactive::Authorization.mark!
+        end
+
         # Subject-bound reply builder — the preferred way to control an action's
         # reply. `reply.replace.flash(:error, msg)` reads cleaner than
         # `Phlex::Reactive::Response.replace(self).flash(:error, msg)`: the

--- a/lib/phlex/reactive/component/registry.rb
+++ b/lib/phlex/reactive/component/registry.rb
@@ -50,7 +50,11 @@ module Phlex
           state_keys: :@reactive_own_state_keys,
           collections: :@reactive_own_collections,
           computes: :@reactive_own_computes,
-          record_key: :@reactive_own_record_key
+          record_key: :@reactive_own_record_key,
+          # verify_authorized opt-out (issue #168, registry #6): a scalar bare
+          # flag (skip the WHOLE component) plus a list of named actions.
+          skip_all: :@reactive_own_skip_all,
+          skip_actions: :@reactive_own_skip_actions
         }.freeze
 
         # The identity-side hot-path memos swept by bump! (see the contract

--- a/lib/phlex/reactive/doctor.rb
+++ b/lib/phlex/reactive/doctor.rb
@@ -74,7 +74,8 @@ module Phlex
           verifier_check,
           base_controller_check,
           action_check(components),
-          id_check(components)
+          id_check(components),
+          authorization_check(components)
         ]
       end
 
@@ -180,6 +181,23 @@ module Phlex
                "derive a default id from.")
       end
 
+      # ADVISORY (issue #168): the presence-side static heuristic complementing
+      # the runtime verify_authorized guard. Flags a non-skipped action whose
+      # component defines NONE of Phlex::Reactive.authorization_methods anywhere
+      # in its ancestry AND whose body (Prism-scanned via the Inspector) makes no
+      # authorization / mark_authorized! call. It is :unknown, NEVER a hard fail:
+      # a helper may authorize indirectly, so this is a hint, not a verdict.
+      def authorization_check(components)
+        suspects = components.flat_map { unauthorized_action_labels(it) }
+        return Check.new(:ok, "every mutating action appears to authorize", name: :authorization) if suspects.empty?
+
+        Check.new(:unknown, "actions with no detected authorization call: #{suspects.join(", ")}",
+          name: :authorization,
+          fix: "This is a heuristic (a helper may authorize indirectly). If each is intentional, " \
+               "confirm it authorizes; if an action is genuinely public, declare " \
+               "`skip_verify_authorized`. See the Debugging & tooling docs page.")
+      end
+
       # --- rendering --------------------------------------------------------
 
       # The full plain-text report: a line per check, plus an indented fix under
@@ -256,6 +274,42 @@ module Phlex
           !(klass.respond_to?(:reactive_record_key) && klass.reactive_record_key)
       rescue StandardError
         false
+      end
+
+      # "Klass#action" for every declared action on `klass` that (advisory)
+      # appears unauthorized: the component defines no authorization method in its
+      # ancestry, the action isn't skipped, and the Prism scan (via the shared
+      # Inspector) finds no authorization / mark_authorized! call in its body.
+      def unauthorized_action_labels(klass)
+        return [] if component_defines_authorization_method?(klass)
+
+        info = Phlex::Reactive::Inspector.components.find { it.klass == klass }
+        return [] unless info
+
+        info.actions
+          .reject { skips_authorization?(klass, it.name) }
+          .reject(&:authorization_call_detected?)
+          .map { "#{klass}##{it.name}" }
+      rescue StandardError
+        []
+      end
+
+      # Does the class define any CONFIGURED authorization method anywhere in its
+      # ancestry (public or private)? If so, it plausibly authorizes through a
+      # helper the static scan can't follow — stay quiet. Deliberately reads
+      # Phlex::Reactive.authorization_methods and NOT the Inspector's set, which
+      # folds in mark_authorized! — every component inherits that instance helper,
+      # so including it would silence the check for everything.
+      def component_defines_authorization_method?(klass)
+        Phlex::Reactive.authorization_methods.any? do
+          klass.method_defined?(it) || klass.private_method_defined?(it)
+        end
+      rescue StandardError
+        false
+      end
+
+      def skips_authorization?(klass, action_name)
+        klass.respond_to?(:skip_verify_authorized?) && klass.skip_verify_authorized?(action_name)
       end
 
       def stimulus_missing_check

--- a/spec/dummy/app/components/authorized_todo_component.rb
+++ b/spec/dummy/app/components/authorized_todo_component.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# verify_authorized fixture (issue #168). Record-backed so the request specs can
+# assert a DB mutation ROLLS BACK when an action fails the guard. It defines its
+# own `authorize!` (the interceptor wraps it, marking the tracking cell on a
+# non-raising return — exactly how a real app's Pundit/CanCanCan helper behaves)
+# and exercises every guard path across its actions:
+#
+#   rename           — calls authorize! (intercepted) → passes the guard
+#   rename_marked    — calls mark_authorized! (manual) → passes the guard
+#   rename_unguarded — authorizes NOTHING → the guard raises + rolls back
+#   rename_skipped   — per-action skip_verify_authorized → bypasses the guard
+#   rename_denied    — authorize! RAISES (registered) → 403, no mark, no mutation
+class AuthorizedTodoComponent < ApplicationComponent
+  include Phlex::Reactive::Component
+
+  # Registered in config/initializers/phlex_reactive.rb so a raise maps to 403.
+  class Denied < StandardError; end
+
+  reactive_record :todo
+
+  action :rename, params: { title: :string }
+  action :rename_marked, params: { title: :string }
+  action :rename_unguarded, params: { title: :string }
+  action :rename_skipped, params: { title: :string }
+  action :rename_denied, params: { title: :string }
+
+  # Only this action is public-by-declaration; the rest must authorize.
+  skip_verify_authorized :rename_skipped
+
+  def initialize(todo:)
+    @todo = todo
+  end
+
+  # The app-provided authorization helper the interceptor wraps. Returns truthy
+  # on allow; raises Denied on deny (the deny path is exercised by rename_denied).
+  # Named `authorize!` (bang, not `?`) to mirror the real Pundit/CanCanCan helper
+  # the interceptor targets — the predicate-naming cop doesn't apply.
+  def authorize!(allowed: true) # rubocop:disable Naming/PredicateMethod
+    raise Denied, "not allowed" unless allowed
+
+    true
+  end
+
+  def rename(title:)
+    authorize!
+    @todo.update!(title:)
+  end
+
+  def rename_marked(title:)
+    # A bespoke check the interceptor can't see — assert it manually.
+    mark_authorized!
+    @todo.update!(title:)
+  end
+
+  # Mutates, then authorizes nothing — the guard must raise AND roll the update
+  # back (fail-closed). The observable proof the transaction wrap works.
+  def rename_unguarded(title:)
+    @todo.update!(title:)
+  end
+
+  def rename_skipped(title:)
+    @todo.update!(title:)
+  end
+
+  def rename_denied(title:)
+    authorize!(allowed: false) # raises Denied → 403
+    @todo.update!(title:)      # never reached
+  end
+
+  def view_template
+    li(id:, **reactive_attrs) { @todo.title }
+  end
+end

--- a/spec/dummy/app/components/public_counter_component.rb
+++ b/spec/dummy/app/components/public_counter_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# verify_authorized fixture (issue #168): a genuinely public, state-backed
+# component with NO authorization — the canonical `skip_verify_authorized` case.
+# The bare skip covers every action, so the guard never fires even with
+# verify_authorized on.
+class PublicCounterComponent < ApplicationComponent
+  include Phlex::Reactive::Component
+
+  skip_verify_authorized
+
+  reactive_state :count
+  action :increment
+
+  def initialize(count: 0)
+    @count = count
+  end
+
+  def id = "public-counter"
+
+  def increment = @count += 1
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      span(data: { testid: "count" }) { @count.to_s }
+      button(**mix(on(:increment), data: { testid: "inc" })) { "+" }
+    end
+  end
+end

--- a/spec/dummy/config/initializers/phlex_reactive.rb
+++ b/spec/dummy/config/initializers/phlex_reactive.rb
@@ -5,6 +5,13 @@
 Rails.application.config.after_initialize do
   Phlex::Reactive.renderer = DemosController
 
+  # The dummy deliberately has no authorization layer — most of its components
+  # are demos with no user/policy. verify_authorized (issue #168) is default-ON,
+  # so disable it globally here; the dedicated verify_authorized feature specs
+  # re-enable it around their examples and drive purpose-built fixtures
+  # (AuthorizedTodoComponent, PublicCounterComponent).
+  Phlex::Reactive.verify_authorized = false
+
   # Register the optimistic demo's authorization error so a DECLARED, slow-failing
   # action returns a clean 403 (issue #98 system spec) — mirroring how a real app
   # registers Pundit::NotAuthorizedError. Lets the failing-revert spec observe the
@@ -19,4 +26,9 @@ Rails.application.config.after_initialize do
   # observe. Registering the errors maps them to that 403.
   Phlex::Reactive.authorization_errors << CounterComponent::Denied
   Phlex::Reactive.authorization_errors << FailureSurfaceComponent::Denied
+
+  # verify_authorized fixture (issue #168): AuthorizedTodoComponent#rename_denied
+  # raises this so the request spec proves a genuine denial still 403s through
+  # authorization_errors — NOT the verify guard's 500.
+  Phlex::Reactive.authorization_errors << AuthorizedTodoComponent::Denied
 end

--- a/spec/phlex/reactive/authorization_spec.rb
+++ b/spec/phlex/reactive/authorization_spec.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# verify_authorized (issue #168) is the presence-side complement to
+# authorization_errors: a default-ON runtime guard that raises when an action
+# completes WITHOUT any authorization call, rolling back the transaction
+# (fail-closed). This spec covers the tracking primitive (fiber-local, Falcon-
+# safe, mirroring with_connection_id), the interception (a prepend that marks the
+# tracking cell only on a non-raising return of a configured authorization
+# method), and the config surface (defaults + defined?-guard).
+RSpec.describe Phlex::Reactive::Authorization do
+  # Save and RESTORE the config across every example — the dummy sets
+  # verify_authorized = false globally in its initializer, so removing the ivar
+  # would re-default it to true and leak into later request specs. We snapshot
+  # whatever was configured (ivar present or not) and put it back exactly.
+  around do
+    saved = %i[@verify_authorized @authorization_methods].to_h do
+      present = Phlex::Reactive.instance_variable_defined?(it)
+      [it, [present, (Phlex::Reactive.instance_variable_get(it) if present)]]
+    end
+    it.run
+  ensure
+    saved.each do |ivar, (present, value)|
+      if present
+        Phlex::Reactive.instance_variable_set(ivar, value)
+      elsif Phlex::Reactive.instance_variable_defined?(ivar)
+        Phlex::Reactive.remove_instance_variable(ivar)
+      end
+    end
+  end
+
+  describe ".with_tracking / .marked? / .mark!" do
+    it "is untracked outside a tracking window" do
+      expect(described_class.marked?).to be(false)
+    end
+
+    it "reports unmarked inside a fresh tracking window" do
+      described_class.with_tracking do
+        expect(described_class.marked?).to be(false)
+      end
+    end
+
+    it "reports marked after mark! within the window" do
+      described_class.with_tracking do
+        described_class.mark!
+        expect(described_class.marked?).to be(true)
+      end
+    end
+
+    it "restores the previous tracking cell after the window (save/restore)" do
+      described_class.with_tracking do
+        described_class.mark!
+      end
+      # Outside, the cell is back to its pre-window state (nil).
+      expect(described_class.marked?).to be(false)
+    end
+
+    it "isolates a nested window and restores the outer cell (nesting)" do
+      described_class.with_tracking do
+        described_class.mark!
+        expect(described_class.marked?).to be(true)
+
+        described_class.with_tracking do
+          # Fresh inner window — the outer mark must NOT leak in.
+          expect(described_class.marked?).to be(false)
+          described_class.mark!
+          expect(described_class.marked?).to be(true)
+        end
+
+        # The outer mark survives the inner window's restore.
+        expect(described_class.marked?).to be(true)
+      end
+    end
+
+    it "restores the cell even when the block raises" do
+      expect do
+        described_class.with_tracking do
+          described_class.mark!
+          raise "boom"
+        end
+      end.to raise_error("boom")
+      expect(described_class.marked?).to be(false)
+    end
+  end
+
+  describe ".instrument! (prepend that marks on a non-raising auth call)" do
+    let(:klass) do
+      Class.new do
+        attr_reader :calls
+
+        def initialize = (@calls = [])
+
+        def authorize!(*)
+          @calls << :authorize!
+          :ok
+        end
+
+        def act_authorized
+          authorize!(:thing)
+          :done
+        end
+
+        def act_unauthorized = :done
+      end
+    end
+
+    before { Phlex::Reactive.authorization_methods = %i[authorize!] }
+
+    it "marks the tracking cell when a wrapped authorization method returns" do
+      described_class.instrument!(klass)
+      instance = klass.new
+      described_class.with_tracking do
+        instance.act_authorized
+        expect(described_class.marked?).to be(true)
+      end
+    end
+
+    it "does NOT mark when the action calls no authorization method" do
+      described_class.instrument!(klass)
+      instance = klass.new
+      described_class.with_tracking do
+        instance.act_unauthorized
+        expect(described_class.marked?).to be(false)
+      end
+    end
+
+    it "does NOT mark when the authorization method RAISES (a denial still propagates)" do
+      Phlex::Reactive.authorization_methods = %i[deny!]
+      raising = Class.new do
+        def deny! = raise(ArgumentError, "denied")
+      end
+      described_class.instrument!(raising)
+      described_class.with_tracking do
+        expect { raising.new.deny! }.to raise_error(ArgumentError)
+        expect(described_class.marked?).to be(false)
+      end
+    end
+
+    it "wraps a PRIVATE authorization method too (marks on a non-raising private call)" do
+      Phlex::Reactive.authorization_methods = %i[check]
+      klass2 = Class.new do
+        def check = :ok
+        private :check
+
+        def act
+          check
+          :done
+        end
+      end
+      described_class.instrument!(klass2)
+      described_class.with_tracking do
+        klass2.new.act
+        expect(described_class.marked?).to be(true)
+      end
+    end
+
+    it "is idempotent per class object (double instrument! prepends once)" do
+      described_class.instrument!(klass)
+      first = klass.ancestors.length
+      described_class.instrument!(klass)
+      expect(klass.ancestors.length).to eq(first)
+    end
+
+    it "runs the wrapped method exactly once even when double-instrumented" do
+      described_class.instrument!(klass)
+      described_class.instrument!(klass)
+      instance = klass.new
+      described_class.with_tracking { instance.act_authorized }
+      expect(instance.calls).to eq([:authorize!])
+    end
+  end
+
+  describe "config surface" do
+    # The booted dummy sets verify_authorized = false in its initializer, so the
+    # UNCONFIGURED default is only observable with the ivar removed (the around
+    # block restores it afterward).
+    it "defaults verify_authorized to true when unconfigured" do
+      Phlex::Reactive.remove_instance_variable(:@verify_authorized) if
+        Phlex::Reactive.instance_variable_defined?(:@verify_authorized)
+      expect(Phlex::Reactive.verify_authorized).to be(true)
+    end
+
+    it "honors an explicit false via the defined?-guard (not ||=)" do
+      Phlex::Reactive.verify_authorized = false
+      expect(Phlex::Reactive.verify_authorized).to be(false)
+    end
+
+    it "defaults authorization_methods to the common set" do
+      Phlex::Reactive.remove_instance_variable(:@authorization_methods) if
+        Phlex::Reactive.instance_variable_defined?(:@authorization_methods)
+      expect(Phlex::Reactive.authorization_methods).to contain_exactly(:authorize!, :authorize, :allowed_to?)
+    end
+  end
+
+  describe ".verify! (the enforcement decision)" do
+    let(:component_class) do
+      Class.new do
+        def self.name = "Phlex::Reactive::AuthorizationSpec::Widget"
+      end
+    end
+    let(:action_def) { Phlex::Reactive::Component::Action.new(name: :save, params: {}, schema: nil) }
+
+    it "raises AuthorizationNotVerified when on, not skipped, and unmarked" do
+      Phlex::Reactive.verify_authorized = true
+      described_class.with_tracking do
+        expect { described_class.verify!(component_class, action_def) }
+          .to raise_error(Phlex::Reactive::AuthorizationNotVerified, /save/)
+      end
+    end
+
+    it "is a no-op when marked" do
+      Phlex::Reactive.verify_authorized = true
+      described_class.with_tracking do
+        described_class.mark!
+        expect { described_class.verify!(component_class, action_def) }.not_to raise_error
+      end
+    end
+
+    it "is a no-op when verify_authorized is off" do
+      Phlex::Reactive.verify_authorized = false
+      described_class.with_tracking do
+        expect { described_class.verify!(component_class, action_def) }.not_to raise_error
+      end
+    end
+
+    it "is a no-op when the action is skipped" do
+      Phlex::Reactive.verify_authorized = true
+      skipping = Class.new do
+        def self.name = "Phlex::Reactive::AuthorizationSpec::Skipped"
+        def self.skip_verify_authorized?(_name) = true
+      end
+      described_class.with_tracking do
+        expect { described_class.verify!(skipping, action_def) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/phlex/reactive/doctor_spec.rb
+++ b/spec/phlex/reactive/doctor_spec.rb
@@ -180,6 +180,99 @@ RSpec.describe Phlex::Reactive::Doctor do
     end
   end
 
+  describe "the advisory authorization check (issue #168)" do
+    # ADVISORY only (:unknown, never a hard fail) — the presence-side static
+    # heuristic that complements the runtime verify_authorized guard. It flags a
+    # non-skipped action whose component defines none of the configured
+    # authorization methods in its ancestry AND whose body (Prism-scanned) makes
+    # no authorization / mark_authorized! call.
+
+    it "flags a mutating action with no authorization method anywhere and no auth call" do
+      unguarded = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        def self.name = "Phlex::Reactive::DoctorSpec::Unguarded"
+        reactive_record :todo
+        action :destroy
+        def initialize(todo:) = (@todo = todo)
+        def destroy = @todo.destroy!
+      end
+      stub_const(unguarded.name, unguarded)
+
+      check = doctor.authorization_check([unguarded])
+      expect(check.status).to eq(:unknown)
+      expect(check.message).to include("destroy")
+    end
+
+    it "does NOT flag an action that calls an authorization method (Prism-detected)" do
+      guarded = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        def self.name = "Phlex::Reactive::DoctorSpec::Guarded"
+        reactive_record :todo
+        action :destroy
+        def initialize(todo:) = (@todo = todo)
+
+        def destroy
+          authorize! @todo, :destroy?
+          @todo.destroy!
+        end
+      end
+      stub_const(guarded.name, guarded)
+
+      expect(doctor.authorization_check([guarded])).to be_ok
+    end
+
+    it "does NOT flag an action covered by skip_verify_authorized" do
+      skipped = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        def self.name = "Phlex::Reactive::DoctorSpec::Skipped"
+        reactive_state :n
+        skip_verify_authorized
+        action :bump
+        def initialize(n: 0) = (@n = n)
+        def id = "skipped"
+        def bump = @n += 1
+      end
+      stub_const(skipped.name, skipped)
+
+      expect(doctor.authorization_check([skipped])).to be_ok
+    end
+
+    it "does NOT flag a component that defines an authorization method in its ancestry" do
+      authz_base = Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Component
+
+        def authorize!(*) = true # rubocop:disable Naming/PredicateMethod
+      end
+      via_helper = Class.new(authz_base) do
+        def self.name = "Phlex::Reactive::DoctorSpec::ViaHelper"
+        reactive_state :n
+        action :bump
+        def initialize(n: 0) = (@n = n)
+        def id = "via-helper"
+        # Authorizes indirectly through a helper the Prism scan can't see, but the
+        # component HAS an authorization method defined — advisory stays quiet.
+        def bump = do_the_thing
+
+        def do_the_thing
+          authorize!
+          @n += 1
+        end
+      end
+      stub_const(via_helper.name, via_helper)
+
+      expect(doctor.authorization_check([via_helper])).to be_ok
+    end
+
+    it "is included in the full check list as advisory when the dummy runs" do
+      Rails.application.eager_load!
+      names = doctor.checks.map(&:name)
+      expect(names).to include(:authorization)
+    end
+  end
+
   describe "output rendering" do
     before { Rails.application.eager_load! }
 

--- a/spec/phlex/reactive/skip_verify_authorized_spec.rb
+++ b/spec/phlex/reactive/skip_verify_authorized_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# skip_verify_authorized (issue #168) is the explicit opt-out from the default-ON
+# verify_authorized guard, for a component (or specific actions) that legitimately
+# has no authorization — a public counter, a client-only filter. It is registry #6
+# (Component::Registry), so it inherits with the SAME semantics as the other five
+# registries (resolve through the superclass at read time).
+RSpec.describe "skip_verify_authorized DSL" do # rubocop:disable RSpec/DescribeClass
+  def component(&) = Class.new(ApplicationComponent, &)
+
+  describe "bare skip (whole component)" do
+    let(:klass) do
+      component do
+        include Phlex::Reactive::Component
+
+        skip_verify_authorized
+        action :bump
+        action :reset
+      end
+    end
+
+    it "skips every action" do
+      expect(klass.skip_verify_authorized?(:bump)).to be(true)
+      expect(klass.skip_verify_authorized?(:reset)).to be(true)
+      # Even an action that isn't declared reads as skipped under a bare skip.
+      expect(klass.skip_verify_authorized?(:anything)).to be(true)
+    end
+  end
+
+  describe "named skip (specific actions only)" do
+    let(:klass) do
+      component do
+        include Phlex::Reactive::Component
+
+        skip_verify_authorized :filter, :page
+        action :filter
+        action :page
+        action :destroy
+      end
+    end
+
+    it "skips the named actions" do
+      expect(klass.skip_verify_authorized?(:filter)).to be(true)
+      expect(klass.skip_verify_authorized?(:page)).to be(true)
+    end
+
+    it "does NOT skip an action not in the list" do
+      expect(klass.skip_verify_authorized?(:destroy)).to be(false)
+    end
+  end
+
+  describe "no skip declared" do
+    let(:klass) do
+      component do
+        include Phlex::Reactive::Component
+
+        action :destroy
+      end
+    end
+
+    it "skips nothing" do
+      expect(klass.skip_verify_authorized?(:destroy)).to be(false)
+    end
+  end
+
+  describe "inheritance (through Registry)" do
+    it "inherits a bare parent skip" do
+      parent = component do
+        include Phlex::Reactive::Component
+
+        skip_verify_authorized
+      end
+      child = Class.new(parent) { action :bump }
+      expect(child.skip_verify_authorized?(:bump)).to be(true)
+    end
+
+    it "inherits a parent's named skips and unions with the child's" do
+      parent = component do
+        include Phlex::Reactive::Component
+
+        skip_verify_authorized :inherited_action
+      end
+      child = Class.new(parent) do
+        skip_verify_authorized :own_action
+      end
+      expect(child.skip_verify_authorized?(:inherited_action)).to be(true)
+      expect(child.skip_verify_authorized?(:own_action)).to be(true)
+      expect(child.skip_verify_authorized?(:other)).to be(false)
+    end
+
+    it "a child's bare skip covers everything even if the parent named only some" do
+      parent = component do
+        include Phlex::Reactive::Component
+
+        skip_verify_authorized :only_this
+      end
+      child = Class.new(parent) { skip_verify_authorized }
+      expect(child.skip_verify_authorized?(:only_this)).to be(true)
+      expect(child.skip_verify_authorized?(:anything_else)).to be(true)
+    end
+  end
+end

--- a/spec/requests/verify_authorized_spec.rb
+++ b/spec/requests/verify_authorized_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# verify_authorized (issue #168): the default-ON runtime guard. An action that
+# completes WITHOUT any authorization call raises AuthorizationNotVerified INSIDE
+# the transaction — so the mutation ROLLS BACK (fail-closed, stronger than
+# Pundit's after-the-fact check). This request spec drives the real endpoint with
+# the feature re-enabled (the dummy sets verify_authorized = false globally),
+# proving every path: violation → raise + rollback, an intercepted authorize!,
+# mark_authorized!, class/per-action skip, the global off switch, and that a
+# genuine denial still 403s through authorization_errors.
+RSpec.describe "verify_authorized enforcement (issue #168)", type: :request do
+  # The dummy disables the guard globally (it has no authz layer). Re-enable it
+  # around these examples, then RESTORE the dummy's configured value — not the
+  # lazy default — so a later request spec that relies on the global-off setting
+  # isn't tripped by this suite (removing the ivar would re-default it to true).
+  around do
+    previous = Phlex::Reactive.verify_authorized
+    Phlex::Reactive.verify_authorized = true
+    it.run
+  ensure
+    Phlex::Reactive.verify_authorized = previous
+  end
+
+  def capture_action_events
+    events = []
+    sub = ActiveSupport::Notifications.subscribe("action.phlex_reactive") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  describe "an action that authorizes (intercepted authorize!)" do
+    it "returns 200 — the authorization call marked the tracking cell" do
+      todo = Todo.create!(title: "orig")
+      post_action(AuthorizedTodoComponent, act: "rename",
+        payload: { "gid" => todo.to_gid.to_s }, params: { title: "renamed" })
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("renamed")
+    end
+  end
+
+  describe "an action that uses mark_authorized! (bespoke check)" do
+    it "returns 200 — the manual mark satisfies the guard" do
+      todo = Todo.create!(title: "orig")
+      post_action(AuthorizedTodoComponent, act: "rename_marked",
+        payload: { "gid" => todo.to_gid.to_s }, params: { title: "manual" })
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("manual")
+    end
+  end
+
+  describe "an action that never authorizes (the violation)" do
+    it "raises AuthorizationNotVerified" do
+      todo = Todo.create!(title: "orig")
+      expect do
+        post_action(AuthorizedTodoComponent, act: "rename_unguarded",
+          payload: { "gid" => todo.to_gid.to_s }, params: { title: "sneaky" })
+      end.to raise_error(Phlex::Reactive::AuthorizationNotVerified, /rename_unguarded/)
+    end
+
+    it "ROLLS BACK the mutation the unguarded action performed" do
+      todo = Todo.create!(title: "orig")
+      begin
+        post_action(AuthorizedTodoComponent, act: "rename_unguarded",
+          payload: { "gid" => todo.to_gid.to_s }, params: { title: "sneaky" })
+      rescue Phlex::Reactive::AuthorizationNotVerified
+        # expected — the raise fires inside the transaction
+      end
+      # Fail-closed: the update! inside the action must NOT have committed.
+      expect(todo.reload.title).to eq("orig")
+    end
+
+    it "tags the action.phlex_reactive event outcome :unverified and re-raises" do
+      todo = Todo.create!(title: "orig")
+      events = capture_action_events do
+        post_action(AuthorizedTodoComponent, act: "rename_unguarded",
+          payload: { "gid" => todo.to_gid.to_s }, params: { title: "sneaky" })
+      rescue Phlex::Reactive::AuthorizationNotVerified
+        # swallow so we can inspect the emitted event
+      end
+      expect(events.first.payload[:outcome]).to eq(:unverified)
+    end
+  end
+
+  describe "skip_verify_authorized" do
+    it "returns 200 for a whole-component skip (public, no authz)" do
+      post_action(PublicCounterComponent, act: "increment", payload: { "s" => { "count" => 1 } })
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 200 for a per-action skip" do
+      todo = Todo.create!(title: "orig")
+      post_action(AuthorizedTodoComponent, act: "rename_skipped",
+        payload: { "gid" => todo.to_gid.to_s }, params: { title: "skipped" })
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("skipped")
+    end
+  end
+
+  describe "the global off switch" do
+    it "returns 200 for an unguarded action when verify_authorized is false" do
+      Phlex::Reactive.verify_authorized = false
+      todo = Todo.create!(title: "orig")
+      post_action(AuthorizedTodoComponent, act: "rename_unguarded",
+        payload: { "gid" => todo.to_gid.to_s }, params: { title: "allowed" })
+      expect(response).to have_http_status(:ok)
+      expect(todo.reload.title).to eq("allowed")
+    end
+  end
+
+  describe "a genuine denial still 403s (authorization_errors is unchanged)" do
+    it "maps a registered authorization error to 403, not the verify guard" do
+      todo = Todo.create!(title: "orig")
+      post_action(AuthorizedTodoComponent, act: "rename_denied",
+        payload: { "gid" => todo.to_gid.to_s }, params: { title: "nope" })
+      expect(response).to have_http_status(:forbidden)
+      # The denial raised (and marked nothing) — the mutation never happened.
+      expect(todo.reload.title).to eq("orig")
+    end
+  end
+end


### PR DESCRIPTION
> **Stacked on #170 (Phase 1).** Base branch is `issue-168-inspector-inventory`; this PR's own diff is the verify_authorized feature. Merge #170 first, then this retargets to `main`.

## Summary

Phase 2 of the developer-tooling issue (#168): **verify_authorized**, a default-ON runtime guard that makes a forgotten `authorize!` a loud, fail-closed error instead of a silent security hole.

When a reactive action completes **without any authorization call**, the endpoint raises `Phlex::Reactive::AuthorizationNotVerified` **inside the transaction** — so the mutation **rolls back** (fail-closed, stronger than Pundit's after-the-fact `verify_authorized` which runs post-commit).

### Mechanism

- **`Phlex::Reactive::Authorization`** — a fiber-local tracking window (`Thread.current`, Falcon-safe, mirroring `with_connection_id`), a `prepend` interceptor that marks the window **only on a non-raising return** of a configured authorization method (a denial still raises → `authorization_errors` → 403), and `verify!` (the enforcement decision: no-op when off / skipped / marked).
- **`mark_authorized!`** instance helper — for a bespoke check the interceptor can't see (a hand-rolled policy, an ownership comparison).
- **`skip_verify_authorized`** DSL — registry #6 (`Component::Registry`), inherits like the other five. Bare skips the whole component; named skips specific actions. `skip_verify_authorized?(name)` reader.
- **Config** — `Phlex::Reactive.verify_authorized` (default `true`) and `authorization_methods` (default `%i[authorize! authorize allowed_to?]`), both `defined?`-guarded so an explicit override sticks. New `AuthorizationNotVerified < Error`.
- **Endpoint** — `run_action` wraps the action in `with_tracking { … verify! }` inside `transaction_wrapper`; `create_action` `instrument!`s the class once (feature-on only) and tags the `action.phlex_reactive` event `:unverified` before re-raising (bubbles as a 500 the error tracker sees — **NOT** masked into a 4xx).
- **Doctor** — a new **advisory** (`:unknown`, never a hard fail) check flagging non-skipped actions with no authorization method in ancestry AND no Prism-detected auth call.

### A root-cause fix along the way

`Streamable` defines a **class method** `prepend(target:, model:)` (the Turbo Stream verb) that shadows Ruby's `Module#prepend` on a component class. The interceptor binds `Module#prepend` explicitly (`MODULE_PREPEND.bind_call`) rather than working around the collision — otherwise `component_class.prepend(module)` dispatches to the stream helper and raises `ArgumentError: required keyword: target`.

## Breaking change

Default-ON is a deliberate, pre-1.0 breaking change. **Three remedies** for each action, all in the CHANGELOG breaking note and the install-generator initializer:
1. call your authorization method (`authorize! @record, :update?`);
2. call `mark_authorized!` after a bespoke check;
3. declare `skip_verify_authorized` for an intentionally public action.

Turn it off with `Phlex::Reactive.verify_authorized = false`.

## Security (mandatory `/security` pass — no vulnerabilities)

| Concern | Verdict |
|---------|---------|
| Fail-closed: can an action mutate + commit unauthorized? | **No** — `verify!` raises inside the transaction; rollback confirmed empirically |
| Mark only on non-raising return | ✅ interceptor is `super` **then** `mark!`; a denial never marks |
| Fiber-local tracking under Falcon | ✅ `Thread.current` is fiber-local; window sets `false` at entry (clears leaks), restores in `ensure` |
| `AuthorizationNotVerified` masked into a 403? | **No** — rescue listed first, re-raises; `authorization_errors` defaults `[]` |
| Render retro-marking | **No** — render runs outside the window |

One documentation note (not a vuln): authorizing inside a custom `around_action` (which runs outside the window) gets a spurious raise — **fail-closed**, remedy is `mark_authorized!`. Will land on the Phase 5 docs page.

## Performance (before/after, same machine, Ruby 3.4.2 +YJIT)

- **OFF path** (dummy default): within noise of baseline — `+6 obj/req` (one boolean read short-circuits the guard). state 1220 → 1256 i/s.
- **ON + public/skip**: 886 obj/req — **identical** to OFF (`with_tracking` is two `Thread.current` writes, no allocation; skip fast-path).
- **ON + interceptor**: `instrument!` runs **once per class object** (memoized), not per request; the wrapper adds `super` + one `mark!` per auth call. No retained growth.
- Honest framing: a **request-level** guard (`run_action`), not a render micro-opt.

## Test Coverage

- `spec/phlex/reactive/authorization_spec.rb` — `with_tracking` save/restore + nesting + raise, `mark!`, `instrument!` idempotence + public/private/inherited wrapping + mark-only-on-non-raising, config defaults + `defined?`-guard, `verify!` decision matrix.
- `spec/phlex/reactive/skip_verify_authorized_spec.rb` — bare/named/no skip, inheritance through Registry.
- `spec/requests/verify_authorized_spec.rb` — intercepted `authorize!` → 200, `mark_authorized!` → 200, unguarded → raise **+ DB rollback asserted**, class/per-action skip → 200, global off → 200, genuine denial → 403, `:unverified` event tagged.
- `spec/phlex/reactive/doctor_spec.rb` — the advisory check (flag / quiet-via-Prism / skip / ancestry).

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests spec/generators` — **826 passing**
- [x] `bundle exec rubocop` — clean (189 files)
- [x] `bin/rails phlex_reactive:doctor` against the dummy still exits 0
- [x] `/security` pass — fail-closed, no bypass
- [x] perf before/after captured (above)

Refs #168
