### PR TITLE
feat(docs): Project board — the kanban flagship demo (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Project board — the kanban flagship demo (#216).** A live three-lane board
+  on the docs site (`/docs/example-project-board`, `/demos/project-board`)
+  composing the toolkit end to end: each card is its own nested reactive root
+  (record + signed style state) whose move is ONE reply — the row's remove
+  (its exit effect animates before the element leaves), a fresh-token append
+  into the new lane (wearing its enter effect), and a `reactive:js` text-op
+  stream repainting all three count badges — with the same delta broadcast to
+  peers, actor echo excluded. Inline rename morphs in place, archive is
+  confirm-gated + optimistic, per-lane composers flash on a blank title, and
+  the effect-style picker (including `random`) rides signed state to drive
+  per-call `effect:` overrides. Peer count badges stay live everywhere via
+  `broadcast_to(js:)` — closing the stale-badge gap the team-inbox flagship
+  documents — and empty lanes are pure CSS `:empty`, so the 0↔1 boundary
+  needs no bookkeeping on either delivery path. Docs-app only; no gem code
+  changes.
+
 - **Reactive effects — animate enter/exit/update on every stream render (#215).**
   Opt-in at three levels, most specific wins: `Phlex::Reactive.effects = true`
   (or a `{ enter:/exit:/update: }` hash) is the global switch AND the app-wide

--- a/README.md
+++ b/README.md
@@ -332,11 +332,13 @@ The [inline edit example](https://phlex-reactive.zoolutions.llc/docs/example-inl
 | [Client-only ops](https://phlex-reactive.zoolutions.llc/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS |
 | [Failure surface](https://phlex-reactive.zoolutions.llc/docs/example-failure) | `error_flash` + `data-reactive-error` + `dismiss_after:` — what you get for free when an action fails |
 | [Team inbox (flagship)](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox) | The whole toolkit in one UI: collection rows, optimistic archive that **reverts on failure**, cross-tab broadcast, an `on_client` kebab, error flashes |
+| [Project board (flagship)](https://phlex-reactive.zoolutions.llc/docs/example-project-board) | The kanban: cards move across lanes with **enter/exit effects** (per-visitor style picker incl. `random`), live count badges in every tab via `broadcast_to(js:)`, nested reactive rows with inline rename, confirm-gated archive |
 
 Every page renders its **real** reactive component inline (source read straight
 off the file), so the demo and the code can never drift. The
-[Team inbox](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox) is the
-flagship — every feature composed into one believable UI.
+[Team inbox](https://phlex-reactive.zoolutions.llc/docs/example-team-inbox) and the
+[Project board](https://phlex-reactive.zoolutions.llc/docs/example-project-board) are the
+flagships — every feature composed into believable UIs.
 
 ---
 

--- a/docs/.rubocop.yml
+++ b/docs/.rubocop.yml
@@ -66,6 +66,9 @@ Metrics/ClassLength:
   - app/views/**/*
   - app/components/**/*
   - app/reactive_components/**/*
+  # The demo registry is a data literal that grows with every demo entry —
+  # length here is content, not complexity.
+  - app/models/demo.rb
 Metrics/CyclomaticComplexity:
   Exclude:
   - app/views/**/*

--- a/docs/app/models/card.rb
+++ b/docs/app/models/card.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# A card on the Project board demo (issue #216). Lives in exactly one of the
+# three fixed lanes; position orders it within its lane (moves append at the
+# bottom). One shared public board — every visitor plays on the same cards,
+# which is what makes the cross-tab story visible between strangers.
+class Card < ApplicationRecord
+  LANES = %w[todo doing done].freeze
+
+  validates :title, presence: true
+  validates :lane, inclusion: { in: LANES }
+
+  scope :by_lane, ->(lane) { where(lane:).order(:position, :id) }
+
+  # The board's broadcast topic — the SAME splat feeds turbo_stream_from
+  # (subscribe) and broadcast_to (publish), so the key can never drift.
+  def self.stream_key = %w[project-board all]
+
+  # New/moved cards land at the bottom of their lane.
+  def self.next_position(lane)
+    (by_lane(lane).maximum(:position) || 0) + 1
+  end
+end

--- a/docs/app/models/demo.rb
+++ b/docs/app/models/demo.rb
@@ -89,6 +89,23 @@ class Demo
         # change broadcasts to teammates' tabs; the row kebab is a pure client op:
         render TeamInboxComponent.new
       RUBY
+    },
+    {
+      slug: 'project-board',
+      title: 'Project board',
+      group: 'Records',
+      blurb: 'The kanban flagship — cards move across lanes with enter/exit effects, ' \
+             'live in every open tab, with inline rename, confirm-gated archive, and ' \
+             'a per-visitor effect-style picker.',
+      component: 'ProjectBoardComponent',
+      build: -> { ProjectBoardComponent.new },
+      call_site: <<~RUBY
+        # One shared board, three lanes. A move is one reply: the row's remove
+        # (its exit animates before the element leaves), the append into the new
+        # lane, and a reactive:js repaint of every count badge — broadcast to
+        # peers with the actor's echo excluded:
+        render ProjectBoardComponent.new
+      RUBY
     }
   ].freeze
 

--- a/docs/app/models/doc.rb
+++ b/docs/app/models/doc.rb
@@ -42,7 +42,9 @@ class Doc
     { slug: 'example-failure', title: 'Failure surface', group: 'Examples',
       view: 'ExampleFailure' },
     { slug: 'example-team-inbox', title: 'Team inbox (flagship)', group: 'Examples',
-      view: 'ExampleTeamInbox' }
+      view: 'ExampleTeamInbox' },
+    { slug: 'example-project-board', title: 'Project board (flagship)', group: 'Examples',
+      view: 'ExampleProjectBoard' }
   ].freeze
 
   attr_reader :slug, :title, :group, :view_name

--- a/docs/app/models/docs_nav.rb
+++ b/docs/app/models/docs_nav.rb
@@ -11,7 +11,8 @@ module DocsNav
     'payment-split' => 'scale',
     'todos' => 'list-checks',
     'chat' => 'messages-square',
-    'team-inbox' => 'inbox'
+    'team-inbox' => 'inbox',
+    'project-board' => 'columns-3'
   }.freeze
 
   # A lucide icon per doc group.

--- a/docs/app/reactive_components/board_card_component.rb
+++ b/docs/app/reactive_components/board_card_component.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# One card on the Project board (issue #216) — its OWN reactive root nested
+# inside the board (issue #15), because it carries a rename input: a tokenless
+# row would feed every card's `title` into the BOARD's root-wide field sweep
+# (last one wins). Identity is the Card's GlobalID PLUS the picked effect
+# style as signed state (the inline-edit record+state pattern), so a move
+# animates with the style THIS visitor chose.
+#
+# The move is the money shot: ONE reply carries the row's own remove (exit
+# animates before the element leaves), the fresh-token append into the new
+# lane, and a reactive:js text-op stream repainting all three count badges —
+# and the same delta broadcasts to peers with the actor's echo excluded.
+class BoardCardComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+
+  reactive_record :card
+  reactive_state :style
+
+  # Effects (issue #215): the board's default polish, declared on the ROW so
+  # the arriving append template carries the enter attr and the in-DOM row the
+  # exit/update attrs. A non-default picked style overrides these PER CALL —
+  # the three-level precedence, demoed live.
+  reactive_effects enter: :slide, exit: :fade, update: :highlight
+
+  action :move, params: { to: :string }
+  action :rename, params: { title: :string }
+  action :archive
+
+  def initialize(card:, style: 'default')
+    @card = card
+    @style = ProjectBoardComponent::STYLES.include?(style) ? style : 'default'
+  end
+
+  # Move to an adjacent lane: remove HERE + append THERE + repaint the count
+  # badges, all in one reply; peers get the same three streams broadcast.
+  def move(to:)
+    return reply.morph unless Card::LANES.include?(to) && to != @card.lane
+
+    @card.update!(lane: to, position: Card.next_position(to))
+    broadcast_move
+    reply.remove(effect: picked_effect)
+         .stream(self.class.append(target: ProjectBoardComponent.lane_target(to), model: @card,
+                                   style: @style, effect: picked_effect))
+         .js(ProjectBoardComponent.count_ops)
+  end
+
+  # Enter-to-save inline rename; the morph keeps the input's focus + caret.
+  def rename(title:)
+    @card.update!(title: title.strip) if title.to_s.strip.present?
+    self.class.broadcast_to(*Card.stream_key, replace: @card, morph: true,
+                                              exclude: reactive_connection_id)
+    reply.morph
+  end
+
+  def archive
+    @card.destroy!
+    self.class.broadcast_to(*Card.stream_key, remove: @card, exclude: reactive_connection_id)
+    ProjectBoardComponent.broadcast_counts(exclude: reactive_connection_id)
+    reply.remove
+         .js(ProjectBoardComponent.count_ops)
+         .flash(:notice, 'Card archived', dismiss_after: 2000)
+  end
+
+  def view_template
+    li(**reactive_root(class: 'flex flex-col gap-1 rounded-field border border-base-300 bg-base-100 p-3 shadow-sm',
+                       data: { testid: 'board-card', lane: @card.lane })) do
+      title_row
+      actions_row
+    end
+  end
+
+  private
+
+  def title_row
+    div(class: 'flex items-center gap-2') do
+      input(**mix(on(:rename, event: 'keydown.enter'),
+                  name: 'title', value: @card.title, autocomplete: 'off',
+                  class: 'input input-ghost input-sm flex-1 font-medium',
+                  data: { testid: 'card-title' }))
+      # Archive is confirm-gated AND optimistic: the row hides the instant you
+      # confirm (to: targets THIS row — :root inside a nested root is the row
+      # anyway, but the explicit id keeps the intent obvious).
+      button(**mix(on(:archive, confirm: 'Archive this card?',
+                                optimistic: { hide: true, to: "##{id}" }),
+                   class: 'btn btn-ghost btn-xs text-error', data: { testid: 'archive-card' })) { '×' }
+    end
+  end
+
+  # Lane moves — deliberately NOT optimistic: the exit/enter animations ARE the
+  # actor's feedback (an optimistic hide would hide the exit effect). busy:
+  # dedupes a double click instead.
+  def actions_row
+    idx = Card::LANES.index(@card.lane)
+    div(class: 'flex items-center justify-between text-xs') do
+      move_button(Card::LANES[idx - 1], '←') if idx.positive?
+      span(class: 'flex-1')
+      move_button(Card::LANES[idx + 1], '→') if idx < Card::LANES.size - 1
+    end
+  end
+
+  def move_button(to, glyph)
+    button(**mix(on(:move, to:, busy: '…'),
+                 class: 'btn btn-ghost btn-xs opacity-70', data: { testid: "move-#{to}" })) do
+      "#{glyph} #{to}"
+    end
+  end
+
+  # 'default' defers to the class-declared effects; anything else overrides
+  # per call. 'random' rides through — the client picks a built-in per
+  # application.
+  def picked_effect
+    @style == 'default' ? nil : @style.to_sym
+  end
+
+  def broadcast_move
+    # Peers see the row leave + arrive with the ROW-DECLARED effects (the
+    # picked style is the actor's preference, not the room's).
+    self.class.broadcast_to(*Card.stream_key, remove: @card, exclude: reactive_connection_id)
+    self.class.broadcast_to(*Card.stream_key, append: @card,
+                                              target: ProjectBoardComponent.lane_target(@card.lane),
+                                              exclude: reactive_connection_id)
+    ProjectBoardComponent.broadcast_counts(exclude: reactive_connection_id)
+  end
+end

--- a/docs/app/reactive_components/project_board_component.rb
+++ b/docs/app/reactive_components/project_board_component.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# The Project board (issue #216) — the kanban flagship. Three fixed lanes on
+# ONE shared public board; each card is its own nested reactive root (see
+# BoardCardComponent) owning move/rename/archive, while the board owns the
+# per-lane composers and the effect-style picker (signed state, threaded into
+# every row so per-call effects use the visitor's pick).
+#
+# Count badges are kept live EVERYWHERE via reactive:js text ops — the actor's
+# reply chains them (reply.js) and every mutation broadcasts them — closing
+# the gap where a peer tab's badges go stale after a row broadcast. Empty
+# lanes are pure CSS (the lane list's :empty pseudo shows the placeholder), so
+# the 0↔1 boundary needs no bookkeeping on either path.
+class ProjectBoardComponent < Phlex::HTML
+  include Phlex::Reactive::Streamable
+  include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::TurboStreamFrom
+
+  STYLES = %w[default fade slide scale highlight shake random].freeze
+  LANE_TITLES = { 'todo' => 'To do', 'doing' => 'Doing', 'done' => 'Done' }.freeze
+
+  # The lane list's :empty placeholder — rendered by CSS the moment the last
+  # card leaves, restored the moment one arrives; no server bookkeeping.
+  EMPTY_LANE_CSS = "empty:before:content-['No_cards_yet'] empty:before:block " \
+                   'empty:before:rounded-field empty:before:border empty:before:border-dashed ' \
+                   'empty:before:border-base-300 empty:before:py-4 empty:before:text-center ' \
+                   'empty:before:text-xs empty:before:opacity-50'
+
+  reactive_state :style
+
+  # Composer inputs are named PER LANE (title_todo/…): the client's field
+  # sweep is root-wide, so three same-named inputs would collide (last wins);
+  # the lane param picks the right one out of the declared trio.
+  action :add_card, params: { title_todo: :string, title_doing: :string, title_done: :string, lane: :string }
+  action :set_style, params: { style: :string }
+
+  def initialize(style: 'default')
+    @style = STYLES.include?(style) ? style : 'default'
+  end
+
+  def id = 'project-board'
+
+  class << self
+    def lane_target(lane) = "lane-#{lane}-cards"
+
+    # One js chain repainting all three count badges from server truth —
+    # chained onto the actor's reply AND broadcast to peers after every
+    # mutation, so no tab's badges ever go stale.
+    def count_ops
+      Card::LANES.reduce(Phlex::Reactive::JS.new) do |chain, lane|
+        chain.text("#lane-#{lane}-count", Card.by_lane(lane).count)
+      end
+    end
+
+    def broadcast_counts(exclude:)
+      broadcast_to(*Card.stream_key, js: count_ops, exclude:)
+    end
+  end
+
+  # Add into the named lane. The full-board re-render (the todo-list
+  # precedent) clears the composer and repaints counts in one go; peers get
+  # the row append + the count sync.
+  def add_card(lane:, title_todo: '', title_doing: '', title_done: '')
+    return reply.replace unless Card::LANES.include?(lane)
+
+    title = { 'todo' => title_todo, 'doing' => title_doing, 'done' => title_done }.fetch(lane).to_s.strip
+    return reply.replace.flash(:error, 'A card needs a title', dismiss_after: 2500) if title.blank?
+
+    card = Card.create!(title:, lane:, position: Card.next_position(lane))
+    BoardCardComponent.broadcast_to(*Card.stream_key, append: card,
+                                                      target: self.class.lane_target(lane),
+                                                      exclude: reactive_connection_id)
+    self.class.broadcast_counts(exclude: reactive_connection_id)
+    reply.replace
+  end
+
+  # The effect-style picker: whitelisted, signed into state, and threaded into
+  # every row on the re-render so subsequent moves animate with the pick.
+  def set_style(style:)
+    @style = style if STYLES.include?(style)
+    reply.replace
+  end
+
+  def view_template
+    div(**reactive_root(class: 'flex flex-col gap-4', data: { testid: 'project-board' })) do
+      turbo_stream_from(*Card.stream_key) # cross-tab sync
+      # The flash landing zone (Phlex::Reactive.flash_target default) — the
+      # archive toast and the blank-title error append here.
+      div(id: 'flash', class: 'flex flex-col gap-1', data: { testid: 'flash' })
+      header_row
+      div(class: 'grid gap-4 sm:grid-cols-3') do
+        Card::LANES.each { |lane| lane_column(lane) }
+      end
+    end
+  end
+
+  private
+
+  def header_row
+    div(class: 'flex flex-wrap items-center justify-between gap-2') do
+      span(class: 'text-sm opacity-70') { 'Move a card and watch it animate — in every open tab.' }
+      style_picker
+    end
+  end
+
+  def style_picker
+    div(class: 'join', data: { testid: 'style-picker' }) do
+      STYLES.each do |name|
+        button(**mix(on(:set_style, style: name),
+                     class: "join-item btn btn-xs #{'btn-active' if name == @style}",
+                     data: { testid: "style-#{name}" })) { name }
+      end
+    end
+  end
+
+  def lane_column(lane)
+    div(class: 'flex flex-col gap-3 rounded-box border border-base-300 bg-base-200/50 p-3',
+        data: { testid: "lane-#{lane}" }) do
+      div(class: 'flex items-center justify-between') do
+        h3(class: 'text-sm font-semibold') { LANE_TITLES.fetch(lane) }
+        span(id: "lane-#{lane}-count", class: 'badge badge-sm', data: { testid: "count-#{lane}" }) do
+          Card.by_lane(lane).count.to_s
+        end
+      end
+      ul(id: self.class.lane_target(lane), class: "flex flex-col gap-2 #{EMPTY_LANE_CSS}") do
+        Card.by_lane(lane).each { |card| render BoardCardComponent.new(card:, style: @style) }
+      end
+      composer(lane)
+    end
+  end
+
+  def composer(lane)
+    div(class: 'flex gap-2') do
+      input(**mix(on(:add_card, lane:, event: 'keydown.enter'),
+                  name: "title_#{lane}", placeholder: 'Add a card…', autocomplete: 'off',
+                  class: 'input input-sm input-bordered min-w-0 flex-1',
+                  data: { testid: "new-card-#{lane}" }))
+      button(**mix(on(:add_card, lane:, busy: '…'),
+                   class: 'btn btn-sm btn-primary', data: { testid: "add-#{lane}" })) { 'Add' }
+    end
+  end
+end

--- a/docs/app/views/docs/pages/example_project_board.rb
+++ b/docs/app/views/docs/pages/example_project_board.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+module Views
+  module Docs
+    module Pages
+      class ExampleProjectBoard < DocsUI::Page
+        title 'Example: Project board (the kanban flagship)'
+        eyebrow 'Examples'
+        description 'Build a live kanban board in reactive Phlex: cards move across lanes with ' \
+                    'enter/exit effects, live count badges in every open tab, inline rename, and ' \
+                    'a confirm-gated archive.'
+
+        def lead
+          'One shared board, three lanes. A move is one reply — the row animates out of its lane, ' \
+            'into the next, and every count badge repaints — live in every open tab, with no ' \
+            'Stimulus controller and no hand-picked Turbo target.'
+        end
+
+        def content
+          try_it
+          whats_here
+          the_move
+          the_row
+          live_counts
+          notes
+        end
+
+        private
+
+        def try_it
+          DocsUI::Section('Try it') do
+            md <<~MD
+              A real kanban. Move a card with **← →** and watch it animate out of
+              one lane and into the next (pick a style — `random` is the fun one).
+              Rename a card inline and press **Enter** — the morph keeps your caret.
+              **×** archives through a confirm gate and hides the card optimistically.
+              Open this page in a second tab: every move, add, rename, and archive
+              arrives there live, count badges included.
+            MD
+            render Views::Examples::LatencyToggle.new(delay_ms: 700)
+            render Views::Examples::LiveExample.new(
+              component: ProjectBoardComponent.new,
+              filename: 'app/components/project_board_component.rb'
+            )
+          end
+        end
+
+        def whats_here
+          DocsUI::Section('Every feature, in one board') do
+            md <<~MD
+              | Feature | Where |
+              |---|---|
+              | **Effects** — declared enter/exit/update on the row, per-call override from the style picker | the move / the picker |
+              | **Nested reactive roots** — each card is its own root inside the board (its rename input stays its own) | the row |
+              | **Record + state identity** — the card's GlobalID AND the picked style in one signed token | the row |
+              | **`reply.remove(...).stream(...).js(...)`** — one reply moves the card and repaints every badge | `move` |
+              | **Live peer counts** — `broadcast_to(js:)` text ops keep every tab's badges honest | every mutation |
+              | **Inline rename + morph** — Enter saves; focus and caret survive | the row |
+              | **`confirm:` + optimistic hide** — archive gates, then hides in the same gesture | the row |
+              | **Per-lane composers** — `busy:` dedupes, a blank title gets an error flash | the board |
+              | **CSS `:empty` lanes** — the placeholder needs zero bookkeeping on either path | the lane list |
+            MD
+          end
+        end
+
+        def the_move
+          DocsUI::Section('The move — one reply, three streams') do
+            md <<~MD
+              A move is the whole mental model in one action: the row removes
+              itself (its **exit effect runs before the element leaves**), a
+              fresh-token render appends into the new lane (wearing its **enter
+              effect**), and a `reactive:js` text-op stream repaints all three
+              count badges from server truth. The same delta broadcasts to peers
+              with the actor's echo excluded:
+
+              ```ruby
+              def move(to:)
+                return reply.morph unless Card::LANES.include?(to) && to != @card.lane
+
+                @card.update!(lane: to, position: Card.next_position(to))
+                broadcast_move
+                reply.remove(effect: picked_effect)
+                     .stream(self.class.append(target: ProjectBoardComponent.lane_target(to),
+                                               model: @card, style: @style, effect: picked_effect))
+                     .js(ProjectBoardComponent.count_ops)
+              end
+              ```
+
+              `picked_effect` is the style picker's choice, signed into the row's
+              own state — `default` defers to the row's declared effects, anything
+              else overrides **per call** (the issue #215 three-level precedence,
+              live).
+            MD
+          end
+        end
+
+        def the_row
+          DocsUI::Section('Why each card is its own reactive root') do
+            md <<~MD
+              The card carries a rename `<input name="title">`. Field collection
+              is **root-wide**, so if the rows were tokenless (the team-inbox
+              pattern) every card's title would land in the board's sweep and the
+              last one would win. Making each card a **nested reactive root**
+              (issue #15) gives every row its own field scope, its own signed
+              identity — the Card's GlobalID plus the picked style — and its own
+              `move`/`rename`/`archive` actions. The board keeps only what is
+              genuinely board-level: the composers and the style picker.
+            MD
+          end
+        end
+
+        def live_counts
+          DocsUI::Section('Live counts in every tab') do
+            md <<~'MD'
+              Row broadcasts alone leave a peer's count badges stale — the
+              collection bookkeeping in a reply is the **actor's** HTTP response.
+              The board closes that gap with one `reactive:js` chain repainting
+              all three badges from server truth, chained onto the actor's reply
+              (`reply.js`) AND broadcast to peers after every mutation:
+
+              ```ruby
+              def self.count_ops
+                Card::LANES.reduce(Phlex::Reactive::JS.new) do |chain, lane|
+                  chain.text("#lane-#{lane}-count", Card.by_lane(lane).count)
+                end
+              end
+
+              def self.broadcast_counts(exclude:)
+                broadcast_to(*Card.stream_key, js: count_ops, exclude:)
+              end
+              ```
+
+              Empty lanes need no bookkeeping at all: the lane list styles its
+              own `:empty` pseudo-class, so the placeholder appears the moment
+              the last card leaves — on the actor's reply and the peer's
+              broadcast alike.
+            MD
+          end
+        end
+
+        def notes
+          DocsUI::Section('Notes') do
+            md <<~MD
+              - The board is **one shared instance** for every visitor — that's
+                what makes the second-tab story visible between strangers. Seeds
+                restore a starting set on boot.
+              - Moves are deliberately **not optimistic**: the exit/enter
+                animations are the actor's feedback, and an optimistic hide would
+                hide them. `busy: '…'` dedupes a double-click instead. Archive IS
+                optimistic — the confirm gate already slowed it down.
+              - Cross-tab delivery runs on whatever transport the app has —
+                Action Cable here, [pgbus](/docs/transport-pgbus) in production —
+                the component code is identical.
+              - The composer inputs are named per lane (`title_todo`, …): the
+                client's field sweep is root-wide, and three same-named inputs
+                would collide.
+            MD
+          end
+        end
+      end
+    end
+  end
+end

--- a/docs/app/views/docs/pages/examples_overview.rb
+++ b/docs/app/views/docs/pages/examples_overview.rb
@@ -25,7 +25,8 @@ module Views
               Each page below renders its **real** reactive component inline — click
               it, it round-trips. They build from the smallest reactive component up
               to record-backed actions, live broadcasts, declared-once collections,
-              and the flagship inbox that composes everything.
+              and the two flagships — the inbox and the kanban board — that compose
+              everything.
 
               | Example | What it shows |
               |---|---|
@@ -41,6 +42,7 @@ module Views
               | [Client-only ops](/docs/example-client-ops) | `on_client` tabs / outside-close menu / accessible drawer — zero fetches, zero custom JS. |
               | [Failure surface](/docs/example-failure) | `error_flash` + `data-reactive-error` + `dismiss_after:` — what an adopter gets for free when an action fails. |
               | [Team inbox (flagship)](/docs/example-team-inbox) | The whole toolkit in one UI: collection rows, optimistic archive that **reverts on failure**, cross-tab broadcast, an `on_client` kebab, and error flashes. |
+              | [Project board (flagship)](/docs/example-project-board) | The kanban: cards move across lanes with **enter/exit effects** (per-visitor style picker incl. `random`), live count badges in every tab via `broadcast_to(js:)`, nested reactive rows with inline rename, confirm-gated archive. |
 
               **Every headline feature now has a live page.** Pick a capability:
 
@@ -53,7 +55,8 @@ module Views
               | **Optimistic visual hints** — `optimistic:` (flip a checkbox / hide a row instantly; revert on failure) | [Todo list](/docs/example-todo-list), [Collections](/docs/example-collections), [Team inbox](/docs/example-team-inbox) |
               | **Keyboard triggers** — `event: "keydown.enter"` / `"keydown.esc"` (Enter-to-add, Escape-to-cancel) | [Todo list](/docs/example-todo-list), [Inline edit](/docs/example-inline-edit) |
               | **Debounced / morph editing** — `debounce:` live-as-you-type + `reply.morph` to keep the caret | [Payment split](/docs/example-payment-split), [Inline edit](/docs/example-inline-edit) |
-              | **Live broadcasts** — `broadcast_to(replace:)` / `broadcast_to(append:)` / `broadcast_to(js:)` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox) |
+              | **Effects** — `reactive_effects` enter/exit/update + per-call `effect:` (incl. `random`) — see the [Effects guide](/docs/effects) | [Project board](/docs/example-project-board) |
+              | **Live broadcasts** — `broadcast_to(replace:)` / `broadcast_to(append:)` / `broadcast_to(js:)` → cross-tab sync | [Chat](/docs/example-chat), [Notifications](/docs/example-notifications), [Todo list](/docs/example-todo-list), [Team inbox](/docs/example-team-inbox), [Project board](/docs/example-project-board) |
               | **Failure surface** — `error_flash` / `data-reactive-error` / `dismiss_after:` / timeout + offline | [Failure surface](/docs/example-failure), [Team inbox](/docs/example-team-inbox) |
               | **Combobox keyboard navigation** — `reactive_listnav` (Arrow keys move a client highlight, Enter picks), composed via `mix` | [Searchable combobox demo](/demos/searchable-combobox) |
               | **File uploads & custom param types** — `:file` / `[:file]` (multipart `FormData`), `Phlex::Reactive.param_type` | [File uploads & custom types](/docs/example-uploads) (code-first) |

--- a/docs/db/migrate/20260709120000_create_cards.rb
+++ b/docs/db/migrate/20260709120000_create_cards.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCards < ActiveRecord::Migration[8.1]
+  def change
+    create_table :cards do |t|
+      t.string :title, null: false
+      t.string :lane, null: false, default: 'todo'
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/docs/db/schema.rb
+++ b/docs/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_210005) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_120000) do
+  create_table "cards", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "lane", default: "todo", null: false
+    t.integer "position", default: 0, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "chat_messages", force: :cascade do |t|
     t.string "author", default: "anon", null: false
     t.text "body", null: false

--- a/docs/db/seeds.rb
+++ b/docs/db/seeds.rb
@@ -29,3 +29,13 @@ if ChatMessage.where(room: 'lobby').none?
     { author: 'you', body: 'Send a message — it broadcasts with zero custom JS.' }
   ].each { |attrs| ChatMessage.create!(room: 'lobby', **attrs) }
 end
+
+if Card.none?
+  {
+    'todo' => ['Sketch the onboarding flow', 'Write the Q3 planning doc'],
+    'doing' => ['Ship the billing webhook'],
+    'done' => ['Fix the flaky signup spec']
+  }.each do |lane, titles|
+    titles.each_with_index { |title, i| Card.create!(title:, lane:, position: i + 1) }
+  end
+end

--- a/docs/spec/requests/project_board_spec.rb
+++ b/docs/spec/requests/project_board_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'turbo/broadcastable/test_helper'
+
+# The Project board flagship (issue #216): a kanban with three fixed lanes.
+# Each card is its OWN nested reactive root (record + signed style state); a
+# MOVE is the money shot — one reply carries the row's remove (exit animates
+# before the element leaves), the append into the new lane, and a reactive:js
+# text-op stream repainting all three count badges — while the same delta
+# broadcasts to peers with the actor's echo excluded.
+RSpec.describe 'Project board actions', type: :request do
+  include ActiveSupport::Testing::Assertions
+  include Turbo::Broadcastable::TestHelper
+
+  before { Card.delete_all }
+
+  def card_payload(card, style: 'default') = { 'gid' => card.to_gid.to_s, 's' => { 'style' => style } }
+  def board_payload(style: 'default') = { 's' => { 'style' => style } }
+
+  describe 'the demo page' do
+    it 'renders three lanes with seeded cards and counts' do
+      Card.create!(title: 'Ship the board', lane: 'todo')
+      Card.create!(title: 'Review PR', lane: 'doing')
+
+      get '/demos/project-board'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('lane-todo-cards')
+      expect(response.body).to include('lane-doing-cards')
+      expect(response.body).to include('lane-done-cards')
+      expect(response.body).to include('Ship the board')
+      expect(response.body).to include('lane-todo-count')
+    end
+  end
+
+  describe 'BoardCardComponent#move' do
+    let!(:card) { Card.create!(title: 'Ship it', lane: 'todo') }
+
+    it 'moves the record and replies with remove + append-to-new-lane + the count repaint' do
+      post_action(BoardCardComponent, payload: card_payload(card), act: 'move', params: { to: 'doing' })
+
+      expect(response).to have_http_status(:ok)
+      expect(card.reload.lane).to eq('doing')
+      body = response.body
+      expect(body).to include('action="remove"')
+      expect(body).to include(%(action="append" target="lane-doing-cards"))
+      expect(body).to include('action="reactive:js"')
+      expect(body).to include('lane-todo-count')
+      expect(body).to include('lane-doing-count')
+    end
+
+    it 'stamps the picked style on the row streams (per-call effect override)' do
+      post_action(BoardCardComponent, payload: card_payload(card, style: 'scale'),
+                                      act: 'move', params: { to: 'doing' })
+
+      expect(response.body).to include('data-reactive-effect="scale"')
+    end
+
+    it 'leaves the row streams unstamped on the default style (the row declarations rule)' do
+      post_action(BoardCardComponent, payload: card_payload(card), act: 'move', params: { to: 'doing' })
+
+      expect(response.body).not_to include('data-reactive-effect=')
+    end
+
+    it 'rejects an unknown lane without moving anything' do
+      post_action(BoardCardComponent, payload: card_payload(card), act: 'move', params: { to: 'trash' })
+
+      expect(card.reload.lane).to eq('todo')
+    end
+
+    it 'broadcasts the move to peers: row remove + append AND the js count sync' do
+      broadcasts = capture_turbo_stream_broadcasts(Card.stream_key) do
+        post_action(BoardCardComponent, payload: card_payload(card), act: 'move', params: { to: 'doing' })
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+
+      expect(html).to include('action="remove"')
+      expect(html).to include(%(target="lane-doing-cards"))
+      expect(html).to include('action="reactive:js"')
+      expect(html).to include('lane-todo-count')
+    end
+  end
+
+  describe 'BoardCardComponent#rename' do
+    let!(:card) { Card.create!(title: 'Old title', lane: 'todo') }
+
+    it 'renames and morphs the row in place (focus survives)' do
+      post_action(BoardCardComponent, payload: card_payload(card), act: 'rename',
+                                      params: { title: 'New title' })
+
+      expect(card.reload.title).to eq('New title')
+      expect(response.body).to include('method="morph"')
+    end
+
+    it 'keeps the old title on a blank rename' do
+      post_action(BoardCardComponent, payload: card_payload(card), act: 'rename', params: { title: '   ' })
+
+      expect(card.reload.title).to eq('Old title')
+    end
+  end
+
+  describe 'BoardCardComponent#archive' do
+    let!(:card) { Card.create!(title: 'Done with this', lane: 'done') }
+
+    it 'destroys the card, removes the row, repaints counts, and confirms with a flash' do
+      expect do
+        post_action(BoardCardComponent, payload: card_payload(card), act: 'archive')
+      end.to change(Card, :count).by(-1)
+
+      expect(response.body).to include('action="remove"')
+      expect(response.body).to include('action="reactive:js"')
+      expect(response.body).to include('data-reactive-dismiss-after="2000"')
+    end
+  end
+
+  describe 'ProjectBoardComponent#add_card' do
+    # Composer inputs are named PER LANE (title_todo/…) — the client's field
+    # sweep is root-wide, so same-named inputs would collide; the lane param
+    # picks the right one.
+    it 'creates the card and re-renders the board (composer clears, counts fresh)' do
+      expect do
+        post_action(ProjectBoardComponent, payload: board_payload, act: 'add_card',
+                                           params: { title_todo: 'New card', lane: 'todo' })
+      end.to change(Card, :count).by(1)
+
+      expect(response.body).to include('New card')
+      expect(response.body).to include('action="replace"')
+    end
+
+    it 'rejects a blank title with an error flash, creating nothing' do
+      expect do
+        post_action(ProjectBoardComponent, payload: board_payload, act: 'add_card',
+                                           params: { title_todo: '   ', lane: 'todo' })
+      end.not_to change(Card, :count)
+
+      expect(response.body).to include('reactive-flash--error')
+    end
+
+    it 'refuses an unknown lane, creating nothing' do
+      expect do
+        post_action(ProjectBoardComponent, payload: board_payload, act: 'add_card',
+                                           params: { title_todo: 'Sneaky', lane: 'trash' })
+      end.not_to change(Card, :count)
+    end
+
+    it 'broadcasts the new row + count sync to peers' do
+      broadcasts = capture_turbo_stream_broadcasts(Card.stream_key) do
+        post_action(ProjectBoardComponent, payload: board_payload, act: 'add_card',
+                                           params: { title_doing: 'Broadcast me', lane: 'doing' })
+      end
+      html = broadcasts.map(&:to_s).join # rubocop:disable Style/MapJoin
+
+      expect(html).to include(%(target="lane-doing-cards"))
+      expect(html).to include('action="reactive:js"')
+    end
+  end
+
+  describe 'ProjectBoardComponent#set_style' do
+    it 'signs the whitelisted style into state and re-renders with it active' do
+      post_action(ProjectBoardComponent, payload: board_payload, act: 'set_style',
+                                         params: { style: 'shake' })
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('action="replace"')
+    end
+
+    it 'ignores an unknown style' do
+      post_action(ProjectBoardComponent, payload: board_payload, act: 'set_style',
+                                         params: { style: 'evil' })
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/docs/spec/system/project_board_spec.rb
+++ b/docs/spec/system/project_board_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'system_helper'
+
+# The Project board flagship (issue #216) in a real browser: menu-driven lane
+# moves with live count badges (reactive:js text ops), per-lane composers,
+# Enter-to-save inline rename (morph — the input survives), confirm-gated
+# archive, and the effect-style picker riding signed state. Cross-tab delivery
+# is asserted at the request level (broadcast specs) per the docs convention —
+# the demo site's cable adapter is in-process.
+RSpec.describe 'Project board', type: :system do
+  # System specs hit a real server on a separate DB connection — seed
+  # explicitly per example, never rely on transactional fixtures.
+  before { Card.delete_all }
+
+  def demo = first("[data-testid='live-example-demo']")
+
+  it 'moves a card across lanes with live counts, twice, without a reload' do
+    Card.create!(title: 'Ship the board', lane: 'todo', position: 1)
+    visit '/docs/example-project-board'
+    expect(page).to have_css("[data-testid='count-todo']", text: '1')
+
+    page.execute_script("window.__noReload = 'alive'")
+
+    within demo do
+      # The row carries the DECLARED effect attrs (issue #215) — static proof
+      # the effects wiring reached the DOM, no animation-timing race.
+      expect(page).to have_css("[data-testid='board-card'][data-reactive-effect-exit='fade']")
+
+      find("[data-testid='move-doing']").click
+      # The card's title lives in an input VALUE — assert via have_field
+      # scoped to the destination lane (text: can't see input values).
+      within "[data-testid='lane-doing']" do
+        expect(page).to have_field('title', with: 'Ship the board')
+      end
+      expect(page).to have_css("[data-testid='count-todo']", text: '0')
+      expect(page).to have_css("[data-testid='count-doing']", text: '1')
+
+      # A second move proves the appended row arrived with a FRESH token
+      # (the add-once-only regression class, cosmos#1939).
+      find("[data-testid='move-done']").click
+      within "[data-testid='lane-done']" do
+        expect(page).to have_field('title', with: 'Ship the board')
+      end
+      expect(page).to have_css("[data-testid='count-done']", text: '1')
+      expect(page).to have_css("[data-testid='count-doing']", text: '0')
+    end
+
+    expect(page.evaluate_script('window.__noReload')).to eq('alive')
+  end
+
+  it 'adds a card from a lane composer and flashes on a blank title' do
+    visit '/docs/example-project-board'
+
+    within demo do
+      find("[data-testid='new-card-doing']").fill_in(with: 'Write the docs page')
+      find("[data-testid='add-doing']").click
+      within "[data-testid='lane-doing']" do
+        expect(page).to have_field('title', with: 'Write the docs page')
+      end
+      expect(page).to have_css("[data-testid='count-doing']", text: '1')
+      # The board replace cleared the composer (the have_css above is the
+      # barrier — the fresh render has landed).
+      expect(find("[data-testid='new-card-doing']").value).to eq('')
+
+      find("[data-testid='add-todo']").click # blank title
+    end
+    expect(page).to have_css('#flash', text: 'A card needs a title')
+  end
+
+  it 'renames inline on Enter — the morph keeps the row in place' do
+    card = Card.create!(title: 'Old name', lane: 'todo', position: 1)
+    visit '/docs/example-project-board'
+
+    within demo do
+      input = find("[data-testid='card-title']")
+      input.fill_in(with: 'New name')
+      input.send_keys(:enter)
+      expect(page).to have_field('title', with: 'New name')
+    end
+    expect(Card.find(card.id).title).to eq('New name')
+  end
+
+  it 'archives through the confirm gate and repaints the count' do
+    Card.create!(title: 'Done with this', lane: 'done', position: 1)
+    visit '/docs/example-project-board'
+    expect(page).to have_css("[data-testid='count-done']", text: '1')
+
+    within demo do
+      accept_confirm { find("[data-testid='archive-card']").click }
+      expect(page).to have_no_css("[data-testid='board-card']")
+      expect(page).to have_css("[data-testid='count-done']", text: '0')
+    end
+    expect(page).to have_css('#flash', text: 'Card archived')
+  end
+
+  it 'keeps the picked effect style across round trips (signed state)' do
+    Card.create!(title: 'Style me', lane: 'todo', position: 1)
+    visit '/docs/example-project-board'
+
+    within demo do
+      find("[data-testid='style-scale']").click
+      expect(page).to have_css("[data-testid='style-scale'].btn-active")
+
+      # The pick survives the next action's round trip — it rides the signed
+      # state, not the DOM.
+      find("[data-testid='move-doing']").click
+      expect(page).to have_css("[data-testid='count-doing']", text: '1')
+      expect(page).to have_css("[data-testid='style-scale'].btn-active")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The **Project board** — the kanban flagship demo (issue #216). One shared three-lane board on the docs site (`/docs/example-project-board` + `/demos/project-board`) composing the toolkit end to end, dogfooding the #215 effects as its headline.

- **The move is the money shot** — one reply: the row's own remove (its **exit effect animates before the element leaves**), a fresh-token append into the new lane (wearing its **enter effect**), and a `reactive:js` text-op stream repainting all three count badges from server truth. The same delta broadcasts to peers with `exclude: reactive_connection_id`.
- **Each card is its own nested reactive root** (issue #15) carrying record + signed style state (the inline-edit identity pattern): `move` / `rename` (Enter-to-save, morph keeps the caret) / `archive` (confirm-gated + optimistic hide) live on the row.
- **Effect-style picker** (`default`/`fade`/`slide`/`scale`/`highlight`/`shake`/`random`) rides signed state and drives **per-call `effect:` overrides** — the #215 three-level precedence, live; `default` defers to the row's declared effects.
- **Live peer counts** — `broadcast_to(js:)` text ops after every mutation close the stale-badge gap the team-inbox flagship documents as a known limitation. **Empty lanes are pure CSS `:empty`** — zero bookkeeping on either delivery path.
- Per-lane composers (`busy:` dedupe, blank-title error flash with `dismiss_after:`), `Card` model + migration + idempotent seeds, Demo/Doc registry entries + nav icon, examples-overview + README + CHANGELOG rows.

**Docs-app only — zero gem code changes** (the issue's hard boundary).

## Test coverage

- `docs/spec/requests/project_board_spec.rb` (15) — page render; move (record + compound reply streams + js counts + per-call effect stamping + default-style bare wire + lane whitelist + peer broadcast incl. `reactive:js`); add (create + blank-title flash + lane whitelist + broadcast); rename (morph + blank guard); archive (destroy + counts + flash); style picker (whitelist).
- `docs/spec/system/project_board_spec.rb` (5) — two consecutive moves with live counts and no reload (fresh-token regression guard, cosmos#1939); composer add + clear + blank-title flash; inline rename via Enter (morph); confirm-gated archive with count repaint; style pick surviving round trips (signed state). **Green under Puma AND Falcon.**
- Full docs suite 177 passed; docs `rake lint` clean (139 files); gem suite 1351 passed + rubocop clean (untouched, verified).

Closes #216

## Deviations & judgment calls

- **Architecture deviation**: cards are their OWN nested reactive roots (record + signed style state), NOT tokenless `reactive_collection` rows as the issue sketched. Two forcing facts: (1) each card carries a rename `<input name="title">`, and the client's field sweep is root-wide — tokenless rows would collide on every card's title (last one wins); (2) a cross-lane move spans TWO collections, which the reply API composes awkwardly. `reactive_collection` is deliberately absent from this page — the Collections/Notifications pages own that showcase.
- **Counts/empty deviation**: peer count badges sync via `broadcast_to(js:)` text ops (also chained on the actor's reply via `reply.js`) — closing the stale-peer-badge gap rather than inheriting it. Empty lanes are pure CSS `:empty` instead of the `empty:` collection machinery (whose argument-free `new()` contract would force three near-identical per-lane empty classes).
- Composer inputs are named per lane (`title_todo`/`title_doing`/`title_done`) with the `lane` param picking the right one — three same-named inputs in one root collide in the field sweep.
- Moves are NOT optimistic (the issue suggested optimistic moves) — an optimistic hide would hide the exit animation, which is the whole showcase; `busy:` dedupes instead. Archive keeps the optimistic hide. The optimistic-REVERT scenario is not on this page: the board has no deny path, and Team inbox already demos revert-on-failure.
- Cross-tab delivery is asserted at the REQUEST level (`capture_turbo_stream_broadcasts`) rather than a two-session system spec — the docs suite convention (the chat spec documents the same choice; no docs system spec uses `using_session`).
- The system specs assert the STATIC declared effect attrs on rows (`data-reactive-effect-exit="fade"`), not a mid-animation class — no timing race; animation timing is pinned by the gem's own effects system specs.
- `add_card` replies with a full board replace (the todo-list precedent) so the composer clears; a surgical append would leave the typed text in the input (no client op writes input values, by design).
- `app/models/demo.rb` joined the docs rubocop `Metrics/ClassLength` exclude — the registry is a data literal that grows with every demo entry (this entry tipped it to 109/100); the config already excludes the same cop for the content-heavy views/components dirs.
- The docs_kit page generator's registry injection reports "File unchanged" against this repo's REGISTRY array — both new registry lines (Demo + Doc) were added by hand, same as the Effects page.
