### PR TITLE
fix(docs): chat example — sender sees their own message + Enter-to-send

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    phlex-reactive (0.9.3)
+    phlex-reactive (0.11.0)
       globalid (~> 1.0)
       phlex-rails (>= 2.0, < 3)
       railties (>= 7.1, < 9.0)
@@ -664,7 +664,7 @@ CHECKSUMS
   pgmq-ruby (0.7.0) sha256=018a33e304b0c4513d3dc8cd06322ac767ebc0b475422738a71c198f066f2a76
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
-  phlex-reactive (0.9.3)
+  phlex-reactive (0.11.0)
   playwright-ruby-client (1.61.0) sha256=1f5c5f0307a2f6bd70b4fa797020a30eef5680caf8d5bd9ccc8d3937f6666e08
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193

--- a/docs/app/reactive_components/chat_composer_component.rb
+++ b/docs/app/reactive_components/chat_composer_component.rb
@@ -24,19 +24,34 @@ class ChatComposerComponent < Phlex::HTML
     return if body.blank?
 
     message = ChatMessage.create!(room: @room, author: @author, body:)
+    target = "chat-messages-#{@room}"
+    # Broadcast the new message to every OTHER subscribed tab — excluding the
+    # actor's own connection so they don't get it twice (the reply below already
+    # appends it for the sender).
     ChatMessageComponent.broadcast_to(
       *ChatMessage.stream_key(@room),
       append: message,
-      target: "chat-messages-#{@room}",
-      exclude: reactive_connection_id # suppress the actor's own echo
+      target:,
+      exclude: reactive_connection_id
     )
+    # Append the message to the SENDER's own list via their reply — the composer's
+    # root doesn't own #chat-messages (it's in the parent room), and the broadcast
+    # excludes the actor, so without this the sender's own message never appears.
+    # Mirrors the todo `add` / inbox `archive` pattern: actor via reply, others via
+    # the excluded broadcast. reply.replace re-renders the composer (clears the
+    # input); .stream adds the cross-container append targeting the room's list.
+    reply.replace.stream(ChatMessageComponent.append(target:, model: message))
   end
 
   def view_template
     div(**mix(reactive_root, class: 'flex gap-2')) do
-      input(type: 'text', name: 'body', placeholder: "Message as #{@author}…",
-            autocomplete: 'off', class: 'input input-bordered flex-1',
-            data: { testid: 'chat-input' })
+      # Enter in the field sends — the same :send_message action the button fires
+      # on click. event: "keydown.enter" is Stimulus's native keyboard filter, so
+      # only Enter dispatches. The field's value rides as the `body` param.
+      input(**mix(on(:send_message, event: 'keydown.enter'),
+                  type: 'text', name: 'body', placeholder: "Message as #{@author}…",
+                  autocomplete: 'off', class: 'input input-bordered flex-1',
+                  data: { testid: 'chat-input' }))
       button(**mix(on(:send_message), class: 'btn btn-primary',
                                       data: { testid: 'chat-send' })) { 'Send' }
     end

--- a/docs/spec/system/chat_example_spec.rb
+++ b/docs/spec/system/chat_example_spec.rb
@@ -2,16 +2,17 @@
 
 require 'system_helper'
 
-# The live chat room embedded on the example page: sending a message creates it
-# and broadcasts it to the room stream — the same reactive round trip proven on
-# /demos/chat, now dogfooded inline on the docs page. (Delivery to the SENDER's
-# own tab needs a real pub/sub backend — pgbus in production; the in-process async
-# cable this demo runs on fans out cross-CLIENT, so a single session asserts the
-# create + the round trip, not a same-tab echo. See the component's own note.)
+# The live chat room embedded on the example page: sending a message creates it,
+# appends it to the SENDER's own list via their reply, and broadcasts it to every
+# OTHER subscribed tab (excluding the actor). So a single session sees its own
+# message immediately — the same actor-via-reply / others-via-excluded-broadcast
+# pattern as the todo list and inbox examples. (True cross-tab delivery still needs
+# a real pub/sub backend — pgbus in production; the demo's in-process async cable
+# fans out cross-CLIENT.)
 RSpec.describe 'Chat example page', type: :system do
   before { ChatMessage.delete_all }
 
