### PR TITLE
feat(ci): transport verification matrix — prove Action Cable OR pgbus (#187)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,21 +150,48 @@ jobs:
 
   system:
     runs-on: ubuntu-latest
-    name: System (${{ matrix.server }})
-    # Run the browser suite under BOTH real web servers — Puma (sync, thread-pool)
-    # and Falcon (async, fiber-per-request) — so a reactive round trip is proven
-    # transport-agnostic. CAPYBARA_SERVER selects the server (see
-    # spec/system/support/capybara_setup.rb).
+    name: System (${{ matrix.server }} / ${{ matrix.transport }})
+    # Run the browser suite across TWO real servers × TWO transports (issue #187):
+    #   server:    puma (sync, thread-pool) | falcon (async, fiber-per-request)
+    #   transport: cable (Action Cable, SQLite) | pgbus (Postgres SSE)
+    # So a reactive round trip is proven transport-agnostic — the same specs pass
+    # on both, and the pgbus cells additionally prove real cross-tab broadcast
+    # delivery + actor-echo exclusion over live SSE (the :pgbus-tagged specs).
+    # The falcon × pgbus cell is the one that matters most (async + streaming).
     strategy:
       fail-fast: false
       matrix:
         server:
           - puma
           - falcon
+        transport:
+          - cable
+          - pgbus
+    # A plain postgres:18 for the pgbus cells (pgbus vendors the PGMQ schema via
+    # its own migrations — no extension image needed). It idles harmlessly for
+    # the cable cells; TRANSPORT gates whether the dummy uses it.
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: phlex_reactive_pgbus_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       RAILS_ENV: test
       HEADLESS: "true"
       CAPYBARA_SERVER: ${{ matrix.server }}
+      TRANSPORT: ${{ matrix.transport }}
+      # Read by spec/dummy/config/database.yml under TRANSPORT=pgbus (ignored on
+      # the cable cells, which stay SQLite).
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/phlex_reactive_pgbus_test
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v4
@@ -181,14 +208,22 @@ jobs:
       - name: Install JS dependencies
         run: bun install --frozen-lockfile
       - name: JS unit tests (client controller)
+        # Transport-independent; run once (the cable/puma cell) to avoid 4× repeats.
+        if: matrix.transport == 'cable'
         run: bun test spec/javascript
       - name: Minified client is in sync (drift guard)
         # The committed *.min.js/*.min.js.map must match a fresh build — the bun
         # minifier output is deterministic (and byte-identical across bun patch
         # releases), so a rebuild that changes a tracked byte means someone edited
-        # the source without running `rake build:js`. Runs only under one server.
-        if: matrix.server == 'puma'
+        # the source without running `rake build:js`. Runs only under one cell.
+        if: matrix.server == 'puma' && matrix.transport == 'cable'
         run: bundle exec rake build:js_check
+      - name: Prepare Postgres + pgbus schema
+        # pgbus cells only: load the dummy's app schema into Postgres and install
+        # the vendored PGMQ schema. pgbus is require:false, so PGBUS_PATH is unset
+        # here (uses the released gem). rake task lives in the Rakefile (#187).
+        if: matrix.transport == 'pgbus'
+        run: bundle exec rake pgbus:prepare_test_db
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
@@ -208,6 +243,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: capybara-screenshots
+          name: capybara-screenshots-${{ matrix.server }}-${{ matrix.transport }}
           path: spec/dummy/tmp/capybara/**/*.png
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`exclude:`/`visible_to:` now actually reach pgbus — actor-echo suppression works over SSE (#187).**
+  `broadcast_*_to`/`broadcast_*_to_each` passed `exclude:`/`visible_to:` as keyword
+  arguments to `Turbo::StreamsChannel.broadcast_*_to`, but turbo-rails swallows
+  unknown kwargs into its render locals — so on the pgbus transport the options were
+  **silently dropped** and `exclude: reactive_connection_id` never suppressed the
+  actor's own broadcast echo. They are now threaded through the thread-locals pgbus
+  reads (`Thread.current[:pgbus_broadcast_exclude]`/`_visible_to`), capability-gated
+  on `pgbus_streams?` so the Action Cable path is unchanged. Found by the new
+  end-to-end pgbus transport suite (below) — the prior unit doubles only proved the
+  option was *forwarded to the method*, never that it *reached pgbus*.
+
+### Added
+
+- **CI transport verification matrix — the browser suite runs on Action Cable AND pgbus (#187).**
+  The system job is now `server × transport` (Puma/Falcon × cable/pgbus). The pgbus
+  cells add a plain `postgres:18` (pgbus vendors the PGMQ schema via its own
+  migrations — no extension image) and set `TRANSPORT=pgbus`, so the existing browser
+  suite proves the reactive round trip is transport-agnostic, and new `:pgbus`-tagged
+  specs prove real cross-tab broadcast delivery + actor-echo exclusion over live
+  Postgres SSE. `rake spec:system_matrix` runs the 2×2 locally (pgbus cells skip with
+  a note when Postgres isn't reachable); `rake pgbus:prepare_test_db` sets up the DB.
+  pgbus remains an optional, non-gemspec dependency — it is now a first-class *tested*
+  transport, not a required one.
+
 ### Changed
 
 - **BREAKING: `reactive_show` speaks ONE conditions language — `if:`/`if_any:`/`unless:` (#180).**

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,40 @@ namespace :spec do
       sh({ "CAPYBARA_SERVER" => server }, "bundle exec rspec spec/system")
     end
   end
+
+  desc "Run the browser system specs across server × transport (puma/falcon × cable/pgbus)"
+  task :system_matrix do
+    # Issue #187: the full transport matrix, mirroring :system_servers one
+    # dimension over. The pgbus cells need Postgres + the pgbus schema (rake
+    # pgbus:prepare_test_db); they're SKIPPED with a clear note when Postgres
+    # isn't reachable locally, so the cable cells still prove the round trip.
+    servers = %w[puma falcon]
+    transports = %w[cable pgbus]
+    postgres = system("pg_isready", %i[out err] => File::NULL)
+    warn "\e[1;33m\n### Postgres not reachable — skipping pgbus cells (cable only) ###\e[0m" unless postgres
+
+    servers.each do |server|
+      transports.each do |transport|
+        pgbus = transport == "pgbus"
+        next puts("\e[1;33m### SKIP #{server}/pgbus (no Postgres) ###\e[0m") if pgbus && !postgres
+
+        sh({ "TRANSPORT" => "pgbus" }, "bundle exec rake pgbus:prepare_test_db") if pgbus
+        puts "\e[1;35m\n### system specs — CAPYBARA_SERVER=#{server} TRANSPORT=#{transport} ###\e[0m"
+        sh({ "CAPYBARA_SERVER" => server, "TRANSPORT" => transport }, "bundle exec rspec spec/system")
+      end
+    end
+  end
+end
+
+namespace :pgbus do
+  desc "Prepare the Postgres test DB for the pgbus transport cell (schema + PGMQ) — issue #187"
+  task :prepare_test_db do
+    # The setup lives in spec/support/prepare_pgbus_db.rb (boots the dummy under
+    # TRANSPORT=pgbus, loads the app schema, installs pgbus's vendored PGMQ — no
+    # CREATE EXTENSION, so a plain postgres:18 works). Used by CI and :system_matrix.
+    sh({ "TRANSPORT" => "pgbus", "RAILS_ENV" => "test" },
+      "bundle exec ruby spec/support/prepare_pgbus_db.rb")
+  end
 end
 
 require "rubocop/rake_task"

--- a/docs/app/views/docs/pages/testing.rb
+++ b/docs/app/views/docs/pages/testing.rb
@@ -289,7 +289,41 @@ module Views
                 plain 's or two browser contexts), act in one, and assert the morph appears in the other. ' \
                       'Allow a beat for the SSE round trip.'
               end
+              p do
+                strong { 'The transport matrix.' }
+                plain ' The gem is transport-agnostic — a reactive round trip must work on ' \
+                      'Action Cable AND pgbus. Its own CI proves this by running the browser suite ' \
+                      'across '
+                code { 'server × transport' }
+                plain ' (Puma/Falcon × cable/pgbus). The '
+                code { 'cable' }
+                plain ' cells run on SQLite; the '
+                code { 'pgbus' }
+                plain ' cells add a plain '
+                code { 'postgres:18' }
+                plain ' (pgbus vendors the PGMQ schema via its own migrations — no extension image) ' \
+                      'and set '
+                code { 'TRANSPORT=pgbus' }
+                plain ', so the same specs run over real Postgres-backed SSE. A handful of '
+                code { ':pgbus' }
+                plain '-tagged specs additionally prove real cross-tab delivery and actor-echo ' \
+                      'exclusion (the '
+                code { 'exclude: reactive_connection_id' }
+                plain ' contract) end to end.'
+              end
             end
+            DocsUI::Code(<<~BASH, lexer: :shell)
+              # both servers, Action Cable (the default local sweep)
+              bundle exec rake spec:system_servers
+
+              # the full matrix: puma/falcon × cable/pgbus (needs local Postgres;
+              # the pgbus cells skip with a note when Postgres isn't reachable)
+              bundle exec rake spec:system_matrix
+
+              # one pgbus cell by hand
+              bundle exec rake pgbus:prepare_test_db          # once, sets up the DB
+              TRANSPORT=pgbus CAPYBARA_SERVER=falcon bundle exec rspec spec/system
+            BASH
           end
         end
 

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -246,11 +246,11 @@ module Phlex
         # transports (Action Cable AND pgbus): it wraps this class-method body,
         # which is the same on either, so pgbus optionality is preserved.
         def broadcast_replace_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("replace", streamables) do
+          instrument_broadcast("replace", streamables, exclude:, visible_to:) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_replace_to(
               *streamables, target: component.id, html: render_component(component),
-              **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
+              **morph_attributes(morph)
             )
           end
         end
@@ -261,41 +261,38 @@ module Phlex
         # flag, it rides through `attributes:` (the broadcast path has no
         # `method:` kwarg) via morph_attributes.
         def broadcast_update_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("update", streamables) do
+          instrument_broadcast("update", streamables, exclude:, visible_to:) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_update_to(
               *streamables, target: component.id, html: render_component(component),
-              **morph_attributes(morph), **broadcast_transport_opts(exclude:, visible_to:)
+              **morph_attributes(morph)
             )
           end
         end
 
         def broadcast_append_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("append", streamables) do
+          instrument_broadcast("append", streamables, exclude:, visible_to:) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_append_to(
-              *streamables, target:, html: render_component(component),
-              **broadcast_transport_opts(exclude:, visible_to:)
+              *streamables, target:, html: render_component(component)
             )
           end
         end
 
         def broadcast_prepend_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("prepend", streamables) do
+          instrument_broadcast("prepend", streamables, exclude:, visible_to:) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_prepend_to(
-              *streamables, target:, html: render_component(component),
-              **broadcast_transport_opts(exclude:, visible_to:)
+              *streamables, target:, html: render_component(component)
             )
           end
         end
 
         def broadcast_remove_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("remove", streamables) do
+          instrument_broadcast("remove", streamables, exclude:, visible_to:) do
             component = build(model, options)
             ::Turbo::StreamsChannel.broadcast_remove_to(
-              *streamables, target: component.id,
-              **broadcast_transport_opts(exclude:, visible_to:)
+              *streamables, target: component.id
             )
           end
         end
@@ -303,8 +300,8 @@ module Phlex
         # Push server-side client DOM ops to EVERY subscriber of a stream (issue
         # #97) — the broadcast sibling of Response#js. Rides a `reactive:js`
         # custom stream action over Turbo::StreamsChannel, so it works on Action
-        # Cable AND pgbus (transport opts pass through broadcast_transport_opts
-        # exactly like every other broadcast):
+        # Cable AND pgbus (exclude:/visible_to: thread to pgbus via
+        # instrument_broadcast exactly like every other broadcast):
         #
         #   Notifications::Badge.broadcast_js_to(user, :alerts,
         #     js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
@@ -320,15 +317,14 @@ module Phlex
         # actor-reply concern only (Response#js), so it raises ArgumentError here
         # rather than silently shipping a hostile-feeling broadcast.
         def broadcast_js_to(*streamables, ops, exclude: nil, visible_to: nil, target: nil)
-          instrument_broadcast("reactive:js", streamables) do
+          instrument_broadcast("reactive:js", streamables, exclude:, visible_to:) do
             json = broadcast_js_ops_json(ops)
             ::Turbo::StreamsChannel.broadcast_action_to(
               *streamables,
               action: "reactive:js",
               target: target,
               attributes: { data: { reactive_ops: json } },
-              render: false,
-              **broadcast_transport_opts(exclude:, visible_to:)
+              render: false
             )
           end
         end
@@ -356,49 +352,45 @@ module Phlex
         # render-per-viewer by definition and can't be shared. This fan-out is
         # for the same payload to many keys.
         def broadcast_replace_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("replace", stream_keys) do
+          instrument_broadcast("replace", stream_keys, exclude:, visible_to:) do
             component = build(model, options)
             html = render_component(component)
-            transport = broadcast_transport_opts(exclude:, visible_to:)
             stream_keys.each do
               ::Turbo::StreamsChannel.broadcast_replace_to(
-                *Array(it), target: component.id, html:, **morph_attributes(morph), **transport
+                *Array(it), target: component.id, html:, **morph_attributes(morph)
               )
             end
           end
         end
 
         def broadcast_update_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("update", stream_keys) do
+          instrument_broadcast("update", stream_keys, exclude:, visible_to:) do
             component = build(model, options)
             html = render_component(component)
-            transport = broadcast_transport_opts(exclude:, visible_to:)
             stream_keys.each do
               ::Turbo::StreamsChannel.broadcast_update_to(
-                *Array(it), target: component.id, html:, **morph_attributes(morph), **transport
+                *Array(it), target: component.id, html:, **morph_attributes(morph)
               )
             end
           end
         end
 
         def broadcast_append_to_each(stream_keys, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("append", stream_keys) do
+          instrument_broadcast("append", stream_keys, exclude:, visible_to:) do
             component = build(model, options)
             html = render_component(component)
-            transport = broadcast_transport_opts(exclude:, visible_to:)
             stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_append_to(*Array(it), target:, html:, **transport)
+              ::Turbo::StreamsChannel.broadcast_append_to(*Array(it), target:, html:)
             end
           end
         end
 
         def broadcast_prepend_to_each(stream_keys, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("prepend", stream_keys) do
+          instrument_broadcast("prepend", stream_keys, exclude:, visible_to:) do
             component = build(model, options)
             html = render_component(component)
-            transport = broadcast_transport_opts(exclude:, visible_to:)
             stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_prepend_to(*Array(it), target:, html:, **transport)
+              ::Turbo::StreamsChannel.broadcast_prepend_to(*Array(it), target:, html:)
             end
           end
         end
@@ -406,11 +398,10 @@ module Phlex
         # remove has no body — nothing to render. It still builds ONCE to read
         # the component's #id (the target), then loops the cheap channel call.
         def broadcast_remove_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("remove", stream_keys) do
+          instrument_broadcast("remove", stream_keys, exclude:, visible_to:) do
             component = build(model, options)
-            transport = broadcast_transport_opts(exclude:, visible_to:)
             stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_remove_to(*Array(it), target: component.id, **transport)
+              ::Turbo::StreamsChannel.broadcast_remove_to(*Array(it), target: component.id)
             end
           end
         end
@@ -418,16 +409,46 @@ module Phlex
         private
 
         # Wrap a broadcast_*_to body in a broadcast.phlex_reactive event (issue
-        # #107). Payload: the component NAME, the Turbo stream action, and the
-        # streamables COUNT — never the model/state. Fires on both transports
-        # because it wraps the shared class-method body. Returns the block's value
-        # (the broadcast result) so callers are unaffected.
-        def instrument_broadcast(stream_action, streamables, &)
+        # #107) AND thread the pgbus transport opts (issue #187). Payload: the
+        # component NAME, the Turbo stream action, and the streamables COUNT —
+        # never the model/state. Fires on both transports because it wraps the
+        # shared class-method body. Returns the block's value (the broadcast
+        # result) so callers are unaffected.
+        #
+        # exclude:/visible_to: (issue #187): pgbus reads these from thread-locals
+        # (Thread.current[:pgbus_broadcast_exclude]/_visible_to), which its
+        # Turbo::StreamsChannel#broadcast_stream_to patch consults — NOT from the
+        # broadcast_*_to kwargs (turbo-rails swallows unknown kwargs into its
+        # render locals, so passing exclude: as a kwarg to StreamsChannel silently
+        # drops it: the actor-echo suppression never fired on pgbus). We set the
+        # thread-locals around the broadcast (capability-gated on pgbus_streams?)
+        # and clear them in ensure. On Action Cable there is no such thread-local
+        # reader, so this is a no-op there — pgbus optionality preserved.
+        def instrument_broadcast(stream_action, streamables, exclude: nil, visible_to: nil, &)
           Phlex::Reactive.instrument(
             "broadcast",
-            { component: name, stream_action: stream_action, streamables: streamables.size },
-            &
-          )
+            { component: name, stream_action: stream_action, streamables: streamables.size }
+          ) { with_pgbus_broadcast_opts(exclude:, visible_to:, &) }
+        end
+
+        # Set the pgbus broadcast thread-locals for the duration of the block,
+        # ONLY when streams-capable pgbus is present (the capability gate — an old
+        # pgbus / Action Cable never reads these keys, so we skip the work and the
+        # ensure entirely). Cleared in ensure so a broadcast never leaks its
+        # exclude into a later one on the same thread.
+        def with_pgbus_broadcast_opts(exclude:, visible_to:)
+          return yield unless Phlex::Reactive.pgbus_streams?
+
+          prev_exclude = Thread.current[:pgbus_broadcast_exclude]
+          prev_visible = Thread.current[:pgbus_broadcast_visible_to]
+          Thread.current[:pgbus_broadcast_exclude] = exclude
+          Thread.current[:pgbus_broadcast_visible_to] = visible_to
+          yield
+        ensure
+          if Phlex::Reactive.pgbus_streams?
+            Thread.current[:pgbus_broadcast_exclude] = prev_exclude
+            Thread.current[:pgbus_broadcast_visible_to] = prev_visible
+          end
         end
 
         # Validate + serialize broadcast ops: reject focus-class ops (they steal
@@ -461,15 +482,6 @@ module Phlex
         # render args and be dropped). Same wire result: method="morph".
         def morph_attributes(morph)
           morph ? { attributes: { method: "morph" } } : {}
-        end
-
-        # Only include transport opts that were actually given, so on Action
-        # Cable (which doesn't accept them) the common no-opts call is unchanged.
-        def broadcast_transport_opts(exclude:, visible_to:)
-          opts = {}
-          opts[:exclude] = exclude unless exclude.nil?
-          opts[:visible_to] = visible_to unless visible_to.nil?
-          opts
         end
 
         def renderer

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -16,14 +16,24 @@
     <script type="importmap">
       {
         "imports": {
-          "@hotwired/turbo-rails": "/vendor/turbo.js",
+          <%# Issue #187: pin turbo to a shim that re-exports a NAMED `Turbo`
+              (the raw turbo.js only sets window.Turbo). pgbus's stream-source
+              client does `import { Turbo } from "@hotwired/turbo-rails"`; without
+              the named export its module throws and the SSE element never
+              registers. The shim re-runs turbo.js's side effects, so a bare
+              `import "@hotwired/turbo-rails"` (the cable cells) is unaffected. %>
+          "@hotwired/turbo-rails": "/vendor/turbo_rails_shim.js",
           "@hotwired/stimulus": "/vendor/stimulus.js",
           "reactive_controller": "/vendor/reactive_controller.js",
           "phlex/reactive/confirm": "/vendor/confirm.js",
           "phlex/reactive/compute": "/vendor/compute.js",
           "phlex/reactive/inspect": "/vendor/inspect.js",
           "payment_split_reducer": "/vendor/payment_split_reducer.js",
-          "post_preview_reducer": "/vendor/post_preview_reducer.js"
+          "post_preview_reducer": "/vendor/post_preview_reducer.js"<% if ENV["TRANSPORT"] == "pgbus" %>,
+          <%# Issue #187: pgbus's turbo_stream_from injects `import
+              "pgbus/stream_source_element"`; pin it to the vendored engine asset
+              (this app has no asset pipeline / importmap-rails auto-pin). %>
+          "pgbus/stream_source_element": "/vendor/pgbus_stream_source_element.js"<% end %>
         }
       }
     </script>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -18,6 +18,14 @@ require "phlex/reactive"
 # (e.g. unit specs using spec_helper running before system specs).
 require "phlex/reactive/engine"
 
+# Issue #187: under TRANSPORT=pgbus, require pgbus HERE (it's require: false in
+# the Gemfile) — BEFORE Rails runs its initializers — so pgbus's engine
+# initializer ("pgbus.streams.turbo_broadcastable", after: load_config_initializers)
+# actually joins the run list and patches Turbo::StreamsChannel + turbo_stream_from
+# for the Postgres-SSE transport. Requiring it later (in config/initializers/)
+# registers the engine too late and the patch silently never installs.
+require "pgbus" if ENV["TRANSPORT"] == "pgbus"
+
 module Dummy
   class Application < Rails::Application
     config.load_defaults Rails::VERSION::STRING.to_f

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,3 +1,24 @@
+<%# The default suite (and CI's `cable` transport leg) runs on SQLite — zero
+    external services, per the testing invariant. TRANSPORT=pgbus switches to
+    Postgres so the browser suite can exercise pgbus's real Postgres-backed SSE
+    (issue #187). DATABASE_URL wins when set (CI); else a local default. %>
+<% if ENV["TRANSPORT"] == "pgbus" %>
+<% if ENV["DATABASE_URL"] %>
+test:
+  url: <%= ENV["DATABASE_URL"] %>
+development:
+  url: <%= ENV["DATABASE_URL"] %>
+<% else %>
+test:
+  adapter: postgresql
+  database: phlex_reactive_pgbus_test
+  host: localhost
+development:
+  adapter: postgresql
+  database: phlex_reactive_pgbus_dev
+  host: localhost
+<% end %>
+<% else %>
 development:
   adapter: sqlite3
   database: db/development.sqlite3
@@ -5,3 +26,4 @@ development:
 test:
   adapter: sqlite3
   database: ":memory:"
+<% end %>

--- a/spec/dummy/config/initializers/pgbus.rb
+++ b/spec/dummy/config/initializers/pgbus.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Issue #187: the dummy boots pgbus ONLY under TRANSPORT=pgbus, so the default
+# suite stays Postgres-free and Action-Cable-backed. pgbus is `require: false`
+# in the Gemfile (never a runtime dependency of the gem), so we require it here.
+# Once required, pgbus's engine initializer patches Turbo::StreamsChannel to
+# route broadcasts over Postgres SSE and swaps turbo_stream_from's cable source
+# for <pgbus-stream-source> — the phlex-reactive broadcast path is unchanged.
+#
+# streams_test_mode is left OFF: this env exists to exercise REAL streaming
+# (rack.hijack SSE), so the browser suite proves cross-tab delivery + actor-echo
+# exclusion end to end. The unit/request layers keep using doubles / test mode.
+# pgbus itself is required in config/application.rb (BEFORE Rails initializers,
+# so its engine patch installs) — here we only configure it.
+if ENV["TRANSPORT"] == "pgbus"
+  Pgbus.configure do
+    # Signing secret: Turbo.signed_stream_verifier_key (from secret_key_base) is
+    # used first; set an explicit one so the dummy needs no credentials file.
+    it.streams_signed_name_secret = "phlex-reactive-dummy-pgbus-test-secret"
+    # streams_test_mode OFF: this env exists to exercise REAL streaming (the SSE
+    # stub the default test mode returns would defeat the whole point). Broadcasts
+    # deliver in the web process (one streamer per Puma worker / Falcon reactor) —
+    # phlex-reactive's broadcast_*_to calls Pgbus.stream(...).broadcast(...) inline,
+    # so no worker/supervisor is needed for a single-process Capybara server.
+    it.streams_test_mode = false
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,6 +3,10 @@
 Rails.application.routes.draw do
   mount Turbo::Engine => "/turbo" if defined?(Turbo::Engine)
 
+  # Issue #187: under TRANSPORT=pgbus the dummy mounts pgbus so its SSE stream
+  # endpoint (/pgbus/streams) is live and turbo_stream_from routes over it.
+  mount Pgbus::Engine => "/pgbus" if ENV["TRANSPORT"] == "pgbus" && defined?(Pgbus::Engine)
+
   # Example pages exercised by system specs.
   get "counter" => "demos#counter"
   get "debug" => "demos#debug"

--- a/spec/dummy/public/vendor/pgbus_stream_source_element.js
+++ b/spec/dummy/public/vendor/pgbus_stream_source_element.js
@@ -1,0 +1,363 @@
+// <pgbus-stream-source> — the browser-side counterpart to
+// Pgbus::StreamsHelper#pgbus_stream_from. Drop-in replacement for
+// turbo-rails' <turbo-cable-stream-source> that speaks SSE + pgbus
+// instead of WebSocket + ActionCable.
+//
+// Attributes (set by the view helper):
+//   src                 — absolute path to the SSE endpoint, including
+//                         the URL-safe signed stream name
+//   since-id            — PGMQ msg_id watermark at render time; the
+//                         client sends this as ?since= on the FIRST
+//                         connect so the server can replay any
+//                         broadcasts from the render-to-connect gap
+//                         (rails/rails#52420 fix)
+//   signed-stream-name  — present for parity with turbo-rails; unused
+//                         by this element because the signed name is
+//                         already in the URL path
+//   channel             — compatibility shim; ignored
+//
+// Events (dispatched on the element):
+//   message            (MessageEvent) data = turbo-stream HTML;
+//                      lastEventId = the frame's msg_id (revision)
+//   pgbus:message      { msgId, data } — same frame, for optimistic-UI
+//                      reconciliation (skip morph if a newer rev for the
+//                      target was already applied). See #168.
+//   pgbus:event        { event, data, msgId } — a typed broadcast (any SSE
+//                      event name other than turbo-stream). See #170.
+//   pgbus:<event>      { data, msgId } — the same typed broadcast, named
+//                      for ergonomic addEventListener("pgbus:presence").
+//   pgbus:open         { lastEventId, connectionId }
+//   pgbus:connected    { connectionId }
+//   pgbus:replay-start { fromId, toId }
+//   pgbus:replay-end   {}
+//   pgbus:gap-detected { lastSeenId, archiveOldestId }
+//   pgbus:close        { code, reason }
+//
+// Connection id (issue #165 — actor-echo suppression): the server sends a
+// `pgbus:connected` frame right after the open handshake carrying the
+// server-minted connection id. This element captures it, reflects it onto
+// the `connection-id` attribute, and re-dispatches it as `pgbus:connected`.
+// A page reads it (from the element or a `<meta name="pgbus-connection-id">`
+// the app mirrors it to) and sends it back as the `X-Pgbus-Connection`
+// header on action requests. The broadcaster then passes
+// `exclude: request.headers["X-Pgbus-Connection"]` so the actor does not
+// receive the echo of its own broadcast.
+//
+// The element integrates with Turbo via connectStreamSource /
+// disconnectStreamSource + dispatching MessageEvent("message") so Turbo
+// Stream HTML is automatically consumed by the existing StreamObserver.
+//
+// Transport strategy:
+//   - FIRST connect: use fetch() + ReadableStream to include ?since=
+//     in the URL. Native EventSource cannot send Last-Event-ID on the
+//     initial request, so we need fetch to carry the watermark.
+//   - RECONNECT: switch to native EventSource, which sends Last-Event-ID
+//     automatically based on the last id: we observed. The native
+//     client is more battle-tested for reconnection backoff.
+
+import { Turbo } from "@hotwired/turbo-rails"
+const { connectStreamSource, disconnectStreamSource } = Turbo
+
+class PgbusStreamSourceElement extends HTMLElement {
+  static get observedAttributes() {
+    return ["src", "since-id"]
+  }
+
+  constructor() {
+    super()
+    this.abortController = null
+    this.eventSource = null
+    this.lastEventId = null
+    this.connectionId = null
+    this.closed = false
+  }
+
+  // The server-minted connection id for this SSE connection, or null
+  // until the `pgbus:connected` frame arrives. Public read accessor so
+  // a reactive runtime can grab it without poking at attributes.
+  get pgbusConnectionId() {
+    return this.connectionId
+  }
+
+  connectedCallback() {
+    this.closed = false
+    connectStreamSource(this)
+    const sinceId = this.getAttribute("since-id")
+    this.lastEventId = sinceId && sinceId !== "" ? sinceId : null
+    this.openFetchStream()
+  }
+
+  disconnectedCallback() {
+    this.closed = true
+    disconnectStreamSource(this)
+    this.teardown()
+  }
+
+  teardown() {
+    if (this.abortController) {
+      this.abortController.abort()
+      this.abortController = null
+    }
+    if (this.eventSource) {
+      this.eventSource.close()
+      this.eventSource = null
+    }
+  }
+
+  // First connect: use fetch() so we can include ?since=<watermark> on
+  // the URL. Parses the SSE event stream by hand because EventSource
+  // doesn't expose custom query strings uniformly across browsers.
+  async openFetchStream() {
+    // Each transport open is a fresh connection: the server mints a new id
+    // and sends a new pgbus:connected frame. Clear the previous id so
+    // pgbus:open (which fires before that frame arrives) can't surface a
+    // stale connection id — a stale id would produce a wrong X-Pgbus-Connection
+    // exclude header during reconnect windows.
+    this.resetConnectionId()
+    const url = this.buildUrl({ includeSince: true })
+    this.abortController = new AbortController()
+
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: "text/event-stream" },
+        credentials: "same-origin",
+        signal: this.abortController.signal
+      })
+
+      if (!response.ok) {
+        this.dispatchEvent(new CustomEvent("pgbus:close", {
+          detail: { code: response.status, reason: response.statusText }
+        }))
+        return
+      }
+
+      this.setAttribute("connected", "")
+      this.dispatchEvent(new CustomEvent("pgbus:open", {
+        detail: { lastEventId: this.lastEventId, connectionId: this.connectionId }
+      }))
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder("utf-8")
+      let buffer = ""
+
+      while (!this.closed) {
+        const { value, done } = await reader.read()
+        if (done) {
+          this.removeAttribute("connected")
+          this.switchToEventSource()
+          return
+        }
+
+        buffer += decoder.decode(value, { stream: true })
+        const events = buffer.split("\n\n")
+        buffer = events.pop() // last chunk may be incomplete
+
+        for (const block of events) {
+          this.handleBlock(block)
+        }
+      }
+    } catch (err) {
+      if (err.name !== "AbortError") {
+        this.removeAttribute("connected")
+        // Fall through to reconnect via native EventSource, which
+        // will carry Last-Event-ID from this.lastEventId forward.
+        this.switchToEventSource()
+      }
+    }
+  }
+
+  // Reconnect path: native EventSource with Last-Event-ID baked into
+  // the initial handshake by the browser.
+  switchToEventSource() {
+    if (this.closed) return
+
+    // Fresh connection on reconnect — drop the previous connection id so
+    // pgbus:open can't emit a stale one before the new pgbus:connected
+    // frame lands. See openFetchStream.
+    this.resetConnectionId()
+    const url = this.buildUrl({ includeSince: true })
+    this.eventSource = new EventSource(url, { withCredentials: true })
+
+    this.eventSource.addEventListener("open", () => {
+      this.setAttribute("connected", "")
+      this.dispatchEvent(new CustomEvent("pgbus:open", {
+        detail: { lastEventId: this.lastEventId, connectionId: this.connectionId }
+      }))
+    })
+
+    this.eventSource.addEventListener("error", () => {
+      this.removeAttribute("connected")
+    })
+
+    this.eventSource.addEventListener("turbo-stream", (event) => {
+      this.lastEventId = event.lastEventId
+      this.emitTurboStream(event.data, event.lastEventId)
+    })
+
+    this.eventSource.addEventListener("pgbus:connected", (event) => {
+      this.handleConnected(event.data)
+    })
+
+    this.eventSource.addEventListener("pgbus:gap-detected", (event) => {
+      const detail = this.safeJsonParse(event.data)
+      this.dispatchEvent(new CustomEvent("pgbus:gap-detected", { detail }))
+    })
+
+    this.eventSource.addEventListener("pgbus:shutdown", () => {
+      this.dispatchEvent(new CustomEvent("pgbus:close", {
+        detail: { code: "shutdown", reason: "worker restart" }
+      }))
+    })
+
+    // Typed broadcasts (issue #170): EventSource only fires listeners
+    // registered by name, so we register one per declared typed event.
+    for (const name of this.declaredTypedEvents()) {
+      this.eventSource.addEventListener(name, (event) => {
+        if (event.lastEventId) this.lastEventId = event.lastEventId
+        this.emitTypedEvent(name, event.data, event.lastEventId)
+      })
+    }
+  }
+
+  // Parses a single SSE event block (: comment | id: ... | event: ... | data: ...)
+  handleBlock(block) {
+    if (!block || block.startsWith(":")) return // comment
+
+    let id = null
+    let event = "message"
+    let data = ""
+
+    for (const line of block.split("\n")) {
+      if (line.startsWith("id:")) id = line.slice(3).trim()
+      else if (line.startsWith("event:")) event = line.slice(6).trim()
+      else if (line.startsWith("data:")) data += line.slice(5).trim()
+    }
+
+    if (id !== null) this.lastEventId = id
+
+    if (event === "turbo-stream") {
+      this.emitTurboStream(data, id)
+    } else if (event === "pgbus:connected") {
+      this.handleConnected(data)
+    } else if (event === "pgbus:gap-detected") {
+      this.dispatchEvent(new CustomEvent("pgbus:gap-detected", {
+        detail: this.safeJsonParse(data)
+      }))
+    } else if (event === "pgbus:shutdown") {
+      this.dispatchEvent(new CustomEvent("pgbus:close", {
+        detail: { code: "shutdown", reason: "worker restart" }
+      }))
+    } else {
+      // A typed broadcast (issue #170): event: presence | reactive | ...
+      this.emitTypedEvent(event, data, id)
+    }
+  }
+
+  // Captures the server-minted connection id from a `pgbus:connected`
+  // frame: stores it, reflects it onto the `connection-id` attribute (so
+  // it's visible in the DOM / to MutationObservers), and re-dispatches it
+  // as a `pgbus:connected` CustomEvent. Idempotent across reconnects — the
+  // server mints a fresh id per connection, so a reconnect updates it.
+  handleConnected(data) {
+    const detail = this.safeJsonParse(data)
+    const connectionId = detail && detail.connectionId
+    if (!connectionId) return
+
+    this.connectionId = connectionId
+    this.setAttribute("connection-id", connectionId)
+    this.dispatchEvent(new CustomEvent("pgbus:connected", {
+      detail: { connectionId }
+    }))
+  }
+
+  // Clears the cached connection id and its reflected attribute. Called at
+  // the start of every transport open so a reconnect doesn't carry the
+  // previous connection's id into pgbus:open before the new pgbus:connected
+  // frame arrives.
+  resetConnectionId() {
+    this.connectionId = null
+    this.removeAttribute("connection-id")
+  }
+
+  // Delivers a turbo-stream frame to two audiences (issue #168):
+  //
+  //   1. Turbo's StreamObserver, via a `message` MessageEvent whose `data`
+  //      is the turbo-stream HTML. The MessageEvent's standard
+  //      `lastEventId` field carries the frame's msg_id, so a reactive
+  //      runtime that listens for `message` can read the revision without
+  //      any pgbus-specific API. (Turbo ignores lastEventId.)
+  //
+  //   2. A reactive runtime doing optimistic-UI reconciliation, via a
+  //      `pgbus:message` CustomEvent carrying { msgId, data }. msgId is the
+  //      monotonic per-stream revision (a negative value marks an ephemeral
+  //      frame that was never persisted). Pattern: track the highest msgId
+  //      you have applied per target; when a frame arrives, skip the morph
+  //      if you have already applied a newer revision for that target —
+  //      this stops a late echo from clobbering a newer optimistic edit.
+  //      Complements #165: exclude handles the actor; this handles
+  //      out-of-order delivery for everyone else.
+  //
+  // msgId is parsed to a Number when numeric so consumers can compare
+  // revisions with `>` directly; left as-is otherwise.
+  emitTurboStream(data, id) {
+    const msgId = id === null || id === undefined || id === "" ? null
+      : (Number.isNaN(Number(id)) ? id : Number(id))
+
+    const message = new MessageEvent("message", { data, lastEventId: id == null ? "" : String(id) })
+    this.dispatchEvent(message)
+
+    this.dispatchEvent(new CustomEvent("pgbus:message", {
+      detail: { msgId, data }
+    }))
+  }
+
+  // Delivers a typed broadcast (issue #170) — a frame whose SSE event name
+  // is something other than turbo-stream (e.g. "presence", "reactive").
+  // The payload is still whatever the broadcaster sent (usually a Turbo
+  // Stream); the typed name lets a client route without sniffing the HTML.
+  // Dispatched two ways for ergonomics:
+  //   - a generic `pgbus:event` { event, data, msgId } (one listener for all)
+  //   - a named `pgbus:<event>`  { data, msgId }      (addEventListener by name)
+  emitTypedEvent(event, data, id) {
+    const msgId = id === null || id === undefined || id === "" ? null
+      : (Number.isNaN(Number(id)) ? id : Number(id))
+
+    this.dispatchEvent(new CustomEvent("pgbus:event", {
+      detail: { event, data, msgId }
+    }))
+    this.dispatchEvent(new CustomEvent(`pgbus:${event}`, {
+      detail: { data, msgId }
+    }))
+  }
+
+  // Typed event names the EventSource (reconnect) path should listen for,
+  // declared by the app via the `listen-events` attribute (comma- or
+  // space-separated). EventSource only invokes listeners registered by
+  // name, so unlike the fetch path it cannot route unknown typed events
+  // generically; declaring them here keeps typed delivery working across
+  // reconnects. The fetch (initial) path always routes typed events.
+  declaredTypedEvents() {
+    const raw = this.getAttribute("listen-events")
+    if (!raw) return []
+    return raw.split(/[\s,]+/).filter((name) => name && name !== "turbo-stream")
+  }
+
+  buildUrl({ includeSince }) {
+    const src = this.getAttribute("src")
+    if (!includeSince || !this.lastEventId) return src
+
+    const url = new URL(src, window.location.origin)
+    url.searchParams.set("since", this.lastEventId)
+    return url.toString()
+  }
+
+  safeJsonParse(str) {
+    try { return JSON.parse(str) } catch { return null }
+  }
+}
+
+if (!customElements.get("pgbus-stream-source")) {
+  customElements.define("pgbus-stream-source", PgbusStreamSourceElement)
+}
+
+export { PgbusStreamSourceElement }

--- a/spec/dummy/public/vendor/turbo_rails_shim.js
+++ b/spec/dummy/public/vendor/turbo_rails_shim.js
@@ -1,0 +1,16 @@
+// Issue #187: pgbus's <pgbus-stream-source> client does
+//   import { Turbo } from "@hotwired/turbo-rails"
+// but the vendored turbo.js distribution (real Turbo 8.0.12) exports its
+// symbols individually and only assigns `window.Turbo` — it has NO named
+// `Turbo` export. Without one, pgbus's client module throws at load and the
+// custom element never registers (SSE never connects, silently).
+//
+// This shim re-exports `window.Turbo` under the name pgbus imports. Importing
+// it also runs turbo.js for its side effects (registering the turbo custom
+// elements + setting window.Turbo), so a bare `import "@hotwired/turbo-rails"`
+// (the dummy's own layout script, the cable cells) keeps working unchanged —
+// the shim only ADDS the named export.
+import "./turbo.js"
+
+export const Turbo = window.Turbo
+export default window.Turbo

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,22 @@ RSpec.configure do
   it.infer_spec_type_from_file_location!
   it.use_transactional_fixtures = true
 
+  # Issue #187: the pgbus real-SSE specs (:pgbus tag) need the actor's write to
+  # COMMIT so pgbus's ephemeral LISTEN/NOTIFY broadcast actually fires (NOTIFY is
+  # transactional — it delivers only at commit; inside a rolled-back test
+  # transaction the observer's SSE connection never sees it). rspec-rails reads
+  # use_transactional_tests off the EXAMPLE GROUP, so flip it there (a
+  # prepend_before(:context) runs before the per-example DB transaction opens),
+  # and truncate after each. Only the pgbus cell loads these (they skip
+  # otherwise), so the default suite is untouched.
+  it.prepend_before(:context, :pgbus) { self.class.use_transactional_tests = false }
+  it.after(:each, :pgbus) do
+    conn = ActiveRecord::Base.connection
+    (conn.tables - %w[schema_migrations ar_internal_metadata]).each { conn.truncate(it) }
+  rescue StandardError => e
+    warn "[pgbus cleanup] #{e.class}: #{e.message}"
+  end
+
   # fixture_file_upload (multipart upload specs, issue #34) resolves files here.
   it.file_fixture_path = File.expand_path("fixtures/files", __dir__)
   it.include ActionDispatch::TestProcess::FixtureFile

--- a/spec/requests/broadcast_fanout_spec.rb
+++ b/spec/requests/broadcast_fanout_spec.rb
@@ -82,29 +82,49 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     end
   end
 
-  # exclude:/visible_to: are TRANSPORT opts (pgbus reads them; Action Cable
-  # ignores them). They must forward PER key exactly like every other
-  # broadcast_*_to method — the pgbus-PRESENT path suppresses the actor's echo
-  # on every stream, and the pgbus-ABSENT path stays unchanged.
-  describe "transport opts pass-through (pgbus-present)" do
-    it "forwards exclude: to every key" do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+  # exclude:/visible_to: are TRANSPORT opts. pgbus reads them from THREAD-LOCALS
+  # (Thread.current[:pgbus_broadcast_exclude]/_visible_to) in its
+  # Turbo::StreamsChannel#broadcast_stream_to patch — NOT from the broadcast_*_to
+  # kwargs (turbo-rails swallows unknown kwargs into its render locals, so passing
+  # exclude: as a StreamsChannel kwarg silently dropped it — issue #187). So the
+  # fan-out must set the thread-local for the WHOLE loop (every key is excluded),
+  # gated on pgbus_streams? (Action Cable never reads it → no-op).
+  describe "transport opts thread to pgbus (pgbus-present)" do
+    before { allow(Phlex::Reactive).to receive(:pgbus_streams?).and_return(true) }
+
+    it "sets the exclude thread-local for every key's broadcast" do
+      seen = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do
+        seen << Thread.current[:pgbus_broadcast_exclude]
+      end
 
       CounterComponent.broadcast_replace_to_each(keys, model: nil, exclude: "conn-actor-1")
 
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to)
-        .with(anything, anything, hash_including(exclude: "conn-actor-1"))
-        .exactly(keys.size).times
+      expect(seen).to eq(["conn-actor-1"] * keys.size)
+      # …and it is cleared after the fan-out (never leaks to a later broadcast).
+      expect(Thread.current[:pgbus_broadcast_exclude]).to be_nil
     end
 
-    it "forwards visible_to: to every key" do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+    it "sets the visible_to thread-local for every key's broadcast" do
+      seen = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do
+        seen << Thread.current[:pgbus_broadcast_visible_to]
+      end
 
       CounterComponent.broadcast_replace_to_each(keys, model: nil, visible_to: "user:7")
 
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to)
-        .with(anything, anything, hash_including(visible_to: "user:7"))
-        .exactly(keys.size).times
+      expect(seen).to eq(["user:7"] * keys.size)
+    end
+
+    it "does NOT pass exclude:/visible_to: as StreamsChannel kwargs (turbo-rails would swallow them)" do
+      seen_kwargs = []
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do |*_args, **kwargs|
+        seen_kwargs << kwargs
+      end
+
+      CounterComponent.broadcast_replace_to_each(keys, model: nil, exclude: "conn-actor-1")
+
+      expect(seen_kwargs).to all(satisfy { !it.key?(:exclude) && !it.key?(:visible_to) })
     end
   end
 

--- a/spec/requests/js_broadcast_spec.rb
+++ b/spec/requests/js_broadcast_spec.rb
@@ -64,39 +64,47 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
       .to raise_error(ArgumentError, /no ops/)
   end
 
-  # Transport opts (exclude:/visible_to:) pass through broadcast_transport_opts
-  # to the stream — the pgbus SSE dispatcher reads them; Action Cable ignores
-  # them. We assert the call threads them through (the same contract every other
-  # broadcast_*_to method upholds), so the pgbus-present path suppresses the
-  # actor's own echo and the pgbus-absent path is unaffected.
-  describe "transport opts pass-through (pgbus-present vs pgbus-absent)" do
-    it "forwards exclude: to Turbo::StreamsChannel.broadcast_action_to" do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+  # Transport opts (exclude:/visible_to:) thread to pgbus via THREAD-LOCALS (its
+  # broadcast_stream_to patch reads Thread.current[:pgbus_broadcast_*]), NOT via
+  # StreamsChannel kwargs (turbo-rails swallows unknown kwargs — issue #187). So
+  # broadcast_js_to sets the thread-local when pgbus is present, and passes NO
+  # transport kwargs to broadcast_action_to (Action Cable ignores them anyway).
+  describe "transport opts thread to pgbus (pgbus-present)" do
+    before { allow(Phlex::Reactive).to receive(:pgbus_streams?).and_return(true) }
+
+    it "sets the exclude thread-local during the broadcast" do
+      seen = nil
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to) do
+        seen = Thread.current[:pgbus_broadcast_exclude]
+      end
 
       TodoItemComponent.broadcast_js_to("alerts", ops, exclude: "conn-actor-1")
 
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to)
-        .with("alerts", hash_including(action: "reactive:js", exclude: "conn-actor-1"))
+      expect(seen).to eq("conn-actor-1")
+      expect(Thread.current[:pgbus_broadcast_exclude]).to be_nil # cleared after
     end
 
-    it "forwards visible_to: when given" do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
+    it "sets the visible_to thread-local during the broadcast" do
+      seen = nil
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to) do
+        seen = Thread.current[:pgbus_broadcast_visible_to]
+      end
 
       TodoItemComponent.broadcast_js_to("alerts", ops, visible_to: "user:7")
 
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to)
-        .with("alerts", hash_including(visible_to: "user:7"))
+      expect(seen).to eq("user:7")
     end
 
-    it "omits transport opts entirely when none given (pgbus-absent path unchanged)" do
-      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to)
-
-      TodoItemComponent.broadcast_js_to("alerts", ops)
-
-      expect(Turbo::StreamsChannel).to have_received(:broadcast_action_to) do |*, **kwargs|
-        expect(kwargs).not_to have_key(:exclude)
-        expect(kwargs).not_to have_key(:visible_to)
+    it "never passes exclude:/visible_to: as broadcast_action_to kwargs" do
+      seen_kwargs = nil
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to) do |*_a, **kwargs|
+        seen_kwargs = kwargs
       end
+
+      TodoItemComponent.broadcast_js_to("alerts", ops, exclude: "conn-actor-1", visible_to: "user:7")
+
+      expect(seen_kwargs).not_to have_key(:exclude)
+      expect(seen_kwargs).not_to have_key(:visible_to)
     end
   end
 

--- a/spec/support/prepare_pgbus_db.rb
+++ b/spec/support/prepare_pgbus_db.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Issue #187: prepare the Postgres test DB for the pgbus transport cell. Boots
+# the dummy under TRANSPORT=pgbus (Postgres), loads the app schema, and installs
+# pgbus's vendored PGMQ schema (idempotent — no CREATE EXTENSION, so it runs on a
+# plain postgres:18). Run via `rake pgbus:prepare_test_db` (CI + spec:system_matrix).
+require_relative "../dummy/config/environment"
+require "pgbus/pgmq_schema"
+
+ActiveRecord::Schema.verbose = false
+load Rails.root.join("db/schema.rb")
+
+conn = ActiveRecord::Base.connection
+pgmq_present = conn
+  .select_value("SELECT count(*) FROM information_schema.schemata WHERE schema_name = #{conn.quote("pgmq")}")
+  .to_i
+  .positive?
+conn.execute(Pgbus::PgmqSchema.install_sql) unless pgmq_present
+
+# This is a rake-invoked setup SCRIPT, not an example — the status line is for
+# the CI log, not a spec expectation.
+puts "pgbus test DB ready (app schema + PGMQ)" # rubocop:disable RSpec/Output

--- a/spec/system/pgbus_transport_spec.rb
+++ b/spec/system/pgbus_transport_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# Issue #187: the pgbus transport, verified over REAL SSE (not doubles). These
+# specs run ONLY in the pgbus cells (TRANSPORT=pgbus + a Postgres service); the
+# :pgbus tag + the guard below skip them everywhere else. They prove what the
+# unit doubles can't: a broadcast rendered by one session is delivered to a
+# SECOND session over pgbus's Postgres-backed SSE, and the actor's own echo is
+# suppressed by exclude: reactive_connection_id.
+#
+# pgbus streams are EPHEMERAL (LISTEN/NOTIFY, live-only) — a broadcast reaches
+# only subscribers CONNECTED at broadcast time. So delivery is only observable
+# across live browser sessions, which is exactly the property under test. The
+# :pgbus tag also flips off transactional fixtures (rails_helper.rb) so the
+# actor's write COMMITS and the transactional NOTIFY actually fires.
+RSpec.describe "pgbus transport (real SSE)", :pgbus, type: :system do
+  before do
+    skip "pgbus transport cell only (TRANSPORT=pgbus)" unless ENV["TRANSPORT"] == "pgbus"
+  end
+
+  # Wait until the room's <pgbus-stream-source> has a connection-id — i.e. the
+  # SSE stream is actually OPEN. Broadcasting before it connects would race
+  # (ephemeral delivery only reaches live subscribers).
+  def wait_for_sse_connection
+    expect(page).to have_css("pgbus-stream-source", visible: :all, wait: 10)
+    expect(page).to(
+      have_css("pgbus-stream-source[connection-id]", visible: :all, wait: 10),
+      "the pgbus SSE stream never opened (no connection-id) — the client failed to connect"
+    )
+    # The connection-id attribute lands on the client the instant the SSE handshake
+    # returns, but the server-side subscriber registration the broadcast's exclude:
+    # matches against settles a beat later. Give it that beat so an actor's own
+    # exclusion is deterministic (without this, a just-connected actor can still
+    # receive its own broadcast — the exclude has no registered subscriber to skip).
+    sleep 0.5
+  end
+
+  it "delivers a broadcast from one session to a SECOND session over SSE" do
+    # Session 2 (observer) subscribes and connects first.
+    Capybara.using_session(:observer) do
+      visit "/chat"
+      expect(page).to have_css("#chat-messages-lobby")
+      wait_for_sse_connection
+    end
+
+    # Session 1 (actor) sends a message via the reactive action.
+    Capybara.using_session(:actor) do
+      visit "/chat"
+      wait_for_sse_connection
+      find("[data-testid='chat-input']").set("delivered over pgbus sse")
+      find("[data-testid='chat-send']").click
+      expect(page).to have_field("body", with: "") # round trip completed
+    end
+
+    # Session 2 receives it over SSE — the delivery the test-cable adapter
+    # couldn't assert (spec/system/chat_spec.rb documents that gap).
+    Capybara.using_session(:observer) do
+      expect(page).to have_css("[data-testid='message']", text: "delivered over pgbus sse", wait: 10)
+    end
+  end
+
+  it "suppresses the actor's own echo (exclude: reactive_connection_id)" do
+    # The actor's POST carries X-Pgbus-Connection (the reactive client reads it
+    # off the connected <pgbus-stream-source>), and send_message broadcasts with
+    # exclude: reactive_connection_id. The composer's reply re-renders only the
+    # composer (not the list), so the message reaches a client ONLY via the
+    # broadcast. Therefore, with the actor excluded: the actor sees NONE of its
+    # own message, while a SEPARATE observer (a different, non-excluded
+    # connection) receives it. A broken exclude would echo it back to the actor.
+    Capybara.using_session(:observer) do
+      visit "/chat"
+      expect(page).to have_css("#chat-messages-lobby")
+      wait_for_sse_connection
+    end
+
+    Capybara.using_session(:actor) do
+      visit "/chat"
+      wait_for_sse_connection
+      # Prove the connection id is actually threaded (the exclude has a real
+      # target) — not a no-op that happens to look right.
+      connection_id = page.evaluate_script(
+        "document.querySelector('pgbus-stream-source')?.getAttribute('connection-id')"
+      )
+      expect(connection_id).to be_a(String).and(be_present)
+
+      find("[data-testid='chat-input']").set("no echo to me")
+      find("[data-testid='chat-send']").click
+      expect(page).to have_field("body", with: "")
+    end
+
+    # The observer (NOT excluded) receives it — proving the broadcast fired.
+    Capybara.using_session(:observer) do
+      expect(page).to have_css("[data-testid='message']", text: "no echo to me", wait: 10)
+    end
+
+    # The actor NEVER sees its own message — its connection was excluded. By now
+    # the observer already has it, so any echo to the actor would have landed.
+    Capybara.using_session(:actor) do
+      expect(page).to have_no_css("[data-testid='message']", text: "no echo to me")
+    end
+  end
+end


### PR DESCRIPTION
Closes #187 (epic H).

## Summary

Makes pgbus a first-class **tested** transport (still not a runtime dependency): the browser suite now runs `server × transport` (Puma/Falcon × Action Cable/pgbus), so the "works on Action Cable OR pgbus" claim is proven end-to-end instead of by unit doubles.

**And it caught a real shipping bug in the process** — which is exactly why the issue exists.

## The bug it caught: `exclude:` did nothing on pgbus

`broadcast_*_to` threaded `exclude:`/`visible_to:` as **keyword arguments** to `Turbo::StreamsChannel.broadcast_*_to`. But turbo-rails swallows unknown kwargs into its render locals (`broadcast_append_to(**opts)` → `broadcast_action_to(..., **rendering)`), so on the pgbus path the options were **silently dropped** — pgbus reads them from thread-locals its `broadcast_stream_to` patch consults, which were never set. Result: `exclude: reactive_connection_id` **never suppressed the actor's own broadcast echo** over SSE.

The unit doubles only asserted the option was *forwarded to the method*; they never proved it *reached pgbus*. The real-SSE two-session spec did — the actor received its own echo.

**Fix:** centralize the opt-threading in `instrument_broadcast` (every broadcast already flows through it). It now sets `Thread.current[:pgbus_broadcast_exclude]`/`_visible_to` around the broadcast — capability-gated on `pgbus_streams?`, cleared in `ensure`, nesting-safe — and the swallowed `**broadcast_transport_opts(...)` kwarg spread is removed from all 11 broadcast call sites. The Action Cable path is unchanged (it never read those keys).

## What's in it

- **The dummy gains a `TRANSPORT=pgbus` mode**: conditional Postgres `database.yml`, a conditional pgbus initializer (`streams_test_mode` off for real streaming), the pgbus engine mount, and the vendored `<pgbus-stream-source>` client + importmap pin. All pure `ENV.fetch` at in-process boot — the default suite stays SQLite/Action-Cable.
- **Two `:pgbus`-tagged system specs** (`spec/system/pgbus_transport_spec.rb`): real cross-tab broadcast delivery over SSE, and actor-echo exclusion — both across two live browser sessions. They skip everywhere but the pgbus cell.
- **CI matrix** (`.github/workflows/main.yml`): the system job goes 2×2; the pgbus cells add a plain `postgres:18` (pgbus vendors the PGMQ schema — no extension image) + `pgbus:prepare_test_db`.
- **Rake tasks**: `spec:system_matrix` (the local 2×2, pgbus cells skip with a note when Postgres isn't reachable) and `pgbus:prepare_test_db`.
- **Broadcast request specs rewritten** to assert the thread-local mechanism (not the swallowed kwarg); docs + CHANGELOG.

## Verification

- [x] `bundle exec rspec spec/phlex spec/requests` — 1055 passed
- [x] `bun test spec/javascript` — 403 passed
- [x] `bundle exec rake spec:system_matrix` — **all 4 cells green** (70 examples each; cable cells skip the 2 pgbus specs, pgbus cells run them). The pgbus specs are 3/3 reliable under both Puma and Falcon.
- [x] `bundle exec rubocop` — clean (229 files + docs)
- [x] pgbus remains optional (no gemspec dependency; the default suite needs no Postgres)

## Deviations & judgment calls

Read this first — the audit trail for every decision the plan didn't settle.

- **This validated locally against real PG18 before touching CI, and it paid for itself twice.** The plan was "add a matrix"; the local spike found (1) a client-load blocker and (2) the `exclude:` bug. Neither would have surfaced from doubles.
- **The `exclude:` bug (above) is the headline.** `exclude: reactive_connection_id` — advertised, unit-tested — silently did nothing on pgbus. Root cause traced (turbo-rails swallows the kwarg; pgbus reads a thread-local), reproduced on pgbus 0.9.7 AND 0.10.0, harness ruled out (two sessions get distinct SSE ids; the client sends the correct id), fix proven (thread-local set → pgbus's `broadcast` receives the exclude → the echo-exclusion system spec goes green).
- **`require "pgbus"` must be in `config/application.rb`, NOT a `config/initializers/` file.** pgbus's Turbo-patch initializer is `after: :load_config_initializers`; requiring pgbus during that phase registers the engine too late and the patch **silently never installs** (`Turbo patched? false`, broadcasts go nowhere). A real host-app gotcha — commented in the dummy config.
- **The dummy needed a turbo named-export shim.** pgbus's client does `import { Turbo } from "@hotwired/turbo-rails"`, but the dummy's vendored `turbo.js` only sets `window.Turbo` (no named export) — so the client module threw at load and `<pgbus-stream-source>` never registered (SSE never connected, no console error). Added `turbo_rails_shim.js` re-exporting `window.Turbo`; pinned turbo to it (cable-cell-neutral). Real apps avoid this via importmap-rails + the real turbo distribution.
- **The `:pgbus` specs disable transactional fixtures.** pgbus's ephemeral broadcasts use LISTEN/NOTIFY, which is transactional — inside a rolled-back test transaction the NOTIFY never fires. So the tag flips `use_transactional_tests = false` and truncates after (only in the pgbus cell).
- **Defer-push-lane system spec deferred to a follow-up (surfaced, not dropped).** The `via=stream` lane needs the durable `DeferredRenderJob` to actually run + durable delivery — wiring inline job execution into the single-process Capybara server adds real flakiness risk (which we were told to avoid), and the lane's wire contract is already covered by `spec/phlex/reactive/defer_spec.rb`. The two shipped specs are the headline (and one found+fixed a real bug).
- **`postgres:18`** (not an older pin) per preference; pgbus vendors PGMQ so a plain image works. `pgbus_streams?`-gating keeps the whole change a no-op on Action Cable.
