### PR TITLE
feat(broadcast): one broadcast_to — verbs as kwargs, component payloads, morph: once (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **BREAKING: one `broadcast_to` — verbs as kwargs, components as payloads (#185).**
+  The 11 `broadcast_*_to` / `broadcast_*_to_each` methods collapse into ONE
+  `broadcast_to` where the verb is a kwarg and its value is the payload:
+
+  ```ruby
+  # before                                          # after
+  Item.broadcast_replace_to(@list, :todos,          Item.broadcast_to(@list, :todos,
+    model: @todo, morph: true)                        replace: @todo, morph: true)
+  Row.broadcast_append_to(@list, target: t,         Row.broadcast_to(@list, append: item, target: t)
+    model: item)
+  Counter.broadcast_replace_to_each(keys,           Counter.broadcast_to(each: keys, replace: counter)
+    model: counter)
+  Badge.broadcast_js_to(user, :alerts, ops)         Badge.broadcast_to(user, :alerts, js: ops)
+  ```
+
+  A Hash payload is the component's init kwargs verbatim (`update: { room:, author: }`),
+  killing the old `**options` collision (a component with an init kwarg named
+  `target`/`morph`/`exclude` is broadcastable again). Payloads can be BUILT
+  components, and the new module-level `Phlex::Reactive.broadcast_to(@list, :todos,
+  update: TodoCount.new(...), target: "todos-count")` broadcasts a NON-Streamable
+  component (a count badge) — instrumented — without hand-rolling the raw channel +
+  render. Self-targeting verbs (`replace:`/`remove:`) require a Streamable payload
+  (its `#id` is the target); container verbs (`update:`/`append:`/`prepend:`) take any
+  component. Every removed method raises a guided error printing the `broadcast_to`
+  rewrite. `exclude:`/`visible_to:` still thread to pgbus through the capability-gated
+  thread-local path — unchanged (verified against pgbus 0.11.0).
+
+- **BREAKING: `to_stream_morph` is removed — morph is a kwarg (#185).**
+  Use `to_stream_replace(morph: true)` (byte-identical wire). `reply.morph` /
+  `reply.replace(morph: true)` are unchanged.
+
 - **BREAKING: forms & fields — scope everywhere, one dirty declaration, named schemas (#184).**
   - **`reactive_scope` extends to `reactive_field` and the param unwrap:** a scoped
     field emits `name="scope[field]"` and the endpoint peels one scope level, so the

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ rails g phlex:reactive:claude
    └──────── Turbo applies it in ◀──────────────────────────────┘
 
    ...and for OTHER tabs/users:
-   model change → Component.broadcast_replace_to(stream) → pgbus SSE → same morph
+   model change → Component.broadcast_to(stream, replace: model) → pgbus SSE → same morph
 ```
 
 Client actions and server broadcasts **converge on one re-render unit**: the
@@ -326,7 +326,7 @@ The [inline edit example](https://phlex-reactive.zoolutions.llc/docs/example-inl
 | [Cross-tab chat](https://phlex-reactive.zoolutions.llc/docs/example-chat) | Record-backed action **+ pgbus broadcast** → live sync across tabs/browsers |
 | [Live todo list](https://phlex-reactive.zoolutions.llc/docs/example-todo-list) | Per-row components, add/toggle/rename/archive, optimistic toggle + delete, Enter-to-add, broadcast on change |
 | [Inline edit + dirty tracking](https://phlex-reactive.zoolutions.llc/docs/example-inline-edit) | Show ↔ edit toggle plus an "Unsaved" badge + leave-guard, with zero shipped state |
-| [Notifications / badges](https://phlex-reactive.zoolutions.llc/docs/example-notifications) | Pure broadcast — a background event pushes a re-render, plus a `broadcast_js_to` cross-tab pulse |
+| [Notifications / badges](https://phlex-reactive.zoolutions.llc/docs/example-notifications) | Pure broadcast — a background event pushes a re-render, plus a `broadcast_to(js:)` cross-tab pulse |
 | [Reactive collections](https://phlex-reactive.zoolutions.llc/docs/example-collections) | Add/remove rows + a running count + an empty state, declared **once** with `reactive_collection`, optimistic dismiss |
 | [Loading states](https://phlex-reactive.zoolutions.llc/docs/example-loading-states) | `disable_with:` + `busy_on` + `aria-busy`, with a latency toggle to make the pending window visible |
 | [Client-only ops](https://phlex-reactive.zoolutions.llc/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS |
@@ -350,11 +350,11 @@ flagship — every feature composed into one believable UI.
 | `.replace(model = nil, morph: false, **opts)` | `<turbo-stream action=replace target=id>` of a freshly built component; `morph: true` adds `method="morph"` |
 | `.update(model = nil, morph: false, **opts)` | `<turbo-stream action=update target=id>` (inner-HTML update); `morph: true` adds `method="morph"` so Turbo morphs the inner HTML in place (issue #113) |
 | `.append(target:)` / `.prepend(target:)` / `.remove` | The other Turbo Stream actions |
-| `.broadcast_replace_to(*streamables, model:, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
-| `.broadcast_update_to(*streamables, model:, morph: false)` | Broadcast an inner-HTML update; `morph: true` morphs in place, so a peer editing the component keeps its focus/caret (issue #113) |
-| `.broadcast_append_to(*streamables, target:, model:)` / `_prepend_` / `_remove_` | The other broadcast variants |
-| `.broadcast_replace_to_each(stream_keys, model:, morph: false, exclude:, visible_to:)` / `_update_` / `_append_` / `_prepend_` / `_remove_` | **Render once, fan out** the *same* payload to K different stream keys — a per-tenant loop. K renders + K HMACs collapse to 1 + K cheap channel calls (~9.5× at K=10). Each key is a `[record, :symbol]` pair (or a bare string). Transport opts + `morph:` forward per key. Per-viewer `visible_to:` content stays render-per-call. See [Broadcasting](https://phlex-reactive.zoolutions.llc/docs/broadcasting). |
-| `#to_stream_replace` / `#to_stream_morph` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `reply`); `#to_stream_morph` morphs in place |
+| `.broadcast_to(*streamables, replace: model, morph: false)` | Broadcast a replace over the stream transport (pgbus SSE / Action Cable); `morph: true` morphs in place |
+| `.broadcast_to(*streamables, update: model, morph: false)` | Broadcast an inner-HTML update; `morph: true` morphs in place, so a peer editing the component keeps its focus/caret (issue #113) |
+| `.broadcast_to(*streamables, append: model, target:)` / `prepend:` / `remove:` | The other broadcast verbs — the verb is a kwarg (exactly one of `replace:`/`update:`/`append:`/`prepend:`/`remove:`/`js:`) |
+| `.broadcast_to(each: stream_keys, replace: model, morph: false, exclude:, visible_to:)` | **Render once, fan out** the *same* payload to K different stream keys — a per-tenant loop. Pass `each:` instead of `*streamables`. K renders + K HMACs collapse to 1 + K cheap channel calls (~9.5× at K=10). Each key is a `[record, :symbol]` pair (or a bare string). Transport opts + `morph:` forward per key. Per-viewer `visible_to:` content stays render-per-call. See [Broadcasting](https://phlex-reactive.zoolutions.llc/docs/broadcasting). |
+| `#to_stream_replace(morph: false)` / `#to_stream_remove` | Stream the *already-built* instance (used internally after an action / by `reply`); `morph: true` morphs in place |
 | `#to_stream_update(morph: false)` | Inner-HTML update of the *already-built* instance; `morph: true` morphs in place (issue #113) |
 
 Use in controllers: `render turbo_stream: Counter.replace(counter)`.
@@ -1296,7 +1296,7 @@ gains a seam.
 By default an action re-renders its component in place. To do more, **return**
 `reply.<verb>` — a subject-bound builder available in every component. It governs
 only the actor's HTTP reply (cross-tab updates still use
-`broadcast_*_to(..., exclude: reactive_connection_id)`). Returning anything else
+`broadcast_to(..., exclude: reactive_connection_id)`). Returning anything else
 keeps the default, so existing actions are unaffected.
 
 `reply` reads cleanly: the component is the implicit subject (no `self` to
@@ -1407,7 +1407,7 @@ Semantics you can rely on:
   the action's transaction committed; a rollback or a denied action leaks no
   deferred render (and enqueues no job).
 - **Actor-scoped** — the deferred render reaches only the actor; peers keep
-  getting updates via `broadcast_*_to` (use both when both need the value).
+  getting updates via `broadcast_to` (use both when both need the value).
 - **Superseding** — a newer action for the same target aborts the in-flight
   deferred render; a fast typist never gets stale totals painted over fresh ones.
 - **Interactive on arrival** — the streamed root carries a fresh action token.
@@ -1530,7 +1530,7 @@ reply.replace.flash(:error, Alert.new(level: :error, message: msg))
 Phlex::Reactive.flash_component = ->(level, content) { MyFlash.new(level:, content:) }   # default nil → the built-in wrapper
 ```
 
-#### Server-pushed client ops (`reply.js` + `broadcast_js_to`, issue #97)
+#### Server-pushed client ops (`reply.js` + `broadcast_to(js:)`, issue #97)
 
 Sometimes the server needs the client to do something other than swap HTML —
 focus the next field after a save, dispatch an app event to a toast host, add an
@@ -1560,11 +1560,11 @@ transport (Action Cable **or** pgbus) — a background nudge to all viewers:
 
 ```ruby
 # In a model/job: light up the bell in every viewer's tab, minus the actor's own.
-Notifications::Badge.broadcast_js_to(user, :alerts,
-  js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+Notifications::Badge.broadcast_to(user, :alerts,
+  js: js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
 ```
 
-`broadcast_js_to` **refuses focus-class ops** (`focus`/`focus_first` raise
+`broadcast_to` with `js:` **refuses focus-class ops** (`focus`/`focus_first` raise
 `ArgumentError`): broadcasting focus would steal it in every subscriber's tab, so
 focus is an actor-reply concern only. Everything else is a fair broadcast (class
 and attribute toggles, `dispatch`). As with `on_client`, the ops are
@@ -1584,7 +1584,7 @@ record can be there purely for **identity + authorization** while the action's
 real job is to recompute **live, unsaved form values** the user is mid-edit. The
 record is re-located and instantiated on each action (`from_identity`), never
 auto-saved and never auto-broadcast; persistence and cross-tab broadcast are both
-opt-in (you call `record.update!` / `broadcast_*_to` yourself). Pair that with
+opt-in (you call `record.update!` / `broadcast_to` yourself). Pair that with
 `reply.streams` and you get a first-class "authorize via the row, compute over
 the params, stream a partial update, touch neither the DB nor peer tabs" action:
 
@@ -1906,7 +1906,7 @@ end
   works; pass the raw id only if your row `#id` matches `ActiveRecord::RecordIdentifier`.
 - **Reply governs the actor's HTTP response only.** For a *cross-tab* live list
   (other viewers see the row appear) keep broadcasting the row with
-  `NotificationRow.broadcast_append_to(..., exclude: reactive_connection_id)` —
+  `NotificationRow.broadcast_to(..., append: model, exclude: reactive_connection_id)` —
   `reactive_collection` is the per-actor add/remove + count + empty-state wrapper,
   not a replacement for the broadcast.
 
@@ -2174,7 +2174,7 @@ end
 
 [pgbus](https://github.com/mhenrixon/pgbus) replaces Action Cable's transport
 with Postgres SSE and fixes its reliability gaps. With it installed,
-`broadcast_*_to` and `turbo_stream_from` route over pgbus automatically:
+`broadcast_to` and `turbo_stream_from` route over pgbus automatically:
 
 ```ruby
 class Message < ApplicationRecord
@@ -2206,7 +2206,7 @@ events, all under the `phlex_reactive` namespace:
 |-------|-------|---------|
 | `action.phlex_reactive` | once per request | `component`, `action`, `outcome` (`ok`/`denied_undeclared`/`invalid_token`/`not_found`/`unauthorized`/`unverified`) |
 | `render.phlex_reactive` | per component render | `component`, `bytesize` |
-| `broadcast.phlex_reactive` | per `broadcast_*_to` (Action Cable **and** pgbus) | `component`, `stream_action`, `streamables` |
+| `broadcast.phlex_reactive` | per `broadcast_to` call (Action Cable **and** pgbus) | `component`, `stream_action`, `streamables` |
 
 Payloads carry **names, the outcome, and sizes only** — never the token, params,
 or state, so an event can't leak a secret. Subscribe from an initializer:

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -85,7 +85,7 @@ module Phlex
         end
 
         event[:outcome] = :ok
-        stream = payload["m"] == "morph" ? component.to_stream_morph : component.to_stream_replace
+        stream = component.to_stream_replace(morph: payload["m"] == "morph")
         render turbo_stream: stream
       rescue Phlex::Reactive::InvalidToken => e
         event[:outcome] = :invalid_token

--- a/docs/app/components/diagrams/architecture_flow.rb
+++ b/docs/app/components/diagrams/architecture_flow.rb
@@ -114,7 +114,7 @@ module Components
       def transport_fanout(s)
         # a model change fans the same render out over the transport
         node(s, x: 330, y: 300, w: 250, h: 44,
-                title: 'broadcast_*_to — same render',
+                title: 'broadcast_to — same render',
                 fill: 'var(--color-accent)', stroke: 'var(--color-accent)')
         # accent boxes ~ other viewers, each getting the identical render
         2.times do |i|

--- a/docs/app/components/diagrams/broadcast_fanout.rb
+++ b/docs/app/components/diagrams/broadcast_fanout.rb
@@ -41,7 +41,7 @@ module Components
             s.rect(x: 250, y: 86, width: 200, height: 80, rx: '12',
                    fill: 'none', stroke: 'var(--color-primary)', stroke_width: '1.5')
             text_c(s, 350, 116, 'render ONCE', color: 'var(--color-primary)', weight: '700', size: '16')
-            text_c(s, 350, 138, 'broadcast_replace_to', size: '12', opacity: '0.75')
+            text_c(s, 350, 138, 'broadcast_to(replace:)', size: '12', opacity: '0.75')
             text_c(s, 350, 154, '→ one shared payload', size: '11.5', opacity: '0.6')
 
             s.path(d: 'M200 126 H250', fill: 'none', stroke: 'var(--color-primary)',

--- a/docs/app/reactive_components/chat_composer_component.rb
+++ b/docs/app/reactive_components/chat_composer_component.rb
@@ -24,10 +24,10 @@ class ChatComposerComponent < Phlex::HTML
     return if body.blank?
 
     message = ChatMessage.create!(room: @room, author: @author, body:)
-    ChatMessageComponent.broadcast_append_to(
+    ChatMessageComponent.broadcast_to(
       *ChatMessage.stream_key(@room),
+      append: message,
       target: "chat-messages-#{@room}",
-      model: message,
       exclude: reactive_connection_id # suppress the actor's own echo
     )
   end

--- a/docs/app/reactive_components/inbox_message_component.rb
+++ b/docs/app/reactive_components/inbox_message_component.rb
@@ -69,7 +69,7 @@ class InboxMessageComponent < Phlex::HTML
   # optimistic: { hide: true, to: "##{id}" } hides THIS row the instant you click
   # (the row is tokenless, so to: must target the row's own id, not :root — that
   # would hide the whole inbox). busy: guards a double-click. reply.remove +
-  # broadcast_remove drop it everywhere; a DENIED archive reverts the hide.
+  # broadcast_to(remove:) drop it everywhere; a DENIED archive reverts the hide.
   def archive_button
     button(**mix(on(:archive, id: @message.id, busy: '…', optimistic: { hide: true, to: "##{id}" }),
                  class: 'btn btn-ghost btn-xs justify-start text-error', data: { testid: 'archive' })) { 'Archive' }

--- a/docs/app/reactive_components/notification_bell_component.rb
+++ b/docs/app/reactive_components/notification_bell_component.rb
@@ -4,12 +4,12 @@
 # stream and shows an unread count. "Simulate a background event" stands in for a
 # job finishing: it bumps the count and BROADCASTS the re-rendered bell to every
 # subscribed tab (so a second window updates with no action of its own), then
-# fires a `broadcast_js_to` nudge — a pure client-side pulse animation applied on
+# fires a `broadcast_to(js: ...)` nudge — a pure client-side pulse animation applied on
 # the OTHER tabs with no re-render at all.
 #
 # This is the "the server just pushes" shape: the count update rides a normal
-# broadcast_replace, and the attention-grab (the pulse) rides broadcast_js_to,
-# which ships a whitelisted DOM op — not HTML — to every subscriber.
+# broadcast_to(replace: ...), and the attention-grab (the pulse) rides
+# broadcast_to(js: ...), which ships a whitelisted DOM op — not HTML — to every subscriber.
 class NotificationBellComponent < Phlex::HTML
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
@@ -28,15 +28,15 @@ class NotificationBellComponent < Phlex::HTML
 
   # Bump the count, then push the update to EVERY subscribed tab (the actor
   # included — a replace is id-deduped, so the actor's own HTTP reply and the
-  # broadcast reconcile to the same DOM). broadcast_replace_to rebuilds the bell
-  # from the given state (unread:). The broadcast_js_to nudge pulses the bell on
-  # the OTHER tabs only (exclude: the actor, who already saw the bump).
+  # broadcast reconcile to the same DOM). broadcast_to(replace: ...) rebuilds the
+  # bell from the given state (unread:). The broadcast_to(js: ...) nudge pulses
+  # the bell on the OTHER tabs only (exclude: the actor, who already saw the bump).
   def simulate_event
     @unread += 1
-    NotificationBellComponent.broadcast_replace_to(*STREAM, unread: @unread)
-    NotificationBellComponent.broadcast_js_to(
+    NotificationBellComponent.broadcast_to(*STREAM, replace: { unread: @unread })
+    NotificationBellComponent.broadcast_to(
       *STREAM,
-      js.add_class('#bell-icon', 'animate-bounce'),
+      js: js.add_class('#bell-icon', 'animate-bounce'),
       exclude: reactive_connection_id
     )
   end

--- a/docs/app/reactive_components/notifications_list_component.rb
+++ b/docs/app/reactive_components/notifications_list_component.rb
@@ -35,19 +35,19 @@ class NotificationsListComponent < Phlex::HTML
     return reply.replace if title.blank?
 
     notification = Notification.create!(title:)
-    NotificationRowComponent.broadcast_append_to(*Notification.stream_key, target: 'notifications',
-                                                                           model: notification,
-                                                                           exclude: reactive_connection_id)
+    NotificationRowComponent.broadcast_to(*Notification.stream_key, append: notification,
+                                                                    target: 'notifications',
+                                                                    exclude: reactive_connection_id)
     reply.append(notification, to: :notifications)
   end
 
   # Remove the row + bump the count + restore the empty-state in ONE reply, plus a
-  # self-dismissing flash. The broadcast_remove keeps other tabs in sync.
+  # self-dismissing flash. The broadcast_to(remove:) keeps other tabs in sync.
   def dismiss(id:)
     notification = Notification.find(id)
     notification.destroy!
-    NotificationRowComponent.broadcast_remove_to(*Notification.stream_key, model: notification,
-                                                                           exclude: reactive_connection_id)
+    NotificationRowComponent.broadcast_to(*Notification.stream_key, remove: notification,
+                                                                    exclude: reactive_connection_id)
     reply.remove(notification, from: :notifications).flash(:notice, 'Notification dismissed', dismiss_after: 3000)
   end
 

--- a/docs/app/reactive_components/team_inbox_component.rb
+++ b/docs/app/reactive_components/team_inbox_component.rb
@@ -6,7 +6,7 @@
 #   * an optimistic: archive that hides the row in the same gesture, reverting if
 #     the server denies (a "locked" message);
 #   * busy: guarding the archive button against a double-click;
-#   * cross-tab broadcast_*_to so a teammate's tab stays in sync;
+#   * cross-tab broadcast_to so a teammate's tab stays in sync;
 #   * an on_client kebab menu on each row (pure client op, zero round trips);
 #   * error_flash + a self-dismissing dismiss_after: toast on the reply.
 #
@@ -46,8 +46,8 @@ class TeamInboxComponent < Phlex::HTML
     raise Locked, 'This message is locked and cannot be archived.' if message.sender == 'locked'
 
     message.destroy!
-    InboxMessageComponent.broadcast_remove_to(*InboxMessage.stream_key, model: message,
-                                                                        exclude: reactive_connection_id)
+    InboxMessageComponent.broadcast_to(*InboxMessage.stream_key, remove: message,
+                                                                 exclude: reactive_connection_id)
     reply.remove(message, from: :messages).flash(:notice, 'Archived', dismiss_after: 2000)
   end
 
@@ -56,18 +56,18 @@ class TeamInboxComponent < Phlex::HTML
   def mark_read(id:)
     message = InboxMessage.find(id)
     message.update!(read: true)
-    InboxMessageComponent.broadcast_replace_to(*InboxMessage.stream_key, model: message,
-                                                                         exclude: reactive_connection_id)
+    InboxMessageComponent.broadcast_to(*InboxMessage.stream_key, replace: message,
+                                                                 exclude: reactive_connection_id)
     reply.replace
   end
 
-  # Stand in for a teammate/job pushing a new message: create + broadcast_append to
+  # Stand in for a teammate/job pushing a new message: create + broadcast_to(append:)
   # every subscribed tab. reply.append updates the actor's own list + count + empty.
   def simulate_incoming
     message = InboxMessage.create!(subject: sample_subject, sender: sample_sender)
-    InboxMessageComponent.broadcast_append_to(*InboxMessage.stream_key, target: 'inbox-messages',
-                                                                        model: message,
-                                                                        exclude: reactive_connection_id)
+    InboxMessageComponent.broadcast_to(*InboxMessage.stream_key, append: message,
+                                                                 target: 'inbox-messages',
+                                                                 exclude: reactive_connection_id)
     reply.append(message, to: :messages)
   end
 

--- a/docs/app/reactive_components/todo_item_component.rb
+++ b/docs/app/reactive_components/todo_item_component.rb
@@ -50,7 +50,7 @@ class TodoItemComponent < Phlex::HTML
   # idempotent, so exclude: only spares the actor a redundant echo.
   def archive
     @todo.destroy!
-    TodoItemComponent.broadcast_remove_to(*Todo.stream_key, model: @todo, exclude: reactive_connection_id)
+    TodoItemComponent.broadcast_to(*Todo.stream_key, remove: @todo, exclude: reactive_connection_id)
     reply.remove
   end
 
@@ -82,6 +82,6 @@ class TodoItemComponent < Phlex::HTML
   # Re-render this row into every OTHER subscribed tab — exclude the actor, whose
   # own reply.morph / self-replace already updated them.
   def broadcast
-    TodoItemComponent.broadcast_replace_to(*Todo.stream_key, model: @todo, exclude: reactive_connection_id)
+    TodoItemComponent.broadcast_to(*Todo.stream_key, replace: @todo, exclude: reactive_connection_id)
   end
 end

--- a/docs/app/reactive_components/todo_list_component.rb
+++ b/docs/app/reactive_components/todo_list_component.rb
@@ -32,8 +32,8 @@ class TodoListComponent < Phlex::HTML
     return if title.blank?
 
     todo = Todo.create!(title:)
-    TodoItemComponent.broadcast_append_to(*Todo.stream_key, target: 'todos',
-                                                            model: todo, exclude: reactive_connection_id)
+    TodoItemComponent.broadcast_to(*Todo.stream_key, append: todo, target: 'todos',
+                                                     exclude: reactive_connection_id)
   end
 
   def view_template

--- a/docs/app/views/docs/pages/architecture.rb
+++ b/docs/app/views/docs/pages/architecture.rb
@@ -119,7 +119,7 @@ module Views
             DocsUI::Callout(:tip, title: 'The reply is the actor’s reply') do
               plain 'It governs only the clicking user’s HTTP response. Cross-tab updates still go '
               plain 'out via '
-              code { 'broadcast_*_to' }
+              code { 'broadcast_to' }
               plain ' — see The transport.'
             end
           end
@@ -146,11 +146,11 @@ module Views
                 plain 'Under the hood '
                 code { 'reply.morph' }
                 plain ' calls '
-                code { 'Streamable#to_stream_morph' }
+                code { 'Streamable#to_stream_replace(morph: true)' }
                 plain ', the morph variant of '
                 code { 'to_stream_replace' }
                 plain '. Broadcasts morph too: '
-                code { 'broadcast_replace_to(..., morph: true)' }
+                code { 'broadcast_to(..., replace: model, morph: true)' }
                 plain ' keeps a peer tab’s focus on the morphed row.'
               end
             end
@@ -170,7 +170,7 @@ module Views
                 plain 'The reply above reaches only the actor. To update '
                 strong { 'other tabs and other users' }
                 plain ', a model change (or a job) calls a class-level '
-                code { 'broadcast_*_to' }
+                code { 'broadcast_to' }
                 plain ' — the SAME render, pushed over the stream transport instead of returned as an HTTP reply.'
               end
               p do
@@ -211,7 +211,7 @@ module Views
                         'Including it pulls in Streamable automatically (one include is enough).'
                 end
                 li do
-                  plain 'Streamable mixin — #id, replace/morph/append, broadcast_*_to over the transport. ' \
+                  plain 'Streamable mixin — #id, replace/morph/append, broadcast_to over the transport. ' \
                         'Record-backed components default #id to dom_id(record).'
                 end
               end
@@ -285,8 +285,8 @@ module Views
             # In a model callback or job — light up every
             # OTHER viewer's tab with the same render,
             # pushed over the transport (not returned).
-            Chat::Message.broadcast_append_to(
-              @room, target: "messages", model: message,
+            Chat::Message.broadcast_to(
+              @room, append: message, target: "messages",
               exclude: reactive_connection_id # skip actor
             )
           RUBY

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -19,6 +19,7 @@ module Views
           stream_keys
           methods_table
           model_mapping
+          module_level_broadcast
           multi_key_fanout
           from_action
           actor_echo
@@ -46,12 +47,12 @@ module Views
               turbo_stream_from @list, :todos
 
               # Broadcast (from a model callback, job, service, or a reactive action):
-              Todos::Item.broadcast_replace_to(@list, :todos, model: @todo)
+              Todos::Item.broadcast_to(@list, :todos, replace: @todo)
               ```
 
               The subscriber and broadcaster must agree on the **same stream key**.
               Pass the same `*streamables` to both `turbo_stream_from` and
-              `broadcast_*_to`.
+              `broadcast_to`.
             MD
           end
         end
@@ -59,20 +60,20 @@ module Views
         def transports
           DocsUI::Section('Two transports: Action Cable or pgbus') do
             md <<~MD
-              Every `broadcast_*_to` routes over `Turbo::StreamsChannel`, so it works
+              Every `broadcast_to` routes over `Turbo::StreamsChannel`, so it works
               on **either** transport with no code change:
 
               - **Action Cable** — the Rails default. Broadcasts go over WebSockets.
                 Nothing extra to install.
               - **pgbus** — Postgres-backed SSE. Installing it makes the SAME
-                `broadcast_*_to` calls route over Postgres instead, and unlocks the
+                `broadcast_to` calls route over Postgres instead, and unlocks the
                 transactional guarantee, per-connection `exclude:` / `visible_to:`
                 scoping, and presence tracking below.
 
-              The plain broadcast API (replace / update / append / prepend / remove /
-              js) is identical on both. What pgbus adds are the *guarantees* — the
-              transactional deferral, actor-echo suppression, and presence — noted
-              inline where they apply.
+              The plain broadcast API (`replace:` / `update:` / `append:` / `prepend:` /
+              `remove:` / `js:` as the verb kwarg) is identical on both. What pgbus adds
+              are the *guarantees* — the transactional deferral, actor-echo suppression,
+              and presence — noted inline where they apply.
             MD
           end
         end
@@ -80,61 +81,68 @@ module Views
         def stream_keys
           DocsUI::Section('Stream keys: pass raw parts, not a built key') do
             md <<~MD
-              `broadcast_*_to(*streamables, ...)` builds the stream key itself.
+              `broadcast_to(*streamables, ...)` builds the stream key itself.
               **Pass raw parts** (a record and/or symbols), not an already-built key
               string:
 
               ```ruby
               # GOOD — raw parts
-              Chat::Message.broadcast_append_to("chat", room, target: "...", model: msg)
+              Chat::Message.broadcast_to("chat", room, append: msg, target: "...")
               turbo_stream_from "chat", room
 
               # BAD — double-keying ("chat:lobby" then re-keyed) trips the separator guard
               key = ChatMessage.stream_key(room)             # => "chat:lobby"
-              Chat::Message.broadcast_append_to(key, ...)    # ArgumentError under pgbus
+              Chat::Message.broadcast_to(key, append: msg, target: "...")   # ArgumentError under pgbus
               ```
 
               If you have a helper that returns a built key for the subscriber, pass
               the **same built string** to `turbo_stream_from` only — but give
-              `broadcast_*_to` the raw parts. The simplest rule: **use the same raw
+              `broadcast_to` the raw parts. The simplest rule: **use the same raw
               *streamables on both sides.**
             MD
           end
         end
 
         def methods_table
-          DocsUI::Section('The broadcast methods') do
+          DocsUI::Section('The broadcast method') do
             md <<~MD
-              - `.broadcast_replace_to(*streamables, model:, morph:)` — replace the
-                element with id `component.id`. Pass `morph: true` for a cross-tab
-                morph (see below).
-              - `.broadcast_update_to(*streamables, model:, morph:)` — replace its
-                *inner* HTML. Pass `morph: true` for a cross-tab morph, so a peer
-                editing the component keeps its focus/caret (see below).
-              - `.broadcast_append_to(*streamables, target:, model:)` — append into
-                container `target`.
-              - `.broadcast_prepend_to(*streamables, target:, model:)` — prepend into
-                `target`.
-              - `.broadcast_remove_to(*streamables, model:)` — remove the element with
-                id `component.id`.
-              - `.broadcast_js_to(*streamables, ops, exclude:, visible_to:, target:)` —
-                push **client DOM ops** (class/attr toggles, `dispatch`) to every
-                subscriber. Refuses focus ops (see below).
+              ONE method, `broadcast_to(*streamables, morph:, target:, exclude:,
+              visible_to:, each:, **verb)` — the verb is a **kwarg** whose value is
+              the payload, exactly one of:
 
-              Every one accepts the transport options `exclude:` and `visible_to:`
+              - `replace: model` — replace the element with id `component.id`. Pass
+                `morph: true` for a cross-tab morph (see below).
+              - `update: model` — replace its *inner* HTML. Pass `morph: true` for a
+                cross-tab morph, so a peer editing the component keeps its
+                focus/caret (see below).
+              - `append: model` — append into container `target:`.
+              - `prepend: model` — prepend into container `target:`.
+              - `remove: model` — remove the element with id `component.id`.
+              - `js: ops` — push **client DOM ops** (class/attr toggles, `dispatch`)
+                to every subscriber. Refuses focus ops (see below).
+
+              `replace:`/`remove:` self-target via the payload's `#id` (it must be a
+              `Streamable`); `update:`/`append:`/`prepend:` are container verbs and
+              take an explicit `target:` (or, for `update:`, default to
+              self-targeting when `target:` is omitted). The payload itself is a
+              record (built via `model_param_name`), an init-kwargs `Hash` (verbatim
+              — no `**options` collision), or an already-built Phlex component.
+
+              Every call accepts the transport options `exclude:` and `visible_to:`
               (honored on pgbus, ignored on Action Cable — see those sections).
             MD
           end
         end
 
         def model_mapping
-          DocsUI::Section('How model: maps to the init keyword') do
+          DocsUI::Section('How the verb payload maps to the init keyword') do
             md <<~MD
-              The `model:` argument is passed to the component's `initialize` under the
-              keyword `model_param_name`. For a **record-backed** component
-              (`reactive_record`), that keyword is the record name — the SAME keyword
-              the action endpoint uses to rebuild the component on a click. So a single
-              `initialize(<record>:)` satisfies both clicks and broadcasts:
+              A **record** payload (`replace: @todo`) is passed to the component's
+              `initialize` under the keyword `model_param_name`. For a
+              **record-backed** component (`reactive_record`), that keyword is the
+              record name — the SAME keyword the action endpoint uses to rebuild the
+              component on a click. So a single `initialize(<record>:)` satisfies
+              both clicks and broadcasts:
 
               ```ruby
               class Todos::Item < ApplicationComponent
@@ -143,7 +151,7 @@ module Views
                 def initialize(todo:) = @todo = todo   # the keyword must match `reactive_record :todo`
               end
 
-              Todos::Item.broadcast_replace_to(@list, :todos, model: @todo) # builds new(todo: @todo)
+              Todos::Item.broadcast_to(@list, :todos, replace: @todo) # builds new(todo: @todo)
               ```
 
               For a **Streamable-only** component (broadcast-only, no
@@ -158,46 +166,76 @@ module Views
                 def self.model_param_name = :user   # class name would be :notifications_badge
               end
               ```
+
+              A **Hash** payload (`replace: { room:, author: }`) is passed as init
+              kwargs **verbatim** — `new(**payload)` — with no `model_param_name`
+              involved and no collision with a `**options` merge. An already-**built**
+              Phlex component payload passes straight through unchanged.
+            MD
+          end
+        end
+
+        def module_level_broadcast
+          DocsUI::Section('Broadcasting a plain component (Phlex::Reactive.broadcast_to)') do
+            md <<~MD
+              The class-level `SomeComponent.broadcast_to(...)` needs a `Streamable`
+              class to call it on. When the thing you want to push is a **plain Phlex
+              component** — a count badge, a summary card — that never carries
+              `Streamable` itself, `Phlex::Reactive.broadcast_to` takes the same verb
+              kwargs but the payload is an **already-built component instance**, so you
+              never hand-roll the raw channel call + render:
+
+              ```ruby
+              Phlex::Reactive.broadcast_to(
+                @list, :todos,
+                update: TodoCount.new(list: @list), target: "todos-count"
+              )
+              Phlex::Reactive.broadcast_to(user, :alerts, replace: NotificationsBadge.new(user:))
+              ```
+
+              Self-targeting verbs (`replace:`/`remove:`) still need a `Streamable`
+              payload (its `#id` is the target); container verbs (`update:`/`append:`/
+              `prepend:`) accept **any** Phlex component. Both forms share the exact
+              same render + instrumentation path, so an APM sees identical
+              `broadcast.phlex_reactive` events either way.
             MD
           end
         end
 
         def multi_key_fanout
-          DocsUI::Section('Render once, fan out to many keys (broadcast_*_to_each)') do
+          DocsUI::Section('Render once, fan out to many keys (each:)') do
             md <<~MD
-              `broadcast_*_to` concatenates its `*streamables` into **one** key. To push
+              `broadcast_to` concatenates its `*streamables` into **one** key. To push
               the *same* component to K **different** stream keys — a per-tenant loop,
               "the list page stream AND the dashboard stream" — a hand-written loop over
-              `broadcast_replace_to` pays K builds + K renders + K identity HMACs for
-              **byte-identical HTML**. `broadcast_*_to_each` renders **once** and loops
-              only the cheap channel call:
+              `broadcast_to` pays K builds + K renders + K identity HMACs for
+              **byte-identical HTML**. Pass `each:` instead of `*streamables` and it
+              renders **once** and loops only the cheap channel call:
 
               ```ruby
               # K renders + K HMACs — the cliff
-              accounts.each { |a| Counter.broadcast_replace_to(a, :counters, model: counter) }
+              accounts.each { |a| Counter.broadcast_to(a, :counters, replace: counter) }
 
               # 1 render + 1 HMAC + K channel calls — ~9.5× faster at K=10, ~88% fewer allocations
-              Counter.broadcast_replace_to_each(
-                accounts.map { [it, :counters] }, model: counter,
+              Counter.broadcast_to(
+                each: accounts.map { [it, :counters] }, replace: counter,
                 exclude: reactive_connection_id
               )
               ```
 
-              - **`stream_keys`** is an enumerable of keys; each key is passed to the
+              - **`each:`** is an enumerable of keys; each key is passed to the
                 transport as its raw parts (a `[record, :symbol]` pair, or a bare
-                string — both work). Same raw-parts rule as `broadcast_*_to`.
-              - Every verb has an `_each`: `broadcast_replace_to_each`,
-                `broadcast_update_to_each`, `broadcast_append_to_each` /
-                `broadcast_prepend_to_each` (both take `target:`), and
-                `broadcast_remove_to_each`.
+                string — both work). Same raw-parts rule as the single-key form.
+              - **Every verb supports `each:`** — it's the same `broadcast_to` call,
+                just swapping `*streamables` for `each: keys`.
               - **Transport opts + `morph:` forward per key** — `exclude:` /
                 `visible_to:` are threaded to every stream exactly as the single-key
-                verbs do, so the pgbus path suppresses the actor's echo on every stream
+                form does, so the pgbus path suppresses the actor's echo on every stream
                 and the Action Cable path is unchanged (the no-opts call passes no
                 unknown keyword — the pgbus-optionality invariant holds).
               - **The irreducible exception is per-VIEWER content.** `visible_to:` that
                 renders **different** HTML per viewer can't share a payload — that stays
-                a render-per-call. `_to_each` is for the *same* payload to many keys.
+                a render-per-call. `each:` is for the *same* payload to many keys.
             MD
           end
         end
@@ -216,10 +254,10 @@ module Views
               def add(title:)
                 authorize! @list, :update?
                 todo = @list.todos.create!(title:)
-                Todos::Item.broadcast_append_to(
+                Todos::Item.broadcast_to(
                   @list, :todos,
+                  append: todo,
                   target: dom_id(@list, :todos),
-                  model: todo,
                   exclude: reactive_connection_id # don't echo to the actor — they got the HTTP response
                 )
               end
@@ -257,15 +295,15 @@ module Views
               Where `exclude:` names ONE connection to skip, `visible_to:` names the
               only connections that should receive the broadcast — an allow-list rather
               than a deny-one. It is a first-class transport option on **every**
-              `broadcast_*_to`, alongside `exclude:`:
+              `broadcast_to` call, alongside `exclude:`:
 
               ```ruby
               # Only these two connections see the update — everyone else on the stream
               # is skipped. Useful for a private DM row, a per-seat highlight, or a
               # moderator-only control.
-              Chat::Message.broadcast_replace_to(
+              Chat::Message.broadcast_to(
                 room, :messages,
-                model: msg,
+                replace: msg,
                 visible_to: [alice_connection_id, bob_connection_id]
               )
               ```
@@ -278,33 +316,33 @@ module Views
         end
 
         def cross_tab_morph
-          DocsUI::Section('Cross-tab morphing (broadcast_replace_to morph:)') do
+          DocsUI::Section('Cross-tab morphing (broadcast_to morph:)') do
             md <<~MD
-              A plain `broadcast_replace_to` swaps the whole element. If a peer viewer
-              is mid-interaction on that element — a text caret in an input, an open
-              `<details>`, scroll position — a swap throws that state away. Pass
-              `morph: true` to make the replace **morph in place** instead, so the peer
-              tab keeps its focus and caret on the morphed row:
+              A plain `broadcast_to(..., replace: model)` swaps the whole element. If a
+              peer viewer is mid-interaction on that element — a text caret in an
+              input, an open `<details>`, scroll position — a swap throws that state
+              away. Pass `morph: true` to make the replace **morph in place** instead,
+              so the peer tab keeps its focus and caret on the morphed row:
 
               ```ruby
               # A peer tab editing the same row keeps its caret; only the changed
               # attributes/text are patched in.
-              Todos::Item.broadcast_replace_to(@list, :todos, model: @todo, morph: true)
+              Todos::Item.broadcast_to(@list, :todos, replace: @todo, morph: true)
               ```
 
               This emits `method="morph"` on the broadcast `<turbo-stream>`, so
               idiomorph patches the existing DOM rather than replacing it.
 
-              `broadcast_update_to` takes `morph:` too — a plain `update` swaps the
+              `update:` takes `morph:` too — a plain `update` swaps the
               *inner* HTML (still tearing down a focused input mid-edit), so
               `morph: true` patches the inner HTML in place instead, keeping a peer's
               caret:
 
               ```ruby
-              Totals.broadcast_update_to(@order, :totals, model: @order, morph: true)
+              Totals.broadcast_to(@order, :totals, update: @order, morph: true)
               ```
 
-              `append` / `prepend` / `remove` don't replace an existing element, so
+              `append:` / `prepend:` / `remove:` don't replace an existing element, so
               they take no `morph:`.
             MD
           end
@@ -325,7 +363,7 @@ module Views
               ```ruby
               ActiveRecord::Base.transaction do
                 @order.update!(status: "shipped")
-                Orders::Card.broadcast_replace_to(@order.account, model: @order)  # deferred
+                Orders::Card.broadcast_to(@order.account, replace: @order)  # deferred
                 ChargeService.capture!(@order)   # if this raises → no broadcast, no status change
               end
               ```
@@ -341,7 +379,7 @@ module Views
               `reply.remove` from the action: the actor's element is removed via the
               built-in `Streamable#to_stream_remove` (no endpoint override, no helper to
               add), and other tabs get
-              `broadcast_remove_to(..., exclude: reactive_connection_id)`.
+              `broadcast_to(..., remove: model, exclude: reactive_connection_id)`.
 
               ```ruby
               def destroy
@@ -349,7 +387,7 @@ module Views
                 list = @todo.list
                 @todo.destroy!
                 # other tabs
-                Todos::Item.broadcast_remove_to(list, :todos, model: @todo, exclude: reactive_connection_id)
+                Todos::Item.broadcast_to(list, :todos, remove: @todo, exclude: reactive_connection_id)
                 reply.remove # this tab
               end
               ```
@@ -361,22 +399,24 @@ module Views
         end
 
         def js_ops
-          DocsUI::Section('Pushing client DOM ops to everyone (broadcast_js_to)') do
+          DocsUI::Section('Pushing client DOM ops to everyone (broadcast_to js:)') do
             md <<~MD
               Sometimes a broadcast should nudge the UI rather than swap HTML — light up
-              a bell, toggle a class, dispatch an app event. `broadcast_js_to` pushes
-              the same `js` ops as `reply.js` to every subscriber, over the same
-              transport (Action Cable or pgbus):
+              a bell, toggle a class, dispatch an app event. `broadcast_to(..., js:
+              ops)` pushes the same `js` ops as `reply.js` to every subscriber, over the
+              same transport (Action Cable or pgbus):
 
               ```ruby
               # Light up the bell in every viewer's tab, minus the actor's own connection.
-              Notifications::Badge.broadcast_js_to(user, :alerts,
-                js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+              Notifications::Badge.broadcast_to(user, :alerts,
+                js: js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
               ```
             MD
             DocsUI::Callout(:warning) do
               plain 'Focus ops are refused. '
-              code { 'broadcast_js_to' }
+              code { 'broadcast_to' }
+              plain ' with '
+              code { 'js:' }
               plain ' raises '
               code { 'ArgumentError' }
               plain ' for '
@@ -394,11 +434,11 @@ module Views
         def reply_js
           DocsUI::Section('Nudging the actor only (reply.js)') do
             md <<~MD
-              `broadcast_js_to` is the *everyone* half. Its actor-side sibling is
-              `reply.<verb>.js(ops)` — chained onto the reply the action returns, it
-              runs client DOM ops on the **acting** user's tab only, and it does so
-              AFTER the render streams. Because it rides after the render, a focus op
-              sees the freshly rendered (or morphed) DOM:
+              `broadcast_to(..., js: ops)` is the *everyone* half. Its actor-side
+              sibling is `reply.<verb>.js(ops)` — chained onto the reply the action
+              returns, it runs client DOM ops on the **acting** user's tab only, and it
+              does so AFTER the render streams. Because it rides after the render, a
+              focus op sees the freshly rendered (or morphed) DOM:
 
               ```ruby
               def save(title:)
@@ -413,8 +453,8 @@ module Views
               component's id for `replace` / `morph` / `update` (so `@root` and
               component-relative selectors just work), and to document-scope for a
               subject-free `reply.with`. This is why the focus example above is an
-              actor-reply concern and `broadcast_js_to` refuses focus outright:
-              `reply.js` targets one tab, a broadcast targets all of them.
+              actor-reply concern and `broadcast_to(..., js: ops)` refuses focus
+              outright: `reply.js` targets one tab, a broadcast targets all of them.
             MD
           end
         end

--- a/docs/app/views/docs/pages/deferred_rendering.rb
+++ b/docs/app/views/docs/pages/deferred_rendering.rb
@@ -152,7 +152,7 @@ module Views
                 deferred render can never leak a change that didn't happen.
               - **Actor-scoped.** The deferred render reaches only the acting user;
                 it is never echoed to peers. Cross-tab updates keep going through
-                `broadcast_*_to`, exactly as before.
+                `broadcast_to`, exactly as before.
               - **Superseding.** A newer action for the same target aborts the
                 in-flight deferred render (the fetch is aborted, the one-shot stream
                 unsubscribed). A fast typist never gets stale totals painted over

--- a/docs/app/views/docs/pages/example_chat.rb
+++ b/docs/app/views/docs/pages/example_chat.rb
@@ -70,7 +70,7 @@ module Views
 
                 # The RAW stream key parts both subscribers and broadcasters agree on.
                 # Return the parts, not a pre-built "chat:lobby" string — both sides
-                # splat this so turbo_stream_from and broadcast_append_to build the
+                # splat this so turbo_stream_from and broadcast_to build the
                 # same key. (Double-keying a pre-built string trips pgbus's separator guard.)
                 def self.stream_key(room) = ["chat", room]
               end
@@ -143,10 +143,10 @@ module Views
                   # every subscribed tab. Splat the RAW key parts so subscribe and
                   # broadcast agree; exclude the actor's own connection so the SENDER
                   # doesn't get a doubled message (they already got the action's reply).
-                  Chat::Message.broadcast_append_to(
+                  Chat::Message.broadcast_to(
                     *ChatMessage.stream_key(@room),
+                    append: message,
                     target: "chat-messages-#{@room}",
-                    model: message,
                     exclude: reactive_connection_id      # suppress the actor's own echo
                   )
                 end
@@ -239,7 +239,7 @@ module Views
               2. The endpoint verifies the signed token, rebuilds the composer, and
                  runs `send_message` inside a transaction.
               3. `send_message` creates the `ChatMessage` and calls
-                 `broadcast_append_to(..., exclude: reactive_connection_id)`.
+                 `broadcast_to(..., append: message, exclude: reactive_connection_id)`.
               4. The broadcast fans the rendered `Chat::Message` out over the stream
                  transport to every subscribed room — **except** the sender's own
                  connection, which `exclude:` filters out.

--- a/docs/app/views/docs/pages/example_notifications.rb
+++ b/docs/app/views/docs/pages/example_notifications.rb
@@ -33,10 +33,10 @@ module Views
             md <<~MD
               A **real** live bell. Click "Simulate a background event" — it stands
               in for a job finishing. The count bumps and the bell re-renders via a
-              `broadcast_replace_to`, so **every tab** you have open on this page
-              updates (open a second tab to see it). It also fires a
-              `broadcast_js_to` pulse — a whitelisted DOM op, not HTML — so the bell
-              on the *other* tabs bounces to grab attention, with no re-render at all.
+              `broadcast_to(replace: ...)`, so **every tab** you have open on this
+              page updates (open a second tab to see it). It also fires a
+              `broadcast_to(js: ...)` pulse — a whitelisted DOM op, not HTML — so the
+              bell on the *other* tabs bounces to grab attention, with no re-render at all.
             MD
             render Views::Examples::LiveExample.new(
               component: NotificationBellComponent.new(unread: 0),
@@ -88,8 +88,8 @@ module Views
             MD
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               # Only connections whose id is in this set receive the broadcast.
-              NotificationsBadge.broadcast_replace_to(
-                account, :notifications, model: user,
+              NotificationsBadge.broadcast_to(
+                account, :notifications, replace: user,
                 visible_to: [user.reactive_connection_id]   # per-subscriber authorization
               )
             RUBY
@@ -99,7 +99,7 @@ module Views
                 notifications stream — it decides *who* receives the push.
                 Broadcasting a user's unread count to the wrong subscribers leaks
                 one person's activity into another's UI. Scope every shared-stream
-                broadcast; a per-user stream (`broadcast_*_to(user, …)`) is already
+                broadcast; a per-user stream (`broadcast_to(user, …)`) is already
                 scoped by its key. `visible_to:` is honored on **pgbus**; on Action
                 Cable it is inert (every subscriber of the stream receives it), so
                 on Action Cable rely on a per-user stream key instead.
@@ -123,8 +123,8 @@ module Views
               def mark_all_read
                 @user.notifications.unread.update_all(read_at: Time.current)
                 # Live-update every OTHER tab; this tab already re-rendered via the reply.
-                NotificationsBadge.broadcast_replace_to(
-                  @user, :notifications, model: @user,
+                NotificationsBadge.broadcast_to(
+                  @user, :notifications, replace: @user,
                   exclude: reactive_connection_id
                 )
                 reply.replace
@@ -142,26 +142,26 @@ module Views
         end
 
         def light_the_bell
-          DocsUI::Section('Light up the bell without a re-render (broadcast_js_to)') do
+          DocsUI::Section('Light up the bell without a re-render (broadcast_to js:)') do
             md <<~MD
               The classic notification nudge doesn't need a re-render at all — you
               just want a **has-unread** class on the bell in every viewer's tab.
-              `broadcast_js_to` pushes declared client DOM ops (the same `js`
-              builder as `on_client` / `reply.js`) over the stream, so the server
+              `broadcast_to(..., js: ops)` pushes declared client DOM ops (the same
+              `js` builder as `on_client` / `reply.js`) over the stream, so the server
               lights the bell with **no HTML swap**:
             MD
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               # In a model callback or job — light the bell in every viewer's tab,
               # minus the actor's own (who already knows).
-              Notifications::Badge.broadcast_js_to(
+              Notifications::Badge.broadcast_to(
                 user, :alerts,
-                js.add_class("#bell", "has-unread"),
+                js: js.add_class("#bell", "has-unread"),
                 exclude: reactive_connection_id
               )
             RUBY
             DocsUI::Callout(:note) do
               md <<~MD
-                `broadcast_js_to` **refuses focus ops** (`focus` / `focus_first`
+                `broadcast_to(..., js: ops)` **refuses focus ops** (`focus` / `focus_first`
                 raise `ArgumentError`) — broadcasting focus would steal it in every
                 subscriber's tab, so focus stays an actor-reply concern (`reply.js`).
                 Class and attribute toggles and `dispatch` broadcast fine. Like all
@@ -197,9 +197,9 @@ module Views
               reply.replace.flash(:notice, "Marked all read", dismiss_after: 4000)
 
               # A broadcast flash self-cleans too (the container is a plain host div).
-              NotificationsFlash.broadcast_append_to(
-                user, :notifications, target: "flash",
-                model: notification, exclude: reactive_connection_id
+              NotificationsFlash.broadcast_to(
+                user, :notifications, append: notification, target: "flash",
+                exclude: reactive_connection_id
               )
             RUBY
             md <<~MD
@@ -236,7 +236,7 @@ module Views
           DocsUI::Section('When to use this vs a full reactive component') do
             md <<~MD
               - Server pushes a re-render (job, callback, another user) →
-                `Streamable` + `broadcast_*_to`.
+                `Streamable` + `broadcast_to`.
               - User clicks/types and the same component updates → add `Component` +
                 `action`.
               - Both → add `Component`; broadcast from inside the action.
@@ -318,7 +318,7 @@ module Views
             class Notification < ApplicationRecord
               belongs_to :user
               after_create_commit do
-                NotificationsBadge.broadcast_replace_to(user, :notifications, model: user)
+                NotificationsBadge.broadcast_to(user, :notifications, replace: user)
               end
             end
           RUBY
@@ -330,7 +330,7 @@ module Views
               def perform(import)
                 import.run!
                 # Re-render a status component for everyone watching this import.
-                Imports::Status.broadcast_replace_to(import, model: import)
+                Imports::Status.broadcast_to(import, replace: import)
               end
             end
           RUBY

--- a/docs/app/views/docs/pages/example_team_inbox.rb
+++ b/docs/app/views/docs/pages/example_team_inbox.rb
@@ -54,7 +54,7 @@ module Views
               | **Optimistic archive** — `optimistic: { hide: true }` hides the row in the same gesture | the row's Archive |
               | **Revert on failure** — a denied archive snaps the row back + shows an error flash | the "locked" message |
               | **`busy:`** — the Archive / Simulate buttons dedupe a double-click | container + row |
-              | **Cross-tab broadcast** — `broadcast_append_to` / `broadcast_remove_to` / `broadcast_replace_to` | every mutating action |
+              | **Cross-tab broadcast** — `broadcast_to(append:)` / `broadcast_to(remove:)` / `broadcast_to(replace:)` | every mutating action |
               | **`on_client` menu** — the ⋯ kebab toggles with zero round trips | the row |
               | **`error_flash` + `dismiss_after:`** — a self-dismissing confirmation / error toast | the reply |
             MD
@@ -69,8 +69,8 @@ module Views
               `reply.remove`, broadcasts the removal to teammates, and chains a
               `.flash(dismiss_after: 2000)`. `mark_read` persists + broadcasts the
               updated row. `simulate_incoming` creates a message and
-              `broadcast_append_to`s it (excluding the actor, who gets it from their
-              own `reply.append`).
+              `broadcast_to(..., append: message)`s it (excluding the actor, who gets
+              it from their own `reply.append`).
             MD
             DocsUI::Code(read_component('team_inbox_component.rb'),
                          lexer: :ruby, filename: 'app/components/team_inbox_component.rb')

--- a/docs/app/views/docs/pages/example_todo_list.rb
+++ b/docs/app/views/docs/pages/example_todo_list.rb
@@ -81,8 +81,8 @@ module Views
               row's component to every OTHER subscribed tab**, and re-renders self
               so the actor sees the row and the empty-state clears.
 
-              - **`broadcast_append_to(..., exclude: reactive_connection_id)`** is
-                the load-bearing detail. An `append` *inserts* a child — it is not
+              - **`broadcast_to(..., append: todo, exclude: reactive_connection_id)`**
+                is the load-bearing detail. An `append` *inserts* a child — it is not
                 id-deduped the way a `replace`/`morph` of an existing element is.
                 Without `exclude:`, the actor's own subscribed tab would receive the
                 broadcast and append the row a **second** time, on top of the copy
@@ -106,16 +106,16 @@ module Views
               reply.** The one rule that keeps it correct is
               `exclude: reactive_connection_id` on the broadcast:
 
-              - **`add` → `broadcast_append_to`** — an append inserts a child, so
-                the actor MUST be excluded or the row double-applies (append is not
-                id-deduped).
-              - **`toggle` / `rename` → `broadcast_replace_to`** — a replace/morph
-                is keyed by dom id, so idiomorph dedupes it for the actor even
-                without `exclude:`. Passing `exclude:` anyway keeps every action on
-                one consistent pattern and avoids a redundant echo.
-              - **`archive` → `broadcast_remove_to`** — remove is idempotent, so a
-                double remove is invisible; `exclude:` still spares the actor a
-                redundant echo they already handled via `reply.remove`.
+              - **`add` → `broadcast_to(..., append: todo)`** — an append inserts a
+                child, so the actor MUST be excluded or the row double-applies
+                (append is not id-deduped).
+              - **`toggle` / `rename` → `broadcast_to(..., replace: todo)`** — a
+                replace/morph is keyed by dom id, so idiomorph dedupes it for the
+                actor even without `exclude:`. Passing `exclude:` anyway keeps every
+                action on one consistent pattern and avoids a redundant echo.
+              - **`archive` → `broadcast_to(..., remove: todo)`** — remove is
+                idempotent, so a double remove is invisible; `exclude:` still spares
+                the actor a redundant echo they already handled via `reply.remove`.
             MD
             DocsUI::Callout(:tip) do
               md <<~MD

--- a/docs/app/views/docs/pages/examples_overview.rb
+++ b/docs/app/views/docs/pages/examples_overview.rb
@@ -34,7 +34,7 @@ module Views
               | [Cross-tab chat](/docs/example-chat) | Record-backed action **and broadcast** → live cross-tab sync, zero JS. |
               | [Live todo list](/docs/example-todo-list) | Per-row record-backed components: add / toggle / rename / archive, optimistic toggle + delete, Enter-to-add, morph-in-place, broadcast on change. |
               | [Inline edit + dirty tracking](/docs/example-inline-edit) | Show ↔ edit (Enter saves, Escape cancels) plus an “Unsaved” badge + leave-guard with zero shipped state. |
-              | [Notifications / badges](/docs/example-notifications) | Pure broadcast — a background event pushes a live re-render, plus a `broadcast_js_to` cross-tab pulse. |
+              | [Notifications / badges](/docs/example-notifications) | Pure broadcast — a background event pushes a live re-render, plus a `broadcast_to(js:)` cross-tab pulse. |
               | [Reactive collections](/docs/example-collections) | Add / remove rows + a running count + an empty state, declared **once** with `reactive_collection`, optimistic dismiss + a self-dismissing flash. |
               | [File uploads & custom types](/docs/example-uploads) | `:file` / `[:file]` params (multipart `FormData`), a nested-hash param alongside the file (#39), and a custom `Phlex::Reactive.param_type`. Code-first — no live demo. |
               | [Loading states](/docs/example-loading-states) | `busy:` + `busy_on` + the always-on `aria-busy`, with a latency toggle to make the pending window visible. |
@@ -53,7 +53,7 @@ module Views
               | **Optimistic visual hints** — `optimistic:` (flip a checkbox / hide a row instantly; revert on failure) | [Todo list](/docs/example-todo-list), [Collections](/docs/example-collections), [Team inbox](/docs/example-team-inbox) |
               | **Keyboard triggers** — `event: "keydown.enter"` / `"keydown.esc"` (Enter-to-add, Escape-to-cancel) | [Todo list](/docs/example-todo-list), [Inline edit](/docs/example-inline-edit) |
               | **Debounced / morph editing** — `debounce:` live-as-you-type + `reply.morph` to keep the caret | [Payment split](/docs/example-payment-split), [Inline edit](/docs/example-inline-edit) |
-              | **Live broadcasts** — `broadcast_replace_to` / `broadcast_append_to` / `broadcast_js_to` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
+              | **Live broadcasts** — `broadcast_to(replace:)` / `broadcast_to(append:)` / `broadcast_to(js:)` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
               | **Failure surface** — `error_flash` / `data-reactive-error` / `dismiss_after:` / timeout + offline | [Failure surface](/docs/example-failure), [Team inbox](/docs/example-team-inbox) |
               | **Combobox keyboard navigation** — `reactive_listnav` (Arrow keys move a client highlight, Enter picks), composed via `mix` | [Searchable combobox demo](/demos/searchable-combobox) |
               | **File uploads & custom param types** — `:file` / `[:file]` (multipart `FormData`), `Phlex::Reactive.param_type` | [File uploads & custom types](/docs/example-uploads) (code-first) |

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -46,7 +46,7 @@ module Views
                 strong { 'broadcasts' }
                 plain ', which have no HTTP overhead to amortize against. To be precise about the fan-out: '
                 plain 'a '
-                code { 'broadcast_*_to' }
+                code { 'broadcast_to' }
                 plain ' call renders the component '
                 strong { 'once' }
                 plain ' and hands the finished HTML to the transport, so every subscriber of that stream '
@@ -54,10 +54,10 @@ module Views
                 plain 'render cost multiplies per '
                 strong { 'call' }
                 plain ': pushing one change to K different stream keys with a hand-written loop over '
-                code { 'broadcast_*_to' }
+                code { 'broadcast_to' }
                 plain ' is K builds + K renders + K token signings of byte-identical HTML. For that same-payload, '
-                plain 'many-key fan-out, '
-                code { 'broadcast_*_to_each' }
+                plain 'many-key fan-out, passing '
+                code { 'each:' }
                 plain ' (issue #119) renders '
                 strong { 'once' }
                 plain ' and loops only the cheap channel call — measured at ~9.5× throughput and ~8× fewer '
@@ -189,8 +189,8 @@ module Views
                 li do
                   code { 'broadcast.phlex_reactive' }
                   plain ' — around each '
-                  code { 'broadcast_*_to' }
-                  plain ' (fires on Action Cable AND pgbus). Payload: '
+                  code { 'broadcast_to' }
+                  plain ' call (fires on Action Cable AND pgbus). Payload: '
                   code { 'component' }
                   plain ', '
                   code { 'stream_action' }
@@ -496,9 +496,9 @@ module Views
                 plain ' bench doubles the transport out to a no-op, so what is measured is the server-side '
                 plain 'build + render + identity-HMAC cost a broadcast pays before the wire. Fanning one '
                 plain 'component out to K=10 stream keys, a hand-written loop over '
-                code { 'broadcast_replace_to' }
+                code { 'broadcast_to(key, replace:)' }
                 plain ' vs '
-                code { 'broadcast_replace_to_each' }
+                code { 'broadcast_to(each: keys, replace:)' }
                 plain ':'
               end
               ul do

--- a/docs/app/views/docs/pages/testing.rb
+++ b/docs/app/views/docs/pages/testing.rb
@@ -415,7 +415,7 @@ module Views
                   plain ' to '
                   code { 'turbo_stream_from' }
                   plain ' and '
-                  code { 'broadcast_*_to' }
+                  code { 'broadcast_to' }
                   plain '.'
                 end
                 li do

--- a/docs/app/views/docs/pages/transport_pgbus.rb
+++ b/docs/app/views/docs/pages/transport_pgbus.rb
@@ -30,17 +30,19 @@ module Views
                 plain 'With '
                 a(href: 'https://github.com/mhenrixon/pgbus') { 'pgbus' }
                 plain ' installed, '
-                code { 'broadcast_*_to' }
+                code { 'broadcast_to' }
                 plain ' AND '
                 code { 'turbo_stream_from' }
                 plain ' route over Postgres SSE '
                 strong { 'automatically' }
                 plain ' — with zero code changes. Both transports drive the SAME ' \
                       'broadcast API: the gem\'s '
-                code { 'broadcast_replace_to' }
+                code { 'broadcast_to' }
+                plain ' (with '
+                code { 'replace:' }
                 plain '/'
-                code { 'broadcast_append_to' }
-                plain ' call '
+                code { 'append:' }
+                plain '/etc.) calls '
                 code { '::Turbo::StreamsChannel.*' }
                 plain ' unchanged, so swapping the transport is a Gemfile decision, not a rewrite.'
               end
@@ -146,10 +148,10 @@ module Views
             end
             DocsUI::Code(<<~RUBY, lexer: :ruby)
               # Under pgbus these reach the dispatcher; under Action Cable they no-op.
-              Todos::Item.broadcast_append_to(
+              Todos::Item.broadcast_to(
                 @list, :todos,
+                append: todo,
                 target: dom_id(@list, :todos),
-                model: todo,
                 exclude: reactive_connection_id # actor already has the HTTP response
               )
             RUBY
@@ -161,8 +163,8 @@ module Views
             DocsUI::Prose() do
               p do
                 plain 'Each '
-                code { 'broadcast_*_to' }
-                plain ' wraps its body in a '
+                code { 'broadcast_to' }
+                plain ' call wraps its body in a '
                 code { 'broadcast.phlex_reactive' }
                 plain ' notification that fires on '
                 strong { 'both' }

--- a/docs/spec/requests/notification_bell_spec.rb
+++ b/docs/spec/requests/notification_bell_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 require 'turbo/broadcastable/test_helper'
 
 # The live notification bell: a simulate_event action bumps the unread count,
-# re-renders the bell, and broadcasts both the replaced bell and a broadcast_js_to
-# pulse to the other tabs.
+# re-renders the bell, and broadcasts both the replaced bell and a broadcast_to
+# js: pulse to the other tabs.
 RSpec.describe 'Notification bell actions', type: :request do
   include ActiveSupport::Testing::Assertions
   include Turbo::Broadcastable::TestHelper
@@ -32,7 +32,7 @@ RSpec.describe 'Notification bell actions', type: :request do
     # The replace carries the bumped count to every subscribed tab.
     expect(html).to include('action="replace"')
     expect(html).to include('target="notification-bell"')
-    # The broadcast_js_to nudge ships a whitelisted DOM op (no HTML re-render).
+    # The broadcast_to js: nudge ships a whitelisted DOM op (no HTML re-render).
     expect(html).to include('reactive:js')
     expect(html).to include('animate-bounce')
   end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -673,6 +673,32 @@ module Phlex
         Phlex::Reactive::Defer.with_real_render { component.render_in(off_request_view_context) }
       end
 
+      # Module-level broadcast (issue #185) — the same broadcast_to as the class
+      # form, for a BUILT component payload, so a NON-Streamable target (a count
+      # badge, any plain Phlex component) broadcasts WITHOUT hand-rolling the raw
+      # channel + render, and IS instrumented:
+      #
+      #   Phlex::Reactive.broadcast_to(@list, :todos, update: TodoCount.new(list: @list), target: "todos-count")
+      #   Phlex::Reactive.broadcast_to(user, :alerts, replace: NotificationsBadge.new(user:))
+      #
+      # Container verbs (update:/append:/prepend:) take any component; self-targeting
+      # verbs (replace:/remove:) require a Streamable payload (its #id is the target)
+      # — a plain component gets a guided error steering to update:. Shares the one
+      # broadcast implementation with the class-level form.
+      def broadcast_to(*streamables, morph: false, target: nil, exclude: nil, visible_to: nil, each: nil, **verb)
+        name, payload = Phlex::Reactive::Streamable.extract_module_broadcast_verb(verb)
+        component = name == :js ? nil : payload
+        keys = each ? each.map { Array(it) } : [streamables]
+        # The owner is the payload's class when Streamable (for js ops + instrument),
+        # else Streamable itself (a plain component still instruments via the shared
+        # path). A nil payload (a bare state-backed default) isn't supported here —
+        # the module form is for BUILT component payloads.
+        owner = payload.is_a?(Phlex::Reactive::Streamable) ? payload.class : Phlex::Reactive::Streamable
+        Phlex::Reactive::Streamable.broadcast_component(
+          owner, name, payload, component, keys, morph:, target:, exclude:, visible_to:
+        )
+      end
+
       # A Turbo::Streams::TagBuilder bound to an off-request view context, used
       # to build standalone streams not tied to a specific component's id — a
       # Response flash append, a reactive_collection row removal, a count

--- a/lib/phlex/reactive/deferred_render_job.rb
+++ b/lib/phlex/reactive/deferred_render_job.rb
@@ -57,7 +57,7 @@ module Phlex
         component = klass.from_identity(payload)
         return broadcast_cleanup(stream_key, target) if component.respond_to?(:render?) && !component.render?
 
-        stream = morph ? component.to_stream_morph : component.to_stream_replace
+        stream = component.to_stream_replace(morph:)
         broadcast_payload(stream_key, stream.to_s + teardown_stream(target))
       rescue ::StandardError => e
         log_deferred_failure(e) unless e.is_a?(::ActiveRecord::RecordNotFound)

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -59,7 +59,7 @@ module Phlex
         # `morph: true` morphs the subtree (preserves the focused input + caret)
         # instead of an outerHTML swap — see .build_morph (issue #28).
         def build_replace(component, morph: false)
-          new(streams: [morph ? component.to_stream_morph : component.to_stream_replace],
+          new(streams: [component.to_stream_replace(morph:)],
             subject_component: component)
         end
 
@@ -69,7 +69,7 @@ module Phlex
         # per-field reactive editing (a "spreadsheet" grid where a debounced save
         # fires while the user is still typing/tabbing). The morphed root still
         # carries the fresh signed token, so the next action verifies.
-        def build_morph(component) = new(streams: [component.to_stream_morph], subject_component: component)
+        def build_morph(component) = new(streams: [component.to_stream_replace(morph: true)], subject_component: component)
 
         # Update only inner HTML (preserves the root element + its token attr).
         # `morph: true` morphs the inner HTML in place (issue #113) instead of
@@ -491,7 +491,7 @@ data-reactive-ops="#{ERB::Util.html_escape(json)}"></turbo-stream>).html_safe
         when :__none
           also_targets(targets)
         when ::Phlex::SGML
-          stream(morph ? companion.to_stream_morph : companion.to_stream_replace)
+          stream(companion.to_stream_replace(morph:))
         when Hash
           also_targets(companion)
         else

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -33,9 +33,39 @@ module Phlex
       # up without ever sharing a mutable context across threads.
       ThreadViewContext = Struct.new(:view_context, :builder, :renderer, :generation)
 
-      # Focus ops are actor-only (they steal focus): broadcast_js_to rejects a
+      # Focus ops are actor-only (they steal focus): a js broadcast rejects a
       # broadcast that carries one. Names mirror Phlex::Reactive::JS's focus verbs.
       BROADCAST_REFUSED_OPS = %w[focus focus_first].freeze
+
+      # The broadcast_to verb kwargs (issue #185) → their Turbo stream action.
+      # SELF-TARGETING verbs derive the target from the component's #id (require a
+      # Streamable payload); CONTAINER verbs need an explicit target: and accept any
+      # Phlex component; :js rides the reactive:js custom action.
+      BROADCAST_VERBS = {
+        replace: "replace", update: "update", append: "append",
+        prepend: "prepend", remove: "remove", js: "reactive:js"
+      }.freeze
+      BROADCAST_SELF_TARGETING = %i[replace remove].freeze
+      BROADCAST_CONTAINER = %i[update append prepend].freeze
+      BROADCAST_MORPHABLE = %i[replace update].freeze
+
+      # Issue #185: the 11 broadcast_*_to / _to_each methods are removed — each
+      # raises a guided error printing the broadcast_to rewrite for that verb.
+      # (A module constant, not defined inside class_methods, so it's a clean
+      # top-level definition the removal loop below reads.)
+      REMOVED_BROADCASTS = {
+        broadcast_replace_to: "broadcast_to(*keys, replace: model, morph: …)",
+        broadcast_update_to: "broadcast_to(*keys, update: model, morph: …)",
+        broadcast_append_to: "broadcast_to(*keys, append: model, target: …)",
+        broadcast_prepend_to: "broadcast_to(*keys, prepend: model, target: …)",
+        broadcast_remove_to: "broadcast_to(*keys, remove: model)",
+        broadcast_js_to: "broadcast_to(*keys, js: ops)",
+        broadcast_replace_to_each: "broadcast_to(each: keys, replace: model)",
+        broadcast_update_to_each: "broadcast_to(each: keys, update: model)",
+        broadcast_append_to_each: "broadcast_to(each: keys, append: model, target: …)",
+        broadcast_prepend_to_each: "broadcast_to(each: keys, prepend: model, target: …)",
+        broadcast_remove_to_each: "broadcast_to(each: keys, remove: model)"
+      }.freeze
 
       # Every class that includes Streamable, so the engine can flush their
       # memoized view contexts on a Rails code reload (dev) in one pass. A
@@ -72,6 +102,127 @@ module Phlex
             @registry.each_key { classes << it }
             classes
           end
+        end
+
+        # The ONE broadcast implementation shared by the class-level
+        # Streamable.broadcast_to and the module-level Phlex::Reactive.broadcast_to
+        # (issue #185). `owner` is the Streamable class (for the instrument name +
+        # its build/render seam); `component` is the built payload (nil for :js);
+        # `keys` is a list of key-part arrays (one per fan-out key). Renders ONCE
+        # (instrumented → render.phlex_reactive) and loops the cheap channel call
+        # per key, all wrapped in the broadcast.phlex_reactive event + the pgbus
+        # thread-local path (so exclude:/visible_to: reach pgbus and Action Cable
+        # no-ops). Self-targeting verbs derive the target from the component's #id
+        # and REQUIRE a Streamable payload; container verbs need an explicit target.
+        def broadcast_component(owner, verb, payload, component, keys, morph:, target:, exclude:, visible_to:)
+          resolved_target = resolve_broadcast_target(verb, component, payload, target)
+          # broadcast_js_ops_json is a private class method on the owner Streamable
+          # class (reached via send); the instrumentation + pgbus thread-locals are
+          # owned HERE so the class-level and module-level (plain-component) forms
+          # share ONE path and neither is silently un-instrumented (issue #185).
+          component_name = component ? component.class.name : owner.name
+          Phlex::Reactive.instrument(
+            "broadcast", { component: component_name, stream_action: BROADCAST_VERBS[verb], streamables: keys.size }
+          ) do
+            with_pgbus_broadcast_opts(exclude:, visible_to:) do
+              html = verb == :js ? nil : render_broadcast_html(component)
+              ops_json = verb == :js ? owner.send(:broadcast_js_ops_json, payload) : nil
+              keys.each { dispatch_broadcast(verb, it, resolved_target, html, ops_json, morph) }
+            end
+          end
+        end
+
+        # Render a built component to HTML for a broadcast, ALWAYS instrumented
+        # (issue #185): a Streamable renders through its own render_component (which
+        # fires render.phlex_reactive); a plain component renders through the module
+        # render wrapped in the SAME render event, so neither path is silent.
+        def render_broadcast_html(component)
+          if component.is_a?(Phlex::Reactive::Streamable)
+            component.class.render_component(component)
+          else
+            Phlex::Reactive.instrument(
+              "render", { component: component.class.name }
+            ) { Phlex::Reactive.render(component) }
+          end
+        end
+
+        # Set the pgbus broadcast thread-locals for the block, gated on
+        # pgbus_streams? — the SAME capability-gated path the class-level
+        # instrument_broadcast uses (issue #185/#187). Duplicated at module level so
+        # the shared broadcast_component owns its transport threading. On Action
+        # Cable / old pgbus this is a pure `yield`.
+        def with_pgbus_broadcast_opts(exclude:, visible_to:)
+          return yield unless Phlex::Reactive.pgbus_streams?
+
+          prev_exclude = Thread.current[:pgbus_broadcast_exclude]
+          prev_visible = Thread.current[:pgbus_broadcast_visible_to]
+          Thread.current[:pgbus_broadcast_exclude] = exclude
+          Thread.current[:pgbus_broadcast_visible_to] = visible_to
+          yield
+        ensure
+          if Phlex::Reactive.pgbus_streams?
+            Thread.current[:pgbus_broadcast_exclude] = prev_exclude
+            Thread.current[:pgbus_broadcast_visible_to] = prev_visible
+          end
+        end
+
+        # Resolve the DOM target for a broadcast (issue #185): a self-targeting
+        # verb (replace/remove) uses the component's #id and REQUIRES a Streamable
+        # payload (the #id contract) — a plain component gets a guided error steering
+        # to update:; a container verb (update/append/prepend) uses the caller's
+        # explicit target: (update self-targets a Streamable when no target: given).
+        # :js scopes ops by the caller target (nil → document-scoped).
+        def resolve_broadcast_target(verb, component, payload, target)
+          return target if verb == :js
+
+          streamable = component.is_a?(Phlex::Reactive::Streamable)
+          if BROADCAST_SELF_TARGETING.include?(verb) || (verb == :update && target.nil?)
+            unless streamable
+              raise ArgumentError,
+                "broadcast_to #{verb}: needs a Streamable payload (its #id is the target). A plain " \
+                "component #{payload.class} has no #id — use update: with an explicit target:."
+            end
+            return component.id
+          end
+          raise ArgumentError, "broadcast_to #{verb}: needs a target: (the container element's id)." unless target
+
+          target
+        end
+
+        # Route ONE key to its Turbo::StreamsChannel call for the verb (issue #185).
+        # exclude:/visible_to: are NOT passed here — they ride the pgbus thread-locals
+        # set by with_pgbus_broadcast_opts (turbo-rails would swallow them as kwargs).
+        def dispatch_broadcast(verb, key, target, html, ops_json, morph)
+          parts = Array(key)
+          case verb
+          when :replace then ::Turbo::StreamsChannel.broadcast_replace_to(*parts, target:, html:, **morph_wire(morph))
+          when :update then ::Turbo::StreamsChannel.broadcast_update_to(*parts, target:, html:, **morph_wire(morph))
+          when :append then ::Turbo::StreamsChannel.broadcast_append_to(*parts, target:, html:)
+          when :prepend then ::Turbo::StreamsChannel.broadcast_prepend_to(*parts, target:, html:)
+          when :remove then ::Turbo::StreamsChannel.broadcast_remove_to(*parts, target:)
+          when :js
+            ::Turbo::StreamsChannel.broadcast_action_to(
+              *parts, action: "reactive:js", target:, attributes: { data: { reactive_ops: ops_json } }, render: false
+            )
+          end
+        end
+
+        # The ONE morph wire compiler (issue #185): the broadcast path emits the
+        # method="morph" attribute via `attributes:` (it has no `method:` kwarg).
+        # Replaces the morph_method/morph_attributes twins.
+        def morph_wire(morph)
+          morph ? { attributes: { method: "morph" } } : {}
+        end
+
+        # Split the single verb kwarg out of the module-level broadcast_to's **verb
+        # (issue #185) — public counterpart of the class-level extract_broadcast_verb.
+        def extract_module_broadcast_verb(verb)
+          unless verb.size == 1 && BROADCAST_VERBS.key?(verb.keys.first)
+            raise ArgumentError,
+              "broadcast_to needs exactly ONE verb kwarg (#{BROADCAST_VERBS.keys.join("/")}), got #{verb.keys.inspect}"
+          end
+
+          verb.first
         end
       end
 
@@ -245,168 +396,71 @@ module Phlex
         # COUNT + component name, never the model/state. The event fires on BOTH
         # transports (Action Cable AND pgbus): it wraps this class-method body,
         # which is the same on either, so pgbus optionality is preserved.
-        def broadcast_replace_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("replace", streamables, exclude:, visible_to:) do
-            component = build(model, options)
-            ::Turbo::StreamsChannel.broadcast_replace_to(
-              *streamables, target: component.id, html: render_component(component),
-              **morph_attributes(morph)
-            )
-          end
-        end
-
-        # `morph: true` makes the live cross-tab update morph in place (issue
-        # #113), so a peer tab editing this component keeps its focus/caret
-        # instead of an inner-HTML clobber. Like broadcast_replace_to's morph
-        # flag, it rides through `attributes:` (the broadcast path has no
-        # `method:` kwarg) via morph_attributes.
-        def broadcast_update_to(*streamables, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("update", streamables, exclude:, visible_to:) do
-            component = build(model, options)
-            ::Turbo::StreamsChannel.broadcast_update_to(
-              *streamables, target: component.id, html: render_component(component),
-              **morph_attributes(morph)
-            )
-          end
-        end
-
-        def broadcast_append_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("append", streamables, exclude:, visible_to:) do
-            component = build(model, options)
-            ::Turbo::StreamsChannel.broadcast_append_to(
-              *streamables, target:, html: render_component(component)
-            )
-          end
-        end
-
-        def broadcast_prepend_to(*streamables, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("prepend", streamables, exclude:, visible_to:) do
-            component = build(model, options)
-            ::Turbo::StreamsChannel.broadcast_prepend_to(
-              *streamables, target:, html: render_component(component)
-            )
-          end
-        end
-
-        def broadcast_remove_to(*streamables, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("remove", streamables, exclude:, visible_to:) do
-            component = build(model, options)
-            ::Turbo::StreamsChannel.broadcast_remove_to(
-              *streamables, target: component.id
-            )
-          end
-        end
-
-        # Push server-side client DOM ops to EVERY subscriber of a stream (issue
-        # #97) — the broadcast sibling of Response#js. Rides a `reactive:js`
-        # custom stream action over Turbo::StreamsChannel, so it works on Action
-        # Cable AND pgbus (exclude:/visible_to: thread to pgbus via
-        # instrument_broadcast exactly like every other broadcast):
+        # ONE broadcast method (issue #185) — the verb is a KWARG whose value is
+        # the payload, replacing the 11 broadcast_*_to / _to_each methods:
         #
-        #   Notifications::Badge.broadcast_js_to(user, :alerts,
-        #     js.add_class("#bell", "has-unread"), exclude: reactive_connection_id)
+        #   Item.broadcast_to(@list, :todos, replace: @todo, morph: true)   # self-target
+        #   Item.broadcast_to(@list, :todos, append: todo, target: dom_id(@list, :todos),
+        #     exclude: reactive_connection_id)
+        #   Badge.broadcast_to(user, :alerts, js: js.add_class("#bell", "has-unread"))
+        #   Counter.broadcast_to(each: accounts.map { [it, :counters] }, replace: counter)
+        #   ChatComposer.broadcast_to("chat", room, update: { room:, author: })  # Hash = init kwargs
         #
-        # `ops` is a Phlex::Reactive::JS chain (or a raw [[op, args], ...] array);
-        # `target` (an element id) scopes op resolution on the client (nil →
-        # document-scoped). The ops JSON is HTML-escaped through the TagBuilder's
-        # attributes: path (data-reactive-ops), so a value can't break out of the
-        # attribute.
-        #
-        # The builder REJECTS focus-class ops (focus/focus_first) outright:
-        # broadcasting a focus steals focus in every subscriber's tab. Focus is an
-        # actor-reply concern only (Response#js), so it raises ArgumentError here
-        # rather than silently shipping a hostile-feeling broadcast.
-        def broadcast_js_to(*streamables, ops, exclude: nil, visible_to: nil, target: nil)
-          instrument_broadcast("reactive:js", streamables, exclude:, visible_to:) do
-            json = broadcast_js_ops_json(ops)
-            ::Turbo::StreamsChannel.broadcast_action_to(
-              *streamables,
-              action: "reactive:js",
-              target: target,
-              attributes: { data: { reactive_ops: json } },
-              render: false
-            )
-          end
+        # Exactly ONE verb kwarg — replace:/update:/append:/prepend:/remove:/js:.
+        # The payload is a record (built via model_param_name), an init-kwargs Hash
+        # (verbatim — no **options collision), or a built Phlex component. `each:`
+        # (an enumerable of stream keys) fans ONE render out to K keys (1 build + 1
+        # render + 1 signing + K cheap channel calls); otherwise *streamables is the
+        # single key. `morph:` applies to replace/update. `exclude:`/`visible_to:`
+        # thread to pgbus via the capability-gated instrument_broadcast path; on
+        # Action Cable they no-op. The class-level and module-level (Phlex::Reactive.
+        # broadcast_to) forms share broadcast_component (below).
+        def broadcast_to(*streamables, morph: false, target: nil, exclude: nil, visible_to: nil, each: nil, **verb)
+          name, payload = extract_broadcast_verb(verb)
+          component = name == :js ? nil : coerce_broadcast_payload(payload)
+          keys = each ? each.map { Array(it) } : [streamables]
+          Phlex::Reactive::Streamable.broadcast_component(
+            self, name, payload, component, keys, morph:, target:, exclude:, visible_to:
+          )
         end
 
-        # --- Multi-key fan-out (issue #119) ---------------------------------
-        # Broadcast ONE component to K DIFFERENT stream keys — a per-tenant loop
-        # ("the list page stream AND the dashboard stream"). The classic
-        # broadcast_*_to concatenates *streamables into ONE key, so fanning out
-        # to K keys the hand way is K× build + K× render + K× identity HMAC for
-        # BYTE-IDENTICAL HTML. These render the component ONCE and loop only the
-        # cheap channel call:
-        #
-        #   Counter.broadcast_replace_to_each(
-        #     accounts.map { [it, :counters] }, model: counter, exclude: reactive_connection_id)
-        #
-        # `stream_keys` is an enumerable of keys; each key is passed to the
-        # transport as its raw parts (a [record, :symbol] pair, or a bare string
-        # — `Array(key)` handles both). Transport opts (exclude:/visible_to:) and
-        # morph: forward PER key exactly as the single-key verbs do, so
-        # pgbus-present suppresses the actor's echo on every stream and
-        # pgbus-absent is unchanged (the no-opts call passes no unknown keyword).
-        #
-        # Irreducible exception: per-VIEWER content (visible_to: rendering
-        # DIFFERENT HTML per viewer) still renders per call — that's a
-        # render-per-viewer by definition and can't be shared. This fan-out is
-        # for the same payload to many keys.
-        def broadcast_replace_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("replace", stream_keys, exclude:, visible_to:) do
-            component = build(model, options)
-            html = render_component(component)
-            stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_replace_to(
-                *Array(it), target: component.id, html:, **morph_attributes(morph)
-              )
-            end
+        # Define the guided-error stub for each removed broadcast method (issue
+        # #185). `verb` is referenced in define_method AND the message, so the outer
+        # block param must be named — `it` is illegal here.
+        # rubocop:disable Style/ItBlockParameter
+        Phlex::Reactive::Streamable::REMOVED_BROADCASTS.each_key do |verb|
+          define_method(verb) do |*, **|
+            raise NoMethodError,
+              "#{name}.#{verb} was removed in issue #185 — " \
+              "use #{name}.#{Phlex::Reactive::Streamable::REMOVED_BROADCASTS[verb]}"
           end
         end
-
-        def broadcast_update_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, morph: false, **options)
-          instrument_broadcast("update", stream_keys, exclude:, visible_to:) do
-            component = build(model, options)
-            html = render_component(component)
-            stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_update_to(
-                *Array(it), target: component.id, html:, **morph_attributes(morph)
-              )
-            end
-          end
-        end
-
-        def broadcast_append_to_each(stream_keys, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("append", stream_keys, exclude:, visible_to:) do
-            component = build(model, options)
-            html = render_component(component)
-            stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_append_to(*Array(it), target:, html:)
-            end
-          end
-        end
-
-        def broadcast_prepend_to_each(stream_keys, target:, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("prepend", stream_keys, exclude:, visible_to:) do
-            component = build(model, options)
-            html = render_component(component)
-            stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_prepend_to(*Array(it), target:, html:)
-            end
-          end
-        end
-
-        # remove has no body — nothing to render. It still builds ONCE to read
-        # the component's #id (the target), then loops the cheap channel call.
-        def broadcast_remove_to_each(stream_keys, model: nil, exclude: nil, visible_to: nil, **options)
-          instrument_broadcast("remove", stream_keys, exclude:, visible_to:) do
-            component = build(model, options)
-            stream_keys.each do
-              ::Turbo::StreamsChannel.broadcast_remove_to(*Array(it), target: component.id)
-            end
-          end
-        end
+        # rubocop:enable Style/ItBlockParameter
 
         private
+
+        # Split the single verb kwarg (replace:/update:/…) out of **verb, raising
+        # for zero or more than one — exactly one verb per broadcast_to call.
+        def extract_broadcast_verb(verb)
+          unless verb.size == 1 && BROADCAST_VERBS.key?(verb.keys.first)
+            raise ArgumentError,
+              "broadcast_to needs exactly ONE verb kwarg (#{BROADCAST_VERBS.keys.join("/")}), got #{verb.keys.inspect}"
+          end
+
+          verb.first
+        end
+
+        # Coerce a verb payload into a built component: a Phlex component passes
+        # through (issue #185 — built payloads); a Hash is init kwargs verbatim (no
+        # **options collision); anything else is the record built via
+        # model_param_name. nil builds argument-free (a state-backed default).
+        def coerce_broadcast_payload(payload)
+          case payload
+          when ::Phlex::SGML then payload
+          when Hash then new(**payload)
+          else build(payload, {})
+          end
+        end
 
         # Wrap a broadcast_*_to body in a broadcast.phlex_reactive event (issue
         # #107) AND thread the pgbus transport opts (issue #187). Payload: the
@@ -424,32 +478,10 @@ module Phlex
         # thread-locals around the broadcast (capability-gated on pgbus_streams?)
         # and clear them in ensure. On Action Cable there is no such thread-local
         # reader, so this is a no-op there — pgbus optionality preserved.
-        def instrument_broadcast(stream_action, streamables, exclude: nil, visible_to: nil, &)
-          Phlex::Reactive.instrument(
-            "broadcast",
-            { component: name, stream_action: stream_action, streamables: streamables.size }
-          ) { with_pgbus_broadcast_opts(exclude:, visible_to:, &) }
-        end
-
-        # Set the pgbus broadcast thread-locals for the duration of the block,
-        # ONLY when streams-capable pgbus is present (the capability gate — an old
-        # pgbus / Action Cable never reads these keys, so we skip the work and the
-        # ensure entirely). Cleared in ensure so a broadcast never leaks its
-        # exclude into a later one on the same thread.
-        def with_pgbus_broadcast_opts(exclude:, visible_to:)
-          return yield unless Phlex::Reactive.pgbus_streams?
-
-          prev_exclude = Thread.current[:pgbus_broadcast_exclude]
-          prev_visible = Thread.current[:pgbus_broadcast_visible_to]
-          Thread.current[:pgbus_broadcast_exclude] = exclude
-          Thread.current[:pgbus_broadcast_visible_to] = visible_to
-          yield
-        ensure
-          if Phlex::Reactive.pgbus_streams?
-            Thread.current[:pgbus_broadcast_exclude] = prev_exclude
-            Thread.current[:pgbus_broadcast_visible_to] = prev_visible
-          end
-        end
+        # (issue #185: instrument_broadcast + the class-level with_pgbus_broadcast_opts
+        # were folded into the shared Streamable.broadcast_component — ONE
+        # instrumentation + pgbus-threading path for the class-level and module-level
+        # broadcast_to, so the transport logic has exactly one spelling.)
 
         # Validate + serialize broadcast ops: reject focus-class ops (they steal
         # focus in every tab) and an empty chain (a dead broadcast), then return
@@ -477,12 +509,9 @@ module Phlex
           morph ? { method: :morph } : {}
         end
 
-        # The BROADCAST path renders extra <turbo-stream> attributes through
-        # `attributes:` (it has no `method:` kwarg — that would fall into the
-        # render args and be dropped). Same wire result: method="morph".
-        def morph_attributes(morph)
-          morph ? { attributes: { method: "morph" } } : {}
-        end
+        # (The broadcast path's morph wire moved to Streamable.morph_wire, issue
+        # #185 — the single compiler both the class-level and module-level
+        # broadcast_to share.)
 
         def renderer
           Phlex::Reactive.renderer
@@ -550,24 +579,25 @@ module Phlex
       # Phlex::Reactive::Stream (issue #114) so the endpoint reads the action /
       # target / token-ness structurally instead of regexing the markup; the wire
       # bytes are byte-identical.
-      def to_stream_replace
-        Phlex::Reactive::Stream.wrap(
-          self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self)),
-          action: "replace", target: id, renders_root: true
-        )
+      # `morph: true` emits `<turbo-stream action="replace" method="morph">`
+      # (issue #28): Turbo 8's bundled Idiomorph morphs the subtree in place —
+      # preserving the focused <input> + caret across the re-render — while still
+      # carrying the root's fresh data-reactive-token-value (so the signed token
+      # refreshes). Default (morph: false) is the plain outerHTML replace,
+      # byte-identical to before. Used by reply.replace / reply.morph. The morph:
+      # kwarg replaces the deleted to_stream_morph (issue #185).
+      def to_stream_replace(morph: false)
+        builder = self.class.turbo_stream_builder
+        html = self.class.render_component(self)
+        rendered = morph ? builder.replace(id, html:, method: :morph) : builder.replace(id, html:)
+        Phlex::Reactive::Stream.wrap(rendered, action: "replace", target: id, renders_root: true)
       end
 
-      # Render THIS instance as a MORPHING replace (issue #28):
-      # `<turbo-stream action="replace" method="morph">`. Turbo 8's bundled
-      # Idiomorph morphs the subtree in place — preserving the focused <input> +
-      # caret across the re-render — while still carrying the root's fresh
-      # data-reactive-token-value (so the signed token refreshes). Used by
-      # reply.morph / reply.replace(morph: true).
+      # Issue #185: to_stream_morph is removed — the morph flag is a kwarg now.
+      # Guided error → to_stream_replace(morph: true).
       def to_stream_morph
-        Phlex::Reactive::Stream.wrap(
-          self.class.turbo_stream_builder.replace(id, html: self.class.render_component(self), method: :morph),
-          action: "replace", target: id, renders_root: true
-        )
+        raise NoMethodError,
+          "to_stream_morph was removed in issue #185 — use to_stream_replace(morph: true)"
       end
 
       # `morph: true` emits `<turbo-stream action="update" method="morph">`

--- a/spec/dummy/app/components/chat_composer_component.rb
+++ b/spec/dummy/app/components/chat_composer_component.rb
@@ -22,11 +22,14 @@ class ChatComposerComponent < ApplicationComponent
     return if body.blank?
 
     message = ChatMessage.create!(room: @room, author: @author, body:)
-    ChatMessageComponent.broadcast_append_to(
+    # Issue #185: one broadcast_to — the verb (append:) is the kwarg, its value the
+    # record payload; target: is the container element, exclude: suppresses the
+    # actor's own echo.
+    ChatMessageComponent.broadcast_to(
       *ChatMessage.stream_key(@room),
+      append: message,
       target: "chat-messages-#{@room}",
-      model: message,
-      exclude: reactive_connection_id # suppress the actor's own echo
+      exclude: reactive_connection_id
     )
   end
 

--- a/spec/phlex/reactive/instrumentation_spec.rb
+++ b/spec/phlex/reactive/instrumentation_spec.rb
@@ -36,19 +36,19 @@ RSpec.describe "render + broadcast instrumentation" do
 
     it "fires around a broadcast with the component name, stream action and streamables count" do
       events = capture("broadcast.phlex_reactive") do
-        CounterComponent.broadcast_replace_to("room", :counters, model: nil, count: 3)
+        CounterComponent.broadcast_to(each: [["room", :counters], ["lobby", :counters]], replace: { count: 3 })
       end
       expect(events.size).to eq(1)
       payload = events.first.payload
       expect(payload[:component]).to eq("CounterComponent")
       expect(payload[:stream_action]).to eq("replace")
-      expect(payload[:streamables]).to eq(2) # "room", :counters
+      expect(payload[:streamables]).to eq(2) # fan-out KEY count (each: has 2 keys), not key-part count
       expect(payload).not_to have_key(:model)
     end
 
     it "fires for remove too (no rendered body)" do
       events = capture("broadcast.phlex_reactive") do
-        CounterComponent.broadcast_remove_to("room", model: nil, count: 3)
+        CounterComponent.broadcast_to("room", remove: { count: 3 })
       end
       expect(events.first.payload[:stream_action]).to eq("remove")
     end

--- a/spec/phlex/reactive/lazy_mount_spec.rb
+++ b/spec/phlex/reactive/lazy_mount_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Phlex::Reactive reactive_lazy" do
       captured = nil
       allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) { |*, html:, **| captured = html }
 
-      lazy_class.broadcast_replace_to("somewhere", n: 9)
+      lazy_class.broadcast_to("somewhere", replace: { n: 9 })
       expect(captured).to include("real:9")
     end
   end

--- a/spec/phlex/reactive/streamable_morph_spec.rb
+++ b/spec/phlex/reactive/streamable_morph_spec.rb
@@ -15,17 +15,24 @@ RSpec.describe "Streamable morph (issue #28)" do
   # several of these stream the same component twice (once per assertion).
   let(:todo) { Todo.create!(title: "t", done: false) }
 
-  describe "#to_stream_morph (instance primitive)" do
+  # Issue #185: morph is a kwarg — to_stream_replace(morph: true) replaces the
+  # deleted to_stream_morph. Byte-identical wire (action replace, method="morph").
+  describe "#to_stream_replace(morph: true) (instance primitive)" do
     it "emits a replace action with method=\"morph\" targeting self" do
-      stream = CounterComponent.new(count: 0).to_stream_morph
+      stream = CounterComponent.new(count: 0).to_stream_replace(morph: true)
       expect(stream).to include('action="replace"')
       expect(stream).to include('method="morph"')
       expect(stream).to include('target="counter"')
     end
 
     it "carries the re-rendered root (fresh signed token)" do
-      stream = CounterComponent.new(count: 0).to_stream_morph
+      stream = CounterComponent.new(count: 0).to_stream_replace(morph: true)
       expect(stream).to include("data-reactive-token-value=")
+    end
+
+    it "to_stream_morph raises a guided error naming to_stream_replace(morph: true)" do
+      expect { CounterComponent.new(count: 0).to_stream_morph }
+        .to raise_error(NoMethodError, /to_stream_replace\(morph: true\)/)
     end
   end
 

--- a/spec/requests/broadcast_fanout_spec.rb
+++ b/spec/requests/broadcast_fanout_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 require "turbo/broadcastable/test_helper"
 
-# Issue #119: broadcast_*_to_each — render ONCE, fan the shared payload out over
+# Issue #119: broadcast_to(each:) — render ONCE, fan the shared payload out over
 # K different stream keys. Broadcasting one component to K keys (a per-tenant
-# loop — "the list page stream AND the dashboard stream") with the classic
-# broadcast_*_to is K× build + K× render + K× HMAC for BYTE-IDENTICAL HTML,
-# because *streamables concatenates into ONE key. _to_each renders one component
+# loop — "the list page stream AND the dashboard stream") with a single-key
+# broadcast_to is K× build + K× render + K× HMAC for BYTE-IDENTICAL HTML,
+# because *streamables concatenates into ONE key. each: renders one component
 # and loops only the cheap channel call.
 #
 # These are the correctness guards behind the perf claim: every key receives the
@@ -19,15 +19,15 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
   include Turbo::Broadcastable::TestHelper
 
   # A per-tenant fan-out: the SAME component to N distinct stream keys. Each key
-  # is a [record-or-string, symbol] pair, exactly as broadcast_replace_to takes
-  # via *streamables.
+  # is a [record-or-string, symbol] pair, exactly as broadcast_to takes via
+  # *streamables (single-key form) or each: (fan-out form).
   let(:keys) { [["tenant:1", :counters], ["tenant:2", :counters], ["tenant:3", :counters]] }
 
-  describe ".broadcast_replace_to_each" do
+  describe ".broadcast_to(each:)" do
     it "broadcasts a replace to EVERY key" do
       keys.each do
         broadcasts = capture_turbo_stream_broadcasts(it) do
-          CounterComponent.broadcast_replace_to_each(keys, model: nil)
+          CounterComponent.broadcast_to(each: keys, replace: nil)
         end
         html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
         expect(html).to include('action="replace"')
@@ -38,7 +38,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "delivers BYTE-IDENTICAL HTML to each key (one render, shared payload)" do
       captured = keys.to_h do
         broadcasts = capture_turbo_stream_broadcasts(it) do
-          CounterComponent.broadcast_replace_to_each(keys, model: nil)
+          CounterComponent.broadcast_to(each: keys, replace: nil)
         end
         [it, broadcasts.map(&:to_s).join] # rubocop:disable Style/MapJoin
       end
@@ -49,7 +49,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "renders the component EXACTLY ONCE for a K-key fan-out" do
       allow(CounterComponent).to receive(:render_component).and_call_original
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil)
+      CounterComponent.broadcast_to(each: keys, replace: nil)
 
       expect(CounterComponent).to have_received(:render_component).once
     end
@@ -57,7 +57,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "makes one channel call per key with the identical html" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil)
+      CounterComponent.broadcast_to(each: keys, replace: nil)
 
       expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).exactly(keys.size).times
     end
@@ -65,7 +65,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "accepts a single key as a bare (non-nested) pair too" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
 
-      CounterComponent.broadcast_replace_to_each([["solo", :counters]], model: nil)
+      CounterComponent.broadcast_to(each: [["solo", :counters]], replace: nil)
 
       expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to)
         .with("solo", :counters, hash_including(target: "counter"))
@@ -74,7 +74,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "carries method=\"morph\" to every key when morph: true" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil, morph: true)
+      CounterComponent.broadcast_to(each: keys, replace: nil, morph: true)
 
       expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to)
         .with(anything, anything, hash_including(attributes: { method: "morph" }))
@@ -98,7 +98,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
         seen << Thread.current[:pgbus_broadcast_exclude]
       end
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil, exclude: "conn-actor-1")
+      CounterComponent.broadcast_to(each: keys, replace: nil, exclude: "conn-actor-1")
 
       expect(seen).to eq(["conn-actor-1"] * keys.size)
       # …and it is cleared after the fan-out (never leaks to a later broadcast).
@@ -111,7 +111,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
         seen << Thread.current[:pgbus_broadcast_visible_to]
       end
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil, visible_to: "user:7")
+      CounterComponent.broadcast_to(each: keys, replace: nil, visible_to: "user:7")
 
       expect(seen).to eq(["user:7"] * keys.size)
     end
@@ -122,7 +122,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
         seen_kwargs << kwargs
       end
 
-      CounterComponent.broadcast_replace_to_each(keys, model: nil, exclude: "conn-actor-1")
+      CounterComponent.broadcast_to(each: keys, replace: nil, exclude: "conn-actor-1")
 
       expect(seen_kwargs).to all(satisfy { !it.key?(:exclude) && !it.key?(:visible_to) })
     end
@@ -153,7 +153,7 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
     it "never passes exclude:/visible_to: when none given (no ArgumentError)" do
       stub_const("Turbo::StreamsChannel", old_shape)
 
-      expect { CounterComponent.broadcast_replace_to_each(keys, model: nil) }.not_to raise_error
+      expect { CounterComponent.broadcast_to(each: keys, replace: nil) }.not_to raise_error
       expect(old_shape.calls.size).to eq(keys.size)
       expect(old_shape.calls).to all(include(target: "counter"))
     end
@@ -162,29 +162,29 @@ RSpec.describe "broadcast_*_to_each fan-out (issue #119)", type: :request do
   # Every other verb gets the same fan-out primitive. One spec per verb, mocking
   # the channel, so the contract (once render, per-key channel call) is pinned.
   describe "the other verbs fan out the same way" do
-    it "broadcast_update_to_each" do
+    it "broadcast_to(each:, update:)" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_update_to)
-      CounterComponent.broadcast_update_to_each(keys, model: nil)
+      CounterComponent.broadcast_to(each: keys, update: nil)
       expect(Turbo::StreamsChannel).to have_received(:broadcast_update_to).exactly(keys.size).times
     end
 
-    it "broadcast_append_to_each" do
+    it "broadcast_to(each:, append:)" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_append_to)
-      CounterComponent.broadcast_append_to_each(keys, target: "list", model: nil)
+      CounterComponent.broadcast_to(each: keys, append: nil, target: "list")
       expect(Turbo::StreamsChannel).to have_received(:broadcast_append_to)
         .with(anything, anything, hash_including(target: "list")).exactly(keys.size).times
     end
 
-    it "broadcast_prepend_to_each" do
+    it "broadcast_to(each:, prepend:)" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_prepend_to)
-      CounterComponent.broadcast_prepend_to_each(keys, target: "list", model: nil)
+      CounterComponent.broadcast_to(each: keys, prepend: nil, target: "list")
       expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
         .with(anything, anything, hash_including(target: "list")).exactly(keys.size).times
     end
 
-    it "broadcast_remove_to_each (no render — remove has no body)" do
+    it "broadcast_to(each:, remove:) (no render — remove has no body)" do
       allow(Turbo::StreamsChannel).to receive(:broadcast_remove_to)
-      CounterComponent.broadcast_remove_to_each(keys, model: nil)
+      CounterComponent.broadcast_to(each: keys, remove: nil)
       expect(Turbo::StreamsChannel).to have_received(:broadcast_remove_to)
         .with(anything, anything, hash_including(target: "counter")).exactly(keys.size).times
     end

--- a/spec/requests/broadcast_to_spec.rb
+++ b/spec/requests/broadcast_to_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "turbo/broadcastable/test_helper"
+
+# Issue #185: ONE broadcast_to replaces the 11 broadcast_*_to / _to_each methods.
+# The verb is a kwarg whose value is the payload; each: fans one render out to K
+# keys. These assert the new method's streams are byte-identical to the removed
+# calls, and that the removed names raise a guided rewrite.
+RSpec.describe "broadcast_to (issue #185)", type: :request do
+  include Turbo::Broadcastable::TestHelper
+
+  let(:keys) { [["tenant:1", :counters], ["tenant:2", :counters]] }
+
+  describe "single-key verbs" do
+    it "replace: broadcasts a replace targeting the component id" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", replace: nil)
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="replace"')
+      expect(html).to include('target="counter"')
+      expect(html).not_to include('method="morph"')
+    end
+
+    it "replace: with morph: true emits method=\"morph\"" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", replace: nil, morph: true)
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="replace"')
+      expect(html).to include('method="morph"')
+    end
+
+    it "update: broadcasts an update targeting the component id" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", update: nil)
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="update"')
+      expect(html).to include('target="counter"')
+    end
+
+    it "append: broadcasts an append to an explicit target" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", append: nil, target: "list")
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="append"')
+      expect(html).to include('target="list"')
+    end
+
+    it "prepend: broadcasts a prepend to an explicit target" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", prepend: nil, target: "list")
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="prepend"')
+      expect(html).to include('target="list"')
+    end
+
+    it "remove: broadcasts a remove of the component id" do
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", remove: nil)
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="remove"')
+      expect(html).to include('target="counter"')
+    end
+
+    it "js: broadcasts a reactive:js op stream" do
+      ops = CounterComponent.new.js.add_class("#bell", "unread")
+      html = capture_turbo_stream_broadcasts("room") do
+        CounterComponent.broadcast_to("room", js: ops)
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="reactive:js"')
+      expect(html).to include("add_class")
+    end
+  end
+
+  describe "the each: multi-key fan-out" do
+    it "broadcasts the verb to EVERY key" do
+      # rubocop:disable Style/ItBlockParameter -- broadcast_key is used in a nested block
+      keys.each do |broadcast_key|
+        html = capture_turbo_stream_broadcasts(broadcast_key) do
+          CounterComponent.broadcast_to(each: keys, replace: nil)
+        end.map(&:to_s).join # rubocop:disable Style/MapJoin
+        expect(html).to include('action="replace"')
+      end
+      # rubocop:enable Style/ItBlockParameter
+    end
+
+    it "renders the component EXACTLY ONCE for a K-key fan-out" do
+      allow(CounterComponent).to receive(:render_component).and_call_original
+      CounterComponent.broadcast_to(each: keys, replace: nil)
+      expect(CounterComponent).to have_received(:render_component).once
+    end
+
+    it "makes one channel call per key" do
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+      CounterComponent.broadcast_to(each: keys, replace: nil)
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to).exactly(keys.size).times
+    end
+  end
+
+  describe "transport opts" do
+    it "threads exclude via the pgbus thread-local (pgbus-present), no StreamsChannel kwarg" do
+      allow(Phlex::Reactive).to receive(:pgbus_streams?).and_return(true)
+      seen = nil
+      seen_kwargs = nil
+      allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) do |*_a, **kwargs|
+        seen = Thread.current[:pgbus_broadcast_exclude]
+        seen_kwargs = kwargs
+      end
+
+      CounterComponent.broadcast_to("room", replace: nil, exclude: "conn-1")
+
+      expect(seen).to eq("conn-1")
+      expect(seen_kwargs).not_to have_key(:exclude)
+      expect(Thread.current[:pgbus_broadcast_exclude]).to be_nil # cleared after
+    end
+  end
+
+  describe "module-level Phlex::Reactive.broadcast_to (issue #185)" do
+    # A PLAIN (non-Streamable) component — a count badge with no #id contract.
+    let(:plain_klass) do
+      Class.new(Phlex::HTML) do
+        def self.name = "PlainBadge"
+        def initialize(count: 0) = @count = count
+        def view_template = span(id: "count-badge") { @count.to_s }
+      end
+    end
+
+    it "broadcasts a container verb (update:) with a plain component to an explicit target" do
+      html = capture_turbo_stream_broadcasts("room") do
+        Phlex::Reactive.broadcast_to("room", update: plain_klass.new(count: 5), target: "count-badge")
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('action="update"')
+      expect(html).to include('target="count-badge"')
+      expect(html).to include(">5<")
+    end
+
+    it "instruments the broadcast (broadcast.phlex_reactive fires) for a plain component" do
+      events = []
+      sub = ActiveSupport::Notifications.subscribe("broadcast.phlex_reactive") { |*a| events << a }
+      Phlex::Reactive.broadcast_to("room", update: plain_klass.new(count: 5), target: "count-badge")
+      ActiveSupport::Notifications.unsubscribe(sub)
+      expect(events).not_to be_empty
+    end
+
+    it "steers a self-targeting verb (replace:) with a PLAIN component to a guided error" do
+      expect { Phlex::Reactive.broadcast_to("room", replace: plain_klass.new) }
+        .to raise_error(ArgumentError, /update:|#id|Streamable/)
+    end
+
+    it "defaults a Streamable payload's target to its #id (replace:)" do
+      html = capture_turbo_stream_broadcasts("room") do
+        Phlex::Reactive.broadcast_to("room", replace: CounterComponent.new(count: 0))
+      end.map(&:to_s).join # rubocop:disable Style/MapJoin
+      expect(html).to include('target="counter"')
+    end
+  end
+
+  describe "removed method stubs (guided errors)" do
+    it "broadcast_replace_to raises a guided error naming broadcast_to" do
+      expect { CounterComponent.broadcast_replace_to("room", model: nil) }
+        .to raise_error(NoMethodError, /broadcast_to/)
+    end
+
+    it "broadcast_replace_to_each raises a guided error naming broadcast_to(each:)" do
+      expect { CounterComponent.broadcast_replace_to_each(keys, model: nil) }
+        .to raise_error(NoMethodError, /broadcast_to.*each|each.*broadcast_to/m)
+    end
+
+    it "broadcast_js_to raises a guided error naming broadcast_to(js:)" do
+      expect { CounterComponent.broadcast_js_to("room", CounterComponent.new.js.add_class("#x", "y")) }
+        .to raise_error(NoMethodError, /broadcast_to/)
+    end
+  end
+end

--- a/spec/requests/chat_broadcast_spec.rb
+++ b/spec/requests/chat_broadcast_spec.rb
@@ -54,20 +54,20 @@ RSpec.describe "Chat broadcast", type: :request do
 
   describe "actor-echo suppression (exclude:)" do
     it "passes the X-Pgbus-Connection header through to the broadcast as exclude:" do
-      allow(ChatMessageComponent).to receive(:broadcast_append_to)
+      allow(ChatMessageComponent).to receive(:broadcast_to)
 
       send_message(room: "lobby", body: "hi", connection: "conn-actor-123")
 
-      expect(ChatMessageComponent).to have_received(:broadcast_append_to)
+      expect(ChatMessageComponent).to have_received(:broadcast_to)
         .with("chat", "lobby", hash_including(exclude: "conn-actor-123"))
     end
 
     it "broadcasts with exclude: nil when no connection header is present" do
-      allow(ChatMessageComponent).to receive(:broadcast_append_to)
+      allow(ChatMessageComponent).to receive(:broadcast_to)
 
       send_message(room: "lobby", body: "hi")
 
-      expect(ChatMessageComponent).to have_received(:broadcast_append_to)
+      expect(ChatMessageComponent).to have_received(:broadcast_to)
         .with("chat", "lobby", hash_including(exclude: nil))
     end
 

--- a/spec/requests/csrf_form_reactive_spec.rb
+++ b/spec/requests/csrf_form_reactive_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Reactive action re-rendering a CSRF form (issue #42)", type: :re
   # CSRF-form component must render through the request-bound context too.
   it "broadcasts the CSRF form component without crashing" do
     broadcasts = capture_turbo_stream_broadcasts(todo) do
-      CsrfFormComponent.broadcast_replace_to(todo, model: todo)
+      CsrfFormComponent.broadcast_to(todo, replace: todo)
     end
 
     html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin

--- a/spec/requests/js_broadcast_spec.rb
+++ b/spec/requests/js_broadcast_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
 
   it "broadcasts a reactive:js stream carrying the ops to the stream" do
     broadcasts = capture_turbo_stream_broadcasts("alerts") do
-      TodoItemComponent.broadcast_js_to("alerts", ops)
+      TodoItemComponent.broadcast_to("alerts", js: ops)
     end
 
     html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
@@ -29,7 +29,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
 
   it "accepts a target for root scoping" do
     broadcasts = capture_turbo_stream_broadcasts("alerts") do
-      TodoItemComponent.broadcast_js_to("alerts", ops, target: "sidebar")
+      TodoItemComponent.broadcast_to("alerts", js: ops, target: "sidebar")
     end
 
     html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
@@ -39,28 +39,28 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
   it "rejects a focus op (broadcasting focus steals focus in every tab)" do
     focus_ops = TodoItemComponent.new(todo: Todo.new).js.focus("#field")
 
-    expect { TodoItemComponent.broadcast_js_to("alerts", focus_ops) }
+    expect { TodoItemComponent.broadcast_to("alerts", js: focus_ops) }
       .to raise_error(ArgumentError, /focus/)
   end
 
   it "rejects a focus_first op the same way" do
     focus_ops = TodoItemComponent.new(todo: Todo.new).js.focus_first("#menu")
 
-    expect { TodoItemComponent.broadcast_js_to("alerts", focus_ops) }
+    expect { TodoItemComponent.broadcast_to("alerts", js: focus_ops) }
       .to raise_error(ArgumentError, /focus/)
   end
 
   it "rejects focus even when it is mixed among allowed ops (no partial broadcast)" do
     mixed = TodoItemComponent.new(todo: Todo.new).js.add_class("#bell", "unread").focus("#field")
 
-    expect { TodoItemComponent.broadcast_js_to("alerts", mixed) }
+    expect { TodoItemComponent.broadcast_to("alerts", js: mixed) }
       .to raise_error(ArgumentError, /focus/)
   end
 
   it "rejects an empty op chain (a dead reactive:js broadcast is a mistake)" do
     empty = TodoItemComponent.new(todo: Todo.new).js
 
-    expect { TodoItemComponent.broadcast_js_to("alerts", empty) }
+    expect { TodoItemComponent.broadcast_to("alerts", js: empty) }
       .to raise_error(ArgumentError, /no ops/)
   end
 
@@ -78,7 +78,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
         seen = Thread.current[:pgbus_broadcast_exclude]
       end
 
-      TodoItemComponent.broadcast_js_to("alerts", ops, exclude: "conn-actor-1")
+      TodoItemComponent.broadcast_to("alerts", js: ops, exclude: "conn-actor-1")
 
       expect(seen).to eq("conn-actor-1")
       expect(Thread.current[:pgbus_broadcast_exclude]).to be_nil # cleared after
@@ -90,7 +90,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
         seen = Thread.current[:pgbus_broadcast_visible_to]
       end
 
-      TodoItemComponent.broadcast_js_to("alerts", ops, visible_to: "user:7")
+      TodoItemComponent.broadcast_to("alerts", js: ops, visible_to: "user:7")
 
       expect(seen).to eq("user:7")
     end
@@ -101,7 +101,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
         seen_kwargs = kwargs
       end
 
-      TodoItemComponent.broadcast_js_to("alerts", ops, exclude: "conn-actor-1", visible_to: "user:7")
+      TodoItemComponent.broadcast_to("alerts", js: ops, exclude: "conn-actor-1", visible_to: "user:7")
 
       expect(seen_kwargs).not_to have_key(:exclude)
       expect(seen_kwargs).not_to have_key(:visible_to)
@@ -111,7 +111,7 @@ RSpec.describe "broadcast_js_to (issue #97)", type: :request do
   it "still broadcasts to the stream when no transport opts are passed (real transport)" do
     expect do
       capture_turbo_stream_broadcasts("alerts") do
-        TodoItemComponent.broadcast_js_to("alerts", ops)
+        TodoItemComponent.broadcast_to("alerts", js: ops)
       end
     end.not_to raise_error
   end

--- a/spec/requests/reactive_actions_spec.rb
+++ b/spec/requests/reactive_actions_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Reactive actions", type: :request do
 
       expect do
         broadcasts = capture_turbo_stream_broadcasts(stream) do
-          TodoItemComponent.broadcast_replace_to(stream, model: todo)
+          TodoItemComponent.broadcast_to(stream, replace: todo)
         end
 
         html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
@@ -71,7 +71,7 @@ RSpec.describe "Reactive actions", type: :request do
     # its focus/caret on the morphed row. Default broadcasts stay a plain swap.
     it "broadcasts a morphing replace when morph: true (issue #28)" do
       broadcasts = capture_turbo_stream_broadcasts("todos") do
-        TodoItemComponent.broadcast_replace_to("todos", model: todo, morph: true)
+        TodoItemComponent.broadcast_to("todos", replace: todo, morph: true)
       end
       html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
       expect(html).to include('action="replace"')
@@ -80,13 +80,13 @@ RSpec.describe "Reactive actions", type: :request do
 
     it "broadcasts a plain replace (no morph attr) by default" do
       broadcasts = capture_turbo_stream_broadcasts("todos") do
-        TodoItemComponent.broadcast_replace_to("todos", model: todo)
+        TodoItemComponent.broadcast_to("todos", replace: todo)
       end
       html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
       expect(html).not_to include("method=")
     end
 
-    # Issue #113: broadcast_update_to gains the same morph: flag. A cross-tab
+    # Issue #113: broadcast_to(update:) gains the same morph: flag. A cross-tab
     # update into a component a peer is editing morphs in place, so the peer
     # keeps its focus/caret instead of an inner-HTML clobber. The morph flag
     # rides through `attributes:` (the broadcast path has no method: kwarg).
@@ -94,7 +94,7 @@ RSpec.describe "Reactive actions", type: :request do
     # morph: true is asked for.
     it "broadcasts a morphing update when morph: true (issue #113)" do
       broadcasts = capture_turbo_stream_broadcasts("todos") do
-        TodoItemComponent.broadcast_update_to("todos", model: todo, morph: true)
+        TodoItemComponent.broadcast_to("todos", update: todo, morph: true)
       end
       html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
       expect(html).to include('action="update"')
@@ -103,7 +103,7 @@ RSpec.describe "Reactive actions", type: :request do
 
     it "broadcasts a plain update (no morph attr) by default" do
       broadcasts = capture_turbo_stream_broadcasts("todos") do
-        TodoItemComponent.broadcast_update_to("todos", model: todo)
+        TodoItemComponent.broadcast_to("todos", update: todo)
       end
       html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
       expect(html).to include('action="update"')

--- a/spec/requests/stream_value_object_spec.rb
+++ b/spec/requests/stream_value_object_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Structured Stream value object (issue #114)", type: :request do
     it "the instance builders return Phlex::Reactive::Stream instances" do
       # A fresh instance per call — a Phlex component may only render once.
       expect(CounterComponent.new(count: 1).to_stream_replace).to be_a(Phlex::Reactive::Stream)
-      expect(CounterComponent.new(count: 1).to_stream_morph).to be_a(Phlex::Reactive::Stream)
+      expect(CounterComponent.new(count: 1).to_stream_replace(morph: true)).to be_a(Phlex::Reactive::Stream)
       expect(CounterComponent.new(count: 1).to_stream_update).to be_a(Phlex::Reactive::Stream)
       expect(CounterComponent.new(count: 1).to_stream_remove).to be_a(Phlex::Reactive::Stream)
       expect(CounterComponent.new(count: 1).to_stream_token).to be_a(Phlex::Reactive::Stream)


### PR DESCRIPTION
## Summary

Three changes to the broadcast surface.

**One `broadcast_to` (change 1):** the 11 `broadcast_*_to` / `_to_each` methods collapse
into one where the verb is a kwarg and its value is the payload:

```ruby
Item.broadcast_to(@list, :todos, replace: @todo, morph: true)
Row.broadcast_to(@list, append: item, target: dom_id(@list, :items))
Counter.broadcast_to(each: accounts.map { [it, :counters] }, replace: counter)
Composer.broadcast_to("chat", room, update: { room:, author: })   # Hash = init kwargs
```

A Hash payload is the component's init kwargs verbatim — killing the `**options`
collision (a component with an init kwarg named `target`/`morph`/`exclude` is
broadcastable again). `each:` fans one render out to K keys (1 build + 1 render + K
channel calls). Every removed method raises a guided rewrite.

**Component payloads + module-level form (change 2):** payloads can be built components,
and `Phlex::Reactive.broadcast_to(@list, :todos, update: TodoCount.new(...), target:)`
broadcasts a NON-Streamable component — instrumented — without hand-rolling the raw
channel. Self-targeting verbs (`replace:`/`remove:`) require a Streamable `#id`; container
verbs take any component. One implementation shared by the class-level and module-level
forms.

**`morph:` once (change 3):** `to_stream_morph` is deleted (guided error →
`to_stream_replace(morph: true)`); one wire compiler replaces the morph_method/
morph_attributes twins.

**pgbus:** unchanged. `exclude:`/`visible_to:` still thread through the capability-gated
thread-local path — verified against the pgbus 0.11.0 checkout (key names match, pgbus
reads at broadcast time, the `pgbus_streams?` probe holds).

## Test coverage

- **Unit/request** — new `broadcast_to_spec` covers every verb, `each:` (one render / K
  calls), the pgbus thread-local threading (no StreamsChannel kwarg), the module-level
  form (plain component + guided error + instrumentation), and the removed-method stubs.
  The old broadcast specs (fanout, js, chat) rewritten to `broadcast_to`, keeping the
  byte-identical-HTML / one-render / focus-op-refusal / pgbus-double assertions.
- **System (both servers)** — the chat broadcast round-trips green under Puma AND Falcon.

## Verification

- [x] `bundle exec rubocop` — 234 files, no offenses
- [x] `bundle exec rspec spec/phlex spec/requests` — 1130 examples, 0 failures
- [x] `bundle exec rspec spec/system` — 70 examples, 0 failures (2 pgbus cells pend), Puma AND Falcon
- [x] docs app request+system suite — 148 examples, 0 failures
- [x] pgbus-present + pgbus-absent broadcast paths both covered

## Deviations & judgment calls

- **The class-level `instrument_broadcast` + its `with_pgbus_broadcast_opts` were DELETED,
  not kept.** After the collapse they had no live caller — the shared
  `Streamable.broadcast_component` (a module singleton) owns the instrumentation + pgbus
  threading + render + per-key dispatch, so the class-level and module-level forms share
  ONE path. Keeping two copies of the pgbus thread-local logic is exactly the "two
  spellings" this issue eliminates.
- **A render-instrumentation asymmetry the issue didn't spell out:**
  `Streamable.render_component` fires `render.phlex_reactive`, but the module-level
  `Phlex::Reactive.render` does NOT. So the shared impl's `render_broadcast_html` renders a
  Streamable through `render_component` and a plain component through the module render
  *wrapped in an `instrument("render", …)`* — so neither path is silently un-instrumented.
  Verified both `render.phlex_reactive` and `broadcast.phlex_reactive` fire for the class
  path.
- **`model_param_name` overrides STAY.** The record-payload form still calls
  `build → component_args → { model_param_name => model }`. Change #2 only removes the NEED
  for the override when you pass a component/Hash payload (the badge case) — the overrides
  aren't broken.
- **`to_stream_replace(morph: true)` keeps byte-identical Stream metadata** (action
  "replace", target id, renders_root: true) — the endpoint's token guards read that
  structurally, so a divergence would regress token threading. `morph_method` is KEPT (the
  class stream builders `.replace`/`.update` use the TagBuilder `method:` path — epic G, out
  of scope); only the broadcast-path `morph_attributes` was folded into `morph_wire`.
- **Instrumentation `streamables:` now counts fan-out keys**, not `*streamables` key-parts.
  For `broadcast_to(each: keys, …)` that's `keys.size`; for a single-key call it's 1. The
  instrumentation spec was rewritten to exercise `each:` rather than assert the old
  key-part count.
- **A bare-kwargs broadcast (`broadcast_replace_to(*keys, unread: @unread)`) migrates to a
  Hash payload** (`replace: { unread: @unread }`), per the documented contract that a Hash
  payload is init kwargs verbatim (`coerce_broadcast_payload`: only a literal Hash gets
  `new(**payload)`).
- **Rubocop `it`-autocorrect trap (again):** the `REMOVED_BROADCASTS.each_key do |verb|`
  removal loop references `verb` in `define_method` AND the message, so `it` is illegal;
  kept an explicit param with a block-level disable, and moved the constant out of the
  `class_methods` block (`Lint/ConstantDefinitionInBlock`).

Refs #185