-  it 'renders the live chat room and sends a message (created + composer clears)' do
+  it 'sends a message on click — the sender sees it, the composer clears (no reload)' do
     visit '/docs/example-chat'
     page.execute_script("window.__noReload = 'alive'")
 
@@ -20,13 +21,27 @@ RSpec.describe 'Chat example page', type: :system do
       find("[data-testid='chat-input']").set('hello from the docs page')
       find("[data-testid='chat-send']").click
 
-      # The reactive action creates the record and re-renders the composer clear.
+      # The sender's own message appears in their list (reply append), and the
+      # composer re-renders clear.
+      expect(page).to have_css("[data-testid='message-body']", text: 'hello from the docs page')
       expect(page).to have_field('body', with: '')
     end
 
-    # The message was created and broadcast over the room stream — no full reload.
-    expect(page).to have_css("[data-testid='chat-messages']") # still on the page
     expect(ChatMessage.where(body: 'hello from the docs page')).to exist
     expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+
+  it 'sends on Enter in the input (same :send_message action as the button)' do
+    visit '/docs/example-chat'
+
+    within first("[data-testid='live-example-demo']") do
+      find("[data-testid='chat-input']").set('sent with the enter key')
+      find("[data-testid='chat-input']").send_keys(:enter)
+
+      expect(page).to have_css("[data-testid='message-body']", text: 'sent with the enter key')
+      expect(page).to have_field('body', with: '')
+    end
+
+    expect(ChatMessage.where(body: 'sent with the enter key')).to exist
   end
 end


### PR DESCRIPTION
## Problem

The chat example on the docs site looked broken on a single tab: you send a message, the input clears, but **your own message never appears**.

**Root cause:** `send_message` broadcasts the new message with `exclude: reactive_connection_id` (correct — it prevents a cross-tab double), but the composer's own root doesn't own `#chat-messages` (that list lives in the parent `ChatRoomComponent`). So nothing added the message to the **sender's** own list, and the demo's in-process async cable has no same-tab delivery either. The composer re-render only cleared the input.

## Fix

Two changes, both mirroring patterns the other examples already use:

1. **The sender sees their own message.** `send_message` now returns `reply.replace.stream(ChatMessageComponent.append(target:, model: message))` — the composer re-renders (input clears) AND the message is appended to the room's `#chat-messages` for the actor, while the excluded broadcast still handles other tabs. This is the exact **actor-via-reply / others-via-excluded-broadcast** pattern of the todo `add` and inbox `archive` examples.

2. **Enter sends.** The input gained `on(:send_message, event: "keydown.enter")` — the same action the Send button fires — mirroring the todo list's new-todo field. The `body` value already rode as the param.

## Test Coverage

- `chat_example_spec`: the sender sees their own message on click (the spec previously only asserted the create + composer clear, per the same-tab-echo limitation this fixes)
- `chat_example_spec`: sends on Enter in the input
- `Gemfile.lock`: picks up the local gem bump `0.9.3 -> 0.11.0`

## Verification

- docs chat specs (request + broadcast + system) — **6 examples, 0 failures**
- docs system suite — **48 examples, 0 failures**
- `rubocop` — 0 offenses

The excluded broadcast is unchanged, so cross-tab delivery (with a real pub/sub backend) still works exactly as before — this only adds the sender's own echo that a single tab was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages can now be sent by pressing Enter in the message input.
* **Bug Fixes**
  * Improved chat message delivery so the sender sees their message instantly while other participants receive the update as expected.
  * The message composer now clears reliably after sending a message.
* **Tests**
  * Expanded chat demo coverage to verify click-to-send and Enter-to-send flows, along with message display and no full page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->