### PR TITLE
chore(claude): add unknowns-discovery phases to /plan and /lfg

### DIFF
--- a/.claude/commands/lfg.md
+++ b/.claude/commands/lfg.md
@@ -87,6 +87,16 @@ Create a TaskCreate todo list with specific implementation steps.
 
 ## Phase 4: Implement (TDD)
 
+### The deviation log (keep it from the first edit)
+
+The plan is the map; the codebase is the territory. The moment reality forces a choice the plan or issue didn't settle, log it in `implementation-notes.md` at the repo root — one line, at the moment it happens, not reconstructed later:
+
+- **Deviations** — the plan said X, you did Y, because Z
+- **Discoveries** — facts about the codebase the plan didn't know
+- **Judgment calls** — choices the user might have made differently (defaults, naming, scope cuts)
+
+Pick the conservative option and keep going. The log is how the user audits your judgment afterwards. Never commit the file: its contents move into the PR body (Phase 7), then the file is deleted.
+
 For each logical unit:
 
 ### 4.1: Write Failing Test First
@@ -226,6 +236,20 @@ Write the PR body to a temp file (`--body-file`) to avoid shell-interpolation of
 backticks/tables. The body is copied verbatim — if you would not type a
 backslash in a GitHub comment, do not type one in the heredoc.
 
+The PR body MUST end with a `## Deviations & judgment calls` section copied from
+`implementation-notes.md` (then delete the file). If the plan held completely,
+write "None — the plan held." This section is read FIRST in review — it is the
+audit trail for every decision the plan didn't make.
+
+---
+
+## Phase 8: Comprehension Close-Out
+
+The tests prove the CODE is right; this phase keeps the USER's mental model right. After the PR is up, end your final message with:
+
+1. **The decisions, not the diff** — the 3–5 non-obvious choices in this change someone must understand to maintain it. Lead with anything from the deviation log; the user has never seen those.
+2. **Three merge-gate questions** the user should be able to answer before merging (e.g. "why does the verify run inside the transaction?"). If any answer isn't obvious to them, offer a walkthrough — an unanswerable question is comprehension debt, and merging anyway is how it compounds.
+
 ---
 
 ## Verification Checklist
@@ -237,5 +261,7 @@ backslash in a GitHub comment, do not type one in the heredoc.
 - [ ] Backwards compatible — existing components unchanged
 - [ ] pgbus optionality preserved (works with pgbus AND on Action Cable)
 - [ ] PR created with summary + test plan
+- [ ] PR body ends with `## Deviations & judgment calls` (from implementation-notes.md, since deleted)
+- [ ] Comprehension close-out delivered (decisions + three merge-gate questions)
 
 Now, execute this workflow for the provided issue or feature.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -2,7 +2,7 @@
 model: fable
 description: "Investigates the codebase, designs a solution, and produces a durable plan artifact — a GitHub issue or a plan markdown under docs/plans/. Read-only: never edits library or app code. Use before /lfg for anything non-trivial."
 argument-hint: "issue <feature or problem> | md <feature or problem> | <feature or problem>"
-allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent
+allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(gh search:*), Bash(gh label list:*), Bash(git log:*), Bash(git diff:*), Bash(git branch:*), Bash(date:*), Read, Grep, Glob, Write, Agent, AskUserQuestion
 ---
 
 # Plan — design expensive, execute cheap
@@ -32,7 +32,21 @@ Protect this session's context: delegate mechanical exploration to cheaper subag
 3. Read `CLAUDE.md` and the matching `.claude/rules/*.md` (coding-style, testing, performance, git-workflow, agents) — the invariants and gotchas live there. The published `docs/` site pages (architecture, security, broadcasting, transport-pgbus, testing, performance) are the deeper reference.
 4. Check `git log` for recent related work; the design should extend it, not fight it.
 
