### PR TITLE
feat(component): small sharp knives — the final 0.11 API-clarity pass (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,38 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **BREAKING: small sharp knives — the last 0.11 API-clarity pass (#186).**
+  Four independent edges honed, one contract frozen:
+  - **`reactive_filter` speaks fields, not selectors.** `reactive_filter(:q)` names the
+    driving FIELD and compiles it to `[name="q"]` (scope-aware, like `reactive_field`
+    from #184); `option:` defaults to `[role=option]`. The old
+    `reactive_filter(input: "#search", …)` selector form raises a guided error. The
+    client wire is byte-identical (it still receives selectors) — this is a server-only
+    compile, no client change. `group:`/`empty:` stay opt-in (emit only when passed).
+  - **`transition:` takes named legs.** `js.toggle("#x", transition: { during:, from:, to: })`
+    replaces the positional `transition: [during, from, to]` array (which raises with the
+    caller's values slotted into the named form). Compiles to the same wire array — zero
+    client change.
+  - **BREAKING: one registry reader — the plural frozen hash IS the fetch-one.** The seven
+    singular getters (`reactive_action`, `reactive_action?`, `reactive_collection_def`,
+    `reactive_collection?`, `reactive_compute_def`, `reactive_compute?`, and the bare
+    `reactive_compute(:name)` GETTER form) are removed — each raises a guided error naming
+    the hash form (`reactive_actions[:name]`, `reactive_actions.key?(:name)`,
+    `reactive_computes[:name]`, `reactive_collections[:name]`). The resolved registries now
+    come back FROZEN — they are the memoized dispatch table, so mutation raises `FrozenError`
+    and can never corrupt default-deny. The `reactive_compute :name, inputs:, outputs:`
+    SETTER is unchanged.
+  - **`reply.append`/`reply.prepend` accept row kwargs (non-breaking).** Extra kwargs
+    (`reply.append(item, to: :items, autofocus: true)`) now thread through to the row
+    component's initializer (`ItemRow.new(item:, autofocus: true)`). Additive — no-kwarg
+    calls are unchanged.
+  - **`defer.phlex_reactive` joins the frozen instrumentation contract (non-breaking).**
+    The deferred-render endpoint's `ActiveSupport::Notifications` event now has a
+    request-spec contract test driving all five outcomes (`ok`/`no_content`/`invalid_token`/
+    `not_found`/`unauthorized`), freezing its `{ component:, outcome: }` payload shape (a
+    rename fails CI, like `action`/`render`/`broadcast`). Documented in the README
+    instrumentation table and the observability section of the performance docs page.
+
 - **BREAKING: one `broadcast_to` — verbs as kwargs, components as payloads (#185).**
   The 11 `broadcast_*_to` / `broadcast_*_to_each` methods collapse into ONE
   `broadcast_to` where the verb is a kwarg and its value is the payload:

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Use in controllers: `render turbo_stream: Counter.replace(counter)`.
 | `reactive_text(:name, initial)` | Mirror a compute output (or a declared input) into a **text node** — a live preview heading, a character counter, `"Hello, {name}"` — via `textContent` (XSS-safe). The text sibling of `reactive_field`; carries no `name`, so it's never POSTed. See [Client-side computes](#client-side-computes-reactive_compute--reactive_text). |
 | `reactive_show(if:/if_any:/unless:)` | **Value-conditional visibility** (the `x-show`/`data-show` case): spread onto the element to show/hide — it toggles `hidden` from the fields' **current values**, client-only, zero round trip. One conditions language: a **Hash is an AND**, an **Array is membership**, a **Range is a threshold**, `if_any:` is OR-of-AND, `unless:` negates. `reactive_values` computes first paint; `disable:` disables a hidden section's controls. See [Value-conditional visibility](#value-conditional-visibility-reactive_show). |
 | `reactive_show_targets(:field, "#id" => value)` | **Cross-root visibility**: the component that owns the field declares which **outside**, id-allowlisted elements it governs (a nav tab, a panel in another pane) — the visibility parallel of `mirror:`. Spread on the **root** via `mix(reactive_root, …)`, **once per root** — several fields go in one call via the hash form. The value uses the same `where`-style vocabulary (`"advanced"`, `%w[a b]`, `10..`). Id selectors only (raise at render + client warn-skip); toggles `hidden` only. See [Value-conditional visibility](#value-conditional-visibility-reactive_show). |
-| `reactive_filter(input:, option:, group: nil, empty: nil)` | **Client-side option filtering** for a preloaded combobox: spread onto the root — typing in the named input shows/hides the options by their `data-reactive-filter-text` haystack, **zero round trips**. Optional `group:` collapses an all-hidden group header; `empty:` reveals a no-matches node. See [Client-side option filtering](#client-side-option-filtering-reactive_filter). |
+| `reactive_filter(:field, option: nil, group: nil, empty: nil)` | **Client-side option filtering** for a preloaded combobox: spread onto the root and name the **field** that drives it — `reactive_filter(:q)` compiles `:q` to `[name="q"]` (scope-aware) and typing shows/hides the options by their `data-reactive-filter-text` haystack, **zero round trips**. `option:` defaults to `[role=option]`; optional `group:` collapses an all-hidden group header; `empty:` reveals a no-matches node. See [Client-side option filtering](#client-side-option-filtering-reactive_filter). |
 | `reactive_listnav("[role=option]")` | The **standalone** combobox keyboard wiring (Arrow/Enter/Escape) for an input that fires **no action** — the preload-and-filter case. Same behavior as `on(…, listnav:)`, minus the POST. |
 | `reactive_compute :name, inputs: { title: :string, qty: :number }, outputs:` | **Typed** inputs: a `:string` reaches the JS reducer raw, a `:number` is coerced through `Number`. The array form (`inputs: %i[a b]`) stays all-numeric; the **permit-style** form (`inputs: [:qty, title: :string]`) mixes both — bare symbols default `:number`, a trailing hash types the exceptions. `outputs:` is the field allowlist; a reducer-result key also paints any owned `reactive_text` node by presence and any `mirror:` id, so an `outputs:` entry that exists only to reach a text node is redundant (harmless — a widening). |
 | `reactive_compute :name, ..., mirror: { sum: "#summary-sum" }` | **Cross-root text mirrors**: paint a compute value into declared, id-allowlisted nodes **outside** the reactive root (a recap in another tab pane) via `textContent` — no bespoke listener. See [Cross-root mirrors](#cross-root-mirrors-mirror--painting-a-recap-outside-the-root). |
@@ -820,7 +820,7 @@ the same chain covers the rest of the client-only vocabulary:
 
 ```ruby
 button(**on_client(:click, js
-  .toggle("#menu", transition: %w[transition-opacity opacity-0 opacity-100])
+  .toggle("#menu", transition: { during: "transition-opacity", from: "opacity-0", to: "opacity-100" })
   .toggle_attr(:root, "aria-expanded")   # accessible disclosure state
   .focus_first("#menu")                   # move focus into the opened menu
   .dispatch("app:menu-toggled", detail: { open: true }))) { "Menu" }
@@ -846,7 +846,7 @@ button(**on_client(:click, js
   another component or a plain Stimulus controller can react to a client-only
   interaction — `to:` picks the element (default: the component root), `detail:`
   is the payload.
-- **`transition: [during, from, to]`** on `show`/`hide`/`toggle` animates the
+- **`transition: { during:, from:, to: }`** on `show`/`hide`/`toggle` animates the
   visibility flip: `during`+`from` are applied, then `from`→`to` swaps on the next
   frame, and the helper classes are cleaned up on `animationend` (with a timeout
   fallback, so an element with no animation never leaves them stuck). The op chain
@@ -1153,13 +1153,13 @@ root instead:
 
 ```ruby
 div(**mix(reactive_root, reactive_filter(
-  input:  "#exercise-search",       # the input whose value drives the filter
-  option: "[role=option]",          # the elements to show/hide
-  group:  "[data-filter-group]",    # optional: collapse a header when all its options hide
-  empty:  "#no-matches"             # optional: reveal when 0 options match
+  :q,                               # the FIELD that drives the filter → [name="q"] (scope-aware)
+  group: "[data-filter-group]",     # optional: collapse a header when all its options hide
+  empty: "#no-matches"              # optional: reveal when 0 options match
 ))) do
   # STANDALONE keyboard nav — no action on the input, so typing never POSTs.
-  input(id: "exercise-search", type: "search", **reactive_listnav("[role=option]"))
+  # name: "q" is the field reactive_filter(:q) binds to; option: defaults to [role=option].
+  input(name: "q", type: "search", **reactive_listnav("[role=option]"))
 
   categories.each do |category, exercises|
     div(data: { filter_group: "" }) do
@@ -2207,6 +2207,7 @@ events, all under the `phlex_reactive` namespace:
 | `action.phlex_reactive` | once per request | `component`, `action`, `outcome` (`ok`/`denied_undeclared`/`invalid_token`/`not_found`/`unauthorized`/`unverified`) |
 | `render.phlex_reactive` | per component render | `component`, `bytesize` |
 | `broadcast.phlex_reactive` | per `broadcast_to` call (Action Cable **and** pgbus) | `component`, `stream_action`, `streamables` |
+| `defer.phlex_reactive` | once per deferred render (the `reply.defer` pull/push endpoint) | `component`, `outcome` (`ok`/`no_content`/`invalid_token`/`not_found`/`unauthorized`) |
 
 Payloads carry **names, the outcome, and sizes only** — never the token, params,
 or state, so an event can't leak a secret. Subscribe from an initializer:

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -119,7 +119,7 @@ module Phlex
         payload = verified_payload
         component_class = resolve_component(payload["c"])
         event[:component] = component_class.name
-        action_def = component_class.reactive_action(reactive_action_name)
+        action_def = component_class.reactive_actions[reactive_action_name.to_sym]
 
         # default-deny
         unless action_def
@@ -597,7 +597,7 @@ module Phlex
             diagnostic: :unknown_class
           )
         end
-        unless klass.respond_to?(:reactive_action?) && klass.include?(Phlex::Reactive::Component)
+        unless klass.respond_to?(:reactive_actions) && klass.include?(Phlex::Reactive::Component)
           raise Phlex::Reactive::InvalidToken.new(
             "#{name} resolved but does not include Phlex::Reactive::Component",
             diagnostic: :not_reactive_class

--- a/docs/app/reactive_components/client_tabs_component.rb
+++ b/docs/app/reactive_components/client_tabs_component.rb
@@ -73,7 +73,7 @@ class ClientTabsComponent < Phlex::HTML
   # inside the drawer — the exact accessible-disclosure pattern, one op chain.
   def drawer
     open = js
-           .toggle('#ct-drawer', transition: %w[ct-fade ct-fade-from ct-fade-to])
+           .toggle('#ct-drawer', transition: { during: 'ct-fade', from: 'ct-fade-from', to: 'ct-fade-to' })
            .set_attr(:root, 'aria-expanded', 'true')
            .focus_first('#ct-drawer')
 

--- a/docs/app/views/docs/pages/example_client_ops.rb
+++ b/docs/app/views/docs/pages/example_client_ops.rb
@@ -57,7 +57,7 @@ module Views
               - **Outside-close menu:** `on_client(:click, js.hide("#ct-menu"),
                 outside: true)` on the **root** fires on any click *outside* the menu.
                 A client op costs nothing per stray page click (unlike a server action).
-              - **Accessible drawer:** `js.toggle("#ct-drawer", transition: [...])`
+              - **Accessible drawer:** `js.toggle("#ct-drawer", transition: { during:, from:, to: })`
                 animates it, `set_attr(:root, "aria-expanded", "true")` updates the
                 trigger, and `focus_first("#ct-drawer")` moves focus to the first
                 control inside — the exact accessible-disclosure pattern, one chain.

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -198,6 +198,26 @@ module Views
                   code { 'streamables' }
                   plain ' (the key count).'
                 end
+                li do
+                  code { 'defer.phlex_reactive' }
+                  plain ' — one per deferred render (the '
+                  code { 'reply.defer' }
+                  plain ' endpoint). Payload: '
+                  code { 'component' }
+                  plain ', '
+                  code { 'outcome' }
+                  plain ' ('
+                  code { 'ok' }
+                  plain '/'
+                  code { 'no_content' }
+                  plain '/'
+                  code { 'invalid_token' }
+                  plain '/'
+                  code { 'not_found' }
+                  plain '/'
+                  code { 'unauthorized' }
+                  plain ').'
+                end
               end
               p do
                 strong { 'Payloads carry names, the outcome, and sizes only' }
@@ -230,6 +250,7 @@ module Views
               # [reactive] Counter#drop_table denied_undeclared (0.2ms)
               # [reactive] render Counter 512B (0.9ms)
               # [reactive] broadcast replace Counter →2 (1.4ms)
+              # [reactive] defer SlowTotals ok (18.2ms)
             RUBY
             DocsUI::Callout(:tip) do
               plain 'The events fire whether or not you enable the LogSubscriber — the flag only controls the '

--- a/lib/phlex/reactive/component/dsl.rb
+++ b/lib/phlex/reactive/component/dsl.rb
@@ -214,12 +214,17 @@ module Phlex
             Registry.resolve_hash(self, :actions, :reactive_actions)
           end
 
+          # Issue #186: the fetch-one readers are removed — the plural
+          # reactive_actions hash IS the fetch-one. Guided errors name the rewrite.
           def reactive_action(name)
-            reactive_actions[name.to_sym]
+            raise NoMethodError,
+              "reactive_action(#{name.inspect}) was removed in issue #186 — use reactive_actions[#{name.inspect}]"
           end
 
           def reactive_action?(name)
-            reactive_actions.key?(name.to_sym)
+            raise NoMethodError,
+              "reactive_action?(#{name.inspect}) was removed in issue #186 — " \
+              "use reactive_actions.key?(#{name.inspect})"
           end
 
           # Opt out of the default-ON verify_authorized guard (issue #168).
@@ -287,12 +292,17 @@ module Phlex
             Registry.resolve_hash(self, :collections, :reactive_collections)
           end
 
+          # Issue #186: use the plural reactive_collections hash directly.
           def reactive_collection_def(name)
-            reactive_collections[name.to_sym]
+            raise NoMethodError,
+              "reactive_collection_def(#{name.inspect}) was removed in issue #186 — " \
+              "use reactive_collections[#{name.inspect}]"
           end
 
           def reactive_collection?(name)
-            reactive_collections.key?(name.to_sym)
+            raise NoMethodError,
+              "reactive_collection?(#{name.inspect}) was removed in issue #186 — " \
+              "use reactive_collections.key?(#{name.inspect})"
           end
 
           # Declare a client-side computation, OR (called with just a name) read
@@ -350,17 +360,13 @@ module Phlex
           # the client interpreter re-checks the same shape).
           def reactive_compute(name, inputs: nil, outputs: nil, reducer: nil, mirror: nil)
             if inputs.nil? && outputs.nil?
-              # The bare form is the GETTER — a mirror: passed here would be
-              # silently dropped, so refuse it LOUDLY (declare-time validation,
-              # same posture as normalize_compute_mirror's selector check).
-              unless mirror.nil?
-                raise ArgumentError,
-                  "#{self}: reactive_compute(#{name.inspect}, mirror: ...) without inputs:/outputs: " \
-                  "is the getter form — the mirror would be silently dropped. Declare the mirror " \
-                  "alongside inputs:/outputs:."
-              end
-
-              return reactive_compute_def(name)
+              # Issue #186: the bare getter form is removed — reactive_compute is
+              # the SETTER now; read one compute via the plural hash. (Raising here
+              # keeps the getter/setter overload from silently misfiring.)
+              raise ArgumentError,
+                "reactive_compute(#{name.inspect}) getter was removed in issue #186 — " \
+                "use reactive_computes[#{name.inspect}]. reactive_compute is the declarative " \
+                "SETTER now: reactive_compute(:name, inputs:, outputs:)."
             end
 
             input_names, input_types = normalize_compute_inputs(inputs)
@@ -382,12 +388,17 @@ module Phlex
           # reactive_collection_def (issue #115). The bare reactive_compute(name)
           # getter above is a PERMANENT documented alias (it shipped in the same
           # minor series, #73); both stay, no deprecation.
+          # Issue #186: use the plural reactive_computes hash directly.
           def reactive_compute_def(name)
-            reactive_computes[name.to_sym]
+            raise NoMethodError,
+              "reactive_compute_def(#{name.inspect}) was removed in issue #186 — " \
+              "use reactive_computes[#{name.inspect}]"
           end
 
           def reactive_compute?(name)
-            reactive_computes.key?(name.to_sym)
+            raise NoMethodError,
+              "reactive_compute?(#{name.inspect}) was removed in issue #186 — " \
+              "use reactive_computes.key?(#{name.inspect})"
           end
 
           # Split the `inputs:` argument into [ordered names, types-or-nil].

--- a/lib/phlex/reactive/component/helpers.rb
+++ b/lib/phlex/reactive/component/helpers.rb
@@ -563,12 +563,15 @@ module Phlex
         # keystroke by substring-matching each option's haystack — no round
         # trip, no token, no bespoke per-feature controller:
         #
-        #   div(**mix(reactive_root, reactive_filter(
-        #     input:  "#exercise-search",
-        #     option: "[role=option]",
-        #     group:  "[data-filter-group]",   # optional: collapse empty group headers
-        #     empty:  "#no-matches"            # optional: reveal when 0 match
-        #   ))) { … }
+        # Issue #186: name the FIELD that drives the filter — reactive_filter(:q)
+        # compiles :q to [name="q"] (scope-aware) and defaults option to the
+        # [role=option] convention. group:/empty: stay opt-in; any selector kwarg
+        # overrides a convention:
+        #
+        #   div(**mix(reactive_root, reactive_filter(:q, empty: "#no-matches"))) do
+        #     input(name: "q", type: "search", **reactive_listnav)  # listnav → [role=option]
+        #     …
+        #   end
         #
         # Each option's haystack is its `data-reactive-filter-text` attribute
         # (server-rendered — pack in synonyms/categories), falling back to the
@@ -583,11 +586,25 @@ module Phlex
         # hidden options) and each option's own on(:select, …) trigger —
         # selection still round-trips as a signed action; only FILTERING is
         # local. Blank selectors raise: a dead binding must fail at render.
-        def reactive_filter(input:, option:, group: nil, empty: nil)
+        def reactive_filter(field = nil, input: :__removed, option: nil, group: nil, empty: nil)
+          # Issue #186: the four-selector kwarg form is removed — name the FIELD that
+          # drives the filter instead. A leftover input: means the old call shape.
+          unless input == :__removed
+            raise ArgumentError,
+              "reactive_filter(input:) was removed in issue #186 — name the driving field: " \
+              "reactive_filter(:q) (compiles to [name=\"q\"], scope-aware; option defaults to [role=option])."
+          end
+          raise ArgumentError, "reactive_filter needs a field name — reactive_filter(:q)" if field.nil?
+
           data = {
-            reactive_filter_input: filter_selector!(:input, input),
-            reactive_filter_option: filter_selector!(:option, option)
+            # Compile the field to a scoped [name="…"] selector (same scope convention
+            # reactive_field uses, so the filter input aligns with its own field).
+            reactive_filter_input: %([name="#{scoped_field_name(field)}"]),
+            # option defaults to the [role=option] convention; a kwarg overrides it.
+            reactive_filter_option: option ? filter_selector!(:option, option) : "[role=option]"
           }
+          # group/empty stay OPT-IN (no convention default — a default would change the
+          # byte-stable wire and always-emit an attribute the client would then query).
           data[:reactive_filter_group] = filter_selector!(:group, group) if group
           data[:reactive_filter_empty] = filter_selector!(:empty, empty) if empty
 
@@ -698,7 +715,7 @@ module Phlex
         # input->reactive#recompute action, all on the root element. Raises for an
         # undeclared name (fail fast, not a silent no-op).
         def compute_binding(name)
-          definition = self.class.reactive_compute_def(name)
+          definition = self.class.reactive_computes[name.to_sym]
           raise Error, "#{self.class} has no reactive_compute #{name.inspect}" unless definition
 
           data = {

--- a/lib/phlex/reactive/component/registry.rb
+++ b/lib/phlex/reactive/component/registry.rb
@@ -126,7 +126,10 @@ module Phlex
             fetch(klass, kind) do
               inherited = inherited_value(klass, reader)
               own = own(klass, kind)
-              (inherited || EMPTY_HASH).merge(own || EMPTY_HASH)
+              # FROZEN (issue #186): the resolved hash is the public dispatch table
+              # (reactive_actions[:x] is the default-deny source of truth) — handing
+              # out a mutable memo would let a caller corrupt it. Mutation raises.
+              (inherited || EMPTY_HASH).merge(own || EMPTY_HASH).freeze
             end
           end
 

--- a/lib/phlex/reactive/deferred_render_job.rb
+++ b/lib/phlex/reactive/deferred_render_job.rb
@@ -32,7 +32,7 @@ module Phlex
         # — it raises loudly and broadcasts NOTHING, OUTSIDE the render rescue
         # below (a component with actions can't be forged past the signed
         # identity anyway, so this never fires for a real defer).
-        unless klass.respond_to?(:reactive_action?) && klass.include?(Phlex::Reactive::Component)
+        unless klass.respond_to?(:reactive_actions) && klass.include?(Phlex::Reactive::Component)
           raise ::ArgumentError,
             "#{component_class_name} is not a reactive component — refusing the deferred render"
         end

--- a/lib/phlex/reactive/js.rb
+++ b/lib/phlex/reactive/js.rb
@@ -240,15 +240,23 @@ module Phlex
         self.class.assert_allowed_attr(name)
       end
 
-      # A transition must be exactly [during, from, to] class lists (strings).
+      # A transition is NAMED legs { during:, from:, to: } (issue #186), compiled to
+      # the [during, from, to] wire array (zero client change). The old positional
+      # Array form is removed — it raises with the caller's OWN values slotted into
+      # the named form, so the rewrite is copy-pasteable.
       def normalize_transition(transition)
-        list = Array(transition)
-        unless list.size == 3
+        if transition.is_a?(Array)
+          d, f, t = transition
           raise ArgumentError,
-            "#{self.class}: transition: must be [during, from, to] class lists, got #{transition.inspect}"
+            "#{self.class}: transition: takes named legs (issue #186) — " \
+            "transition: { during: #{d.inspect}, from: #{f.inspect}, to: #{t.inspect} }"
+        end
+        unless transition.is_a?(Hash) && %i[during from to].all? { transition.key?(it) }
+          raise ArgumentError,
+            "#{self.class}: transition: must name during:, from:, to: class lists, got #{transition.inspect}"
         end
 
-        list.map(&:to_s).freeze
+        [transition[:during], transition[:from], transition[:to]].map(&:to_s).freeze
       end
 
       def class_args(to, classes, global:)

--- a/lib/phlex/reactive/reply.rb
+++ b/lib/phlex/reactive/reply.rb
@@ -56,12 +56,15 @@ module Phlex
       #   def remove_item(id:) = (@list.items.find(id).destroy!;   reply.remove(id, from: :items))
       #
       # `model` is the row's record; remove also accepts the row's dom-id string.
-      def append(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG)
-        collection_build!(:build_collection_append, :append, model, legacy_model, to)
+      # Extra kwargs (issue #186) thread to the row component's new(model:, **row_kwargs)
+      # — e.g. reply.append(item, to: :items, autofocus: true) → ItemRow.new(item:,
+      # autofocus: true). Additive: a no-kwarg call is byte-identical to before.
+      def append(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG, **row_kwargs)
+        collection_build!(:build_collection_append, :append, model, legacy_model, to, row_kwargs)
       end
 
-      def prepend(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG)
-        collection_build!(:build_collection_prepend, :prepend, model, legacy_model, to)
+      def prepend(model = UNSET_ARG, legacy_model = UNSET_ARG, to: UNSET_ARG, **row_kwargs)
+        collection_build!(:build_collection_prepend, :prepend, model, legacy_model, to, row_kwargs)
       end
 
       # Two forms, dispatched on the PRESENCE of `from:` (issue #182 — no sentinel
@@ -133,7 +136,7 @@ module Phlex
       # Shared append/prepend build: catch the old two-positional form, require the
       # `to:` keyword, reject a Symbol-first model, then delegate to the Response
       # builder (name first, model second — its internal order).
-      def collection_build!(builder, verb, model, legacy_model, to)
+      def collection_build!(builder, verb, model, legacy_model, to, row_kwargs)
         # Old form `reply.append(:name, model)` passes a SECOND positional — the
         # arity would just error, so intercept it with the guided rewrite.
         reject_legacy_form!(verb, model, legacy_model)
@@ -142,7 +145,7 @@ module Phlex
             "reply.#{verb} needs a target collection — reply.#{verb}(model, to: :name)"
         end
         reject_symbol_first!(verb, model, :to, to)
-        Response.public_send(builder, @component, to, resolve_row_arg(model))
+        Response.public_send(builder, @component, to, resolve_row_arg(model), **row_kwargs)
       end
 
       # The pre-#182 call `reply.<verb>(:name, model)` — a Symbol name first, the

--- a/lib/phlex/reactive/response.rb
+++ b/lib/phlex/reactive/response.rb
@@ -110,15 +110,15 @@ module Phlex
         # container owns the add/remove trigger, so the endpoint appends its inert
         # `reactive:token` stream (the same #30 machinery reply.streams uses) to roll
         # the token forward without re-rendering the rows.
-        def build_collection_append(component, name, model)
+        def build_collection_append(component, name, model, **row_kwargs)
           definition = collection_def!(component, name)
-          new(streams: collection_add_streams(definition, component, model, :append),
+          new(streams: collection_add_streams(definition, component, model, :append, row_kwargs),
             render_self: false, token_component: component)
         end
 
-        def build_collection_prepend(component, name, model)
+        def build_collection_prepend(component, name, model, **row_kwargs)
           definition = collection_def!(component, name)
-          new(streams: collection_add_streams(definition, component, model, :prepend),
+          new(streams: collection_add_streams(definition, component, model, :prepend, row_kwargs),
             render_self: false, token_component: component)
         end
 
@@ -134,15 +134,17 @@ module Phlex
         # for an undeclared name (a typo'd collection should fail loudly, not
         # silently emit an empty Response).
         def collection_def!(component, name)
-          component.class.reactive_collection_def(name) ||
+          component.class.reactive_collections[name.to_sym] ||
             raise(Phlex::Reactive::Error, "undeclared reactive_collection :#{name} on #{component.class}")
         end
 
         # Row add (append/prepend) + count + empty-state clear. The empty-state is
         # removed only when the list just crossed 0->1 (size == 1) — appending to
         # an already-populated list leaves it untouched.
-        def collection_add_streams(definition, component, model, action)
-          streams = [definition.item.public_send(action, target: definition.container, model:)]
+        def collection_add_streams(definition, component, model, action, row_kwargs = {})
+          # row_kwargs (issue #186) thread to the row component's init via the class
+          # stream builder's **options passthrough (ItemRow.new(model:, **row_kwargs)).
+          streams = [definition.item.public_send(action, target: definition.container, model:, **row_kwargs)]
           append_count_stream(streams, definition, component)
 
           size = definition.size_for(component)

--- a/lib/phlex/reactive/test_helpers.rb
+++ b/lib/phlex/reactive/test_helpers.rb
@@ -88,7 +88,7 @@ module Phlex
       #      maps it to 403; a unit test asserts the real exception).
       def run_reactive(component, action, **params)
         klass = component.class
-        action_def = klass.reactive_action(action) || raise_undeclared(klass, action)
+        action_def = klass.reactive_actions[action.to_sym] || raise_undeclared(klass, action)
 
         rebuilt = rebuild_from_identity(component, klass)
         coerced = action_def.schema.coerce(stringify_params(params))

--- a/spec/dummy/app/components/client_tabs_component.rb
+++ b/spec/dummy/app/components/client_tabs_component.rb
@@ -63,7 +63,7 @@ class ClientTabsComponent < ApplicationComponent
   # accessible-disclosure pattern, now one op chain.
   def drawer
     open = js
-      .toggle("#ct-drawer", transition: %w[ct-fade ct-fade-from ct-fade-to])
+      .toggle("#ct-drawer", transition: { during: "ct-fade", from: "ct-fade-from", to: "ct-fade-to" })
       .set_attr(:root, "aria-expanded", "true")
       .focus_first("#ct-drawer")
 

--- a/spec/dummy/app/components/defer_auth_component.rb
+++ b/spec/dummy/app/components/defer_auth_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# A defer target that AUTHORIZES ON RENDER (issue #186 contract test). A deferred
+# render never runs an action, so the :unauthorized defer outcome comes from a
+# component that guards its own visibility — from_identity here raises a registered
+# authorization error (mapped to 403 via config/initializers/phlex_reactive.rb).
+class DeferAuthComponent < ApplicationComponent
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  # Registered in the dummy initializer so a raise maps to a 403 + the defer
+  # instrument's :unauthorized outcome, not a 500.
+  class Denied < StandardError; end
+
+  reactive_state :value
+
+  def self.from_identity(_payload)
+    raise Denied, "not allowed to render"
+  end
+
+  def initialize(value: 0)
+    @value = value
+  end
+
+  def id = "defer-auth"
+
+  def view_template = div(id:, **reactive_attrs) { @value.to_s }
+end

--- a/spec/dummy/app/components/filter_combobox_component.rb
+++ b/spec/dummy/app/components/filter_combobox_component.rb
@@ -47,12 +47,9 @@ class FilterComboboxComponent < ApplicationComponent
   def view_template
     div(**mix(
       reactive_root(data: { testid: "filter-combobox" }),
-      reactive_filter(
-        input: "#filter-combobox-search",
-        option: "[role=option]",
-        group: "[data-filter-group]",
-        empty: "#filter-combobox-empty"
-      )
+      # Issue #186: name the driving field (:q → [name="q"]); option defaults to the
+      # [role=option] convention; group/empty are opt-in.
+      reactive_filter(:q, group: "[data-filter-group]", empty: "#filter-combobox-empty")
     )) do
       search_input
       CATALOG.each { |category, entries| group(category, entries) }
@@ -67,9 +64,10 @@ class FilterComboboxComponent < ApplicationComponent
   # Arrow/Enter/Escape standalone (Enter clicks the highlighted option's own
   # reactive trigger, so selection stays a signed action).
   def search_input
+    # name="q" is the field reactive_filter(:q) compiles to [name="q"] (issue #186).
     input(**mix(
       reactive_listnav("[role=option]"),
-      id: "filter-combobox-search",
+      id: "filter-combobox-search", name: "q",
       type: "search", autocomplete: "off",
       data: { testid: "filter-query" }
     ))

--- a/spec/dummy/config/initializers/phlex_reactive.rb
+++ b/spec/dummy/config/initializers/phlex_reactive.rb
@@ -31,4 +31,7 @@ Rails.application.config.after_initialize do
   # raises this so the request spec proves a genuine denial still 403s through
   # authorization_errors — NOT the verify guard's 500.
   Phlex::Reactive.authorization_errors << AuthorizedTodoComponent::Denied
+  # Defer :unauthorized contract fixture (issue #186): DeferAuthComponent raises on
+  # render, so a deferred render maps to 403 + the defer instrument's :unauthorized.
+  Phlex::Reactive.authorization_errors << DeferAuthComponent::Denied
 end

--- a/spec/phlex/reactive/collection_spec.rb
+++ b/spec/phlex/reactive/collection_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe Phlex::Reactive::Component, "reactive_collection" do
 
   describe "declaration storage" do
     it "registers the collection under its name" do
-      expect(container_klass.reactive_collection?(:items)).to be(true)
-      expect(container_klass.reactive_collection?(:nope)).to be(false)
+      expect(container_klass.reactive_collections.key?(:items)).to be(true)
+      expect(container_klass.reactive_collections.key?(:nope)).to be(false)
     end
 
     it "captures the item component, container id, count id and empty component" do
-      collection = container_klass.reactive_collection_def(:items)
+      collection = container_klass.reactive_collections[:items]
       expect(collection.item).to eq(row_klass)
       expect(collection.container).to eq("items-list")
       expect(collection.count).to eq("items-count")
@@ -52,7 +52,7 @@ RSpec.describe Phlex::Reactive::Component, "reactive_collection" do
     end
 
     it "evaluates the size resolver against a component instance" do
-      collection = container_klass.reactive_collection_def(:items)
+      collection = container_klass.reactive_collections[:items]
       expect(collection.size_for(container_klass.allocate)).to eq(3)
     end
   end
@@ -69,13 +69,13 @@ RSpec.describe Phlex::Reactive::Component, "reactive_collection" do
     end
 
     it "allows omitting count, empty and size" do
-      collection = minimal_klass.reactive_collection_def(:rows)
+      collection = minimal_klass.reactive_collections[:rows]
       expect(collection.count).to be_nil
       expect(collection.empty).to be_nil
     end
 
     it "size defaults to nil when no resolver is declared" do
-      collection = minimal_klass.reactive_collection_def(:rows)
+      collection = minimal_klass.reactive_collections[:rows]
       expect(collection.size_for(minimal_klass.allocate)).to be_nil
     end
   end
@@ -85,13 +85,13 @@ RSpec.describe Phlex::Reactive::Component, "reactive_collection" do
       parent = container_klass
       child = Class.new(parent) do
         def self.name = "ChildList"
-        reactive_collection :extras, item: parent.reactive_collection_def(:items).item, container: "extras"
+        reactive_collection :extras, item: parent.reactive_collections[:items].item, container: "extras"
       end
 
-      expect(child.reactive_collection?(:items)).to be(true)
-      expect(child.reactive_collection?(:extras)).to be(true)
+      expect(child.reactive_collections.key?(:items)).to be(true)
+      expect(child.reactive_collections.key?(:extras)).to be(true)
       # parent is not polluted by the child's addition
-      expect(parent.reactive_collection?(:extras)).to be(false)
+      expect(parent.reactive_collections.key?(:extras)).to be(false)
     end
   end
 end

--- a/spec/phlex/reactive/collection_streams_spec.rb
+++ b/spec/phlex/reactive/collection_streams_spec.rb
@@ -185,6 +185,57 @@ RSpec.describe "reactive_collection streams (issue #35)", type: :request do
     end
   end
 
+  # Issue #186: reply.append/prepend thread extra kwargs to the row component's
+  # new(model:, **kwargs) — the class API + broadcast_append_to already do this;
+  # Response.collection_* was the only caller forwarding nothing.
+  describe "row kwargs (issue #186)" do
+    let(:kw_row) do
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Streamable
+
+        def self.name = "KwRow"
+        def self.model_param_name = :todo
+
+        def initialize(todo:, autofocus: false)
+          @todo = todo
+          @autofocus = autofocus
+        end
+
+        def id = dom_id(@todo)
+        def view_template = li(id:, autofocus: @autofocus) { @todo.title }
+      end
+    end
+
+    let(:kw_container) do
+      row = kw_row
+      Class.new(ApplicationComponent) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "KwList"
+        reactive_collection :todos, item: row, container: "todos-list"
+        def initialize(size: 0) = @size = size
+        def id = "kw-list-root"
+        def view_template = div(id:, **reactive_attrs) { "" }
+      end
+    end
+
+    it "threads a row kwarg to the row component (append)" do
+      response = kw_container.new.reply.append(todo, to: :todos, autofocus: true)
+      expect(response.streams.first.to_s).to include("autofocus")
+    end
+
+    it "threads a row kwarg to the row component (prepend)" do
+      response = kw_container.new.reply.prepend(todo, to: :todos, autofocus: true)
+      expect(response.streams.first.to_s).to include("autofocus")
+    end
+
+    it "is additive — a no-kwarg append still works" do
+      response = kw_container.new.reply.append(todo, to: :todos)
+      expect(response.streams.first.to_s).not_to include("autofocus")
+    end
+  end
+
   describe "errors" do
     it "raises a clear error for an undeclared collection" do
       expect { container_class.new.reply.append(todo, to: :nope) }

--- a/spec/phlex/reactive/component_registry_inheritance_spec.rb
+++ b/spec/phlex/reactive/component_registry_inheritance_spec.rb
@@ -34,24 +34,24 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       parent = reactive_class { action :ping }
       child = reactive_class(parent)
 
-      expect(child.reactive_action?(:ping)).to be(true)
-      expect(child.reactive_action(:ping).params).to eq({})
+      expect(child.reactive_actions.key?(:ping)).to be(true)
+      expect(child.reactive_actions[:ping].params).to eq({})
     end
 
     it "keeps a child's own action out of the parent (no upward leak)" do
       parent = reactive_class { action :ping }
       child = reactive_class(parent) { action :pong }
 
-      expect(child.reactive_action?(:pong)).to be(true)
-      expect(parent.reactive_action?(:pong)).to be(false)
+      expect(child.reactive_actions.key?(:pong)).to be(true)
+      expect(parent.reactive_actions.key?(:pong)).to be(false)
     end
 
     it "lets a child override a parent action's schema; the parent keeps its own" do
       parent = reactive_class { action :save, params: { title: :string } }
       child = reactive_class(parent) { action :save, params: { title: :string, count: :integer } }
 
-      expect(child.reactive_action(:save).params).to eq(title: :string, count: :integer)
-      expect(parent.reactive_action(:save).params).to eq(title: :string)
+      expect(child.reactive_actions[:save].params).to eq(title: :string, count: :integer)
+      expect(parent.reactive_actions[:save].params).to eq(title: :string)
     end
 
     it "merges a three-level chain, nearest declaration winning" do
@@ -60,9 +60,9 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       child = reactive_class(parent) { action(:c) && action(:shared, params: { from: :integer }) }
 
       expect(child.reactive_actions.keys).to contain_exactly(:a, :shared, :b, :c)
-      expect(child.reactive_action(:shared).params).to eq(from: :integer)
-      expect(parent.reactive_action(:shared).params).to eq(from: :string)
-      expect(parent.reactive_action?(:c)).to be(false)
+      expect(child.reactive_actions[:shared].params).to eq(from: :integer)
+      expect(parent.reactive_actions[:shared].params).to eq(from: :string)
+      expect(parent.reactive_actions.key?(:c)).to be(false)
     end
 
     it "sees its OWN declaration made after its registry was read (write-through on self)" do
@@ -70,7 +70,7 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       klass.reactive_actions # materialize the memo
       klass.class_eval { action :late }
 
-      expect(klass.reactive_action?(:late)).to be(true)
+      expect(klass.reactive_actions.key?(:late)).to be(true)
     end
 
     # UNIFIED (#115): pre-#115 this was the snapshot-dup divergence — the
@@ -83,8 +83,8 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       child.reactive_actions # a prior read no longer freezes the parent's registry
       parent.class_eval { action :late }
 
-      expect(parent.reactive_action?(:late)).to be(true)
-      expect(child.reactive_action?(:late)).to be(true)
+      expect(parent.reactive_actions.key?(:late)).to be(true)
+      expect(child.reactive_actions.key?(:late)).to be(true)
     end
   end
 
@@ -134,10 +134,10 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       parent = reactive_class { reactive_collection :items, item: row, container: "items" }
       child = reactive_class(parent) { reactive_collection :extras, item: row, container: "extras" }
 
-      expect(child.reactive_collection?(:items)).to be(true)
-      expect(child.reactive_collection_def(:items).container).to eq("items")
-      expect(child.reactive_collection?(:extras)).to be(true)
-      expect(parent.reactive_collection?(:extras)).to be(false)
+      expect(child.reactive_collections.key?(:items)).to be(true)
+      expect(child.reactive_collections[:items].container).to eq("items")
+      expect(child.reactive_collections.key?(:extras)).to be(true)
+      expect(parent.reactive_collections.key?(:extras)).to be(false)
     end
 
     it "lets a child override a parent collection by name; the parent keeps its own" do
@@ -145,8 +145,8 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       parent = reactive_class { reactive_collection :items, item: row, container: "items" }
       child = reactive_class(parent) { reactive_collection :items, item: row, container: "narrow-items" }
 
-      expect(child.reactive_collection_def(:items).container).to eq("narrow-items")
-      expect(parent.reactive_collection_def(:items).container).to eq("items")
+      expect(child.reactive_collections[:items].container).to eq("narrow-items")
+      expect(parent.reactive_collections[:items].container).to eq("items")
     end
 
     # UNIFIED (#115): pre-#115 this was the same snapshot-dup divergence as
@@ -158,8 +158,8 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       child.reactive_collections # a prior read no longer freezes the parent's registry
       parent.class_eval { reactive_collection :late, item: row, container: "late" }
 
-      expect(parent.reactive_collection?(:late)).to be(true)
-      expect(child.reactive_collection?(:late)).to be(true)
+      expect(parent.reactive_collections.key?(:late)).to be(true)
+      expect(child.reactive_collections.key?(:late)).to be(true)
     end
   end
 
@@ -168,27 +168,26 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       parent = reactive_class { reactive_compute :split, inputs: %i[a], outputs: %i[b] }
       child = reactive_class(parent) { reactive_compute :totals, inputs: %i[p q], outputs: %i[t] }
 
-      expect(child.reactive_compute?(:split)).to be(true)
-      expect(child.reactive_compute(:split).reducer).to eq("split")
-      expect(child.reactive_compute?(:totals)).to be(true)
-      expect(parent.reactive_compute?(:totals)).to be(false)
+      expect(child.reactive_computes.key?(:split)).to be(true)
+      expect(child.reactive_computes[:split].reducer).to eq("split")
+      expect(child.reactive_computes.key?(:totals)).to be(true)
+      expect(parent.reactive_computes.key?(:totals)).to be(false)
     end
 
     it "lets a child override a parent compute by name; the parent keeps its own" do
       parent = reactive_class { reactive_compute :split, inputs: %i[a], outputs: %i[b] }
       child = reactive_class(parent) { reactive_compute :split, inputs: %i[a2], outputs: %i[b2] }
 
-      expect(child.reactive_compute(:split).inputs).to eq(%i[a2])
-      expect(parent.reactive_compute(:split).inputs).to eq(%i[a])
+      expect(child.reactive_computes[:split].inputs).to eq(%i[a2])
+      expect(parent.reactive_computes[:split].inputs).to eq(%i[a])
     end
 
-    it "exposes reactive_compute_def (issue #115) alongside the permanent reactive_compute getter alias" do
+    it "exposes the definition via reactive_computes[:name] (issue #115 registry, issue #186 hash access)" do
       parent = reactive_class { reactive_compute :split, inputs: %i[a], outputs: %i[b] }
       child = reactive_class(parent)
 
-      expect(child.reactive_compute_def(:split)).to eq(child.reactive_compute(:split))
-      expect(child.reactive_compute_def(:split).outputs).to eq(%i[b])
-      expect(child.reactive_compute_def(:nope)).to be_nil
+      expect(child.reactive_computes[:split].outputs).to eq(%i[b])
+      expect(child.reactive_computes[:nope]).to be_nil
     end
 
     # UNIFIED (#115): pre-#115 this was the same snapshot-dup divergence as
@@ -199,8 +198,8 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       child.reactive_computes # a prior read no longer freezes the parent's registry
       parent.class_eval { reactive_compute :late, inputs: %i[a], outputs: %i[b] }
 
-      expect(parent.reactive_compute?(:late)).to be(true)
-      expect(child.reactive_compute?(:late)).to be(true)
+      expect(parent.reactive_computes.key?(:late)).to be(true)
+      expect(child.reactive_computes.key?(:late)).to be(true)
     end
   end
 
@@ -311,9 +310,9 @@ RSpec.describe Phlex::Reactive::Component, "registry inheritance" do
       first = reactive_class { action :a }
       second = reactive_class { action :b } # what a Zeitwerk reload produces: a NEW class object
 
-      expect(first.reactive_action?(:a)).to be(true)
-      expect(second.reactive_action?(:a)).to be(false)
-      expect(second.reactive_action?(:b)).to be(true)
+      expect(first.reactive_actions.key?(:a)).to be(true)
+      expect(second.reactive_actions.key?(:a)).to be(false)
+      expect(second.reactive_actions.key?(:b)).to be(true)
     end
   end
 end

--- a/spec/phlex/reactive/component_spec.rb
+++ b/spec/phlex/reactive/component_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe Phlex::Reactive::Component do
 
   describe "action declarations (default-deny)" do
     it "registers declared actions" do
-      expect(state_klass.reactive_action?(:increment)).to be(true)
-      expect(state_klass.reactive_action(:set).params).to eq({ count: :integer })
+      expect(state_klass.reactive_actions.key?(:increment)).to be(true)
+      expect(state_klass.reactive_actions[:set].params).to eq({ count: :integer })
     end
 
     it "does not register undeclared methods" do
-      expect(state_klass.reactive_action?(:wat)).to be(false)
-      expect(state_klass.reactive_action(:wat)).to be_nil
+      expect(state_klass.reactive_actions.key?(:wat)).to be(false)
+      expect(state_klass.reactive_actions[:wat]).to be_nil
     end
 
     it "compiles the param schema at declaration (issue #109)" do
-      expect(state_klass.reactive_action(:set).schema).to be_a(Phlex::Reactive::ParamSchema)
+      expect(state_klass.reactive_actions[:set].schema).to be_a(Phlex::Reactive::ParamSchema)
     end
 
     it "raises UnknownParamType at CLASS LOAD for a typo'd type symbol (issue #109)" do
@@ -281,11 +281,11 @@ RSpec.describe Phlex::Reactive::Component do
         def decrement = @count -= 1
       end
 
-      expect(child.reactive_action?(:increment)).to be(true) # inherited
-      expect(child.reactive_action?(:decrement)).to be(true) # own
+      expect(child.reactive_actions.key?(:increment)).to be(true) # inherited
+      expect(child.reactive_actions.key?(:decrement)).to be(true) # own
       expect(child.reactive_state_keys).to include(:count)
       # parent unaffected
-      expect(state_klass.reactive_action?(:decrement)).to be(false)
+      expect(state_klass.reactive_actions.key?(:decrement)).to be(false)
     end
   end
 
@@ -1378,22 +1378,22 @@ RSpec.describe Phlex::Reactive::Component do
 
     describe "declaration registry" do
       it "registers a declared compute" do
-        expect(compute_klass.reactive_compute?(:payment_split)).to be(true)
+        expect(compute_klass.reactive_computes.key?(:payment_split)).to be(true)
       end
 
       it "does not register an undeclared name" do
-        expect(compute_klass.reactive_compute?(:wat)).to be(false)
-        expect(compute_klass.reactive_compute(:wat)).to be_nil
+        expect(compute_klass.reactive_computes.key?(:wat)).to be(false)
+        expect(compute_klass.reactive_computes[:wat]).to be_nil
       end
 
       it "captures the inputs and outputs" do
-        definition = compute_klass.reactive_compute(:payment_split)
+        definition = compute_klass.reactive_computes[:payment_split]
         expect(definition.inputs).to eq(%i[allowance cash leasing total])
         expect(definition.outputs).to eq(%i[allowance cash leasing])
       end
 
       it "defaults the reducer key to the compute name" do
-        expect(compute_klass.reactive_compute(:payment_split).reducer).to eq("payment_split")
+        expect(compute_klass.reactive_computes[:payment_split].reducer).to eq("payment_split")
       end
 
       it "honors an explicit reducer key" do
@@ -1403,7 +1403,7 @@ RSpec.describe Phlex::Reactive::Component do
           def self.name = "CustomReducer"
           reactive_compute :split, inputs: %i[a], outputs: %i[b], reducer: "shared_split"
         end
-        expect(klass.reactive_compute(:split).reducer).to eq("shared_split")
+        expect(klass.reactive_computes[:split].reducer).to eq("shared_split")
       end
     end
 
@@ -1414,9 +1414,9 @@ RSpec.describe Phlex::Reactive::Component do
           reactive_compute :totals, inputs: %i[price qty], outputs: %i[total]
         end
 
-        expect(child.reactive_compute?(:payment_split)).to be(true) # inherited
-        expect(child.reactive_compute?(:totals)).to be(true)        # own
-        expect(compute_klass.reactive_compute?(:totals)).to be(false) # parent unaffected
+        expect(child.reactive_computes.key?(:payment_split)).to be(true) # inherited
+        expect(child.reactive_computes.key?(:totals)).to be(true)        # own
+        expect(compute_klass.reactive_computes.key?(:totals)).to be(false) # parent unaffected
       end
     end
 
@@ -1470,16 +1470,16 @@ RSpec.describe Phlex::Reactive::Component do
       end
 
       it "captures the input names in declaration order" do
-        expect(typed_klass.reactive_compute(:preview).inputs).to eq(%i[title qty])
+        expect(typed_klass.reactive_computes[:preview].inputs).to eq(%i[title qty])
       end
 
       it "captures the per-input types keyed by name" do
-        expect(typed_klass.reactive_compute(:preview).input_types)
+        expect(typed_klass.reactive_computes[:preview].input_types)
           .to eq(title: :string, qty: :number)
       end
 
       it "reports nil input_types for the array form (untyped, numeric)" do
-        expect(compute_klass.reactive_compute(:payment_split).input_types).to be_nil
+        expect(compute_klass.reactive_computes[:payment_split].input_types).to be_nil
       end
 
       it "emits the HASH form's inputs param as a JSON object of name→type" do
@@ -1511,15 +1511,15 @@ RSpec.describe Phlex::Reactive::Component do
       end
 
       it "types a bare symbol as :number (the default)" do
-        expect(permit_klass.reactive_compute(:preview).input_types[:qty]).to eq(:number)
+        expect(permit_klass.reactive_computes[:preview].input_types[:qty]).to eq(:number)
       end
 
       it "types a trailing-hash exception as declared" do
-        expect(permit_klass.reactive_compute(:preview).input_types[:title]).to eq(:string)
+        expect(permit_klass.reactive_computes[:preview].input_types[:title]).to eq(:string)
       end
 
       it "captures the input names in declaration order (bare first, then hash keys)" do
-        expect(permit_klass.reactive_compute(:preview).inputs).to eq(%i[qty title])
+        expect(permit_klass.reactive_computes[:preview].inputs).to eq(%i[qty title])
       end
 
       it "emits the mixed inputs as a JSON object of name→type" do
@@ -1574,14 +1574,18 @@ RSpec.describe Phlex::Reactive::Component do
       end
 
       it "captures the mirror map normalized to name → array of id selectors" do
-        expect(mirror_klass.reactive_compute(:split).mirror)
+        expect(mirror_klass.reactive_computes[:split].mirror)
           .to eq(sum_a: ["#sum_a"], sum_total: ["#sum_total", "#footer-total"])
       end
 
       it "reports nil mirror when undeclared" do
-        expect(compute_klass.reactive_compute(:payment_split).mirror).to be_nil
+        expect(compute_klass.reactive_computes[:payment_split].mirror).to be_nil
       end
 
+      # Issue #186: reactive_compute with no inputs:/outputs: now always hits the
+      # removed-bare-getter guard first (that overload collision predates mirror:
+      # validation), so mirror: alone can never reach normalize_compute_mirror —
+      # the call still fails loudly, just via the getter-removed message.
       it "rejects mirror: on the bare GETTER form LOUDLY (never silently drops it)" do
         expect do
           Class.new do
@@ -1590,7 +1594,7 @@ RSpec.describe Phlex::Reactive::Component do
             def self.name = "MirrorOnly"
             reactive_compute :split, mirror: { sum: "#sum" }
           end
-        end.to raise_error(ArgumentError, /mirror:.*inputs/m)
+        end.to raise_error(ArgumentError, /reactive_compute\(:split\).*removed in issue #186/m)
       end
 
       it "rejects a non-id selector LOUDLY at declare time (class, attribute, *, compound)" do
@@ -2002,7 +2006,12 @@ RSpec.describe Phlex::Reactive::Component do
   # client shows/hides options by their data-reactive-filter-text haystack on
   # every input — no round trip, no bespoke per-feature controller. Validation
   # is loud at render time: blank selectors are dead bindings.
-  describe "#reactive_filter (client-side option filtering, issue #163)" do
+  # Issue #186: reactive_filter names the FIELD that drives the filter, not four
+  # selectors. `reactive_filter(:q)` compiles `:q` to [name="q"] (scope-aware) for
+  # the input, defaults option to the [role=option] convention, and leaves
+  # group/empty opt-in. The client wire (selectors) is unchanged — a server-only
+  # compile. The old input:/option: kwarg form raises a guided error.
+  describe "#reactive_filter (field-driven, issue #186)" do
     subject(:instance) { filter_klass.new }
 
     let(:filter_klass) do
@@ -2014,56 +2023,61 @@ RSpec.describe Phlex::Reactive::Component do
       end
     end
 
-    it "emits the input and option selectors as root data attributes" do
-      attrs = instance.send(:reactive_filter, input: "#search", option: "[role=option]")
-      expect(attrs[:data][:reactive_filter_input]).to eq("#search")
+    it "compiles the field name to a [name=…] input selector + the option convention" do
+      attrs = instance.send(:reactive_filter, :q)
+      expect(attrs[:data][:reactive_filter_input]).to eq('[name="q"]')
       expect(attrs[:data][:reactive_filter_option]).to eq("[role=option]")
     end
 
-    it "omits group/empty entirely when not given (byte-stable wire)" do
-      attrs = instance.send(:reactive_filter, input: "#search", option: "[role=option]")
+    it "scope-prefixes the field name under reactive_scope" do
+      scoped = Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Streamable
+        include Phlex::Reactive::Component
+
+        def self.name = "ScopedFilter"
+        reactive_scope :form
+      end
+      attrs = scoped.new.send(:reactive_filter, :q)
+      expect(attrs[:data][:reactive_filter_input]).to eq('[name="form[q]"]')
+    end
+
+    it "leaves group/empty opt-in (byte-stable wire — omitted by default)" do
+      attrs = instance.send(:reactive_filter, :q)
       expect(attrs[:data]).not_to have_key(:reactive_filter_group)
       expect(attrs[:data]).not_to have_key(:reactive_filter_empty)
     end
 
-    it "emits the optional group and empty selectors when given" do
-      attrs = instance.send(:reactive_filter,
-        input: "#search", option: "[role=option]",
-        group: "[data-filter-group]", empty: "#no-matches")
+    it "accepts kwarg overrides for option/group/empty" do
+      attrs = instance.send(:reactive_filter, :q,
+        option: ".opt", group: "[data-filter-group]", empty: "#no-matches")
+      expect(attrs[:data][:reactive_filter_option]).to eq(".opt")
       expect(attrs[:data][:reactive_filter_group]).to eq("[data-filter-group]")
       expect(attrs[:data][:reactive_filter_empty]).to eq("#no-matches")
     end
 
-    it "raises on a blank input selector (a dead binding must fail at render)" do
-      expect { instance.send(:reactive_filter, input: "", option: "[role=option]") }
-        .to raise_error(ArgumentError, /input:/)
+    it "raises a guided error for the removed input: kwarg form" do
+      expect { instance.send(:reactive_filter, input: "#search", option: "[role=option]") }
+        .to raise_error(ArgumentError, /reactive_filter\(:field\)|field/)
     end
 
-    it "raises on a blank option selector" do
-      expect { instance.send(:reactive_filter, input: "#search", option: " ") }
+    it "raises on a blank option override" do
+      expect { instance.send(:reactive_filter, :q, option: " ") }
         .to raise_error(ArgumentError, /option:/)
     end
 
-    it "raises on an explicitly blank group/empty selector" do
-      expect { instance.send(:reactive_filter, input: "#s", option: "[role=option]", group: "") }
-        .to raise_error(ArgumentError, /group:/)
-      expect { instance.send(:reactive_filter, input: "#s", option: "[role=option]", empty: "") }
-        .to raise_error(ArgumentError, /empty:/)
-    end
-
-    it "renders the wire attributes onto the root element" do
+    it "renders the compiled wire attributes onto the root element" do
       klass = Class.new(Phlex::HTML) do
         include Phlex::Reactive::Component
 
         def self.name = "FilterRender"
 
         def view_template
-          div(**reactive_filter(input: "#search", option: "[role=option]", empty: "#none"), id: "combo") { "c" }
+          div(**reactive_filter(:q, empty: "#none"), id: "combo") { "c" }
         end
       end
 
       html = klass.new.call
-      expect(html).to include('data-reactive-filter-input="#search"')
+      expect(html).to include('data-reactive-filter-input="[name=&quot;q&quot;]"')
       expect(html).to include('data-reactive-filter-option="[role=option]"')
       expect(html).to include('data-reactive-filter-empty="#none"')
     end

--- a/spec/phlex/reactive/js_spec.rb
+++ b/spec/phlex/reactive/js_spec.rb
@@ -211,19 +211,23 @@ RSpec.describe Phlex::Reactive::JS do
     end
   end
 
-  # --- Issue #96: the transition: kwarg on show/hide/toggle ---
-
+  # --- Issue #96/#186: the transition: kwarg on show/hide/toggle ---
+  # Issue #186: transition: takes NAMED legs ({ during:, from:, to: }); it compiles
+  # to the same [during, from, to] wire array (zero client change). The old
+  # positional Array form raises with the caller's own values in the named form.
   describe "transition: kwarg on show/hide/toggle" do
-    it "carries [during, from, to] class lists on the visibility op" do
-      ops = js.toggle("#menu", transition: %w[transition-opacity opacity-0 opacity-100]).to_json
+    it "compiles named legs to the [during, from, to] wire array" do
+      ops = js.toggle("#menu",
+        transition: { during: "transition-opacity", from: "opacity-0", to: "opacity-100" }).to_json
       expect(JSON.parse(ops).dig(0, 1, "transition"))
         .to eq(%w[transition-opacity opacity-0 opacity-100])
     end
 
     it "works on show and hide too" do
-      expect(JSON.parse(js.show("#x", transition: %w[t f to]).to_json).dig(0, 1, "transition"))
+      legs = { during: "t", from: "f", to: "to" }
+      expect(JSON.parse(js.show("#x", transition: legs).to_json).dig(0, 1, "transition"))
         .to eq(%w[t f to])
-      expect(JSON.parse(js.hide("#x", transition: %w[t f to]).to_json).dig(0, 1, "transition"))
+      expect(JSON.parse(js.hide("#x", transition: legs).to_json).dig(0, 1, "transition"))
         .to eq(%w[t f to])
     end
 
@@ -231,9 +235,14 @@ RSpec.describe Phlex::Reactive::JS do
       expect(JSON.parse(js.toggle("#x").to_json).dig(0, 1)).not_to have_key("transition")
     end
 
-    it "rejects a transition list that is not exactly [during, from, to]" do
-      expect { js.toggle("#x", transition: %w[only two]) }
-        .to raise_error(ArgumentError, /during, from, to/)
+    it "raises for the removed Array form, slotting the caller's values into named legs" do
+      expect { js.toggle("#x", transition: %w[fade fade-from fade-to]) }
+        .to raise_error(ArgumentError, /during: "fade".*from: "fade-from".*to: "fade-to"/m)
+    end
+
+    it "raises for a Hash missing a leg" do
+      expect { js.toggle("#x", transition: { during: "fade", from: "a" }) }
+        .to raise_error(ArgumentError, /during.*from.*to/m)
     end
   end
 

--- a/spec/phlex/reactive/param_schema_registry_spec.rb
+++ b/spec/phlex/reactive/param_schema_registry_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Phlex::Reactive.param_schema (issue #184)" do # rubocop:disable 
       def self.name = "SchemaByName"
       action :save, params: :todo
     end
-    coerced = klass.reactive_action(:save).schema.coerce({ "title" => "hi", "done" => "true", "x" => "1" }, nil)
+    coerced = klass.reactive_actions[:save].schema.coerce({ "title" => "hi", "done" => "true", "x" => "1" }, nil)
     expect(coerced).to eq(title: "hi", done: true) # x dropped by the schema
   end
 
@@ -47,7 +47,7 @@ RSpec.describe "Phlex::Reactive.param_schema (issue #184)" do # rubocop:disable 
       def self.name = "SchemaComposed"
       action :bulk, params: { **Phlex::Reactive.param_schema(:todo), note: :string }
     end
-    coerced = klass.reactive_action(:bulk).schema.coerce({ "title" => "t", "note" => "n" }, nil)
+    coerced = klass.reactive_actions[:bulk].schema.coerce({ "title" => "t", "note" => "n" }, nil)
     expect(coerced).to eq(title: "t", note: "n")
   end
 
@@ -75,7 +75,7 @@ RSpec.describe "Phlex::Reactive.param_schema (issue #184)" do # rubocop:disable 
       def self.name = "SchemaHashStillWorks"
       action :save, params: { title: :string }
     end
-    expect(klass.reactive_action(:save).schema.coerce({ "title" => "x" }, nil)).to eq(title: "x")
+    expect(klass.reactive_actions[:save].schema.coerce({ "title" => "x" }, nil)).to eq(title: "x")
   end
 
   describe "registry frozen after boot" do

--- a/spec/phlex/reactive/registry_readers_spec.rb
+++ b/spec/phlex/reactive/registry_readers_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #186: ONE registry reader — the plural hash IS the fetch-one. The
+# fetch-one getters (reactive_action, reactive_action?, reactive_collection_def,
+# reactive_collection?, reactive_compute getter, reactive_compute_def,
+# reactive_compute?) are removed → guided errors naming the hash form. The
+# resolved registries come back FROZEN (they are the memoized dispatch table —
+# mutation must FrozenError, never corrupt default-deny).
+RSpec.describe "registry readers (issue #186)" do # rubocop:disable RSpec/DescribeClass
+  let(:klass) do
+    Class.new(Phlex::HTML) do
+      include Phlex::Reactive::Streamable
+      include Phlex::Reactive::Component
+
+      def self.name = "RegistryReaderThing"
+
+      reactive_state :count
+      action :increment
+      action :set, params: { count: :integer }
+      reactive_compute :split, inputs: %i[a b], outputs: %i[a]
+      reactive_collection :items, container: "items-list",
+        item: Class.new(ApplicationComponent) { include Phlex::Reactive::Streamable }
+      def initialize(count: 0) = @count = count
+      def id = "reg"
+    end
+  end
+
+  describe "the plural hash is the fetch-one" do
+    it "reads one action from reactive_actions[:name]" do
+      expect(klass.reactive_actions[:increment]).to be_a(Phlex::Reactive::Component::Action)
+      expect(klass.reactive_actions.key?(:set)).to be(true)
+      expect(klass.reactive_actions.key?(:wat)).to be(false)
+    end
+
+    it "reads one compute from reactive_computes[:name]" do
+      expect(klass.reactive_computes[:split].reducer).to eq("split")
+      expect(klass.reactive_computes.key?(:split)).to be(true)
+    end
+
+    it "reads one collection from reactive_collections[:name]" do
+      expect(klass.reactive_collections.key?(:items)).to be(true)
+    end
+  end
+
+  describe "the resolved registries are FROZEN" do
+    it "reactive_actions is frozen (mutating raises)" do
+      expect(klass.reactive_actions).to be_frozen
+      expect { klass.reactive_actions[:evil] = :x }.to raise_error(FrozenError)
+    end
+
+    it "reactive_computes is frozen" do
+      expect(klass.reactive_computes).to be_frozen
+    end
+
+    it "reactive_collections is frozen" do
+      expect(klass.reactive_collections).to be_frozen
+    end
+  end
+
+  describe "removed getters raise guided errors" do
+    it "reactive_action raises naming reactive_actions[:name]" do
+      expect { klass.reactive_action(:increment) }
+        .to raise_error(NoMethodError, /reactive_actions\[/)
+    end
+
+    it "reactive_action? raises naming reactive_actions.key?" do
+      expect { klass.reactive_action?(:increment) }
+        .to raise_error(NoMethodError, /reactive_actions\.key\?/)
+    end
+
+    it "reactive_compute_def raises naming reactive_computes[:name]" do
+      expect { klass.reactive_compute_def(:split) }
+        .to raise_error(NoMethodError, /reactive_computes\[/)
+    end
+
+    it "reactive_compute? raises naming reactive_computes.key?" do
+      expect { klass.reactive_compute?(:split) }
+        .to raise_error(NoMethodError, /reactive_computes\.key\?/)
+    end
+
+    it "reactive_collection_def raises naming reactive_collections[:name]" do
+      expect { klass.reactive_collection_def(:items) }
+        .to raise_error(NoMethodError, /reactive_collections\[/)
+    end
+
+    it "the bare reactive_compute(:name) GETTER form raises" do
+      expect { klass.reactive_compute(:split) }
+        .to raise_error(ArgumentError, /reactive_computes\[/)
+    end
+  end
+
+  describe "the reactive_compute SETTER stays" do
+    it "still declares a compute with inputs:/outputs:" do
+      k = Class.new(Phlex::HTML) do
+        include Phlex::Reactive::Component
+
+        def self.name = "SetterStays"
+        reactive_compute :totals, inputs: %i[a], outputs: %i[b]
+      end
+      expect(k.reactive_computes[:totals].reducer).to eq("totals")
+    end
+  end
+end

--- a/spec/requests/defer_instrumentation_spec.rb
+++ b/spec/requests/defer_instrumentation_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #186: the defer endpoint emits ONE `defer.phlex_reactive` event per
+# deferred render, carrying the component NAME + the outcome (never the token,
+# params, or state). This CONTRACT spec freezes that payload shape — driving ALL
+# FIVE outcomes — so a future rename fails CI (the same guarantee the action /
+# render / broadcast payloads already have). Payload changes become additive-only.
+RSpec.describe "defer.phlex_reactive instrumentation contract (issue #186)", type: :request do
+  def capture_defer_events
+    events = []
+    sub = ActiveSupport::Notifications.subscribe("defer.phlex_reactive") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+    yield
+    events
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  def post_defer(token)
+    post Phlex::Reactive.defer_path,
+      params: { token: }.to_json,
+      headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+  end
+
+  def defer_token_for(payload) = Phlex::Reactive.sign_defer(payload)
+
+  it "emits :ok with the component name on a successful deferred render" do
+    events = capture_defer_events do
+      post_defer(defer_token_for({ "c" => "SlowTotalsComponent", "s" => { "value" => 7 } }))
+    end
+    expect(response).to have_http_status(:ok)
+    payload = events.first.payload
+    expect(payload[:component]).to eq("SlowTotalsComponent")
+    expect(payload[:outcome]).to eq(:ok)
+  end
+
+  it "emits :no_content when the component suppresses its own render" do
+    SlowTotalsComponent.suppressed = true
+    events = capture_defer_events do
+      post_defer(defer_token_for({ "c" => "SlowTotalsComponent", "s" => { "value" => 7 } }))
+    end
+    expect(response).to have_http_status(:no_content)
+    expect(events.first.payload[:outcome]).to eq(:no_content)
+  ensure
+    SlowTotalsComponent.suppressed = false
+  end
+
+  it "emits :invalid_token for a tampered/garbage token (no component trusted)" do
+    events = capture_defer_events { post_defer("garbage.token.value") }
+    expect(response).to have_http_status(:bad_request)
+    expect(events.first.payload[:outcome]).to eq(:invalid_token)
+  end
+
+  it "emits :not_found when the record vanished mid-flight" do
+    todo = Todo.create!(title: "gone", done: false)
+    token = defer_token_for({ "c" => "TodoItemComponent", "gid" => todo.to_gid.to_s })
+    todo.destroy!
+    events = capture_defer_events { post_defer(token) }
+    expect(response).to have_http_status(:not_found)
+    expect(events.first.payload[:outcome]).to eq(:not_found)
+  end
+
+  it "emits :unauthorized when the render raises a registered authorization error" do
+    events = capture_defer_events do
+      post_defer(defer_token_for({ "c" => "DeferAuthComponent", "s" => { "value" => 1 } }))
+    end
+    expect(response).to have_http_status(:forbidden)
+    expect(events.first.payload[:outcome]).to eq(:unauthorized)
+  end
+
+  it "the payload carries NO secrets on any outcome (only component + outcome)" do
+    events = capture_defer_events do
+      post_defer(defer_token_for({ "c" => "SlowTotalsComponent", "s" => { "value" => 7 } }))
+    end
+    payload = events.first.payload
+    expect(payload.keys).to contain_exactly(:component, :outcome)
+    expect(payload.values.join).not_to include("value") # no state leaked
+  end
+end


### PR DESCRIPTION
## Summary

The final issue in the 0.11 "part-2" API-simplification wave (#181–#185 merged). Four independent public-API edges honed, one instrumentation contract frozen — each a small, sharp knife, none entangled with the others.

| # | Change | Breaking? |
|---|--------|-----------|
| 1 | `reactive_filter` speaks **fields**, not selectors | yes (guided error) |
| 2 | `reply.append`/`prepend` accept **row kwargs** | no (additive) |
| 3 | `transition:` takes **named legs** (Hash) | yes (guided error) |
| 4 | **One registry reader** — the plural frozen hash replaces 7 fetch-one getters | yes (guided errors) |
| 5 | `defer.phlex_reactive` joins the **frozen instrumentation contract** | no (additive) |

### 1. `reactive_filter` speaks fields, not selectors

```ruby
# before                                    # after
reactive_filter(input: "#search",           reactive_filter(:q)   # :q -> [name="q"], scope-aware
  option: "[role=option]")                   #                       option: defaults to [role=option]
```

`reactive_filter(:q)` names the FIELD that drives the filter and compiles it to `[name="q"]` — scope-aware, exactly like `reactive_field` from #184. `option:` now defaults to `[role=option]`; `group:`/`empty:` stay opt-in (emit only when passed). The old selector form raises a guided error. **The client wire is byte-identical** (it still receives selectors) — a server-only compile, no client change.

### 2. Collection rows accept kwargs (non-breaking)

```ruby
reply.append(item, to: :items, autofocus: true)   # autofocus: reaches ItemRow.new(item:, autofocus: true)
```

Extra kwargs thread through to the row component's initializer. Additive — no-kwarg calls are unchanged; `prepend` threads identically.

### 3. `transition:` takes named legs

```ruby
# before                                          # after
js.toggle("#x", transition:                       js.toggle("#x", transition:
  ["fade", "fade-from", "fade-to"])                 { during: "fade", from: "fade-from", to: "fade-to" })
```

Compiles to the same `[during, from, to]` wire array (zero client change). The Array form raises with the caller's values slotted into the named form, so the error teaches the fix.

### 4. One registry reader — the plural frozen hash IS the fetch-one

Seven singular getters removed, each raising a guided error naming the hash form:

| removed | use instead |
|---------|-------------|
| `reactive_action(:x)` | `reactive_actions[:x]` |
| `reactive_action?(:x)` | `reactive_actions.key?(:x)` |
| `reactive_collection_def(:x)` | `reactive_collections[:x]` |
| `reactive_collection?(:x)` | `reactive_collections.key?(:x)` |
| `reactive_compute_def(:x)` | `reactive_computes[:x]` |
| `reactive_compute?(:x)` | `reactive_computes.key?(:x)` |
| `reactive_compute(:x)` (bare GETTER) | `reactive_computes[:x]` |

The resolved registries now come back **FROZEN** — they are the memoized dispatch table, so mutation raises `FrozenError` and can never corrupt default-deny. The `reactive_compute :name, inputs:, outputs:` **SETTER is unchanged** (only the bare-getter overload died). Internal callers (endpoint, deferred-render job, test helpers) migrated to the hash form; the `respond_to?(:reactive_action?)`/`reactive_compute?` reflection guards migrated to `respond_to?(:reactive_actions)`.

### 5. `defer.phlex_reactive` joins the frozen instrumentation contract

A request-spec now drives **all five** defer outcomes (`ok`/`no_content`/`invalid_token`/`not_found`/`unauthorized`), freezing the `{ component:, outcome: }` payload shape — a rename fails CI, the same guarantee `action`/`render`/`broadcast` already have. Documented in the README instrumentation table and the observability section of the performance docs page. The payload carries only the component NAME and the outcome — never the token, params, or state (asserted).

## Test Coverage

- `spec/phlex/reactive/registry_readers_spec.rb` (new, 13) — frozen plural hashes, the 7 guided errors, the compute SETTER stays
- `spec/requests/defer_instrumentation_spec.rb` (new, 6) — all 5 defer outcomes end-to-end, no secrets in the payload
- `spec/dummy/app/components/defer_auth_component.rb` (new) — a defer target that authorizes-on-render, driving the `:unauthorized` outcome
- `component_spec` `#reactive_filter (field-driven)` — compile, scope-awareness, overrides, guided error
- `js_spec` — transition named-legs compile + Array-form guided error
- `collection_streams_spec` — append/prepend row kwargs thread through
- migrated `component_spec` / `component_registry_inheritance_spec` / `collection_spec` / `param_schema_registry_spec` to the hash form

## Verification

- `bundle exec rubocop` — 237 files, 0 offenses
- `bundle exec rspec spec/phlex spec/requests` — 1153 examples, 0 failures
- `bundle exec rake spec:system_servers` — 70 examples, 0 failures under **Puma AND Falcon**
- pgbus optionality untouched (no broadcast-path change)

## Deviations & judgment calls

- **Change 1 — `group:`/`empty:` stay opt-in.** The plan floated convention defaults (`[data-filter-group]`/`[data-filter-empty]`) for all four selectors. But `group:`/`empty:` are OPT-IN today (they emit only when truthy), and always-emitting them would be a wire change that breaks the byte-stable-wire spec and the "omits group/empty" spec. Decision: only `option:` gets a convention default (`[role=option]`, always emitted — it's required); `group:`/`empty:` keep a nil default and emit only when passed. `reactive_filter(:q)` therefore emits `input=[name="q"]` + `option=[role=option]` and nothing else.
- **Change 4 — the `respond_to?` reflection guards had to migrate too.** `reactive_action?`/`reactive_compute?` were used not just as predicates but as `respond_to?(...)` reflection guards (`deferred_render_job.rb`, `actions_controller.rb`) — removing the methods breaks those guards silently. Migrated them to `respond_to?(:reactive_actions)`. `reactive_compute` is a getter/SETTER overload; only the bare-getter path was killed, and `reactive_compute_def` (a documented alias asserted by the inheritance spec) went with the getter — the inheritance-spec alias-equality test was rewritten to the hash form.
- **Change 4 — froze the *merged* result, not just the own-hash.** `Registry#resolve_hash` returned an unfrozen `(inherited).merge(own)`; the freeze goes on the memoized merged value so a subclass's resolved registry is frozen too (inheritance-aware).
- **Consumer migration caught two live stragglers.** The both-server system run surfaced `client_tabs_component.rb` (dummy AND docs) still passing the array `transition:`, and the README carried the old `reactive_filter(input:)` sample + `transition: [...]` prose — all migrated. The docs observability section (in `performance.rb`, not the tooling page) gained the `defer.phlex_reactive` row + a `[reactive] defer …` log-line sample.
- **No client edit.** Every change compiles server-side to the existing wire, so the minified client and its vendored copy are untouched (the two build-drift guards stay green without a rebuild).

Closes #186.
