### PR TITLE
feat(reply): one door for the action reply — remove Response class verbs, unify collections/flash/also (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: `reply` is the only door — the `Response` class verbs are removed (#182).**
+  `Phlex::Reactive::Response.replace(self)` / `.morph` / `.update` / `.remove` /
+  `.redirect` / `.with` / `.streams` (and the collection class methods) are removed
+  as public entry points — each raises a guided `ArgumentError` naming the
+  `reply.<verb>` rewrite. Actions return `reply.<verb>` (the subject-bound door added
+  earlier); the immutable `Response` value object and its instance chain
+  (`.flash`/`.stream`/`.also`/`.js`/`.defer`) are unchanged, so the endpoint reads it
+  exactly as before. One concept, one entry point.
+
+- **BREAKING: reactive-collection replies read as Ruby — `to:`/`from:` keywords (#182).**
+  The collection name moved from a leading Symbol to a keyword, and the `UNSET`
+  sentinel that overloaded `reply.remove` is gone (dispatch keys on `from:`'s
+  presence):
+
+  | Before (removed) | After |
+  |---|---|
+  | `reply.append(:items, item)` | `reply.append(item, to: :items)` |
+  | `reply.prepend(:items, item)` | `reply.prepend(item, to: :items)` |
+  | `reply.remove(:items, id)` | `reply.remove(id, from: :items)` |
+  | `reply.remove` (bare) | `reply.remove` — unchanged (removes self) |
+
+  A Symbol in the model position (the old shape) raises a guided rewrite.
+
+- **BREAKING: one flash contract — `flash_component` is a callable (#182).**
+  `Phlex::Reactive.flash_component` is now a lambda the app owns, so the gem no
+  longer guesses your component's kwargs (the old hardcoded `new(level:, content:)`
+  collided with real flash components):
+
+  ```ruby
+  # before: Phlex::Reactive.flash_component = MyFlash   (gem calls MyFlash.new(level:, content:))
+  # after:
+  Phlex::Reactive.flash_component = ->(level, content) { MyFlash.new(level:, message: content) }
+  ```
+
+  Assigning a Class raises a guided error printing the one-line lambda. The internal
+  flash builders (`flash_stream`/`flash_html`/`default_flash_html`) are now private.
+
+- **BREAKING: `also_update` / `also_replace` collapse into one `.also` (#182).**
+  The lying `html:` kwarg (it accepted components too) and the per-companion method
+  choice are gone:
+
+  ```ruby
+  # before
+  reply.replace.also_update("page_heading", html: @account.name)
+  reply.replace.also_replace(SummaryCard.new(account: @account), morph: true)
+  # after
+  reply.replace.also(page_heading: @account.name)                        # target => content
+  reply.replace.also(SummaryCard.new(account: @account), morph: true)    # a component at its own id
+  ```
+
+  String content is HTML-escaped, component content rendered — the escaping contract
+  is verbatim. `also_update`/`also_replace` raise guided rewrites.
+
+- **BREAKING: the `flash_builder` / `reset_flash_builder!` aliases are removed (#182).**
+  They were "permanent aliases" for `stream_builder` / `reset_stream_builder!` that
+  contradicted the clean-break rule. Each old name now raises a guided `NoMethodError`
+  naming the real method.
+
 ### Fixed
 
 - **A pending-state text swap no longer destroys a composite trigger's icon (#181).**

--- a/README.md
+++ b/README.md
@@ -1276,7 +1276,7 @@ def add(item:) = reply.replace.stream(Totals.update(@order))               # mul
 def update(name:) = (@row.update!(name:); reply.morph)
 
 # Re-render a COMPANION element (a heading mirroring the edited name) alongside self:
-def rename(value:) = (@account.update!(name: value); reply.replace.also_update("page_heading", html: @account.name))
+def rename(value:) = (@account.update!(name: value); reply.replace.also(page_heading: @account.name))
 
 # Update ONLY part of the component (issue #30): re-stream just the total cell,
 # NOT the whole row. reply.streams emits exactly your streams plus a tiny
@@ -1289,8 +1289,8 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 |---|---|
 | `reply.replace` / `reply.update(morph: false)` | re-render in place (default; `replace` swaps the whole element via outerHTML, `update` swaps only the inner HTML) |
 | `reply.morph` / `reply.replace(morph: true)` / `reply.update(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (`replace` #28; `update` #113) |
-| `.also_update(target, html:)` | also re-render a companion element by DOM id; `html` is a plain string (escaped) or a Phlex component |
-| `.also_replace(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
+| `.also(target => content, …)` | also re-render companion elements by DOM id; `content` is a plain string (escaped) or a Phlex component |
+| `.also(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
 | `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped, wrapped in a level-carrying `<div>` — see [Flash levels](#flash-levels)) or a Phlex component (rendered verbatim; off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `reply.remove` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `reply.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |
@@ -1299,7 +1299,7 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 | `.defer(component, placeholder:, morph:)` | take an **expensive segment off the actor's critical path** (issue #165) — the reply returns immediately and the real render streams to the SAME actor when ready; see [Deferred segments](#deferred-segments-replydefer--reactive_lazy) |
 | `reply.with(*streams)` / `#stream(*more)` | multi-stream (self re-render still injected for the token) |
 
-`.flash`/`.stream`/`.also_*` are additive on a self-replace, so the component's
+`.flash`/`.stream`/`.also` are additive on a self-replace, so the component's
 signed token always refreshes. **`reply.streams`** is the exception that proves
 the rule: it deliberately skips the full-self replace (so your hand-built streams
 update only the targets you name) and refreshes the token via a tiny inert
@@ -1479,9 +1479,11 @@ Prefer your own markup? Two escape hatches:
 #    (you own the markup entirely, including the level styling):
 reply.replace.flash(:error, Alert.new(level: :error, message: msg))
 
-# 2. Or configure a flash component ONCE — string flashes render through it
-#    (instantiated new(level:, content:)); component content still bypasses it:
-Phlex::Reactive.flash_component = MyFlash   # default nil → the built-in wrapper
+# 2. Or configure a flash component ONCE — string flashes render through it;
+#    component content still bypasses it. flash_component is an app-owned
+#    CALLABLE (issue #182): it maps (level, content) to your component —
+#    the gem never guesses kwargs:
+Phlex::Reactive.flash_component = ->(level, content) { MyFlash.new(level:, content:) }   # default nil → the built-in wrapper
 ```
 
 #### Server-pushed client ops (`reply.js` + `broadcast_js_to`, issue #97)
@@ -1565,9 +1567,10 @@ Broadcasting is deliberately omitted so peer tabs with their own in-flight edits
 aren't clobbered. Authorize the record as always — identity is never permission.
 
 > **Under the hood.** `reply.<verb>` returns a `Phlex::Reactive::Response` — the
-> immutable value object the endpoint reads. You can build one directly
-> (`Phlex::Reactive::Response.replace(self)`) and it still works, but `reply` is
-> the preferred surface; treat `Response` as an internal detail.
+> immutable value object the endpoint reads. `reply` is the ONE documented door
+> (issue #182): the old `Phlex::Reactive::Response.replace(self)` class verbs
+> are removed and raise a guided `ArgumentError` naming the `reply.<verb>`
+> rewrite; treat `Response` as an internal detail.
 > **`html:`/`content` escaping.** A plain string is **HTML-escaped** by Turbo, so
 > `html: @account.name` is safe even for user-supplied values. To emit intentional
 > markup, pass a **Phlex component** (`html: Heading.new(name: @record.name)`) —
@@ -1825,12 +1828,12 @@ class NotificationsList < ApplicationComponent
 
   def add(title:)
     todo = Todo.create!(title:)
-    reply.append(:notifications, todo)   # append row + bump count + clear empty-state
+    reply.append(todo, to: :notifications)   # append row + bump count + clear empty-state
   end
 
   def dismiss(id:)
     Todo.find(id).destroy!
-    reply.remove(:notifications, id)     # remove row + bump count + restore empty-state at 0
+    reply.remove(id, from: :notifications)   # remove row + bump count + restore empty-state at 0
   end
 
   # view_template renders the count, the container <ul>, and the empty-state on
@@ -1840,9 +1843,9 @@ end
 
 | Builder | Reply (one `Response`) |
 |---|---|
-| `reply.append(name, model)` | append the row into the container + update the count + remove the empty-state when the list crosses 0→1 |
-| `reply.prepend(name, model)` | as `append`, but the row goes to the top |
-| `reply.remove(name, model)` | remove the row by its `dom_id` + update the count + append the empty-state back when the list crosses →0 |
+| `reply.append(model, to: name)` | append the row into the container + update the count + remove the empty-state when the list crosses 0→1 |
+| `reply.prepend(model, to: name)` | as `append`, but the row goes to the top |
+| `reply.remove(model, from: name)` | remove the row by its `dom_id` + update the count + append the empty-state back when the list crosses →0 |
 
 - **`size:` is the source of truth** — it's *re-counted* server-side after the
   mutation, so the badge and the empty-state are correct-by-construction (no
@@ -1854,7 +1857,7 @@ end
   (correct on the first click, silently rejected after); the helper bakes the
   refresh in so you never hit it.
 - **`remove` takes the record or its `dom_id` string** — a just-destroyed
-  ActiveRecord still answers `dom_id` correctly, so `reply.remove(:items, todo)`
+  ActiveRecord still answers `dom_id` correctly, so `reply.remove(todo, from: :items)`
   works; pass the raw id only if your row `#id` matches `ActiveRecord::RecordIdentifier`.
 - **Reply governs the actor's HTTP response only.** For a *cross-tab* live list
   (other viewers see the row appear) keep broadcasting the row with

--- a/README.md
+++ b/README.md
@@ -1832,8 +1832,9 @@ class NotificationsList < ApplicationComponent
   end
 
   def dismiss(id:)
-    Todo.find(id).destroy!
-    reply.remove(id, from: :notifications)   # remove row + bump count + restore empty-state at 0
+    todo = Todo.find(id)
+    todo.destroy!
+    reply.remove(todo, from: :notifications)   # remove row + bump count + restore empty-state at 0
   end
 
   # view_template renders the count, the container <ul>, and the empty-state on

--- a/README.md
+++ b/README.md
@@ -1289,8 +1289,8 @@ def update(quantity:, price:) = (@item.update!(quantity:, price:); reply.streams
 |---|---|
 | `reply.replace` / `reply.update(morph: false)` | re-render in place (default; `replace` swaps the whole element via outerHTML, `update` swaps only the inner HTML) |
 | `reply.morph` / `reply.replace(morph: true)` / `reply.update(morph: true)` | re-render in place via Idiomorph (`method="morph"`) — preserves the focused `<input>` + caret; for per-field reactive editing (`replace` #28; `update` #113) |
-| `.also(target => content, …)` | also re-render companion elements by DOM id; `content` is a plain string (escaped) or a Phlex component |
-| `.also(component, morph: false)` | also re-render another Streamable component, targeting its own `#id`; `morph: true` morphs it in place |
+| `.also(target => content, …)` | **UPDATE** (inner HTML) companion elements by DOM id; `content` is a plain string (escaped) or a Phlex component. The argument *type* picks the action — pairs mean `update` |
+| `.also(component, morph: false)` | **REPLACE** another Streamable component at its own `#id` (`morph: true` morphs in place). A component argument means `replace` |
 | `.flash(level, content, target: …)` | append a flash; `content` is a plain string (escaped, wrapped in a level-carrying `<div>` — see [Flash levels](#flash-levels)) or a Phlex component (rendered verbatim; off-request — no Rails `flash`); target defaults to `Phlex::Reactive.flash_target` (`"flash"`) |
 | `reply.remove` | remove the element (backed by `Streamable#to_stream_remove`) |
 | `reply.redirect(url)` | client-side `Turbo.visit` (pass a `*_url`); rides a `reactive:visit` turbo-stream, not an HTTP 3xx |

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -189,7 +189,9 @@ module Phlex
         return unless callable
 
         message = callable.call(kind)
-        Phlex::Reactive::Response.flash_stream(:error, message, target: Phlex::Reactive.flash_target)
+        # flash_stream is a private Response builder (issue #182) — the endpoint's
+        # error path is an internal caller, so reach it via send.
+        Phlex::Reactive::Response.send(:flash_stream, :error, message, target: Phlex::Reactive.flash_target)
       rescue => e # rubocop:disable Style/RescueStandardError
         ::Rails.logger&.warn("[phlex-reactive] error_flash raised: #{e.message}") if defined?(::Rails) &&
                                                                                      ::Rails.respond_to?(:logger)
@@ -298,7 +300,7 @@ module Phlex
 
         streams = result.streams
 
-        # Partial update (Response.streams / reply.streams, issue #30): the action
+        # Partial update (reply.streams, issue #30): the action
         # re-rendered only PART of the component and opted out of the full-self
         # replace. Append a tiny token-only stream so the signed token still rolls
         # forward WITHOUT re-rendering (and clobbering) the live inputs. Skip it
@@ -320,7 +322,7 @@ module Phlex
         # for replace AND update of self (both re-render the root via
         # render_component, carrying the token), and still adds the fallback
         # replace when a hand-built `with(...)` stream omits it. Idempotent: a
-        # Response.replace(self)/update(self) already carries the token, so we
+        # reply.replace/update already carries the token, so we
         # don't double the self-render.
         #
         # GUARD 2 (issue #114): GLOBAL, un-scoped — "does ANY stream carry a
@@ -329,7 +331,7 @@ module Phlex
         # scan. Deliberately NOT rx_refreshes_token_for? (target-scoped): scoping
         # this guard would regress update/morph of self on an aliased id.
         #
-        # A self-render reply (Response.replace/update/morph — subject_component
+        # A self-render reply (reply.replace/update/morph — subject_component
         # set) whose streams somehow carry no token gets the full self-replace
         # (defensive, unchanged). A companion-only reply.with (NO subject, NO
         # token_component) that doesn't re-render the root gets a token-ONLY

--- a/docs/app/reactive_components/defer_demo_component.rb
+++ b/docs/app/reactive_components/defer_demo_component.rb
@@ -10,7 +10,7 @@
 #   * Log set (skeleton)  — placeholder: true replaces the totals with the
 #     component's deferred_placeholder shell immediately.
 #   * Log set (sync)      — the deliberate ANTI-example: the SAME rollup
-#     rendered synchronously via also_replace, so the whole reply (set count
+#     rendered synchronously via also, so the whole reply (set count
 #     included) freezes for the 400 ms defer takes off the critical path.
 class DeferDemoComponent < Phlex::HTML
   include Phlex::Reactive::Streamable
@@ -43,7 +43,7 @@ class DeferDemoComponent < Phlex::HTML
   # The anti-example: the same rollup ON the critical path.
   def log_set_sync
     @sets += 1
-    reply.streams(sets_stream).also_replace(SessionTotalsComponent.new(sets: @sets))
+    reply.streams(sets_stream).also(SessionTotalsComponent.new(sets: @sets))
   end
 
   def view_template

--- a/docs/app/reactive_components/notifications_list_component.rb
+++ b/docs/app/reactive_components/notifications_list_component.rb
@@ -38,7 +38,7 @@ class NotificationsListComponent < Phlex::HTML
     NotificationRowComponent.broadcast_append_to(*Notification.stream_key, target: 'notifications',
                                                                            model: notification,
                                                                            exclude: reactive_connection_id)
-    reply.append(:notifications, notification)
+    reply.append(notification, to: :notifications)
   end
 
   # Remove the row + bump the count + restore the empty-state in ONE reply, plus a
@@ -48,7 +48,7 @@ class NotificationsListComponent < Phlex::HTML
     notification.destroy!
     NotificationRowComponent.broadcast_remove_to(*Notification.stream_key, model: notification,
                                                                            exclude: reactive_connection_id)
-    reply.remove(:notifications, notification).flash(:notice, 'Notification dismissed', dismiss_after: 3000)
+    reply.remove(notification, from: :notifications).flash(:notice, 'Notification dismissed', dismiss_after: 3000)
   end
 
   def view_template

--- a/docs/app/reactive_components/team_inbox_component.rb
+++ b/docs/app/reactive_components/team_inbox_component.rb
@@ -48,7 +48,7 @@ class TeamInboxComponent < Phlex::HTML
     message.destroy!
     InboxMessageComponent.broadcast_remove_to(*InboxMessage.stream_key, model: message,
                                                                         exclude: reactive_connection_id)
-    reply.remove(:messages, message).flash(:notice, 'Archived', dismiss_after: 2000)
+    reply.remove(message, from: :messages).flash(:notice, 'Archived', dismiss_after: 2000)
   end
 
   # Mark read: persist, re-render the row for the actor, and broadcast the updated
@@ -68,7 +68,7 @@ class TeamInboxComponent < Phlex::HTML
     InboxMessageComponent.broadcast_append_to(*InboxMessage.stream_key, target: 'inbox-messages',
                                                                         model: message,
                                                                         exclude: reactive_connection_id)
-    reply.append(:messages, message)
+    reply.append(message, to: :messages)
   end
 
   def view_template

--- a/docs/app/views/docs/pages/example_collections.rb
+++ b/docs/app/views/docs/pages/example_collections.rb
@@ -53,9 +53,9 @@ module Views
               action governs the reply with a single call — no hand-deriving the
               container id, the count, and the empty-state in every action.
 
-              - `reply.append(:notifications, record)` → row stream + count + clears
+              - `reply.append(record, to: :notifications)` → row stream + count + clears
                 the empty-state.
-              - `reply.remove(:notifications, record)` → row remove + count +
+              - `reply.remove(record, from: :notifications)` → row remove + count +
                 restores the empty-state.
 
               The size resolver reads `Notification.count` server-side, so the badge

--- a/docs/app/views/docs/pages/example_defer.rb
+++ b/docs/app/views/docs/pages/example_defer.rb
@@ -37,7 +37,7 @@ module Views
               - **Log set (skeleton)** — `placeholder: true` replaces the totals with
                 the component's `deferred_placeholder` shell immediately.
               - **Log set (sync)** — the deliberate anti-example: the same rollup
-                rendered synchronously (`also_replace`), so the **whole** reply —
+                rendered synchronously (`also`), so the **whole** reply —
                 set count included — freezes for the 400 ms the deferred variants
                 take off the critical path.
 

--- a/docs/app/views/docs/pages/example_notifications.rb
+++ b/docs/app/views/docs/pages/example_notifications.rb
@@ -264,7 +264,7 @@ module Views
 
                 def dismiss(id:)
                   current_user.notifications.find(id).destroy!
-                  reply.remove(:notifications, id)  # row + count + empty-state at 0
+                  reply.remove(id, from: :notifications)  # row + count + empty-state at 0
                 end
                 ```
 

--- a/docs/app/views/docs/pages/example_notifications.rb
+++ b/docs/app/views/docs/pages/example_notifications.rb
@@ -263,8 +263,9 @@ module Views
                   size: -> { current_user.notifications.count }
 
                 def dismiss(id:)
-                  current_user.notifications.find(id).destroy!
-                  reply.remove(id, from: :notifications)  # row + count + empty-state at 0
+                  notification = current_user.notifications.find(id)
+                  notification.destroy!
+                  reply.remove(notification, from: :notifications)  # row + count + empty-state at 0
                 end
                 ```
 

--- a/docs/app/views/docs/pages/installation.rb
+++ b/docs/app/views/docs/pages/installation.rb
@@ -241,7 +241,7 @@ module Views
               # Phlex::Reactive.action_path = "/_r/actions"                   # custom endpoint
               # Phlex::Reactive.verifier    = ActiveSupport::MessageVerifier.new(ENV["REACTIVE_KEY"])
               # Phlex::Reactive.flash_target = "flash"                         # DOM id reply…flash appends into
-              # Phlex::Reactive.flash_component = MyFlash                      # renders string flashes: new(level:, content:)
+              # Phlex::Reactive.flash_component = ->(level, content) { MyFlash.new(level:, content:) } # renders string flashes
               # Phlex::Reactive.error_flash  = ->(kind) { "Something went wrong (#{kind})." } # flash on endpoint failures
             RUBY
             DocsUI::Prose() do

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -560,13 +560,29 @@ module Phlex
       # diagnostic still goes to the log.
       attr_accessor :error_flash
 
-      # Component class used to render STRING flash content (issue #77).
-      # Instantiated as flash_component.new(level:, content:) and rendered
-      # through the existing render path, replacing the built-in
-      # <div class="reactive-flash reactive-flash--{level}"> wrapper. Default
-      # nil (the built-in wrapper). Phlex component content passed to
+      # A CALLABLE that builds a flash component from STRING flash content (issue
+      # #182). Given (level, content), it returns a Phlex component the gem renders
+      # in place of the built-in <div class="reactive-flash reactive-flash--{level}">
+      # wrapper — so the APP owns the kwarg mapping (no hardcoded new(level:,
+      # content:) contract that collides with a real app's flash component):
+      #
+      #   Phlex::Reactive.flash_component = ->(level, content) { MyFlash.new(level:, message: content) }
+      #
+      # Default nil (the built-in wrapper). Phlex component content passed to
       # reply.flash always renders verbatim and bypasses this.
-      attr_accessor :flash_component
+      attr_reader :flash_component
+
+      # Reject a bare Class (the pre-#182 contract) with the exact lambda rewrite —
+      # the gem no longer guesses the component's kwargs.
+      def flash_component=(callable)
+        if callable.is_a?(Class)
+          raise ArgumentError,
+            "Phlex::Reactive.flash_component is now a callable (issue #182) — " \
+            "flash_component = ->(level, content) { #{callable}.new(level:, content:) }"
+        end
+
+        @flash_component = callable
+      end
 
       # Render a Phlex component to HTML with a full (off-request) view context.
       # Uses phlex-rails' #render_in against the memoized view context — a direct
@@ -584,7 +600,7 @@ module Phlex
       # A Turbo::Streams::TagBuilder bound to an off-request view context, used
       # to build standalone streams not tied to a specific component's id — a
       # Response flash append, a reactive_collection row removal, a count
-      # companion update, an also_update companion. Cached PER THREAD alongside
+      # companion update, an also() companion. Cached PER THREAD alongside
       # the context it's bound to (see off_request_view_context for why
       # per-thread). Renamed from flash_builder (issue #113): the builder does
       # far more than flashes, so the name misled. flash_builder stays a
@@ -615,11 +631,18 @@ module Phlex
         @off_request_view_context_generation = off_request_view_context_generation + 1
       end
 
-      # Permanent aliases for the pre-#113 names. Kept forever (no deprecation)
-      # so the engine's to_prepare hook and any app code calling the old names
-      # keep working unchanged.
-      alias flash_builder stream_builder
-      alias reset_flash_builder! reset_stream_builder!
+      # Issue #182: the pre-#113 aliases are removed (they contradicted the
+      # clean-break rule — two names for one thing). Each raises a guided error
+      # naming the real method. The engine (to_prepare) already uses the new names.
+      def flash_builder
+        raise NoMethodError,
+          "Phlex::Reactive.flash_builder was removed in issue #182 — use stream_builder"
+      end
+
+      def reset_flash_builder!
+        raise NoMethodError,
+          "Phlex::Reactive.reset_flash_builder! was removed in issue #182 — use reset_stream_builder!"
+      end
 
       def off_request_view_context_generation
         @off_request_view_context_generation ||= 0

--- a/lib/phlex/reactive/component.rb
+++ b/lib/phlex/reactive/component.rb
@@ -6,9 +6,9 @@ module Phlex
     # reactive unit: declare actions in Ruby, and the generic `reactive`
     # Stimulus controller wires clicks/inputs to an HTTP round trip that
     # re-renders the component and applies it back into the DOM (a plain replace
-    # by default; return Response.morph(self) to morph in place and keep the
-    # focused input — issue #28). No per-feature Stimulus controllers, no
-    # hand-picked Turbo targets.
+    # by default; return reply.morph to morph in place and keep the focused
+    # input — issue #28). No per-feature Stimulus controllers, no hand-picked
+    # Turbo targets.
     #
     # Including Component pulls in Phlex::Reactive::Streamable automatically
     # (Concern dependency — Streamable lands on the base first, exactly the old

--- a/lib/phlex/reactive/component/dsl.rb
+++ b/lib/phlex/reactive/component/dsl.rb
@@ -218,9 +218,10 @@ module Phlex
           #     empty: ItemsEmptyComponent, # optional empty-state component
           #     size: -> { @record.items.size } # resolves the live size
           #
-          # An action then governs the reply with one call:
-          #   reply.append(:items, item)   # row append + count + clear empty-state
-          #   reply.remove(:items, id)     # row remove + count + restore empty-state
+          # An action then governs the reply with one call (the collection is
+          # named by the to:/from: keyword, issue #182):
+          #   reply.append(item, to: :items)   # row append + count + clear empty-state
+          #   reply.remove(id, from: :items)   # row remove + count + restore empty-state
           #
           # count/empty/size are optional: a list with just rows omits them and the
           # corresponding stream isn't emitted. See Phlex::Reactive::Reply and the

--- a/lib/phlex/reactive/component/helpers.rb
+++ b/lib/phlex/reactive/component/helpers.rb
@@ -47,7 +47,7 @@ module Phlex
 
         # Subject-bound reply builder — the preferred way to control an action's
         # reply. `reply.replace.flash(:error, msg)` reads cleaner than
-        # `Phlex::Reactive::Response.replace(self).flash(:error, msg)`: the
+        # `reply.replace.flash(:error, msg)`: the
         # component is the implicit subject (no `self` to thread) and there's no
         # constant to qualify (reply is a method, so a namespaced component needs
         # no `Response = …` alias). It returns the same immutable Response the

--- a/lib/phlex/reactive/defer.rb
+++ b/lib/phlex/reactive/defer.rb
@@ -309,7 +309,7 @@ data-reactive-defer-pending="true" aria-busy="true">#{inner}</div>)
         end
 
         # Resolve the segment's placeholder to inner HTML — nil means "no
-        # shell". Same content contract as flash/also_update: a Phlex component
+        # shell". Same content contract as flash/also: a Phlex component
         # renders through the configured renderer (auto-escaped), a plain
         # String is DATA and gets escaped, an html_safe String is intentional
         # markup and passes verbatim (ERB::Util.html_escape's own contract).

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -2,35 +2,25 @@
 
 module Phlex
   module Reactive
-    # A component-bound facade over Response — the surface an action body uses to
-    # control its reply. Component#reply returns one, so an action writes
+    # The ONE door for building an action's reply (issue #182). Component#reply
+    # returns one, so an action writes
     #
     #   reply.replace.flash(:error, msg)
     #
-    # instead of
+    # There is no constant to qualify (reply is a method, resolved on the
+    # component — so a namespaced component needs no `Response = …` alias) and no
+    # `self` to thread (the component is bound).
     #
-    #   Phlex::Reactive::Response.replace(self).flash(:error, msg)
+    # Reply is NOT a Response and does NOT subclass one: each verb calls the
+    # Response `build_*` class method, supplying the bound component as the
+    # subject, and returns the real, frozen Response value the endpoint honors. So
+    # immutability, chaining (.flash/.stream/.also/.js/.defer), and render_self?
+    # come from the Response value object untouched — the chain is plain Response
+    # all the way down.
     #
-    # Two warts disappear: there is no constant to qualify (reply is a method,
-    # resolved on the component — so a namespaced component needs no
-    # `Response = …` alias) and no `self` to thread (the component is bound).
-    #
-    # Reply is NOT a Response and does NOT subclass one: each verb forwards to
-    # the Response class method, supplying the bound component as the subject, and
-    # returns the real, frozen Response value the endpoint already honors. So
-    # immutability, chaining (.flash/.stream/.also_update/.also_replace), and
-    # render_self? are inherited untouched — and there is no "verb after a chained
-    # Response" asymmetry, because the chain is plain Response all the way down.
-    #
-    # Response remains the public value object (it's what the endpoint reads); it
-    # is simply an internal detail you rarely name directly now.
+    # Response remains the value object the endpoint reads; you never construct it
+    # directly (its former public class verbs raise a guided rewrite).
     class Reply
-      # Distinguishes `reply.remove` (no args — remove the bound component
-      # itself) from `reply.remove(:items, model)` (remove a collection row).
-      # A sentinel, not nil, so `reply.remove(:items, nil)` stays unambiguous.
-      UNSET = Object.new
-      private_constant :UNSET
-
       def initialize(component)
         @component = component
       end
@@ -40,70 +30,83 @@ module Phlex
       # Re-render in place. `morph: true` morphs the subtree (preserves the
       # focused input + caret) instead of an outerHTML swap — see #morph.
       def replace(morph: false)
-        Response.replace(@component, morph:)
+        Response.build_replace(@component, morph:)
       end
 
       # Re-render in place via Idiomorph (method="morph") — keeps focus + caret.
       def morph
-        Response.morph(@component)
+        Response.build_morph(@component)
       end
 
       # Update only inner HTML (preserves the root element + its token attr).
       # `morph: true` morphs the inner HTML in place (issue #113) so a
       # cross-tab/per-field update keeps a focused input's caret.
       def update(morph: false)
-        Response.update(@component, morph:)
+        Response.build_update(@component, morph:)
       end
 
       # Reactive collections (issue #35) — add/remove a row in a declared
       # reactive_collection, emitting the row stream + the count companion +
       # the empty-state toggle as ONE Response. The bound component is the
-      # container (it carries the declaration + size resolver).
+      # container (it carries the declaration + size resolver). The collection is
+      # named by the `to:`/`from:` keyword (issue #182 — reads as Ruby, and a
+      # `to:` present unambiguously means "a collection row"):
       #
-      #   def add_item(...)    = (item = @list.items.create!(...); reply.append(:items, item))
-      #   def remove_item(id:) = (@list.items.find(id).destroy!;   reply.remove(:items, id))
+      #   def add_item(...)    = (item = @list.items.create!(...); reply.append(item, to: :items))
+      #   def remove_item(id:) = (@list.items.find(id).destroy!;   reply.remove(id, from: :items))
       #
       # `model` is the row's record; remove also accepts the row's dom-id string.
-      def append(name, model)
-        Response.collection_append(@component, name, model)
+      def append(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG)
+        collection_build!(:build_collection_append, :append, model, legacy_model, to)
       end
 
-      def prepend(name, model)
-        Response.collection_prepend(@component, name, model)
+      def prepend(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG)
+        collection_build!(:build_collection_prepend, :prepend, model, legacy_model, to)
       end
 
-      # Two forms:
-      #   reply.remove               # remove the bound component's own element
-      #   reply.remove(:items, model) # remove a collection row + count + empty
-      def remove(name = UNSET, model = UNSET)
-        return Response.remove(@component) if name.equal?(UNSET)
+      # Two forms, dispatched on the PRESENCE of `from:` (issue #182 — no sentinel
+      # overload): bare `reply.remove` removes the bound component's own element;
+      # `reply.remove(model, from: :items)` removes a collection row + count +
+      # empty-state. `model` may be the record or the row's dom-id string.
+      #
+      #   reply.remove                       # remove the bound component's element
+      #   reply.remove(model, from: :items)  # remove a collection row
+      def remove(model = UNSET_ARG, legacy_model = UNSET_ARG, from: UNSET_ARG)
+        reject_legacy_form!(:remove, model, legacy_model)
+        # Bare `reply.remove` (no positional, no from:) removes self.
+        return Response.build_remove(@component) if from.equal?(UNSET_ARG) && model.equal?(UNSET_ARG)
 
-        Response.collection_remove(@component, name, model)
+        if from.equal?(UNSET_ARG)
+          raise ArgumentError,
+            "reply.remove(model, …) needs a source collection — reply.remove(model, from: :name)"
+        end
+        reject_symbol_first!(:remove, model, :from, from)
+        Response.build_collection_remove(@component, from, resolve_row_arg(model))
       end
 
       # Subject-free builders — pass straight through so they read naturally.
 
       # Client-side full navigation (Turbo.visit). Pass a *_url.
       def redirect(url)
-        Response.redirect(url)
+        Response.build_redirect(url)
       end
 
       # Escape hatch / multi-stream root: zero or more raw turbo-stream strings.
       def with(*strings)
-        Response.with(*strings)
+        Response.build_with(*strings)
       end
 
       # Self-targeting again: emit exactly these streams with a TOKEN-ONLY refresh
       # (issue #30) — partial/per-field update, NO full-self replace, so the
       # component's live inputs survive. The bound component supplies the token.
       def streams(*strings)
-        Response.streams(@component, *strings)
+        Response.build_streams(@component, *strings)
       end
 
       # Defer an expensive segment (issue #165): `reply.defer(Totals.new(...))`.
       #
       # With NO prior verb, the bound component's token is refreshed via a tiny
-      # token-only stream (Response.streams), NOT a full self-replace: a full
+      # token-only stream (reply.streams), NOT a full self-replace: a full
       # replace would re-render the acting component SYNCHRONOUSLY on the request
       # thread — and if you defer your OWN subject (`reply.defer(self)`), that is
       # the very render you meant to move OFF the critical path, so the defer
@@ -115,7 +118,62 @@ module Phlex
       #   reply.streams(volume_cell).defer(SessionTotals.new(workout: @workout))
       #   reply.replace.defer(Totals.new(order: @order))   # explicit self re-render
       def defer(component, placeholder: nil, morph: false)
-        Response.streams(@component).defer(component, placeholder:, morph:)
+        Response.build_streams(@component).defer(component, placeholder:, morph:)
+      end
+
+      private
+
+      # Sentinel distinguishing "keyword omitted" from an explicit nil value, so
+      # `reply.remove(nil, from: :items)` (remove a row whose id resolves to nil)
+      # stays distinct from bare `reply.remove` (remove self). Reused for the
+      # positional model too, so the Symbol-first misuse can be caught precisely.
+      UNSET_ARG = Object.new
+      private_constant :UNSET_ARG
+
+      # Shared append/prepend build: catch the old two-positional form, require the
+      # `to:` keyword, reject a Symbol-first model, then delegate to the Response
+      # builder (name first, model second — its internal order).
+      def collection_build!(builder, verb, model, legacy_model, to)
+        # Old form `reply.append(:name, model)` passes a SECOND positional — the
+        # arity would just error, so intercept it with the guided rewrite.
+        reject_legacy_form!(verb, model, legacy_model)
+        if to.equal?(UNSET_ARG)
+          raise ArgumentError,
+            "reply.#{verb} needs a target collection — reply.#{verb}(model, to: :name)"
+        end
+        reject_symbol_first!(verb, model, :to, to)
+        Response.public_send(builder, @component, to, resolve_row_arg(model))
+      end
+
+      # The pre-#182 call `reply.<verb>(:name, model)` — a Symbol name first, the
+      # model second. Detect it by the presence of the second positional and print
+      # the exact keyword rewrite.
+      def reject_legacy_form!(verb, model, legacy_model)
+        return if legacy_model.equal?(UNSET_ARG)
+
+        keyword = verb == :remove ? :from : :to
+        raise ArgumentError,
+          "reply.#{verb}(#{model.inspect}, …) — the collection name moved to a keyword " \
+          "(issue #182): reply.#{verb}(model, #{keyword}: #{model.inspect})"
+      end
+
+      # Issue #182 removed the Symbol-first form (`reply.append(:items, model)`).
+      # A Symbol in the model position is almost certainly that old call shape, so
+      # raise the exact keyword rewrite instead of trying to build a row from a
+      # Symbol "record".
+      def reject_symbol_first!(verb, model, keyword, name)
+        return unless model.is_a?(Symbol)
+
+        raise ArgumentError,
+          "reply.#{verb}(#{model.inspect}, …) — the collection name moved to a keyword " \
+          "(issue #182): reply.#{verb}(model, #{keyword}: #{name.inspect})"
+      end
+
+      # A row build needs a real model/dom-id — never the omitted sentinel.
+      def resolve_row_arg(model)
+        raise ArgumentError, "reply collection verbs need a model or dom-id as the first argument" if model.equal?(UNSET_ARG)
+
+        model
       end
     end
   end

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -452,23 +452,35 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
       end
 
       # Also re-render COMPANION elements alongside self (issue #182 — one door,
-      # replacing also_update + also_replace). Two argument shapes:
+      # replacing also_update + also_replace). The ARGUMENT TYPE picks the Turbo
+      # action; there is no verb to choose:
       #
-      #   * target => content pairs — updates each element BY ID. Content is a
-      #     plain String (HTML-ESCAPED by Turbo, so a model value is safe), a Phlex
-      #     component (rendered + auto-escaped), or an html_safe String for raw HTML.
-      #     Written brace-less as keywords or as an explicit Hash:
-      #       reply.replace.also(page_heading: @record.name, badge: Badge.new(...))
-      #       reply.replace.also("dom-id-with-dashes" => @record.name)
-      #   * a Streamable COMPONENT (positional) — replaced at its OWN #id;
-      #     `morph: true` morphs it in place (issue #28) when it holds focusable
-      #     inputs to preserve:
-      #       reply.replace.also(SummaryCard.new(order: @order), morph: true)
+      #   .also(SummaryCard.new(order: @order))          -> REPLACE at the component's own #id
+      #   .also(SummaryCard.new(order: @order), morph:)  -> the same, MORPHED in place
+      #   .also(page_heading: @record.name)              -> UPDATE (inner HTML) of id "page_heading"
+      #   .also("nav-badge" => @record.name)             -> UPDATE of id "nav-badge" (dashed id)
+      #
+      # So the two shapes are:
+      #
+      #   * a Streamable COMPONENT (positional) — a `replace` targeting its OWN #id
+      #     (it self-targets, like every reactive component). `morph: true` morphs
+      #     it in place (issue #28) when it holds focusable inputs to preserve.
+      #   * target => content pairs — an `update` (inner HTML) of each id. The id
+      #     need NOT be a reactive component (it's any element), so the only sound
+      #     swap is its inner HTML. Content is a plain String (HTML-ESCAPED by
+      #     Turbo, so a model value is safe), a Phlex component (rendered +
+      #     auto-escaped), or an html_safe String for intentional raw HTML. Written
+      #     brace-less as keywords or as an explicit Hash.
+      #
+      # This is NOT for collection rows — a row add/remove goes through
+      # reply.append(model, to: :name) / reply.remove(id, from: :name), which also
+      # emit the count + empty-state streams. `.also` only re-renders EXISTING
+      # companion elements.
       #
       # Returns a NEW Response (immutable). `companion` is EITHER a positional
-      # component OR target=>content pairs — never both. The brace-less keyword
-      # form lands in **targets; an explicit Hash lands in `companion`. `morph:` is
-      # reserved for the component form.
+      # component OR target=>content pairs — never both (that raises). The
+      # brace-less keyword form lands in **targets; an explicit Hash lands in
+      # `companion`. `morph:` is reserved for the component form.
       def also(companion = :__none, morph: false, **targets)
         if companion != :__none && !targets.empty?
           raise ArgumentError, "reply.also takes EITHER a component OR target => content pairs, not both"

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -10,20 +10,54 @@ module Phlex
     # A Response governs ONLY the actor's HTTP reply. Cross-tab updates still go
     # through Streamable's broadcast_*_to(..., exclude: reactive_connection_id).
     #
-    #   Response.replace(self)                          # re-render in place (the default, explicit)
-    #   Response.replace(self).flash(:error, msg)       # surface a validation error
-    #   Response.replace(self).also_update("heading", html: @record.name)  # + a companion element
-    #   Response.remove(self)                           # drop the element (e.g. moderation queue)
-    #   Response.redirect(article_url(@article))        # slug changed -> Turbo.visit the new URL
-    #   Response.replace(self).stream(Totals.update(@order))  # multi-stream
+    # An action builds one through `reply` (issue #182 — the ONE door; the former
+    # Response.* class verbs are removed and raise a guided rewrite):
+    #
+    #   reply.replace                          # re-render in place (the default, explicit)
+    #   reply.replace.flash(:error, msg)       # surface a validation error
+    #   reply.replace.also(heading: @record.name)  # + a companion element by id
+    #   reply.remove                           # drop the element (e.g. moderation queue)
+    #   reply.redirect(article_url(@article))  # slug changed -> Turbo.visit the new URL
+    #   reply.replace.stream(Totals.update(@order))  # multi-stream
     class Response
       attr_reader :streams, :redirect_url, :token_component, :subject_component
+
+      # Issue #182: `reply` is the ONE documented door. Each former public class
+      # verb (Response.replace(self), …) is removed — it raises a guided
+      # ArgumentError naming the `reply.<verb>` rewrite. The builder BODIES live
+      # on as private `build_*` class methods (the Response value object stays the
+      # single place that knows how to construct itself); Reply calls them. The
+      # rewrite shown for a collection verb points at the keyword form (issue #182).
+      REMOVED_CLASS_VERBS = {
+        replace: "reply.replace",
+        morph: "reply.morph",
+        update: "reply.update",
+        remove: "reply.remove",
+        redirect: "reply.redirect(url)",
+        with: "reply.with(*streams)",
+        streams: "reply.streams(*streams)",
+        collection_append: "reply.append(model, to: :name)",
+        collection_prepend: "reply.prepend(model, to: :name)",
+        collection_remove: "reply.remove(model, from: :name)"
+      }.freeze
+
+      # rubocop:disable Style/ItBlockParameter -- `it` is illegal inside the
+      # define_singleton_method block (it takes ordinary |*, **| params), so the
+      # outer each_key must name its param explicitly.
+      REMOVED_CLASS_VERBS.each_key do |verb|
+        define_singleton_method(verb) do |*, **|
+          raise ArgumentError,
+            "Phlex::Reactive::Response.#{verb} was removed in issue #182 — " \
+            "return #{REMOVED_CLASS_VERBS[verb]} from the action (reply is the only door)"
+        end
+      end
+      # rubocop:enable Style/ItBlockParameter
 
       class << self
         # Re-render the component in place (explicit form of today's default).
         # `morph: true` morphs the subtree (preserves the focused input + caret)
-        # instead of an outerHTML swap — see .morph (issue #28).
-        def replace(component, morph: false)
+        # instead of an outerHTML swap — see .build_morph (issue #28).
+        def build_replace(component, morph: false)
           new(streams: [morph ? component.to_stream_morph : component.to_stream_replace],
             subject_component: component)
         end
@@ -34,27 +68,27 @@ module Phlex
         # per-field reactive editing (a "spreadsheet" grid where a debounced save
         # fires while the user is still typing/tabbing). The morphed root still
         # carries the fresh signed token, so the next action verifies.
-        def morph(component) = new(streams: [component.to_stream_morph], subject_component: component)
+        def build_morph(component) = new(streams: [component.to_stream_morph], subject_component: component)
 
         # Update only inner HTML (preserves the root element + its token attr).
         # `morph: true` morphs the inner HTML in place (issue #113) instead of
         # replacing it, so a cross-tab update keeps a peer's focus/caret.
-        def update(component, morph: false)
+        def build_update(component, morph: false)
           new(streams: [component.to_stream_update(morph:)], subject_component: component)
         end
 
         # Remove the component's element from the DOM. Uses the instance
         # to_stream_remove (the component already knows its own #id — no
         # class-builder reconstruction; works for record- and state-backed).
-        def remove(component) = new(streams: [component.to_stream_remove], render_self: false)
+        def build_remove(component) = new(streams: [component.to_stream_remove], render_self: false)
 
         # Client-side full navigation (Turbo.visit). Use when the current URL
         # is dead (slug rename) or the outcome belongs on another page. Pass a
         # *_url (the off-request render context has no request host for *_path).
-        def redirect(url) = new(redirect_url: url, render_self: false)
+        def build_redirect(url) = new(redirect_url: url, render_self: false)
 
         # Escape hatch / multi-stream root: zero or more raw turbo-stream strings.
-        def with(*strings) = new(streams: strings.flatten)
+        def build_with(*strings) = new(streams: strings.flatten)
 
         # --- Reactive collections (issue #35) ---
         # Add/remove a row in a declared reactive_collection, emitting the row
@@ -75,19 +109,19 @@ module Phlex
         # container owns the add/remove trigger, so the endpoint appends its inert
         # `reactive:token` stream (the same #30 machinery reply.streams uses) to roll
         # the token forward without re-rendering the rows.
-        def collection_append(component, name, model)
+        def build_collection_append(component, name, model)
           definition = collection_def!(component, name)
           new(streams: collection_add_streams(definition, component, model, :append),
             render_self: false, token_component: component)
         end
 
-        def collection_prepend(component, name, model)
+        def build_collection_prepend(component, name, model)
           definition = collection_def!(component, name)
           new(streams: collection_add_streams(definition, component, model, :prepend),
             render_self: false, token_component: component)
         end
 
-        def collection_remove(component, name, model)
+        def build_collection_remove(component, name, model)
           definition = collection_def!(component, name)
           new(streams: collection_remove_streams(definition, component, model),
             render_self: false, token_component: component)
@@ -162,11 +196,11 @@ module Phlex
         # spreadsheet-like grid where a debounced save re-streams only a total
         # cell and the user is still typing in a sibling field.
         #
-        #   Response.streams(self, Totals.update(@invoice))   # update only the totals
+        #   reply.streams(Totals.update(@invoice))   # update only the totals
         #
         # render_self is false (we do NOT inject the full replace); the token is
         # refreshed by the bound component's token stream instead.
-        def streams(component, *strings)
+        def build_streams(component, *strings)
           new(streams: strings.flatten, render_self: false, token_component: component)
         end
 
@@ -194,9 +228,11 @@ module Phlex
           # so dismiss_after has nowhere to hang — it wraps only string content.
           return render_html(content) if content.is_a?(::Phlex::SGML)
 
-          component_class = Phlex::Reactive.flash_component
-          if component_class
-            html = render_html(component_class.new(level:, content:))
+          builder = Phlex::Reactive.flash_component
+          if builder
+            # The app-owned callable maps (level, content) to its own component —
+            # the gem no longer guesses kwargs (issue #182).
+            html = render_html(builder.call(level, content))
             return dismiss_after ? wrap_dismiss(html, dismiss_after) : html
           end
 
@@ -225,6 +261,13 @@ module Phlex
 data-reactive-flash-level="#{level_attr}"#{dismiss_attr(dismiss_after)}>#{body}</div>).html_safe
         end
 
+        # Issue #182: flash rendering is an INTERNAL concern — the endpoint's
+        # error_flash path and Response#flash reach these via send. They are not
+        # part of the public reply surface. (Inside `class << self`, plain `private`
+        # marks these singleton methods private — private_class_method is for the
+        # class body, not here.)
+        private :flash_stream, :flash_html, :default_flash_html
+
         # The self-dismiss attribute, or "" when off. The value is forced through
         # to_i so a String/float (or an injection attempt) becomes a plain integer
         # — the client's document-level handler reads it as a timeout in ms.
@@ -242,7 +285,7 @@ data-reactive-flash-level="#{level_attr}"#{dismiss_attr(dismiss_after)}>#{body}<
         end
 
         # Build a turbo-stream that updates an arbitrary target id with `content`
-        # (a Phlex component instance or an HTML string). Used by #also_update to
+        # (a Phlex component instance or an HTML string). Used by #also to
         # re-render a companion element that isn't itself a Streamable component.
         def update_stream(target, content)
           Phlex::Reactive.stream_builder.update(target, html: render_html(content))
@@ -405,30 +448,55 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
       # container, so it works for reply AND broadcast flashes (issue #100). It
       # wraps only STRING content; a verbatim Phlex component owns its lifecycle.
       def flash(level, content, target: Phlex::Reactive.flash_target, dismiss_after: nil)
-        stream(self.class.flash_stream(level, content, target:, dismiss_after:))
+        stream(self.class.send(:flash_stream, level, content, target:, dismiss_after:))
       end
 
-      # Also re-render a COMPANION element alongside self — a page heading, a
-      # summary card, a badge that recomputes from the saved value (issue #25).
-      # `target` is the sibling element's DOM id. `html` is either:
-      #   * a plain String — HTML-ESCAPED by Turbo, so a model value is safe:
-      #       Response.replace(self).also_update("page_heading", html: @record.name)
-      #   * a Phlex component — rendered + auto-escaped through the renderer (use
-      #     this when the companion has its own markup), or an `html_safe` String
-      #     for intentional raw HTML.
-      # Returns a NEW Response (immutable). The common "re-render self + N
-      # siblings" case no longer needs raw turbo_stream_builder.
-      def also_update(target, html:)
-        stream(self.class.update_stream(target, html))
+      # Also re-render COMPANION elements alongside self (issue #182 — one door,
+      # replacing also_update + also_replace). Two argument shapes:
+      #
+      #   * target => content pairs — updates each element BY ID. Content is a
+      #     plain String (HTML-ESCAPED by Turbo, so a model value is safe), a Phlex
+      #     component (rendered + auto-escaped), or an html_safe String for raw HTML.
+      #     Written brace-less as keywords or as an explicit Hash:
+      #       reply.replace.also(page_heading: @record.name, badge: Badge.new(...))
+      #       reply.replace.also("dom-id-with-dashes" => @record.name)
+      #   * a Streamable COMPONENT (positional) — replaced at its OWN #id;
+      #     `morph: true` morphs it in place (issue #28) when it holds focusable
+      #     inputs to preserve:
+      #       reply.replace.also(SummaryCard.new(order: @order), morph: true)
+      #
+      # Returns a NEW Response (immutable). `companion` is EITHER a positional
+      # component OR target=>content pairs — never both. The brace-less keyword
+      # form lands in **targets; an explicit Hash lands in `companion`. `morph:` is
+      # reserved for the component form.
+      def also(companion = :__none, morph: false, **targets)
+        if companion != :__none && !targets.empty?
+          raise ArgumentError, "reply.also takes EITHER a component OR target => content pairs, not both"
+        end
+
+        case companion
+        when :__none
+          also_targets(targets)
+        when ::Phlex::SGML
+          stream(morph ? companion.to_stream_morph : companion.to_stream_replace)
+        when Hash
+          also_targets(companion)
+        else
+          raise ArgumentError,
+            "reply.also expects target => content pairs or a Streamable component, got #{companion.class}"
+        end
       end
 
-      # Like #also_update, but renders ANOTHER Streamable component and replaces
-      # it by its own #id — for a companion that is itself a component.
-      #   Response.replace(self).also_replace(SummaryCard.new(order: @order))
-      # `morph: true` morphs the companion in place (issue #28) — use it when the
-      # companion also holds focusable inputs that must survive the re-render.
-      def also_replace(component, morph: false)
-        stream(morph ? component.to_stream_morph : component.to_stream_replace)
+      # Issue #182: also_update / also_replace collapsed into #also. Guided errors
+      # naming the rewrite (the html: kwarg lied — it accepted components too).
+      def also_update(target, **)
+        raise ArgumentError,
+          "also_update was removed in issue #182 — use also(#{target.inspect} => content)"
+      end
+
+      def also_replace(*, **)
+        raise ArgumentError,
+          "also_replace was removed in issue #182 — use also(component, morph: …)"
       end
 
       def redirect? = !@redirect_url.nil?
@@ -447,6 +515,14 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
       # document-scoped unless the caller passes target: explicitly.
       def default_js_target
         (@subject_component || @token_component)&.id
+      end
+
+      # Build one update stream per { target_id => content } pair (issue #182). An
+      # empty call is a dead reply.also — fail loudly rather than return unchanged.
+      def also_targets(targets)
+        raise ArgumentError, "reply.also needs target => content pairs (or a component) — got nothing" if targets.empty?
+
+        stream(*targets.map { |target, content| self.class.update_stream(target, content) })
       end
     end
   end

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -25,8 +25,9 @@ module Phlex
       # Issue #182: `reply` is the ONE documented door. Each former public class
       # verb (Response.replace(self), …) is removed — it raises a guided
       # ArgumentError naming the `reply.<verb>` rewrite. The builder BODIES live
-      # on as private `build_*` class methods (the Response value object stays the
-      # single place that knows how to construct itself); Reply calls them. The
+      # on as internal-use `build_*` class methods (public in Ruby terms — Reply
+      # calls them directly — but NOT part of the documented reply-facing surface;
+      # Response stays the single place that knows how to construct itself). The
       # rewrite shown for a collection verb points at the keyword form (issue #182).
       REMOVED_CLASS_VERBS = {
         replace: "reply.replace",

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -562,7 +562,7 @@ module Phlex
       # Idiomorph morphs the subtree in place — preserving the focused <input> +
       # caret across the re-render — while still carrying the root's fresh
       # data-reactive-token-value (so the signed token refreshes). Used by
-      # Response.morph / Response.replace(self, morph: true).
+      # reply.morph / reply.replace(morph: true).
       def to_stream_morph
         Phlex::Reactive::Stream.wrap(
           self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph),
@@ -575,7 +575,7 @@ module Phlex
       # focused <input> + caret across a per-field update. Default (morph:
       # false) is the unchanged plain update. Passing `method: :morph` inline
       # (as #to_stream_morph does) keeps the plain call's wire byte-identical.
-      # Used by Response.update.
+      # Used by reply.update.
       def to_stream_update(morph: false)
         builder = self.class.turbo_stream_builder
         html = self.class.render_component(self)
@@ -591,7 +591,7 @@ module Phlex
       # attribute (#extractToken) and an inert client action writes it onto the
       # root (a pure attribute set, so a focused <input> + caret survive). Unlike
       # to_stream_replace, it does NOT re-render the children, so a live input
-      # the user is typing into is never torn down. Used by Response.streams.
+      # the user is typing into is never torn down. Used by reply.streams.
       #
       # The component carries its token via Component#reactive_token; a Streamable
       # that isn't a Component (no token) simply has nothing to refresh — guarded
@@ -616,7 +616,7 @@ module Phlex
 
       # Render THIS instance as a remove stream. The component already knows its
       # own #id, so no record/class reconstruction is needed (works for record-
-      # and state-backed components alike). Used by Response.remove.
+      # and state-backed components alike). Used by reply.remove.
       def to_stream_remove
         Phlex::Reactive::Stream.wrap(
           self.class.turbo_stream_builder.remove(id),

--- a/spec/dummy/app/components/defer_demo_component.rb
+++ b/spec/dummy/app/components/defer_demo_component.rb
@@ -47,11 +47,11 @@ class DeferDemoComponent < ApplicationComponent
   # The synchronous baseline: SAME work, ON the actor's critical path.
   def bump_sync
     @count += 1
-    reply.streams(mirror_stream).also_replace(SlowTotalsComponent.new(value: @count * 2))
+    reply.streams(mirror_stream).also(SlowTotalsComponent.new(value: @count * 2))
   end
 
   # reply.defer with NO prior verb: the token rolls forward via a tiny
-  # token-only stream (Response.streams), NOT a full synchronous self-render —
+  # token-only stream (reply.streams), NOT a full synchronous self-render —
   # so deferring your own subject doesn't pay the acting component's render on
   # the request thread (issue #165 review fix).
   def bump_bare

--- a/spec/dummy/app/components/morph_grid_component.rb
+++ b/spec/dummy/app/components/morph_grid_component.rb
@@ -2,8 +2,8 @@
 
 # Issue #28: the "edit a row, it saves" grid. Each field fires a DEBOUNCED
 # `update` while the user is still typing/tabbing. The action returns
-# Response.morph(self), so the row re-renders via Idiomorph — the focused input
-# and its in-progress value survive the save. With a plain Response.replace this
+# reply.morph, so the row re-renders via Idiomorph — the focused input
+# and its in-progress value survive the save. With a plain reply.replace this
 # row would outerHTML-swap, blur the field, and drop the just-typed value.
 class MorphGridComponent < ApplicationComponent
   include Phlex::Reactive::Streamable

--- a/spec/dummy/app/components/notifications_list_component.rb
+++ b/spec/dummy/app/components/notifications_list_component.rb
@@ -30,13 +30,13 @@ class NotificationsListComponent < ApplicationComponent
     return reply.replace if title.blank?
 
     todo = Todo.create!(title:)
-    reply.append(:notifications, todo)
+    reply.append(todo, to: :notifications)
   end
 
   def dismiss(id:)
     todo = Todo.find(id)
     todo.destroy!
-    reply.remove(:notifications, todo)
+    reply.remove(todo, from: :notifications)
   end
 
   def view_template

--- a/spec/dummy/app/components/reactive_rows_list_component.rb
+++ b/spec/dummy/app/components/reactive_rows_list_component.rb
@@ -23,7 +23,7 @@ class ReactiveRowsListComponent < ApplicationComponent
 
   def add(title:)
     todo = Todo.create!(title: title.to_s.strip, done: false)
-    reply.append(:rows, todo)
+    reply.append(todo, to: :rows)
   end
 
   def view_template

--- a/spec/dummy/app/components/todo_item_component.rb
+++ b/spec/dummy/app/components/todo_item_component.rb
@@ -32,30 +32,27 @@ class TodoItemComponent < ApplicationComponent
     @todo.update!(title:) if title.present?
   end
 
-  # This component deliberately keeps the fully-qualified
-  # Phlex::Reactive::Response.* form (the others use the preferred reply.*) so the
-  # back-compat path stays covered by the live request/system suites: reply.* is
-  # sugar over Response.*, and Response.* must keep working verbatim.
+  # reply is the ONE door (issue #182 — the former Response.* class verbs are gone).
 
-  # Response: remove self from the DOM (render_self false — no doomed re-render).
+  # Remove self from the DOM (render_self false — no doomed re-render).
   def archive
-    Phlex::Reactive::Response.remove(self)
+    reply.remove
   end
 
-  # Response: surface a validation error as a flash while still refreshing the
-  # row's token (replace self + flash); on success, plain replace.
+  # Surface a validation error as a flash while still refreshing the row's token
+  # (replace self + flash); on success, plain replace.
   def rename_strict(title:)
-    return Phlex::Reactive::Response.replace(self).flash(:error, "blank") if title.blank?
+    return reply.replace.flash(:error, "blank") if title.blank?
 
     @todo.update!(title:)
-    Phlex::Reactive::Response.replace(self)
+    reply.replace
   end
 
   def view_template
     li(**mix(reactive_attrs, id:, data: { testid: "todo", done: @todo.done?.to_s })) do
       button(**mix(on(:toggle), data: { testid: "toggle" })) { @todo.done? ? "✓" : "○" }
       input(**mix(on(:rename, event: "change"), name: "title", value: @todo.title))
-      # archive returns Response.remove(self) — drops this row in place. (The
+      # archive returns reply.remove — drops this row in place. (The
       # rename_strict flash-on-blank path would need a second title input that
       # collides with field collection above, so it's covered by the request
       # specs rather than wired into this single-input demo row.)

--- a/spec/phlex/reactive/collection_streams_spec.rb
+++ b/spec/phlex/reactive/collection_streams_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
   let(:todo) { Todo.create!(title: "buy milk", done: false) }
   let(:dom_id) { ActionView::RecordIdentifier.dom_id(todo) }
 
-  describe "reply.append(name, model)" do
+  describe "reply.append(model, to:)" do
     it "appends the row component into the container" do
-      response = container_class.new(size: 1).reply.append(:todos, todo)
+      response = container_class.new(size: 1).reply.append(todo, to: :todos)
       append = response.streams.find { it.include?('action="append"') }
       expect(append).to include('target="todos-list"')
       expect(append).to include(%(id="#{dom_id}"))
@@ -69,25 +69,25 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
     end
 
     it "updates the count companion with the fresh size" do
-      response = container_class.new(size: 1).reply.append(:todos, todo)
+      response = container_class.new(size: 1).reply.append(todo, to: :todos)
       count = response.streams.find { it.include?('target="todos-count"') }
       expect(count).to include('action="update"')
       expect(count).to include(">1<").or include("1")
     end
 
     it "removes the empty-state when the list crosses 0->1 (size becomes 1)" do
-      response = container_class.new(size: 1).reply.append(:todos, todo)
+      response = container_class.new(size: 1).reply.append(todo, to: :todos)
       empty = response.streams.find { it.include?('target="todos-empty"') }
       expect(empty).to include('action="remove"')
     end
 
     it "does NOT touch the empty-state when the list was already non-empty (size > 1)" do
-      response = container_class.new(size: 2).reply.append(:todos, todo)
+      response = container_class.new(size: 2).reply.append(todo, to: :todos)
       expect(response.streams).not_to include(a_string_including('target="todos-empty"'))
     end
 
     it "opts to render_self false (the row append is the update, not a self replace)" do
-      response = container_class.new(size: 1).reply.append(:todos, todo)
+      response = container_class.new(size: 1).reply.append(todo, to: :todos)
       expect(response.render_self?).to be(false)
     end
 
@@ -96,57 +96,57 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
     # so the endpoint appends its inert reactive:token stream (the #30 machinery).
     it "binds the container as token_component so its token rolls forward" do
       container = container_class.new(size: 1)
-      response = container.reply.append(:todos, todo)
+      response = container.reply.append(todo, to: :todos)
       expect(response.refresh_token?).to be(true)
       expect(response.token_component).to eq(container)
     end
   end
 
-  describe "reply.prepend(name, model)" do
+  describe "reply.prepend(model, to:)" do
     it "prepends the row into the container and still updates count" do
-      response = container_class.new(size: 1).reply.prepend(:todos, todo)
+      response = container_class.new(size: 1).reply.prepend(todo, to: :todos)
       expect(response.streams).to include(a_string_including('action="prepend"', 'target="todos-list"'))
       expect(response.streams).to include(a_string_including('target="todos-count"'))
     end
 
     it "binds the container as token_component (cosmos#1939)" do
       container = container_class.new(size: 1)
-      expect(container.reply.prepend(:todos, todo).token_component).to eq(container)
+      expect(container.reply.prepend(todo, to: :todos).token_component).to eq(container)
     end
   end
 
-  describe "reply.remove(name, model)" do
+  describe "reply.remove(model, from:)" do
     it "removes the row by its dom id" do
-      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      response = container_class.new(size: 0).reply.remove(todo, from: :todos)
       remove = response.streams.find { it.include?(%(target="#{dom_id}")) }
       expect(remove).to include('action="remove"')
     end
 
     it "updates the count companion with the fresh size" do
-      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      response = container_class.new(size: 0).reply.remove(todo, from: :todos)
       expect(response.streams).to include(a_string_including('target="todos-count"', 'action="update"'))
     end
 
     it "restores the empty-state when the list crosses ->0 (size becomes 0)" do
-      response = container_class.new(size: 0).reply.remove(:todos, todo)
+      response = container_class.new(size: 0).reply.remove(todo, from: :todos)
       empty = response.streams.find { it.include?('target="todos-list"') && it.include?("No todos yet") }
       expect(empty).to include('action="append"')
     end
 
     it "does NOT restore the empty-state while rows remain (size > 0)" do
-      response = container_class.new(size: 3).reply.remove(:todos, todo)
+      response = container_class.new(size: 3).reply.remove(todo, from: :todos)
       expect(response.streams).not_to include(a_string_including("No todos yet"))
     end
 
     it "binds the container as token_component so repeated removes work (cosmos#1939)" do
       container = container_class.new(size: 0)
-      response = container.reply.remove(:todos, todo)
+      response = container.reply.remove(todo, from: :todos)
       expect(response.refresh_token?).to be(true)
       expect(response.token_component).to eq(container)
     end
 
     it "accepts a dom-id string as well as a model" do
-      response = container_class.new(size: 0).reply.remove(:todos, dom_id)
+      response = container_class.new(size: 0).reply.remove(dom_id, from: :todos)
       remove = response.streams.find { it.include?('action="remove"') }
       expect(remove).to include(%(target="#{dom_id}"))
     end
@@ -167,7 +167,7 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
     end
 
     it "emits only the row stream when count/empty/size are not declared" do
-      response = minimal_container.new.reply.append(:todos, todo)
+      response = minimal_container.new.reply.append(todo, to: :todos)
       expect(response.streams.size).to eq(1)
       expect(response.streams.first).to include('action="append"')
     end
@@ -175,20 +175,25 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
 
   describe "chaining" do
     it "the returned Response chains .flash like any other reply" do
-      response = container_class.new(size: 1).reply.append(:todos, todo).flash(:notice, "added")
+      response = container_class.new(size: 1).reply.append(todo, to: :todos).flash(:notice, "added")
       expect(response.streams.last).to include('action="append"')
       expect(response.streams.last).to include("added")
     end
 
     it "the returned Response is frozen" do
-      expect(container_class.new(size: 1).reply.append(:todos, todo)).to be_frozen
+      expect(container_class.new(size: 1).reply.append(todo, to: :todos)).to be_frozen
     end
   end
 
   describe "errors" do
     it "raises a clear error for an undeclared collection" do
-      expect { container_class.new.reply.append(:nope, todo) }
+      expect { container_class.new.reply.append(todo, to: :nope) }
         .to raise_error(Phlex::Reactive::Error, /undeclared reactive_collection :nope/)
+    end
+
+    it "raises a guided ArgumentError for the removed Symbol-first form" do
+      expect { container_class.new.reply.append(:nope, todo) }
+        .to raise_error(ArgumentError, /to:/)
     end
   end
 end

--- a/spec/phlex/reactive/reply_spec.rb
+++ b/spec/phlex/reactive/reply_spec.rb
@@ -2,14 +2,17 @@
 
 require "rails_helper"
 
-# Component#reply returns a subject-bound facade over Response, so an action body
-# writes `reply.replace.flash(:error, msg)` instead of
-# `Phlex::Reactive::Response.replace(self).flash(:error, msg)` — no constant to
-# qualify (it's a method, resolved on the component) and no `self` to thread.
+# Component#reply returns a subject-bound facade that builds the Response value
+# object the endpoint reads, so an action body writes `reply.replace.flash(:error,
+# msg)` — no constant to qualify (it's a method, resolved on the component) and no
+# `self` to thread. Issue #182 made reply the ONLY door (the Response.* class
+# verbs are removed), so the builder logic lives on Response as private-by-name
+# `build_*` class methods that Reply calls.
 #
-# Reply is sugar: every verb returns the SAME frozen Response the endpoint reads,
-# so these specs lock parity with Response.* on the observable surface (streams,
-# redirect?, render_self?) rather than via == (Response has no value equality).
+# Reply is the ONE door (issue #182): every verb returns a frozen Response the
+# endpoint reads. These specs lock the observable surface (streams, redirect?,
+# render_self?) directly — the former Response.* class verbs are removed, so
+# there is nothing to mirror against, only the behavior to assert.
 RSpec.describe Phlex::Reactive::Reply do
   let(:counter) { CounterComponent.new(count: 0) }
   let(:todo) { Todo.create!(title: "t", done: false) }
@@ -43,56 +46,55 @@ RSpec.describe Phlex::Reactive::Reply do
     end
   end
 
-  describe "verbs return a real Response with the same surface as Response.*" do
-    it "replace mirrors Response.replace(self)" do
+  describe "verbs return a real Response with the expected surface" do
+    it "replace re-renders self in place (render_self, plain swap)" do
       via_reply = counter.reply.replace
-      via_class = Phlex::Reactive::Response.replace(CounterComponent.new(count: 0))
 
       expect(via_reply).to be_a(Phlex::Reactive::Response)
-      expect(via_reply.render_self?).to eq(via_class.render_self?)
+      expect(via_reply.render_self?).to be(true)
       expect(via_reply.streams.first).to include('action="replace"')
       expect(via_reply.streams.first).not_to include("method=") # plain swap by default
     end
 
-    it "replace(morph: true) mirrors Response.replace(self, morph: true)" do
+    it "replace(morph: true) emits a morph swap" do
       stream = counter.reply.replace(morph: true).streams.first
       expect(stream).to include('action="replace"')
       expect(stream).to include('method="morph"')
     end
 
-    it "morph mirrors Response.morph(self)" do
+    it "morph emits a morph swap" do
       stream = counter.reply.morph.streams.first
       expect(stream).to include('action="replace"')
       expect(stream).to include('method="morph"')
     end
 
-    it "update mirrors Response.update(self)" do
+    it "update emits a plain update stream" do
       stream = counter.reply.update.streams.first
       expect(stream).to include('action="update"')
       expect(stream).not_to include("method=") # plain update by default
     end
 
-    it "update(morph: true) mirrors Response.update(self, morph: true) — issue #113" do
+    it "update(morph: true) emits a morph update — issue #113" do
       stream = counter.reply.update(morph: true).streams.first
       expect(stream).to include('action="update"')
       expect(stream).to include('method="morph"')
     end
 
-    it "remove mirrors Response.remove(self) — render_self false" do
+    it "remove drops self, render_self false" do
       response = item.reply.remove
       expect(response.render_self?).to be(false)
       expect(response.streams.first).to include('action="remove"')
       expect(response.streams.first).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
     end
 
-    it "redirect mirrors Response.redirect(url) — render_self false, carries url" do
+    it "redirect carries the url, render_self false" do
       response = counter.reply.redirect("/x")
       expect(response.redirect?).to be(true)
       expect(response.redirect_url).to eq("/x")
       expect(response.render_self?).to be(false)
     end
 
-    it "with mirrors Response.with(*streams)" do
+    it "with emits raw streams verbatim" do
       response = counter.reply.with("<turbo-stream></turbo-stream>")
       expect(response).to be_a(Phlex::Reactive::Response)
       expect(response.streams).to eq(["<turbo-stream></turbo-stream>"])
@@ -101,7 +103,7 @@ RSpec.describe Phlex::Reactive::Reply do
     # Issue #30: reply.streams(*) is the bound form of Response.streams(self, *) —
     # emit exactly these streams, refresh the token via a tiny stream (NOT a full
     # self replace), so per-field/partial updates don't clobber live inputs.
-    it "streams mirrors Response.streams(self, *streams) — render_self false, component bound" do
+    it "streams emits partial streams, render_self false, component bound" do
       response = counter.reply.streams(item.to_stream_update)
       expect(response).to be_a(Phlex::Reactive::Response)
       expect(response.render_self?).to be(false)
@@ -118,8 +120,8 @@ RSpec.describe Phlex::Reactive::Reply do
       expect(response.streams.last).to include("hi")
     end
 
-    it "reply.replace.also_update appends a companion stream" do
-      response = counter.reply.replace.also_update("page_heading", html: "New")
+    it "reply.replace.also appends a companion stream" do
+      response = counter.reply.replace.also(page_heading: "New")
       expect(response.streams.size).to eq(2)
       expect(response.streams.last).to include('target="page_heading"')
     end

--- a/spec/phlex/reactive/response_defer_spec.rb
+++ b/spec/phlex/reactive/response_defer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Phlex::Reactive::Response#defer" do
 
   describe "recording segments" do
     it "returns a NEW frozen Response carrying the segment (immutable chain)" do
-      base = Phlex::Reactive::Response.replace(counter)
+      base = counter.reply.replace
       deferred = base.defer(totals)
 
       expect(deferred).not_to equal(base)
@@ -25,13 +25,13 @@ RSpec.describe "Phlex::Reactive::Response#defer" do
     end
 
     it "defaults to keep-content (no placeholder) and a plain replace arrival" do
-      segment = Phlex::Reactive::Response.replace(counter).defer(totals).deferred_segments.first
+      segment = counter.reply.replace.defer(totals).deferred_segments.first
       expect(segment.placeholder).to be_nil
       expect(segment.morph).to be(false)
     end
 
     it "records placeholder: and morph:" do
-      segment = Phlex::Reactive::Response.replace(counter)
+      segment = counter.reply.replace
         .defer(totals, placeholder: "<p>loading</p>", morph: true)
         .deferred_segments.first
 
@@ -41,31 +41,31 @@ RSpec.describe "Phlex::Reactive::Response#defer" do
 
     it "stacks multiple segments in order" do
       other = CounterComponent.new(count: 7)
-      response = Phlex::Reactive::Response.replace(counter).defer(totals).defer(other)
+      response = counter.reply.replace.defer(totals).defer(other)
 
       expect(response.deferred_segments.map(&:component)).to eq([totals, other])
     end
 
     it "deferred? reflects the presence of segments" do
-      # Fresh instances per Response.replace — a Phlex component renders once.
-      expect(Phlex::Reactive::Response.replace(CounterComponent.new(count: 0)).deferred?).to be(false)
-      expect(Phlex::Reactive::Response.replace(CounterComponent.new(count: 0)).defer(totals).deferred?).to be(true)
+      # Fresh instances per reply.replace — a Phlex component renders once.
+      expect(CounterComponent.new(count: 0).reply.replace.deferred?).to be(false)
+      expect(CounterComponent.new(count: 0).reply.replace.defer(totals).deferred?).to be(true)
     end
   end
 
   describe "chain preservation" do
-    it "survives .flash / .stream / .also_update chained AFTER defer" do
-      response = Phlex::Reactive::Response.replace(counter)
+    it "survives .flash / .stream / .also AFTER defer" do
+      response = counter.reply.replace
         .defer(totals)
         .flash(:notice, "saved")
-        .also_update("heading", html: "Hi")
+        .also("heading" => "Hi")
 
       expect(response.deferred_segments.size).to eq(1)
-      expect(response.streams.size).to eq(3) # replace + flash + also_update
+      expect(response.streams.size).to eq(3) # replace + flash + also
     end
 
     it "preserves token_component / render_self through the defer chain" do
-      response = Phlex::Reactive::Response.streams(counter, "<turbo-stream></turbo-stream>").defer(totals)
+      response = counter.reply.streams("<turbo-stream></turbo-stream>").defer(totals)
 
       expect(response.render_self?).to be(false)
       expect(response.token_component).to equal(counter)
@@ -74,7 +74,7 @@ RSpec.describe "Phlex::Reactive::Response#defer" do
 
   describe "loud failures at the call site" do
     it "rejects defer on a redirect reply (the client is navigating away)" do
-      expect { Phlex::Reactive::Response.redirect("/x").defer(totals) }
+      expect { counter.reply.redirect("/x").defer(totals) }
         .to raise_error(Phlex::Reactive::Error, /redirect/)
     end
 
@@ -84,12 +84,12 @@ RSpec.describe "Phlex::Reactive::Response#defer" do
         def view_template = div { "x" }
       end
 
-      expect { Phlex::Reactive::Response.replace(counter).defer(plain.new) }
+      expect { counter.reply.replace.defer(plain.new) }
         .to raise_error(ArgumentError, /Phlex::Reactive::Component/)
     end
 
     it "rejects a placeholder that is neither nil, true, a String, nor a Phlex component" do
-      expect { Phlex::Reactive::Response.replace(counter).defer(totals, placeholder: 42) }
+      expect { counter.reply.replace.defer(totals, placeholder: 42) }
         .to raise_error(ArgumentError, /placeholder/)
     end
   end

--- a/spec/phlex/reactive/response_removed_verbs_spec.rb
+++ b/spec/phlex/reactive/response_removed_verbs_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #182: `reply` is the ONE documented door. The Response CLASS verbs
+# (Response.replace/morph/update/remove/redirect/with/streams and the collection
+# class methods) are removed as public entry points — each raises a guided
+# ArgumentError naming the `reply.<verb>` rewrite. The immutable Response value
+# object (Response.new + its instance chain .flash/.stream/.also/.js/.defer) is
+# UNCHANGED; the endpoint still reads it. These specs lock the stubs.
+RSpec.describe Phlex::Reactive::Response, "class verbs are removed (issue #182)" do
+  let(:counter) { CounterComponent.new(count: 0) }
+
+  # Each class verb → the reply.<verb> it points at.
+  {
+    replace: "reply.replace",
+    morph: "reply.morph",
+    update: "reply.update",
+    remove: "reply.remove",
+    redirect: "reply.redirect",
+    with: "reply.with",
+    streams: "reply.streams"
+  }.each do |verb, rewrite|
+    it "Response.#{verb} raises a guided error naming #{rewrite}" do
+      expect { described_class.public_send(verb, counter) }
+        .to raise_error(ArgumentError, /#{Regexp.escape(rewrite)}/)
+    end
+  end
+
+  it "the guided error names the removal (issue #182 reference)" do
+    expect { described_class.replace(counter) }
+      .to raise_error(ArgumentError, /removed|reply\.replace/)
+  end
+
+  # rubocop:disable Style/ItBlockParameter -- the block param `verb` is referenced
+  # in the `it` description AND the call; `it` would shadow RSpec's own `it`.
+  %i[collection_append collection_prepend collection_remove].each do |verb|
+    it "Response.#{verb} raises a guided error naming reply" do
+      expect { described_class.public_send(verb, counter, :items, nil) }
+        .to raise_error(ArgumentError, /reply\./)
+    end
+  end
+  # rubocop:enable Style/ItBlockParameter
+
+  it "keeps Response.new as the constructor (the value object is unchanged)" do
+    response = described_class.new(streams: ["<turbo-stream></turbo-stream>"])
+    expect(response).to be_a(described_class)
+    expect(response).to be_frozen
+    expect(response.streams).to eq(["<turbo-stream></turbo-stream>"])
+  end
+
+  it "keeps the instance chain (.flash/.stream) working on a reply-built Response" do
+    response = counter.reply.replace.flash(:notice, "hi")
+    expect(response.streams.size).to eq(2)
+    expect(response.streams.last).to include("hi")
+  end
+end

--- a/spec/phlex/reactive/response_spec.rb
+++ b/spec/phlex/reactive/response_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Phlex::Reactive::Response do
   let(:item) { TodoItemComponent.new(todo:) }
 
   it "replace renders a self-targeted replace stream and keeps render_self" do
-    response = described_class.replace(counter)
+    response = counter.reply.replace
     expect(response.render_self?).to be(true)
     expect(response.redirect?).to be(false)
     expect(response.streams.size).to eq(1)
@@ -20,7 +20,7 @@ RSpec.describe Phlex::Reactive::Response do
   end
 
   it "replace + flash composes two streams" do
-    response = described_class.replace(counter).flash(:notice, "hi")
+    response = counter.reply.replace.flash(:notice, "hi")
     expect(response.streams.size).to eq(2)
     expect(response.streams.last).to include('action="append"')
     expect(response.streams.last).to include('target="flash"')
@@ -28,14 +28,14 @@ RSpec.describe Phlex::Reactive::Response do
   end
 
   it "remove opts out of render_self and emits a remove stream" do
-    response = described_class.remove(item)
+    response = item.reply.remove
     expect(response.render_self?).to be(false)
     expect(response.streams.first).to include('action="remove"')
     expect(response.streams.first).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
   end
 
   it "redirect carries the url, opts out of render_self, and has no streams" do
-    response = described_class.redirect("/x")
+    response = counter.reply.redirect("/x")
     expect(response.redirect?).to be(true)
     expect(response.redirect_url).to eq("/x")
     expect(response.render_self?).to be(false)
@@ -43,7 +43,7 @@ RSpec.describe Phlex::Reactive::Response do
   end
 
   it "is immutable — stream/flash return new instances" do
-    base = described_class.replace(counter)
+    base = counter.reply.replace
     expect(base.stream("<turbo-stream></turbo-stream>")).not_to equal(base)
     expect(base.streams.size).to eq(1) # original unchanged
     expect(base).to be_frozen
@@ -51,9 +51,9 @@ RSpec.describe Phlex::Reactive::Response do
 
   # Issue #25: re-render self + a companion element/component without dropping to
   # raw turbo_stream_builder.
-  describe "also_update / also_replace (companion elements)" do
-    it "also_update appends an update stream for an arbitrary target id" do
-      response = described_class.replace(counter).also_update("page_heading", html: "New name")
+  describe "also (companion elements)" do
+    it "also appends an update stream for an arbitrary target id" do
+      response = counter.reply.replace.also("page_heading" => "New name")
 
       expect(response.streams.size).to eq(2)
       expect(response.render_self?).to be(true)
@@ -62,51 +62,51 @@ RSpec.describe Phlex::Reactive::Response do
       expect(response.streams.last).to include("New name")
     end
 
-    it "also_update renders a Phlex component (auto-escaped) into the companion stream" do
+    it "also renders a Phlex component (auto-escaped) into the companion stream" do
       probe = Class.new(Phlex::HTML) do
         def self.name = "HeadingProbe"
         def view_template = strong { "Bold heading" }
       end
-      response = described_class.with.also_update("page_heading", html: probe.new)
+      response = counter.reply.with.also("page_heading" => probe.new)
 
       expect(response.streams.first).to include("<strong>Bold heading</strong>")
     end
 
-    it "also_update HTML-escapes a plain string (a model value is safe)" do
+    it "also HTML-escapes a plain string (a model value is safe)" do
       # Turbo's TagBuilder escapes a plain String passed to html:, so a model
       # value can't inject markup. (Pass an html_safe string or a Phlex
       # component to emit intentional raw HTML.)
-      response = described_class.with.also_update("page_heading", html: "<em>Live</em>")
+      response = counter.reply.with.also("page_heading" => "<em>Live</em>")
 
       expect(response.streams.first).to include("&lt;em&gt;Live&lt;/em&gt;")
       expect(response.streams.first).not_to include("<em>Live</em>")
     end
 
-    it "also_update emits an html_safe string as raw markup" do
-      response = described_class.with.also_update("page_heading", html: "<em>Live</em>".html_safe)
+    it "also emits an html_safe string as raw markup" do
+      response = counter.reply.with.also("page_heading" => "<em>Live</em>".html_safe)
 
       expect(response.streams.first).to include("<em>Live</em>")
     end
 
-    it "also_replace renders another Streamable component, targeting its own id" do
-      response = described_class.replace(counter).also_replace(item)
+    it "also renders another Streamable component, targeting its own id" do
+      response = counter.reply.replace.also(item)
 
       expect(response.streams.size).to eq(2)
       expect(response.streams.last).to include('action="replace"')
       expect(response.streams.last).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
     end
 
-    it "is immutable — also_* return new instances and keep render_self" do
-      base = described_class.replace(counter)
-      extended = base.also_update("h", html: "x")
+    it "is immutable — also returns new instances and keeps render_self" do
+      base = counter.reply.replace
+      extended = base.also("h" => "x")
       expect(extended).not_to equal(base)
       expect(base.streams.size).to eq(1) # original unchanged
       expect(extended.render_self?).to be(true)
     end
 
     it "chains alongside flash and stream" do
-      response = described_class.replace(counter)
-        .also_update("heading", html: "n")
+      response = counter.reply.replace
+        .also("heading" => "n")
         .flash(:notice, "saved")
 
       expect(response.streams.size).to eq(3)
@@ -114,12 +114,12 @@ RSpec.describe Phlex::Reactive::Response do
   end
 
   # Issue #28: morph re-renders self in place via Idiomorph (method="morph"),
-  # preserving the focused input + caret. Response.morph(self) is the explicit
-  # builder; Response.replace(self, morph: true) is the opt-in flag; also_replace
-  # gains a morph: flag for companion components.
+  # preserving the focused input + caret. reply.morph is the explicit
+  # builder; reply.replace(morph: true) is the opt-in flag; also gains a
+  # morph: flag for companion components.
   describe "morph (issue #28)" do
     it "morph renders a self-targeted morphing replace and keeps render_self" do
-      response = described_class.morph(counter)
+      response = counter.reply.morph
       expect(response.render_self?).to be(true)
       expect(response.redirect?).to be(false)
       expect(response.streams.size).to eq(1)
@@ -129,43 +129,43 @@ RSpec.describe Phlex::Reactive::Response do
     end
 
     it "replace(morph: true) emits the morph attribute" do
-      response = described_class.replace(counter, morph: true)
+      response = counter.reply.replace(morph: true)
       expect(response.streams.first).to include('method="morph"')
     end
 
     it "replace defaults to a plain swap (no morph attr) — back-compat" do
-      response = described_class.replace(counter)
+      response = counter.reply.replace
       expect(response.streams.first).not_to include("method=")
     end
 
     it "morph composes with flash (token still refreshes via the morph)" do
-      response = described_class.morph(counter).flash(:notice, "saved")
+      response = counter.reply.morph.flash(:notice, "saved")
       expect(response.streams.size).to eq(2)
       expect(response.streams.first).to include('method="morph"')
       expect(response.streams.last).to include('action="append"')
     end
 
-    it "also_replace(component, morph: true) morphs the companion component" do
-      response = described_class.morph(counter).also_replace(item, morph: true)
+    it "also(component, morph: true) morphs the companion component" do
+      response = counter.reply.morph.also(item, morph: true)
       expect(response.streams.size).to eq(2)
       expect(response.streams.last).to include('method="morph"')
       expect(response.streams.last).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
     end
 
-    it "also_replace defaults to a plain replace (no morph attr)" do
-      response = described_class.replace(counter).also_replace(item)
+    it "also defaults to a plain replace (no morph attr)" do
+      response = counter.reply.replace.also(item)
       expect(response.streams.last).not_to include("method=")
     end
 
-    # Issue #113: Response.update gains the same morph: flag replace already has.
+    # Issue #113: reply.update gains the same morph: flag replace already has.
     it "update(morph: true) emits a morphing update" do
-      response = described_class.update(counter, morph: true)
+      response = counter.reply.update(morph: true)
       expect(response.streams.first).to include('action="update"')
       expect(response.streams.first).to include('method="morph"')
     end
 
     it "update defaults to a plain update (no morph attr) — back-compat" do
-      response = described_class.update(counter)
+      response = counter.reply.update
       expect(response.streams.first).to include('action="update"')
       expect(response.streams.first).not_to include("method=")
     end
@@ -178,8 +178,8 @@ RSpec.describe Phlex::Reactive::Response do
   # flash component (string content only).
   describe "flash levels (issue #77)" do
     it ":error and :notice produce different streams" do
-      error = described_class.with.flash(:error, "boom").streams.first
-      notice = described_class.with.flash(:notice, "saved").streams.first
+      error = counter.reply.with.flash(:error, "boom").streams.first
+      notice = counter.reply.with.flash(:notice, "saved").streams.first
 
       expect(error.to_s.gsub("boom", "MSG")).not_to eq(notice.to_s.gsub("saved", "MSG"))
       expect(error).to include('class="reactive-flash reactive-flash--error"')
@@ -189,7 +189,7 @@ RSpec.describe Phlex::Reactive::Response do
     end
 
     it "keeps HTML-escaping plain string content (injection contract unchanged)" do
-      stream = described_class.with.flash(:notice, "<em>x</em> & y").streams.first
+      stream = counter.reply.with.flash(:notice, "<em>x</em> & y").streams.first
 
       expect(stream).to include("&lt;em&gt;x&lt;/em&gt; &amp; y")
       expect(stream).not_to include("<em>x</em>")
@@ -197,14 +197,14 @@ RSpec.describe Phlex::Reactive::Response do
     end
 
     it "passes an html_safe string verbatim INSIDE the wrapper (intentional raw HTML)" do
-      stream = described_class.with.flash(:notice, "<em>x</em>".html_safe).streams.first
+      stream = counter.reply.with.flash(:notice, "<em>x</em>".html_safe).streams.first
 
       expect(stream).to include('data-reactive-flash-level="notice"')
       expect(stream).to include("<em>x</em>")
     end
 
     it "HTML-escapes the level (it lands in a class name and a data attribute)" do
-      stream = described_class.with.flash(%(err"or><script>), "x").streams.first
+      stream = counter.reply.with.flash(%(err"or><script>), "x").streams.first
 
       expect(stream).not_to include('err"or><script>')
       expect(stream).to include("err&quot;or&gt;&lt;script&gt;")
@@ -216,8 +216,8 @@ RSpec.describe Phlex::Reactive::Response do
         def view_template = span { "rendered flash" }
       end
 
-      via_flash = described_class.with.flash(:error, klass.new).streams.first
-      raw = Phlex::Reactive.flash_builder.append("flash", html: Phlex::Reactive.render(klass.new))
+      via_flash = counter.reply.with.flash(:error, klass.new).streams.first
+      raw = Phlex::Reactive.stream_builder.append("flash", html: Phlex::Reactive.render(klass.new))
 
       expect(via_flash.to_s).to eq(raw.to_s)
       expect(via_flash).not_to include("reactive-flash")
@@ -238,14 +238,14 @@ RSpec.describe Phlex::Reactive::Response do
       end
 
       around do
-        Phlex::Reactive.flash_component = flash_component
+        Phlex::Reactive.flash_component = ->(level, content) { flash_component.new(level:, content:) }
         it.run
       ensure
         Phlex::Reactive.flash_component = nil
       end
 
       it "renders string content through the configured component (level + content)" do
-        stream = described_class.with.flash(:error, "Save failed").streams.first
+        stream = counter.reply.with.flash(:error, "Save failed").streams.first
 
         expect(stream).to include('class="toast toast--error"')
         expect(stream).to include("Save failed")
@@ -258,7 +258,7 @@ RSpec.describe Phlex::Reactive::Response do
           def view_template = span { "custom card" }
         end
 
-        stream = described_class.with.flash(:error, klass.new).streams.first
+        stream = counter.reply.with.flash(:error, klass.new).streams.first
 
         expect(stream).to include("<span>custom card</span>")
         expect(stream).not_to include("toast")
@@ -272,41 +272,41 @@ RSpec.describe Phlex::Reactive::Response do
       def self.name = "FlashAlertProbe"
       def view_template = span { "rendered flash" }
     end
-    response = described_class.with.flash(:error, klass.new)
+    response = counter.reply.with.flash(:error, klass.new)
     expect(response.streams.first).to include("rendered flash")
   end
 
-  # Issue #30: Response.streams(component, *strings) emits EXACTLY the caller's
-  # streams plus a token-only refresh — render_self is false (no full-self
-  # replace), so partial/per-field updates don't clobber live inputs, yet the
-  # signed token still rolls forward via the tiny reactive:token stream the
-  # endpoint appends from the bound component.
+  # Issue #30: reply.streams(*strings) emits EXACTLY the caller's streams plus
+  # a token-only refresh — render_self is false (no full-self replace), so
+  # partial/per-field updates don't clobber live inputs, yet the signed token
+  # still rolls forward via the tiny reactive:token stream the endpoint
+  # appends from the bound component.
   describe "streams (issue #30 — partial update, token-only refresh)" do
     it "opts out of render_self (no forced full-self replace)" do
-      response = described_class.streams(counter, "<turbo-stream></turbo-stream>")
+      response = counter.reply.streams("<turbo-stream></turbo-stream>")
       expect(response.render_self?).to be(false)
     end
 
     it "carries exactly the caller's streams (does not prepend a self replace)" do
-      response = described_class.streams(counter, item.to_stream_update)
+      response = counter.reply.streams(item.to_stream_update)
       expect(response.streams.size).to eq(1)
       expect(response.streams.first).to include('action="update"')
       expect(response.streams.first).to include(%(target="#{ActionView::RecordIdentifier.dom_id(todo)}"))
     end
 
     it "remembers the bound component so the endpoint can refresh its token" do
-      response = described_class.streams(counter, "<turbo-stream></turbo-stream>")
+      response = counter.reply.streams("<turbo-stream></turbo-stream>")
       expect(response.token_component).to eq(counter)
     end
 
     it "is NOT redirect and is immutable" do
-      response = described_class.streams(counter)
+      response = counter.reply.streams
       expect(response.redirect?).to be(false)
       expect(response).to be_frozen
     end
 
     it "chains flash/stream while staying render_self false and keeping the component" do
-      response = described_class.streams(counter, item.to_stream_update).flash(:notice, "saved")
+      response = counter.reply.streams(item.to_stream_update).flash(:notice, "saved")
       expect(response.streams.size).to eq(2)
       expect(response.streams.last).to include('action="append"')
       expect(response.render_self?).to be(false)
@@ -324,7 +324,7 @@ RSpec.describe Phlex::Reactive::Response do
     let(:ops) { CounterComponent.new(count: 0).js.focus("[name=next]").dispatch("app:saved") }
 
     it "chains a reactive:js op stream onto a replace, immutably" do
-      base = described_class.replace(counter)
+      base = counter.reply.replace
       response = base.js(ops)
 
       expect(response).not_to equal(base)
@@ -335,14 +335,14 @@ RSpec.describe Phlex::Reactive::Response do
     end
 
     it "emits the op stream LAST (after the render stream)" do
-      response = described_class.morph(counter).js(ops)
+      response = counter.reply.morph.js(ops)
 
       expect(response.streams.first).to include('action="replace"') # the morph render
       expect(response.streams.last).to include('action="reactive:js"')
     end
 
     it "carries the ops as an HTML-escaped data-reactive-ops attribute" do
-      stream = described_class.with.js(ops).streams.first
+      stream = counter.reply.with.js(ops).streams.first
 
       # The wire format is the JSON op list, HTML-escaped (quotes → &quot;).
       expect(stream).to include("data-reactive-ops=")
@@ -354,7 +354,7 @@ RSpec.describe Phlex::Reactive::Response do
 
     it "escapes a hostile op payload (no attribute break-out)" do
       hostile = CounterComponent.new(count: 0).js.dispatch(%(x"><script>alert(1)</script>))
-      stream = described_class.with.js(hostile).streams.first
+      stream = counter.reply.with.js(hostile).streams.first
 
       expect(stream).not_to include('"><script>')
       expect(stream).to include("&quot;")
@@ -363,37 +363,37 @@ RSpec.describe Phlex::Reactive::Response do
     it "defaults the stream target to the bound component's id (self-scoped ops)" do
       # replace/morph/update bind the component, so js ops scope to its root by
       # default — reply.morph.js(js.focus("@root")) focuses the morphed root.
-      stream = described_class.replace(counter).js(ops).streams.last
+      stream = counter.reply.replace.js(ops).streams.last
       expect(stream).to include('target="counter"')
     end
 
     it "accepts an explicit target: override" do
-      stream = described_class.with.js(ops, target: "sidebar").streams.first
+      stream = counter.reply.with.js(ops, target: "sidebar").streams.first
       expect(stream).to include('target="sidebar"')
     end
 
     it "omits target entirely for a subject-free reply with no explicit target (document-scoped)" do
-      stream = described_class.with.js(ops).streams.first
+      stream = counter.reply.with.js(ops).streams.first
       expect(stream).not_to include("target=")
     end
 
     it "accepts a raw op array as well as a JS chain" do
-      stream = described_class.with.js([["focus", { "to" => "@root" }]]).streams.first
+      stream = counter.reply.with.js([["focus", { "to" => "@root" }]]).streams.first
       expect(stream).to include("&quot;focus&quot;")
     end
 
     it "enforces the attr allowlist on a raw op array (escape hatch can't bypass it)" do
       hostile = [["set_attr", { "to" => "#x", "name" => "onclick", "value" => "alert(1)" }]]
-      expect { described_class.with.js(hostile) }.to raise_error(ArgumentError, /onclick/)
+      expect { counter.reply.with.js(hostile) }.to raise_error(ArgumentError, /onclick/)
     end
 
     it "rejects an empty op chain (a dead reactive:js stream is a mistake)" do
       empty = CounterComponent.new(count: 0).js
-      expect { described_class.with.js(empty) }.to raise_error(ArgumentError, /no ops/)
+      expect { counter.reply.with.js(empty) }.to raise_error(ArgumentError, /no ops/)
     end
 
     it "chains alongside flash (ops stay after the render, flash after that)" do
-      response = described_class.replace(counter).flash(:notice, "saved").js(ops)
+      response = counter.reply.replace.flash(:notice, "saved").js(ops)
       expect(response.streams.size).to eq(3)
       expect(response.streams.last).to include('action="reactive:js"')
     end
@@ -406,7 +406,7 @@ RSpec.describe Phlex::Reactive::Response do
   # no attribute unless the caller opts in.
   describe "dismiss_after: (issue #100)" do
     it "wraps a string flash with data-reactive-dismiss-after when set" do
-      stream = described_class.with.flash(:error, "boom", dismiss_after: 4000).streams.first
+      stream = counter.reply.with.flash(:error, "boom", dismiss_after: 4000).streams.first
 
       expect(stream).to include('data-reactive-dismiss-after="4000"')
       expect(stream).to include('class="reactive-flash reactive-flash--error"')
@@ -414,20 +414,20 @@ RSpec.describe Phlex::Reactive::Response do
     end
 
     it "omits the attribute entirely when dismiss_after is not given (default)" do
-      stream = described_class.with.flash(:error, "boom").streams.first
+      stream = counter.reply.with.flash(:error, "boom").streams.first
 
       expect(stream).not_to include("data-reactive-dismiss-after")
     end
 
     it "coerces the ms to an integer string (a float/String can't inject an attribute)" do
-      stream = described_class.with.flash(:notice, "hi", dismiss_after: "4000\"><script>").streams.first
+      stream = counter.reply.with.flash(:notice, "hi", dismiss_after: "4000\"><script>").streams.first
 
       expect(stream).to include('data-reactive-dismiss-after="4000"')
       expect(stream).not_to include("<script>")
     end
 
     it "still HTML-escapes the content inside a dismissing wrapper (injection contract)" do
-      stream = described_class.with.flash(:notice, "<em>x</em> & y", dismiss_after: 3000).streams.first
+      stream = counter.reply.with.flash(:notice, "<em>x</em> & y", dismiss_after: 3000).streams.first
 
       expect(stream).to include("&lt;em&gt;x&lt;/em&gt; &amp; y")
       expect(stream).not_to include("<em>x</em>")
@@ -444,9 +444,9 @@ RSpec.describe Phlex::Reactive::Response do
 
         def view_template = div(class: "toast") { @content }
       end
-      allow(Phlex::Reactive).to receive(:flash_component).and_return(klass)
+      allow(Phlex::Reactive).to receive(:flash_component).and_return(->(level, content) { klass.new(level:, content:) })
 
-      stream = described_class.with.flash(:error, "boom", dismiss_after: 2000).streams.first
+      stream = counter.reply.with.flash(:error, "boom", dismiss_after: 2000).streams.first
 
       expect(stream).to include('data-reactive-dismiss-after="2000"')
       expect(stream).to include("toast")
@@ -458,7 +458,7 @@ RSpec.describe Phlex::Reactive::Response do
         def view_template = span { "flash" }
       end
 
-      stream = described_class.with.flash(:error, klass.new, dismiss_after: 2000).streams.first
+      stream = counter.reply.with.flash(:error, klass.new, dismiss_after: 2000).streams.first
 
       # Component content renders verbatim — no built-in wrapper, so no place for
       # the gem to hang dismiss_after. Documented limitation: dismiss_after wraps

--- a/spec/phlex/reactive/streamable_view_context_spec.rb
+++ b/spec/phlex/reactive/streamable_view_context_spec.rb
@@ -194,35 +194,27 @@ RSpec.describe "Streamable view-context memoization (performance)" do
     end
   end
 
-  # Issue #113: the builder is used well beyond flashes (row-removal, count
-  # updates, also_update), so flash_builder → stream_builder and
-  # reset_flash_builder! → reset_stream_builder!. The old names stay as
-  # permanent aliases so the engine's to_prepare hook and app code keep working.
-  describe "stream_builder / reset_stream_builder! rename (issue #113)" do
+  # Issue #113 renamed flash_builder → stream_builder; issue #182 REMOVED the old
+  # flash_builder / reset_flash_builder! aliases entirely (they contradicted the
+  # clean-break rule). Each old name now raises a guided NoMethodError.
+  describe "stream_builder / reset_stream_builder!" do
     it "exposes stream_builder returning a Turbo::Streams::TagBuilder" do
       expect(Phlex::Reactive.stream_builder).to be_a(Turbo::Streams::TagBuilder)
     end
 
-    it "keeps flash_builder as a permanent alias for stream_builder" do
-      expect(Phlex::Reactive.flash_builder).to be(Phlex::Reactive.stream_builder)
+    it "raises a guided error for the removed flash_builder alias (issue #182)" do
+      expect { Phlex::Reactive.flash_builder }
+        .to raise_error(NoMethodError, /stream_builder/)
     end
 
-    it "responds to reset_stream_builder! and reset_flash_builder! (permanent alias)" do
-      expect(Phlex::Reactive).to respond_to(:reset_stream_builder!)
-      expect(Phlex::Reactive).to respond_to(:reset_flash_builder!)
+    it "raises a guided error for the removed reset_flash_builder! alias (issue #182)" do
+      expect { Phlex::Reactive.reset_flash_builder! }
+        .to raise_error(NoMethodError, /reset_stream_builder!/)
     end
 
     it "reset_stream_builder! rebuilds the memoized builder" do
       first = Phlex::Reactive.stream_builder
       Phlex::Reactive.reset_stream_builder!
-      expect(Phlex::Reactive.stream_builder).not_to be(first)
-    ensure
-      Phlex::Reactive.reset_stream_builder!
-    end
-
-    it "reset_flash_builder! (the alias) also rebuilds the memoized builder" do
-      first = Phlex::Reactive.stream_builder
-      Phlex::Reactive.reset_flash_builder!
       expect(Phlex::Reactive.stream_builder).not_to be(first)
     ensure
       Phlex::Reactive.reset_stream_builder!


### PR DESCRIPTION
## Summary

`reply` becomes the ONE door for an action's response. Five overlapping surfaces
collapse into one, each removed form raising a guided rewrite:

1. **`Response` class verbs → `reply.<verb>`** — `Phlex::Reactive::Response.replace(self)`
   etc. are removed; the immutable `Response` value object (and its `.flash`/`.stream`/
   `.also`/`.js`/`.defer` chain) is unchanged, so the endpoint reads it identically.
2. **Collection kwargs** — `reply.append(:items, x)` → `reply.append(x, to: :items)`;
   `reply.remove(:items, id)` → `reply.remove(id, from: :items)`. The `UNSET` sentinel
   that overloaded `reply.remove` is gone (dispatch keys on `from:`'s presence).
3. **One flash contract** — `flash_component` is now an app-owned callable
   (`->(level, content) { … }`), not a Class the gem instantiates with a guessed
   `new(level:, content:)`. The flash builders go private.
4. **`also_update`/`also_replace` → one `.also`** — `.also(target => content)` for
   companion updates, `.also(component, morph:)` for a component. The lying `html:`
   kwarg is gone.
5. **`flash_builder`/`reset_flash_builder!` aliases removed** — they contradicted the
   clean-break rule; each names `stream_builder`/`reset_stream_builder!`.

pgbus optionality and the broadcast path are **untouched** — this is a reply/response/
endpoint change only (confirmed by exploration: no `broadcast`/`pgbus_streams?` in the
diff surface).

## Test coverage

- **Unit** — new `response_removed_verbs_spec` locks every class-verb + collection stub;
  `reply_spec` reframed to assert behavior directly (no longer mirrors the removed class
  verbs); `response_spec` (50 ex) rebuilt through `reply` + `.also` + the flash lambda;
  `collection_streams_spec` migrated to `to:`/`from:` + a new Symbol-first guided-error
  test; `streamable_view_context_spec` asserts the `flash_builder` removal.
- **Request** — all 255 green through the real endpoint (dummy components migrated to the
  single dialect, incl. `TodoItemComponent` which had deliberately kept the old `Response.*`
  form).
- **System** — 70 green under Puma; the collection/todo specs re-checked under Falcon.
- **Docs app** — its own request suite (101) green; docs components + prose + README migrated.

## Verification

- [x] `bundle exec rubocop` — 230 files, no offenses
- [x] `bundle exec rspec spec/phlex spec/requests` — 1073 examples, 0 failures
- [x] `bundle exec rspec spec/system` — 70 examples, 0 failures (2 pgbus cells pend)
- [x] docs app request suite — 101 examples, 0 failures
- [x] client-touching dummy specs green under `CAPYBARA_SERVER=falcon`

## Deviations & judgment calls

- **The builder logic stays on `Response` as private-by-name `build_*` class methods**,
  not inlined into `Reply`. The public verb names became the guided stubs; `Reply` calls
  `Response.build_*`. Rationale: the collection builder machinery is correctness-critical
  and well-tested (#35/#30) — moving it wholesale into `Reply` is churn and risk for no
  gain. `Response` stays the single place that knows how to construct itself; `Reply` is
  the only public door.
- **`reply.also` signature is `also(companion = :__none, morph: false, **targets)`.**
  Ruby 3 parses `also(page_heading: x)` as keywords, so a single positional-Hash param
  can't catch the brace-less form — the keyword pairs land in `**targets`; an explicit
  Hash or a component lands in `companion`. Passing both a component AND targets raises;
  an empty `.also` raises (a dead call).
- **The removed forms accept the OLD arity so a stale call reaches the guided error,**
  not a bare Ruby "wrong number of arguments". `also_update(target, **)`, and
  `append`/`prepend`/`remove` take an optional 2nd positional (`legacy_model`) whose mere
  presence triggers `reject_legacy_form!` with the `to:`/`from:` rewrite.
- **Flash helpers privatized with `private` INSIDE `class << self`** (not
  `private_class_method`, which is for the class body). The two internal callers
  (`Response#flash`, the endpoint's `error_flash_stream`) switched to
  `Response.send(:flash_stream, …)` — the endpoint's error path is an internal caller, so
  `send` is the honest reach, not a leak.
- **`flash_builder`/`reset_flash_builder!` raise `NoMethodError`** (not `ArgumentError`) —
  they were methods being removed, so `NoMethodError` is the truthful class.
- **Rubocop `it`-autocorrect trap (again, cf #180):** `rubocop -A` rewrote the
  `REMOVED_CLASS_VERBS.each_key do |verb|` block param to `it`, which is a SyntaxError
  inside the nested `define_singleton_method(verb) do |*, **|` (that block takes ordinary
  params, so `it` is illegal). Reverted to explicit `|verb|` with a scoped
  disable/enable + a comment. The lesson holds: never blind-autocorrect a file with nested
  blocks.
- **README factual fix:** an "Under the hood" callout claimed `Response.replace(self)`
  "still works" — false after this change; corrected to the `reply` form (caught during the
  docs sweep).

Refs #182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated several public APIs to use newer reply-based calls and keyword-targeted collection updates.
  * Removed older companion-update variants in favor of a single `also` API.
  * Flash configuration now expects a callable builder instead of a class.
  * Some legacy aliases were removed and now point to the newer names with guidance.

* **Documentation**
  * Refreshed examples and reference docs to match the updated APIs and calling patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->