### PR TITLE
fix(docs): repoint deploy at zoolutions org and bump docs-kit to 1.0.8

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy docs
 
 # Deploys the docs site (docs/) to the oss-infrastructure server via Kamal when a
 # release is published, or on demand. The build+deploy logic is shared across all
-# docs-kit sites — see mhenrixon/docs-kit/.github/workflows/deploy.yml.
+# docs-kit sites — see zoolutions/docs-kit/.github/workflows/deploy.yml.
 #
 # `image`/`service` are the REPO name (phlex-reactive, not -docs) so the pushed
 # ghcr package auto-links to this repo and GITHUB_TOKEN can push + pull it (no
@@ -22,8 +22,8 @@ permissions:
 
 jobs:
   deploy:
-    uses: mhenrixon/docs-kit/.github/workflows/deploy.yml@main
+    uses: zoolutions/docs-kit/.github/workflows/deploy.yml@main
     with:
-      image: mhenrixon/phlex-reactive
+      image: zoolutions/phlex-reactive
       service: phlex-reactive
     secrets: inherit

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,12 @@ group :test do
   # System tests
   gem "capybara", require: false
   gem "capybara-playwright-driver", require: false
+  # The Ruby client MUST track the npm playwright version pinned in bun.lock
+  # (currently 1.61.0) — the root Gemfile.lock is untracked, so CI resolves
+  # fresh every run, and an unpinned client drifts to a newer protocol than the
+  # installed driver speaks (symptom: "timeout: expected float, got undefined"
+  # on every visit). Bump this pin and bun.lock's playwright together.
+  gem "playwright-ruby-client", "~> 1.61.0", require: false
   gem "puma", require: false
   # Falcon is the real-server fallback for the browser suite (CAPYBARA_SERVER=falcon)
   # — an async, production-grade alternative to Puma. No webrick (not a real server).

--- a/docs/.claude/skills/write-docs-page/SKILL.md
+++ b/docs/.claude/skills/write-docs-page/SKILL.md
@@ -5,7 +5,7 @@ description: "Write, add, or update a documentation page in this docs-kit site. 
 
 # Write a docs page
 
