### PR TITLE
fix(test-helpers): have_reactive_value reads the .value property (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`have_reactive_value` now reads the field's `.value` property, so it can verify a
+  reducer-set disabled/computed field (#204).** The matcher (added in #201) delegated to
+  Capybara's `have_field(with:)`, which matches the value **attribute** — but a
+  `reactive_compute` reducer paints a computed output by setting its JS `.value`
+  **property** (`el.value = …`), and for a **disabled / read-only** output the attribute
+  never reflects that. So the matcher read `""` and failed on exactly the fields it was
+  built for. It now re-resolves the field by id **or name** each poll and asserts the live
+  `.value` property (via `evaluate_script`), covering enabled AND disabled/computed fields
+  while keeping the morph-immunity. `have_reactive_text` (textContent) was unaffected.
+
 - **A freshly-rendered `reactive_compute` root now self-seeds its derived fields on connect (#199).**
   Before, a compute root computed nothing until the first user `input` — a fresh render
   (or a server validation-error re-render that replaced the body) left every derived

--- a/docs/app/views/docs/pages/testing.rb
+++ b/docs/app/views/docs/pages/testing.rb
@@ -372,9 +372,20 @@ module Views
                 end
                 li do
                   code { 'have_reactive_value(id, value)' }
-                  plain ' / '
+                  plain ' — assert a field by RE-RESOLVING it every poll (by id or name) and reading its live '
+                  code { '.value' }
+                  strong { ' property' }
+                  plain ', not the value attribute. A '
+                  code { 'reactive_compute' }
+                  plain ' reducer paints a computed output with '
+                  code { 'el.value = …' }
+                  plain '; for a '
+                  strong { 'disabled' }
+                  plain ' output the attribute never reflects that, so an attribute matcher reads blank — the property read sees it. Immune to a morph detaching the node.'
+                end
+                li do
                   code { 'have_reactive_text(id, value)' }
-                  plain ' — assert a field / mirror node by RE-RESOLVING it by id every poll, immune to a morph detaching the node.'
+                  plain ' — the mirror/recap twin for a text sink (textContent), re-resolving by id each poll.'
                 end
               end
             end

--- a/lib/phlex/reactive/test_helpers/system.rb
+++ b/lib/phlex/reactive/test_helpers/system.rb
@@ -63,21 +63,24 @@ module Phlex
         end
 
         # Assert (waiting) that the field with DOM id `id` has value `value`,
-        # RE-RESOLVING the field by its id on every poll. Use it as the barrier for
-        # a value that settles a beat after the triggering action — a reactive_compute
-        # re-seed or a morph replaces the input node AFTER the action returns, so a
-        # node captured by `find` would go stale; keying on the id and letting
-        # Capybara re-query each cycle is immune to that.
+        # RE-RESOLVING the field by its id on every poll and reading its live
+        # `.value` PROPERTY (issue #204) — NOT the value attribute. A
+        # reactive_compute reducer paints a computed output with `el.value = …`
+        # (the property); for a DISABLED / read-only output the value attribute
+        # never reflects that, so an attribute-based matcher reads "" and fails.
+        # Reading the property covers enabled AND disabled/computed fields — the
+        # exact case this matcher was built for — and keeps the morph-immunity
+        # (each poll re-finds the node by id, so a re-seed/morph that replaces the
+        # input can't surface a stale node or a transient blank).
         #
         #   expect(page).to have_reactive_value("total", "6")
         #
-        # A thin, intention-revealing wrapper over Capybara's field matcher scoped
-        # by id — the value the app is waiting on, named for what it is. The
-        # `have_` prefix is Capybara-matcher convention (have_field/have_css), NOT a
-        # predicate — hence the PredicatePrefix disable, mirroring matchers.rb.
+        # `timeout:` (or `wait:`) overrides Capybara's default max wait. The
+        # `have_` prefix is Capybara-matcher convention (have_field/have_css), NOT
+        # a predicate — hence the PredicatePrefix disable, mirroring matchers.rb.
         # rubocop:disable Naming/PredicatePrefix
-        def have_reactive_value(id, value, **)
-          have_field(id, with: value, **)
+        def have_reactive_value(id, value, timeout: nil, wait: nil)
+          ReactiveValueMatcher.new(id, value, wait: timeout || wait)
         end
 
         # Assert (waiting) that the node with DOM id `id` has TEXT `value`,
@@ -90,6 +93,91 @@ module Phlex
           have_css("##{id}", text: value, **)
         end
         # rubocop:enable Naming/PredicatePrefix
+
+        # A waiting matcher that asserts a field's live `.value` PROPERTY (issue
+        # #204), read by id via evaluate_script so it sees a value a reducer set
+        # on a DISABLED output (where the value attribute stays blank). Polls until
+        # the property equals the expected value or the wait budget elapses,
+        # re-resolving the node by id every cycle (morph-immune). Supports negation
+        # (`not_to`) the Capybara way: the negative holds as soon as the property
+        # differs from the expected value (an absent field reads nil, which never
+        # equals a String expectation — so a missing field satisfies `not_to`).
+        #
+        # A plain class (not RSpec::Matchers.define) so it needs no RSpec at load
+        # time beyond the duck-typed matcher protocol RSpec calls (matches?,
+        # does_not_match?, failure_message*), keeping System loadable under Capybara
+        # alone. The expected value is stringified because a DOM `.value` is always
+        # a JS string on the wire (a numeric literal like 6 compares as "6").
+        class ReactiveValueMatcher
+          def initialize(id, value, wait: nil)
+            @id = id
+            @expected = value.to_s
+            @wait = wait
+          end
+
+          def matches?(page)
+            @page = page
+            poll_until { current_value == @expected }
+          end
+
+          # does_not_match? is RSpec's REQUIRED negated-matcher protocol method — its
+          # name is fixed by RSpec, not a predicate we get to rename.
+          # rubocop:disable Naming/PredicatePrefix
+          def does_not_match?(page)
+            @page = page
+            # The negative is satisfied the moment the property is NOT the expected
+            # value (or the field is absent → nil). poll_until returns true as soon
+            # as that holds, false if it stayed equal for the whole budget.
+            poll_until { current_value != @expected }
+          end
+          # rubocop:enable Naming/PredicatePrefix
+
+          def failure_message
+            "expected ##{@id} to have value #{@expected.inspect} (its .value property), " \
+              "but after waiting it was #{current_value.inspect}"
+          end
+
+          def failure_message_when_negated
+            "expected ##{@id} NOT to have value #{@expected.inspect} (its .value property), but it did"
+          end
+
+          private
+
+          # The field's live `.value` property, re-resolved each call. The
+          # identifier is matched by DOM id OR name (mirroring Capybara's
+          # have_field, which matches id/name/label) — reactive_field emits a
+          # `name`, not an `id`, so an id-only lookup would find nothing. Returns
+          # the String value, or nil when the field is absent (Playwright serializes
+          # a JS null as an empty Hash, so a non-String result is normalized to nil
+          # — the matcher then treats it as "not settled yet" and keeps polling
+          # rather than comparing a Hash to the expected String).
+          def current_value
+            raw = @page.evaluate_script(<<~JS)
+              (() => {
+                const k = #{@id.to_json}
+                const el = document.getElementById(k) || document.getElementsByName(k)[0]
+                return el ? el.value : null
+              })()
+            JS
+            raw.is_a?(::String) ? raw : nil
+          end
+
+          # Bounded poll on a JS-property condition Capybara can't express as a
+          # built-in waiting matcher. Uses the monotonic clock and the configured
+          # (or overridden) Capybara max wait — the same shape the system specs'
+          # hand-rolled wait_for used, now lifted into the helper.
+          def poll_until
+            deadline = now + (@wait || ::Capybara.default_max_wait_time)
+            loop do
+              return true if yield
+              return false if now >= deadline
+
+              sleep 0.05
+            end
+          end
+
+          def now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        end
 
         private
 

--- a/spec/dummy/app/components/compute_seed_component.rb
+++ b/spec/dummy/app/components/compute_seed_component.rb
@@ -17,11 +17,14 @@ class ComputeSeedComponent < ApplicationComponent
   include Phlex::Reactive::Streamable
   include Phlex::Reactive::Component
 
-  # Two numeric outputs (total, half) + a cross-root text mirror (total_label) —
-  # the issue's minimal repro. The reducer returns ALL keys every pass.
+  # Two numeric outputs (total, half) + a DISABLED computed twin (total_ro, issue
+  # #204) + a cross-root text mirror (total_label) — the issue's minimal repro. The
+  # reducer returns ALL keys every pass. total_ro is rendered `disabled`: the
+  # reducer sets its `.value` PROPERTY (never the attribute), so have_reactive_value
+  # must read the property to see it — the bug #204 fixes.
   reactive_compute :sums,
     inputs: %i[a b],
-    outputs: %i[total half],
+    outputs: %i[total half total_ro],
     mirror: { total_label: "#seed-total-label" }
 
   # Fixed seed values (2 + 4): the fixture always renders the same repro. The
@@ -42,6 +45,10 @@ class ComputeSeedComponent < ApplicationComponent
       input(**reactive_field(:b, value: @second, type: "number", data: { testid: "b" }))
       input(**reactive_field(:total, value: "", type: "number", data: { testid: "total" }))
       input(**reactive_field(:half, value: "", type: "number", data: { testid: "half" }))
+      # A DISABLED computed twin (issue #204): the reducer sets its `.value`
+      # property, but the value ATTRIBUTE stays "" — the exact field
+      # have_field(with:) can't see and have_reactive_value must (via the property).
+      input(**reactive_field(:total_ro, value: "", type: "number", disabled: true, data: { testid: "total-ro" }))
     end
   end
 end

--- a/spec/dummy/public/vendor/compute_seed_reducer.js
+++ b/spec/dummy/public/vendor/compute_seed_reducer.js
@@ -9,6 +9,8 @@ import { setComputeReducer } from "phlex/reactive/compute"
 export function registerComputeSeed() {
   setComputeReducer("sums", ({ a, b }) => {
     const total = Number(a) + Number(b)
-    return { total, half: total / 2, total_label: `${total}` }
+    // total_ro (issue #204) mirrors total onto a DISABLED field — proves the
+    // property write reaches a disabled output the value attribute never shows.
+    return { total, half: total / 2, total_ro: total, total_label: `${total}` }
   })
 }

--- a/spec/phlex/reactive/test_helpers_system_spec.rb
+++ b/spec/phlex/reactive/test_helpers_system_spec.rb
@@ -56,4 +56,51 @@ RSpec.describe Phlex::Reactive::TestHelpers::System do
       expect(helper.wait_option(5)).to eq(wait: 5)
     end
   end
+
+  # The property matcher (issue #204) in isolation — a fake page returns scripted
+  # evaluate_script results, so the polling / normalization / message logic is
+  # covered with no browser. The matcher reads the field's live `.value` PROPERTY,
+  # which is what a reducer sets on a disabled/computed output.
+  describe described_class::ReactiveValueMatcher do
+    # A page whose evaluate_script yields the NEXT scripted value each call, the
+    # last repeating — so a test can model "blank, blank, then settles to 6".
+    def fake_page(*values)
+      queue = values.dup
+      Object.new.tap do |o|
+        # rubocop:disable Style/ItBlockParameter -- a stub method body, not an it-example
+        o.define_singleton_method(:evaluate_script) { |*| queue.length > 1 ? queue.shift : queue.first }
+        # rubocop:enable Style/ItBlockParameter
+      end
+    end
+
+    it "matches once the .value property settles to the expected string" do
+      matcher = described_class.new("total_ro", "6", wait: 1)
+      expect(matcher.matches?(fake_page(nil, nil, "6"))).to be(true)
+    end
+
+    it "stringifies a numeric expectation (a DOM .value is always a JS string)" do
+      matcher = described_class.new("total", 6, wait: 1)
+      expect(matcher.matches?(fake_page("6"))).to be(true)
+    end
+
+    it "normalizes a non-String result (Playwright's {} for a JS null) to 'not settled'" do
+      # A missing field yields {} under Playwright; it must never equal the
+      # expected String, so matches? fails within the (tiny) budget rather than
+      # comparing a Hash to '6'.
+      matcher = described_class.new("nope", "6", wait: 0)
+      expect(matcher.matches?(fake_page({}))).to be(false)
+    end
+
+    it "does_not_match? holds as soon as the property differs (or the field is absent)" do
+      matcher = described_class.new("total_ro", "999", wait: 0)
+      expect(matcher.does_not_match?(fake_page("6"))).to be(true)
+      expect(matcher.does_not_match?(fake_page({}))).to be(true) # absent → nil ≠ "999"
+    end
+
+    it "reports the settled value in its failure message" do
+      matcher = described_class.new("total_ro", "6", wait: 0)
+      matcher.matches?(fake_page("5"))
+      expect(matcher.failure_message).to include("total_ro", '"6"', '"5"')
+    end
+  end
 end

--- a/spec/system/reactive_value_property_spec.rb
+++ b/spec/system/reactive_value_property_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+# have_reactive_value must read the field's live `.value` PROPERTY, not the value
+# ATTRIBUTE (issue #204). A reactive_compute reducer paints a computed output by
+# setting `el.value = …` (the property); for a DISABLED / read-only output the
+# value attribute never reflects that, so the attribute-based have_field(with:)
+# reads "" and fails. The property read covers enabled AND disabled fields — the
+# exact case the matcher was built for.
+#
+# Waiting matchers are the barrier for every async hop — never a snapshot right
+# after a click.
+RSpec.describe "have_reactive_value reads the .value property (issue #204)", type: :system do
+  it "verifies a DISABLED reducer-set output (the attribute stays blank; the property holds the value)" do
+    visit "/compute_seed"
+
+    # total_ro is disabled and seeded blank; the connect-time compute sets its
+    # `.value` PROPERTY to the total (2 + 4 = 6). have_reactive_value reads the
+    # property, so it settles on "6" — where have_field(with:) would read the
+    # empty attribute and fail.
+    expect(page).to have_reactive_value("total_ro", "6")
+
+    # Prove the field really is disabled AND its value ATTRIBUTE is still blank —
+    # so this assertion could ONLY have passed by reading the property. The field
+    # has a `name` (reactive_field emits name, not id), so resolve by name.
+    expect(page).to have_field("total_ro", disabled: true)
+    expect(page.evaluate_script("document.getElementsByName('total_ro')[0].getAttribute('value')")).to eq("")
+    expect(page.evaluate_script("document.getElementsByName('total_ro')[0].value")).to eq("6")
+  end
+
+  it "still verifies an ENABLED reducer-set output (backwards compatible)" do
+    visit "/compute_seed"
+
+    expect(page).to have_reactive_value("total", "6")
+    expect(page).to have_reactive_value("half", "3")
+  end
+
+  it "supports negation — a wrong expected value does not match" do
+    visit "/compute_seed"
+    # Wait for the layer to settle first, then the negated assertion is stable.
+    wait_for_reactive
+    expect(page).not_to have_reactive_value("total_ro", "999")
+  end
+end


### PR DESCRIPTION
Closes #204.

## The bug

`have_reactive_value(id, value)` (added in #201) delegated to Capybara's `have_field(id, with: value)`, which matches against the field's value **attribute**. But a `reactive_compute` reducer paints a computed output by setting its JS `.value` **property** (`field.value = result[name]` at `reactive_controller.js:1599`) — and for a **disabled / read-only** output the value attribute never reflects that. So the matcher read `""` and failed on exactly the fields it was meant to cover (a computed total/remainder the reducer paints into a disabled input).

## The fix

`have_reactive_value` is now a small waiting matcher (`ReactiveValueMatcher`) that, on every poll:

- re-resolves the field **by id OR name** (`getElementById(k) || getElementsByName(k)[0]`), and
- reads its live **`.value` property** via `evaluate_script`,

until the property equals the expected value or the wait budget elapses. It covers enabled **and** disabled/computed fields, keeps the morph-immunity (re-resolves each cycle), stringifies a numeric expectation (a DOM `.value` is always a JS string), and supports negation (`not_to`) + a `timeout:`/`wait:` override.

`have_reactive_text` (textContent) was unaffected. **No client/runtime change** — the gem's `reactive_controller.js` is untouched, so the JS suite and the vendored-controller-sync guard are unaffected.

## Test plan

| Layer | File | Proves |
|---|---|---|
| System | `spec/system/reactive_value_property_spec.rb` | a **disabled** reducer-set output (`total_ro`): value **attribute** stays `""`, the `.value` **property** holds `"6"`, and `have_reactive_value` settles on it. Enabled fields still verify (backwards compatible). Negation. |
| Ruby unit | `spec/phlex/reactive/test_helpers_system_spec.rb` | `ReactiveValueMatcher` in isolation with a fake page (no browser): eventual settle, numeric→string, Playwright's `{}`-for-null normalized to "not settled", negation, failure message. |
| Dummy | `compute_seed_component.rb` + `compute_seed_reducer.js` | a disabled `total_ro` output + one reducer key reproduce the exact shape. |

Verification (same machine):

- `bundle exec rubocop` — clean (248 files)
- `bundle exec rspec spec/phlex spec/requests` — 1176 passed
- `bundle exec rspec spec/system` — 85 passed (Puma); `#204` + `compute_seed` green under `CAPYBARA_SERVER=falcon`
- `bun test spec/javascript` — 448 passed (gem client unchanged)

RED was confirmed before the fix: `have_reactive_value("total_ro", "6")` on the disabled field failed with the old attribute-based matcher ("found '', which matched the selector but not with the given value").

## Deviations & judgment calls

- **`reactive_field(:name)` emits `name="…"`, NOT a DOM `id`.** The fields `have_reactive_value` is meant to assert have a **name**, not an id — even though the issue (and the #201 docstring) said "by id" and showed `getElementById`. The old `have_field("total", with:)` worked precisely because `have_field` matches by id OR name OR label. A `getElementById`-only property read finds `null` for a name-only field. So the matcher resolves by **id OR name**, mirroring `have_field` — not id alone. (Discovered mid-implementation; the first RED run read `null` until I fixed the resolver.)

- **Playwright's `evaluate_script` returns `{}` (an empty Hash) for a JS `null`/`undefined`.** So "field absent" is `{}`, not `nil`. The matcher normalizes any non-String result to `nil` ("not settled yet") and keeps polling, rather than comparing a Hash to the expected String. Unit-covered.

- **Repro shape: a NEW `total_ro` disabled twin, not making the existing `half` disabled.** Making `half` disabled would entangle the #201 `compute_seed`/activity specs (they assert `have_reactive_value("half", "3")`) — it would break under the old matcher and pass under the new one, muddying which spec proves what. A dedicated disabled `total_ro` output (one new reducer key + one disabled field) isolates the #204 repro.

- **The property read is UNCONDITIONAL, not an opt-in `property: true`.** The issue offered an opt-in as a fallback; the property is what the field actually holds for **both** enabled and disabled fields (a user-typed value lands in the property too), so reading it is strictly more correct and needs no new keyword. Backwards compatible — the #201 enabled-field assertions still pass.