-## Phase 2 — Design
+## Phase 2 — Surface the unknowns (blindspot pass + interview)
+
+Investigation tells you what the codebase says; this phase finds what the REQUEST doesn't say. Run it BEFORE designing — a wrong assumption caught here costs one question; caught in review it costs a rewrite.
+
+1. **Blindspot pass.** Write down the unknowns you are carrying into the design:
+   - decisions the request leaves open (defaults, naming, public API/config surface, rollout & upgrade story)
+   - edge cases the codebase makes possible that the request never mentions
+   - anything with no precedent in this repo — flag it explicitly as unknown-unknown territory
+2. **Interview the user** with AskUserQuestion, one question at a time, prioritized by blast radius: architecture-changing answers first, then public API / config surface, then UX. Rules:
+   - Skip anything the codebase, CLAUDE.md, or an existing issue already answers.
+   - 2–5 questions is the sweet spot; zero is fine when the request is genuinely unambiguous — say so rather than inventing questions.
+   - Every question offers concrete options with a recommended default, never an open-ended essay prompt.
+3. **Record the answers** in the plan's Decision section as `Settled in interview:` bullets — constraints the executor must not re-litigate.
+
+## Phase 3 — Design
 
 - Develop 2–3 candidate approaches with real tradeoffs. Pick one and say why; record why the others lost.
 - The chosen design must respect the project invariants (see CLAUDE.md "Critical Rules"):
@@ -45,7 +59,7 @@ Protect this session's context: delegate mechanical exploration to cheaper subag
 - Decide the test strategy per `.claude/rules/testing.md`: unit (`spec/phlex`), request (`spec/requests`), broadcast (`spec/requests/*_broadcast_spec.rb`), system (`spec/system`, under Puma AND Falcon). Specs are named before the implementation steps they cover (TDD).
 - If the change touches a hot path (render, token signing, param coercion, broadcast, client dispatch), the plan must include a `rake bench` baseline-and-after step per `.claude/rules/performance.md`.
 
-## Phase 3 — Emit the plan artifact
+## Phase 4 — Emit the plan artifact
 
 Use this structure for the issue body or markdown file. Every section is load-bearing — an executor uses Context to avoid re-discovery, Steps to act, Gates to verify, Boundaries to stop.
 
@@ -59,7 +73,7 @@ Use this structure for the issue body or markdown file. Every section is load-be
 <Bullet list: `path/to/file.rb` — why it matters to this change. Include the mixin, the endpoint, the client controller, the relevant specs and dummy components. Self-contained: no references to "as discussed" or this session.>
 
 ## Decision
-<Chosen approach and rationale. Then: alternatives considered and why each was rejected. Call out the pgbus-present vs pgbus-absent behavior explicitly.>
+<Chosen approach and rationale. Then: alternatives considered and why each was rejected. Call out the pgbus-present vs pgbus-absent behavior explicitly. End with `Settled in interview:` bullets for every constraint the user confirmed in Phase 2 — the executor must not re-litigate these.>
 
 ## Implementation steps
 <Ordered, small, each mapped to a specialist where useful (/tdd, /architect, /perf). Specs come before the code they cover. Name exact files to create or change.>
@@ -82,6 +96,6 @@ For GitHub issues: create with `gh issue create --title "..." --body "$(cat <<'E
 
 For markdown files: Write to `docs/plans/YYYY-MM-DD-<slug>.md`. Leave it uncommitted — committing is the user's call.
 
-## Phase 4 — Handoff
+## Phase 5 — Handoff
 
 Report back: link to the issue (or file path), the chosen approach in 2–3 sentences, and the exact execute command. Stop there — do not start implementing.


### PR DESCRIPTION
## Summary

Adds three unknowns-discovery mechanisms to the workflow commands, so ambiguity is caught before execution instead of in post-hoc review loops:

- **`/plan` — Phase 2 "Surface the unknowns"**: a blindspot pass (open decisions, unmentioned edge cases, no-precedent territory) followed by a one-question-at-a-time `AskUserQuestion` interview, prioritized by blast radius (architecture > public API/config > UX). Answers land in the plan as `Settled in interview:` constraints the executor must not re-litigate. `AskUserQuestion` added to allowed-tools.
- **`/lfg` — deviation log**: every mid-run judgment call (deviation from plan, discovery, scope cut) is logged in `implementation-notes.md` the moment it happens, and surfaces as a mandatory `## Deviations & judgment calls` section at the end of the PR body (the file itself is never committed).
- **`/lfg` — Phase 8 comprehension close-out**: after the PR is up, the run ends with the 3–5 non-obvious decisions (deviation log first) and three merge-gate questions the reviewer should be able to answer before merging.

## Why

An 8-month analysis of prompt history showed a ~12:1 ratio of review-fix command invocations to planning invocations: unknowns were consistently paid for after execution (in `/github-review-*` loops) rather than before (in discovery). These phases make the discovery step structural instead of a habit to remember.

## Test plan

- Prose-only change to `.claude/commands/` — no library, app, or spec code touched.
- Next `/plan` run should interview before designing; next `/lfg` run should produce a PR with a `## Deviations & judgment calls` section and end with a comprehension close-out.