-This is a [docs-kit](https://github.com/mhenrixon/docs-kit) site (Site).
+This is a [docs-kit](https://github.com/zoolutions/docs-kit) site (Site).
 Every page is a `DocsUI::Page` subclass; the shell, sidebar, "On this page" TOC,
 search, and the `.md` twin all come free. Your job is to scaffold a page and
 write its `#content` — never hand-write HTML or daisyUI markup.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@ reads it through the bundled `write-docs-page` skill. Edit freely — a
 <!-- BEGIN docs-kit -->
 ## Writing docs pages (docs-kit)
 
-Site is a [docs-kit](https://github.com/mhenrixon/docs-kit) site: a
+Site is a [docs-kit](https://github.com/zoolutions/docs-kit) site: a
 Phlex/daisyUI chrome where **every page is a `DocsUI::Page` subclass** and the
 sidebar, TOC, search, and Markdown twin come free. To document something, you
 scaffold a page, then write its `#content`. Never hand-write HTML or daisyUI

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -36,7 +36,7 @@ gem "daisyui", github: "mhenrixon/daisyui", require: "daisy_ui"
 # DocsKit.configure (see config/initializers/docs_kit.rb). Pulled from RubyGems
 # now the gem is released there — the old GitHub ref (needed while the sibling
 # repo sat outside the Docker build context) is obsolete.
-gem "docs-kit", "~> 1.0.3", require: "docs_kit"
+gem "docs-kit", "~> 1.0.8", require: "docs_kit"
 
 # MCP — docs-kit's optional Model Context Protocol server (read-only, stateless).
 # Not a docs-kit gemspec dependency; present here so the /mcp endpoint (routes in

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mhenrixon/daisyui.git
-  revision: 46c3d1e700279ea7a5ce2231d7f29958687013cf
+  revision: 1fc5a896fec0bc227ff8f15bbb00c4bc53512e77
   specs:
     daisyui (1.2.1)
       phlex (~> 2.0, >= 2.0.0)
@@ -21,29 +21,29 @@ GEM
   specs:
     action_text-trix (2.1.19)
       railties
-    actioncable (8.1.3)
-      actionpack (= 8.1.3)
-      activesupport (= 8.1.3)
+    actioncable (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (8.1.3)
-      actionpack (= 8.1.3)
-      activejob (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionmailbox (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      activejob (= 8.1.3.1)
+      activerecord (= 8.1.3.1)
+      activestorage (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       mail (>= 2.8.0)
-    actionmailer (8.1.3)
-      actionpack (= 8.1.3)
-      actionview (= 8.1.3)
-      activejob (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionmailer (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      actionview (= 8.1.3.1)
+      activejob (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (8.1.3)
-      actionview (= 8.1.3)
-      activesupport (= 8.1.3)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -51,36 +51,36 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.1.3)
+    actiontext (8.1.3.1)
       action_text-trix (~> 2.1.15)
-      actionpack (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
+      actionpack (= 8.1.3.1)
+      activerecord (= 8.1.3.1)
+      activestorage (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (8.1.3)
-      activesupport (= 8.1.3)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (8.1.3)
-      activesupport (= 8.1.3)
+    activejob (8.1.3.1)
+      activesupport (= 8.1.3.1)
       globalid (>= 0.3.6)
-    activemodel (8.1.3)
-      activesupport (= 8.1.3)
-    activerecord (8.1.3)
-      activemodel (= 8.1.3)
-      activesupport (= 8.1.3)
+    activemodel (8.1.3.1)
+      activesupport (= 8.1.3.1)
+    activerecord (8.1.3.1)
+      activemodel (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       timeout (>= 0.4.0)
-    activestorage (8.1.3)
-      actionpack (= 8.1.3)
-      activejob (= 8.1.3)
-      activerecord (= 8.1.3)
-      activesupport (= 8.1.3)
+    activestorage (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      activejob (= 8.1.3.1)
+      activerecord (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       marcel (~> 1.0)
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -147,14 +147,14 @@ GEM
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)
-    commonmarker (2.8.2-aarch64-linux)
-    commonmarker (2.8.2-aarch64-linux-musl)
-    commonmarker (2.8.2-arm-linux)
-    commonmarker (2.8.2-arm64-darwin)
-    commonmarker (2.8.2-x86_64-darwin)
-    commonmarker (2.8.2-x86_64-linux)
-    commonmarker (2.8.2-x86_64-linux-musl)
-    concurrent-ruby (1.3.7)
+    commonmarker (2.9.0-aarch64-linux)
+    commonmarker (2.9.0-aarch64-linux-musl)
+    commonmarker (2.9.0-arm-linux)
+    commonmarker (2.9.0-arm64-darwin)
+    commonmarker (2.9.0-x86_64-darwin)
+    commonmarker (2.9.0-x86_64-linux)
+    commonmarker (2.9.0-x86_64-linux-musl)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     console (1.36.0)
       fiber-annotation
@@ -166,7 +166,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
-    docs-kit (1.0.4)
+    docs-kit (1.0.8)
       commonmarker (~> 2.0)
       daisyui (>= 1.2, < 2)
       nokogiri (>= 1.15, < 2)
@@ -175,7 +175,7 @@ GEM
       rouge (>= 4.0, < 6)
       zeitwerk (~> 2.6)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.7)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -210,7 +210,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     io-endpoint (0.17.2)
     io-event (1.19.1)
     io-stream (0.13.1)
@@ -219,7 +219,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.20.0)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -230,7 +230,7 @@ GEM
     localhost (1.8.0)
       bake
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)
@@ -254,7 +254,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.3)
-    net-imap (0.6.4.1)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -339,7 +339,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
     rack-session (2.1.2)
@@ -349,33 +349,33 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    rails (8.1.3)
-      actioncable (= 8.1.3)
-      actionmailbox (= 8.1.3)
-      actionmailer (= 8.1.3)
-      actionpack (= 8.1.3)
-      actiontext (= 8.1.3)
-      actionview (= 8.1.3)
-      activejob (= 8.1.3)
-      activemodel (= 8.1.3)
-      activerecord (= 8.1.3)
-      activestorage (= 8.1.3)
-      activesupport (= 8.1.3)
+    rails (8.1.3.1)
+      actioncable (= 8.1.3.1)
+      actionmailbox (= 8.1.3.1)
+      actionmailer (= 8.1.3.1)
+      actionpack (= 8.1.3.1)
+      actiontext (= 8.1.3.1)
+      actionview (= 8.1.3.1)
+      activejob (= 8.1.3.1)
+      activemodel (= 8.1.3.1)
+      activerecord (= 8.1.3.1)
+      activestorage (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       bundler (>= 1.15.0)
-      railties (= 8.1.3)
+      railties (= 8.1.3.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails_icons (1.9.0)
       icons (~> 0.9.0)
       rails (>= 7.0)
-    railties (8.1.3)
-      actionpack (= 8.1.3)
-      activesupport (= 8.1.3)
+    railties (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -384,7 +384,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.0.3)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -397,9 +397,9 @@ GEM
       prism
       zeitwerk
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
-    rouge (5.0.0)
+    rouge (5.1.0)
       strscan (~> 3.1)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
@@ -502,7 +502,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.2)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux
@@ -522,7 +522,7 @@ DEPENDENCIES
   capybara-playwright-driver
   daisyui!
   debug
-  docs-kit (~> 1.0.3)
+  docs-kit (~> 1.0.8)
   falcon
   importmap-rails
   mcp
@@ -556,17 +556,17 @@ DEPENDENCIES
 
 CHECKSUMS
   action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
-  actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
-  actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
-  actionmailer (8.1.3) sha256=831f724891bb70d0aaa4d76581a6321124b6a752cb655c9346aae5479318448d
-  actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
-  actiontext (8.1.3) sha256=d291019c00e1ea9e6463011fa214f6081a56d7b9a1d224e7d3f6384c1dafc7d2
-  actionview (8.1.3) sha256=1347c88c7f3edb38100c5ce0e9fb5e62d7755f3edc1b61cce2eb0b2c6ea2fd5d
-  activejob (8.1.3) sha256=a149b1766aa8204c3c3da7309e4becd40fcd5529c348cffbf6c9b16b565fe8d3
-  activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
-  activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
-  activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
-  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  actioncable (8.1.3.1) sha256=e318528295c878a3efdfe25f0f2267c80cb7a76eba41bb5f64d44aa380a3d91b
+  actionmailbox (8.1.3.1) sha256=5f704972097d843ade8e435e93694a1dac732b926df1717aceba1f3840082b1c
+  actionmailer (8.1.3.1) sha256=88ea441b28ff02a0c6c006468892642a3d9942affce9d294e81a74504aa5c43c
+  actionpack (8.1.3.1) sha256=974cb7154548e81f470b1b0f247b99cb38e87825899dca58610596e2817723d0
+  actiontext (8.1.3.1) sha256=5da729d833d1a29cddb1eee938878e55e503d2613e00e735f5daf58c2ba98af2
+  actionview (8.1.3.1) sha256=2da68b8414c47b43bfbed1ce69c5afe1c04f78c267aacb5660a4cab5ca12cfb6
+  activejob (8.1.3.1) sha256=1c8dd275df930df40deecffec63d913a550a33fd94bd298f69721dd96939954a
+  activemodel (8.1.3.1) sha256=99cc02ce2faec371d14440949d85787ebd23a907c9baef0a9d4bcd4d21888f88
+  activerecord (8.1.3.1) sha256=0a2fb6c28f4938f6b013a3a549bec0a7e37d535f3dc8990e804bcc3258c0403b
+  activestorage (8.1.3.1) sha256=f555254f387b1cffa499d2fd3115d12635eadc5b15206a8534316a67036163ef
+  activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   async (2.42.0) sha256=536078293b8c95d5b5679fa01bf7d2458bcc65cd46dec2c4cb3580feaeb965c6
@@ -584,14 +584,14 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.9) sha256=4c17fed20817b7e1bde2cfc8186e7bf5cd72017ce1aa695e35130f8e600e7282
-  commonmarker (2.8.2-aarch64-linux) sha256=715a5df28e5c1ec7b520e6441466062e9717b82193d2a5bd11a9c94f2f1e15f0
-  commonmarker (2.8.2-aarch64-linux-musl) sha256=c7d587bd7978416978e84d0de7488906b8f29b3f67ce8424942f0ca9aa6899db
-  commonmarker (2.8.2-arm-linux) sha256=da9da5c08d5133ad429ece13f2e93d3a30e1b23621ffac9040e185d7ea29bde6
-  commonmarker (2.8.2-arm64-darwin) sha256=cd7364f1fb9735d60218e4af0a4afbbeedbc465eb81cccca56f29a4efe2b5013
-  commonmarker (2.8.2-x86_64-darwin) sha256=fb946e0bb01f0e5742aef75cc972b51ffe099e5b983ce9cd792b4a78c5d2c297
-  commonmarker (2.8.2-x86_64-linux) sha256=42cfb6532b15dd5821ce99e47397923255f32dcfc81024ef4c17e01e66ac7d75
-  commonmarker (2.8.2-x86_64-linux-musl) sha256=66568dce1c6f265e85d57ea7f749a148446527c7dd599c6ded4cdc819997c43e
-  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  commonmarker (2.9.0-aarch64-linux) sha256=e2b4aadb9a2cfa4e206582641ce3a49465549ac1ed4c289fdd63b78d8f24579c
+  commonmarker (2.9.0-aarch64-linux-musl) sha256=1cf4d2821f2a7e64945f1ed7c4eeced586fdb27ea7fe7337788802cf8f57cfca
+  commonmarker (2.9.0-arm-linux) sha256=290a000947cf9d154d0480c33c0a36bcef49ce4c2e74bb75e9d06f5afe93f670
+  commonmarker (2.9.0-arm64-darwin) sha256=1748dbfa4f5813b0d2a14bb4bbfa65a4ec293aa1c825016d60029ee0e132b046
+  commonmarker (2.9.0-x86_64-darwin) sha256=0a9914ccfd2f5d2a59c7bd0dda4fe90eb084cf513b477e499008e09ec9d6edd6
+  commonmarker (2.9.0-x86_64-linux) sha256=8cfe92970eef585a19ddf6613224b91cab64d6029834661bda801f877c9c7f43
+  commonmarker (2.9.0-x86_64-linux-musl) sha256=293921398b839f79ceaf55010e061357e34f053822c3b003cd0be6686176335e
+  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   console (1.36.0) sha256=45599ea906cf80a73d8941f03abf873fe66a6a954e0bac5bc1c01e2cdc406f07
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
@@ -599,9 +599,9 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docs-kit (1.0.4) sha256=2165c439f09a1283799d76ec3c59f850cf320e7565731cb5e4b5e2dee2f56b84
+  docs-kit (1.0.8) sha256=a4ae96211888b55f17139474003be9d86bd39a1d5a70ac6b14bd0faa8eb63e8e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   falcon (0.55.5) sha256=8622db11361b6678578dd7e06b953aaef10e5006929ced618069bb62b0ff118d
@@ -614,18 +614,18 @@ CHECKSUMS
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   icons (0.9.0) sha256=128365c3414a1b76de4ea1913ef9190163fec1f8c701fa9a37fa301c04f4c9dc
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
   io-endpoint (0.17.2) sha256=3feaf766c116b35839c11fac68b6aaadc47887bb488902a57bf8e1d288fb3338
   io-event (1.19.1) sha256=851aa9a318889cbfdaa9a982b5cd266750f893748752a17f52f880d93ceb6ee6
   io-stream (0.13.1) sha256=570d7c4dfb0fbd767480b4a222048a2be6d9b78febc1ec68258d0e0a4cde20de
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   localhost (1.8.0) sha256=df7ea825b4f64949c588c17efac86bc47ddc4460d723778abe933b71759b2701
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -637,7 +637,7 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
-  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
+  net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
@@ -680,24 +680,24 @@ CHECKSUMS
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack (3.2.7) sha256=93e13e1c24f93556671d85d2d79fa228c3485815c50d7e2f265b5330c6528fb7
   rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
-  rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
+  rails (8.1.3.1) sha256=ccd11a36bfc171bf9c66d585d14c0ece91c0c9dde840aae60c0118d6f5c9c52a
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   rails_icons (1.9.0) sha256=f62aa09908a978d76756c13b610b8596bb953fc622dc224ea8bd5a8c6899a4d1
-  railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
+  railties (8.1.3.1) sha256=2388a232579a00cefea4487de66c8553c3408c1300abdc6cf1799d86ffb04487
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
-  rouge (5.0.0) sha256=e2de9bba2f9cb88f8a73bca3643b560b2b398f32f91bf716f584477bc0175ebc
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
+  rouge (5.1.0) sha256=b77c632842ab7f5147940212f0345808cccfbce864fd5b631d7d12a35ac85452
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
@@ -745,7 +745,7 @@ CHECKSUMS
   websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
-  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
+  zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
 
 BUNDLED WITH
   4.0.9

--- a/docs/app/views/docs/pages/performance.rb
+++ b/docs/app/views/docs/pages/performance.rb
@@ -901,7 +901,7 @@ module Views
             DocsUI::Prose() do
               p do
                 plain 'See '
-                a(href: 'https://github.com/mhenrixon/phlex-reactive/blob/main/.claude/rules/performance.md') do
+                a(href: 'https://github.com/zoolutions/phlex-reactive/blob/main/.claude/rules/performance.md') do
                   plain '.claude/rules/performance.md'
                 end
                 plain ': any change to a hot path ships with a bench, the README/CHANGELOG/docs are updated, '

--- a/docs/app/views/docs/pages/transport_pgbus.rb
+++ b/docs/app/views/docs/pages/transport_pgbus.rb
@@ -28,7 +28,7 @@ module Views
             DocsUI::Prose() do
               p do
                 plain 'With '
-                a(href: 'https://github.com/mhenrixon/pgbus') { 'pgbus' }
+                a(href: 'https://github.com/zoolutions/pgbus') { 'pgbus' }
                 plain ' installed, '
                 code { 'broadcast_to' }
                 plain ' AND '

--- a/docs/app/views/landings/show.rb
+++ b/docs/app/views/landings/show.rb
@@ -57,7 +57,7 @@ module Views
             a(href: doc_path('installation'),
               class: 'btn btn-primary', data: { testid: 'cta-get-started' }) { 'Get started' }
             a(href: doc_path('architecture'), class: 'btn btn-ghost') { 'How it works' }
-            a(href: 'https://github.com/mhenrixon/phlex-reactive',
+            a(href: 'https://github.com/zoolutions/phlex-reactive',
               class: 'btn btn-ghost', target: '_blank', rel: 'noopener') { 'GitHub ↗' }
           end
           render Components::Diagrams::MentalModel.new

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -4,10 +4,10 @@
   "workspaces": {
     "": {
       "devDependencies": {
-        "@tailwindcss/cli": "latest",
-        "daisyui": "latest",
-        "playwright": "latest",
-        "tailwindcss": "latest",
+        "@tailwindcss/cli": "^4.3.2",
+        "daisyui": "^5.6.13",
+        "playwright": "^1.61.1",
+        "tailwindcss": "^4.3.2",
       },
     },
   },

--- a/docs/config/deploy.yml
+++ b/docs/config/deploy.yml
@@ -2,10 +2,10 @@
 # Routing is via kamal-proxy behind a Cloudflare Tunnel (no Traefik; TLS is
 # terminated at the Cloudflare edge), per oss-infrastructure/docs/adding-a-new-gem.md.
 service: phlex-reactive
-# Match the repo (ghcr.io/mhenrixon/phlex-reactive) so GitHub auto-links the
+# Match the repo (ghcr.io/zoolutions/phlex-reactive) so GitHub auto-links the
 # package to this repo and the Actions GITHUB_TOKEN can push to it. A package
 # named differently from the repo stays user-owned + unlinked → push 403s in CI.
-image: mhenrixon/phlex-reactive
+image: zoolutions/phlex-reactive
 
 servers:
   web:

--- a/docs/config/initializers/docs_kit.rb
+++ b/docs/config/initializers/docs_kit.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# docs-kit synced: v1.0.8
+
 # Per-site configuration for the shared docs chrome (docs-kit). Everything that
 # makes this site look like "phlex-reactive" rather than any other docs site
 # lives here; the Shell/Sidebar/ThemeSwitcher themselves are shared with the
@@ -37,7 +39,7 @@ Rails.application.config.to_prepare do
     # Topbar: the brand clicks home; a GitHub link with the shipped brand mark.
     c.brand_href    = '/'
     c.topbar_links  = [
-      { href: 'https://github.com/mhenrixon/phlex-reactive', label: 'GitHub', icon: :github }
+      { href: 'https://github.com/zoolutions/phlex-reactive', label: 'GitHub', icon: :github }
     ]
 
     # SEO / social sharing (docs-kit 1.0.2, DocsUI::MetaTags). Every page emits a

--- a/phlex-reactive.gemspec
+++ b/phlex-reactive.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
     reliable, transactional, reconnect-safe live updates with no Action Cable
     and no Redis.
   DESC
-  spec.homepage = "https://github.com/mhenrixon/phlex-reactive"
+  spec.homepage = "https://github.com/zoolutions/phlex-reactive"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.4.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/mhenrixon/phlex-reactive/tree/main"
-  spec.metadata["changelog_uri"] = "https://github.com/mhenrixon/phlex-reactive/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/zoolutions/phlex-reactive/tree/main"
+  spec.metadata["changelog_uri"] = "https://github.com/zoolutions/phlex-reactive/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   # List the gem's files. Prefer `git ls-files` (respects .gitignore), but fall


### PR DESCRIPTION
## Summary

Same fix as [pgbus#408](https://github.com/zoolutions/pgbus/pull/408) / [docs-kit#70](https://github.com/zoolutions/docs-kit/pull/70): reusable-workflow `uses:` refs do **not** follow repo redirects, so the docs deploy has failed at parse time since the org move.

- `.github/workflows/deploy-docs.yml` → `zoolutions/docs-kit/...@main`, `image: zoolutions/phlex-reactive`; same `image:` in `docs/config/deploy.yml`
- docs-kit `~> 1.0.3` → `~> 1.0.8`; ran the version-aware `docs_kit:install --sync`; sync stamp kept below `# frozen_string_literal: true`
- gemspec metadata + docs content URLs (landing, performance, transport_pgbus pages) → zoolutions; CSS rebuilt

## Test plan

- [x] `docs/: bundle exec rspec` — 177 examples, 0 failures
- [x] `docs/: bundle exec rubocop` — no offenses
- [x] `actionlint .github/workflows/deploy-docs.yml`
- [ ] After merge: `workflow_dispatch` **Deploy docs**; check the new `zoolutions/phlex-reactive` ghcr package once

## Deviations & judgment calls

- None beyond the pattern established in pgbus#408 (registry username kept; gemspec change is metadata-only, root suite left to CI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points docs deploy to the `zoolutions` org and upgrades `docs-kit` to `1.0.8`; also pins `playwright-ruby-client` to match the `playwright` driver so CI system tests pass. Previously the workflow referenced `mhenrixon` and failed to parse, and system tests errored on protocol mismatch; now the workflow parses and the client/driver versions align.

- `.github/workflows/deploy-docs.yml` uses `zoolutions/docs-kit/.github/workflows/deploy.yml@main`; `image: zoolutions/phlex-reactive` here and in `docs/config/deploy.yml`.
- Docs site upgrades to `docs-kit ~> 1.0.8` in `docs/Gemfile` and lock; initializer sync stamp updated; URLs in docs and `phlex-reactive.gemspec` point to `zoolutions`.
- CI: add `playwright-ruby-client ~> 1.61.x` in the root `Gemfile` to match the `playwright` version pinned in `docs/bun.lock`, preventing system-test timeouts; `docs/bun.lock` pins `@tailwindcss/cli`, `tailwindcss`, `daisyui`, and `playwright` for reproducible builds.
- After merge: run workflow_dispatch “Deploy docs” and confirm the `ghcr.io/zoolutions/phlex-reactive` package is linked to the repo.

<sup>Written for commit 38d484b8d6bd1f89bcdfed4d90c0836dfdf7851b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/phlex-reactive/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

