### PR TITLE
fix(controller): thread request url_options into actor replies (#232)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -233,6 +233,9 @@ RSpec/DescribeClass:
     - spec/phlex/reactive/lazy_mount_spec.rb
     - spec/phlex/reactive/defer_binding_spec.rb
     - spec/phlex/reactive/deferred_render_job_failure_spec.rb
+    # url_options threading (issue #232) cuts across the module thread-local,
+    # the view-context override, the endpoint, and the broadcast guard.
+    - spec/phlex/reactive/url_options_spec.rb
 
 # The `describe Klass, "label"` form uses the second arg as a context label
 # (e.g. `describe Component, "reactive_collection"`), not a method name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Reply-rendered components now generate absolute URLs with the REQUESTING
+  host, not the process default (#232).** Actor replies (`reply.replace`,
+  `reply.streams(...)`, the implicit replace) render through the memoized
+  off-request view context, whose `url_options` were process defaults — so any
+  absolute URL helper (`image_tag` on an Active Storage attachment being the
+  everyday case) rendered the wrong host on a multi-host app: a broken image
+  after every save, healed by the next full page load. The action endpoint now
+  threads the request's protocol/host/port into the reply render (the
+  `ActiveStorage::SetCurrent` move) via a thread-local the memoized context
+  merges per call — the context is never rebuilt, so the render memoization
+  win is untouched (allocations byte-identical, throughput flat within noise).
+  The defer **pull** endpoint gets the same treatment (it is an actor request).
+  **Broadcasts are unchanged by design** — there is no request and subscribers
+  can be on different hosts, so a broadcast fired *inside* an action explicitly
+  clears the actor's url_options around its render; "URLs in broadcast-rendered
+  components must be host-relative" is now documented in the Broadcasting guide.
+
 - **`rake bench` ran the removed `broadcast_replace_to` API and exited 1.**
   `benchmark/micro/broadcast.rb` migrated to the #185 spellings
   (`broadcast_to(*key, replace:)` / `broadcast_to(each:, replace:)`); the

--- a/app/controllers/phlex/reactive/actions_controller.rb
+++ b/app/controllers/phlex/reactive/actions_controller.rb
@@ -39,9 +39,17 @@ module Phlex
         # #165 security), so the defer endpoint accepts them ONLY back from this
         # same actor. The defer token is built in response_streams (inside this
         # block via the Defer builder), so the binding must be established here.
-        Phlex::Reactive.with_defer_binding(Phlex::Reactive.defer_binding_for(request)) do
-          Phlex::Reactive.instrument("action", event) do
-            create_action(event)
+        # Thread the ACTOR's url_options (protocol/host/port) into the reply
+        # render (issue #232): the reply renders through the memoized
+        # off-request view context, whose process-default url_options emit the
+        # wrong host for absolute URL helpers on a multi-host app. Broadcasts
+        # fired inside the action are exempted at their render (see
+        # Streamable.broadcast_component) — subscribers can be on other hosts.
+        Phlex::Reactive.with_url_options(Phlex::Reactive.url_options_for(request)) do
+          Phlex::Reactive.with_defer_binding(Phlex::Reactive.defer_binding_for(request)) do
+            Phlex::Reactive.instrument("action", event) do
+              create_action(event)
+            end
           end
         end
       end
@@ -62,9 +70,14 @@ module Phlex
         # so a leaked token can't be exchanged here for this actor's render (and
         # its embedded fresh identity token). Unbound requests (no session) are
         # unchanged.
-        Phlex::Reactive.with_defer_binding(Phlex::Reactive.defer_binding_for(request)) do
-          Phlex::Reactive.instrument("defer", event) do
-            deferred_action(event)
+        # The defer PULL is an actor request too (issue #232) — its render gets
+        # the same request-derived url_options as the action reply. The PUSH
+        # lane (job → SSE) has no request and stays on process defaults.
+        Phlex::Reactive.with_url_options(Phlex::Reactive.url_options_for(request)) do
+          Phlex::Reactive.with_defer_binding(Phlex::Reactive.defer_binding_for(request)) do
+            Phlex::Reactive.instrument("defer", event) do
+              deferred_action(event)
+            end
           end
         end
       end

--- a/docs/app/views/docs/pages/broadcasting.rb
+++ b/docs/app/views/docs/pages/broadcasting.rb
@@ -22,6 +22,7 @@ module Views
           module_level_broadcast
           multi_key_fanout
           from_action
+          url_options_contract
           actor_echo
           visible_to
           cross_tab_morph
@@ -263,6 +264,36 @@ module Views
                 )
               end
               ```
+            MD
+          end
+        end
+
+        def url_options_contract
+          DocsUI::Section('URLs in broadcast-rendered components: keep them host-relative') do
+            md <<~MD
+              A broadcast renders **off-request** — there is no acting request, and
+              the subscribers can be on *different hosts* (multi-tenant apps,
+              `lvh.me` subdomains). So a broadcast-rendered component that emits an
+              **absolute** URL gets the process-default `url_options`, which is the
+              wrong host for at least some subscribers. That makes host-relative
+              URLs the contract:
+
+              ```ruby
+              # In a component that gets BROADCAST — host-relative, correct for every subscriber:
+              img(src: rails_storage_proxy_path(@record.image))
+
+              # Absolute (image_tag on an attachment resolves via polymorphic_url) —
+              # renders the PROCESS-DEFAULT host in a broadcast. Avoid in broadcast paths:
+              image_tag(@record.image)
+              ```
+
+              The actor's own **reply** is different: it renders *during* the request,
+              so absolute URL helpers there carry the requesting protocol/host/port
+              automatically — `image_tag(attachment)` is simply correct in a
+              `reply.replace` / `reply.streams(...)` render. The same applies to a
+              deferred segment fetched over the pull lane. But the *push* lane
+              (`reply.defer` delivered via a job + SSE) and every `broadcast_to`
+              render off-request: keep those host-relative.
             MD
           end
         end

--- a/lib/phlex/reactive.rb
+++ b/lib/phlex/reactive.rb
@@ -513,6 +513,22 @@ module Phlex
         instance = controller_class.new
         instance.set_request!(request)
         instance.set_response!(controller_class.make_response!(request))
+
+        # Issue #232: during a reactive request the endpoint threads the actor's
+        # protocol/host/port via with_url_options; merge them over this
+        # instance's defaults so absolute URL helpers in a reply render the
+        # REQUESTING host. View contexts delegate url_options to their
+        # controller (ActionView::RoutingUrlFor), so this one override covers
+        # every helper spelling. Off-request (thread-local nil — jobs, console,
+        # broadcasts) returns super's frozen memo untouched: zero-alloc, byte-
+        # identical URLs. Defined on the singleton because this instance is
+        # MEMOIZED per thread — its request (and super's @_url_options) never
+        # changes, so the per-call merge is the only per-request seam.
+        def instance.url_options
+          overrides = Phlex::Reactive.current_url_options
+          overrides ? super.merge(overrides) : super
+        end
+
         instance.view_context
       end
 
@@ -966,6 +982,40 @@ module Phlex
         yield
       ensure
         Thread.current[:phlex_reactive_connection_id] = previous
+      end
+
+      # The acting request's url_options during a reactive request, or nil
+      # (issue #232). Set by the ActionsController (the action AND defer
+      # endpoints) so absolute URL helpers in a reply-rendered component —
+      # image_tag on an Active Storage attachment being the everyday case —
+      # carry the REQUESTING host/port/protocol instead of the process default
+      # (the ActiveStorage::SetCurrent move). The memoized off-request view
+      # context merges this over its defaults per call (see
+      # request_bound_view_context); nil (jobs, console, plain broadcasts)
+      # leaves the defaults untouched — byte-identical to before.
+      def current_url_options
+        Thread.current[:phlex_reactive_url_options]
+      end
+
+      # Thread `options` for the block, restoring the previous value after.
+      # `nil` CLEARS the actor options — the broadcast render uses this to keep
+      # a broadcast fired inside an action on process defaults (subscribers can
+      # be on different hosts; "URLs in broadcast-rendered components must be
+      # host-relative" is the broadcast contract).
+      def with_url_options(options)
+        previous = Thread.current[:phlex_reactive_url_options]
+        Thread.current[:phlex_reactive_url_options] = options.presence
+        yield
+      ensure
+        Thread.current[:phlex_reactive_url_options] = previous
+      end
+
+      # The url_options trio derived from a live request. `port` is optional_port
+      # — nil on the default port — and is INCLUDED even when nil so a
+      # default-port request clears any configured default port rather than
+      # inheriting it (the merge must own the whole trio).
+      def url_options_for(request)
+        { protocol: request.protocol, host: request.host, port: request.optional_port }
       end
 
       # The controller a correctly-mounted action path resolves to. Used by the

--- a/lib/phlex/reactive/streamable.rb
+++ b/lib/phlex/reactive/streamable.rb
@@ -137,7 +137,13 @@ module Phlex
             "broadcast", { component: component_name, stream_action: BROADCAST_VERBS[verb], streamables: keys.size }
           ) do
             with_pgbus_broadcast_opts(exclude:, visible_to:) do
-              html = verb == :js ? nil : render_broadcast_html(component)
+              # A broadcast render NEVER inherits the actor's url_options (issue
+              # #232): this call may run inside an action request (where the
+              # endpoint threaded the actor's host), but subscribers can be on
+              # different hosts — absolute URLs in broadcast-rendered components
+              # keep the process defaults, so "host-relative URLs" stays the
+              # broadcast contract. Off-request callers pay one nil-write pair.
+              html = verb == :js ? nil : Phlex::Reactive.with_url_options(nil) { render_broadcast_html(component) }
               ops_json = verb == :js ? broadcast_js_ops_json(payload) : nil
               keys.each { dispatch_broadcast(verb, it, resolved_target, html, ops_json, morph, effect) }
             end

--- a/spec/dummy/app/components/settings_link_component.rb
+++ b/spec/dummy/app/components/settings_link_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Fixture for issue #232: a reply-rendered component that emits an ABSOLUTE URL
+# (`counter_url` — the same url_options path image_tag takes for an Active
+# Storage attachment). On a multi-host app the reply must carry the REQUESTING
+# host, not the process default; a broadcast of the same component must keep
+# the process default (subscribers can be on other hosts).
+class SettingsLinkComponent < ApplicationComponent
+  include Phlex::Reactive::Component
+  include Phlex::Rails::Helpers::Routes
+
+  reactive_state :saved
+
+  action :save
+  action :save_and_broadcast
+
+  def initialize(saved: false)
+    @saved = saved
+  end
+
+  def id = "settings-link"
+
+  def save
+    @saved = true
+  end
+
+  # Broadcast the SAME component while handling the actor's request — the
+  # broadcast render must NOT inherit the actor's url_options (issue #232).
+  def save_and_broadcast
+    @saved = true
+    self.class.broadcast_to("settings", replace: self.class.new(saved: true))
+  end
+
+  def view_template
+    div(id:, **reactive_attrs) do
+      a(href: counter_url, data: { testid: "abs-link" }) { "counter" }
+      span(data: { testid: "saved" }) { @saved.to_s }
+      button(**mix(on(:save), data: { testid: "save" })) { "save" }
+    end
+  end
+end

--- a/spec/phlex/reactive/url_options_spec.rb
+++ b/spec/phlex/reactive/url_options_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #232: the request-derived url_options thread-local that makes URL
+# helpers correct in ACTOR replies. The endpoint sets it for the duration of a
+# reactive request; the memoized off-request view context merges it over its
+# process defaults; the broadcast render clears it (subscribers can be on
+# different hosts).
+RSpec.describe "Phlex::Reactive url_options threading (issue #232)" do
+  describe ".with_url_options / .current_url_options" do
+    it "defaults to nil (off-request renders keep process defaults)" do
+      expect(Phlex::Reactive.current_url_options).to be_nil
+    end
+
+    it "exposes the options inside the block and restores the previous value after" do
+      Phlex::Reactive.with_url_options({ host: "yoga.test" }) do
+        expect(Phlex::Reactive.current_url_options).to eq({ host: "yoga.test" })
+      end
+      expect(Phlex::Reactive.current_url_options).to be_nil
+    end
+
+    it "restores on raise" do
+      expect do
+        Phlex::Reactive.with_url_options({ host: "yoga.test" }) { raise "boom" }
+      end.to raise_error("boom")
+      expect(Phlex::Reactive.current_url_options).to be_nil
+    end
+
+    it "nests — nil CLEARS the actor options for an inner render (the broadcast guard)" do
+      Phlex::Reactive.with_url_options({ host: "yoga.test" }) do
+        Phlex::Reactive.with_url_options(nil) do
+          expect(Phlex::Reactive.current_url_options).to be_nil
+        end
+        expect(Phlex::Reactive.current_url_options).to eq({ host: "yoga.test" })
+      end
+    end
+  end
+
+  describe ".url_options_for(request)" do
+    def request_for(url)
+      ActionDispatch::Request.new(Rack::MockRequest.env_for(url))
+    end
+
+    it "extracts protocol, host, and explicit port" do
+      options = Phlex::Reactive.url_options_for(request_for("http://yoga.local:1120/x"))
+      expect(options).to eq({ protocol: "http://", host: "yoga.local", port: 1120 })
+    end
+
+    it "extracts a nil port on the default port (so a stale configured port is cleared)" do
+      options = Phlex::Reactive.url_options_for(request_for("https://yoga.test/x"))
+      expect(options).to eq({ protocol: "https://", host: "yoga.test", port: nil })
+    end
+  end
+
+  describe "the memoized off-request view context" do
+    after { Phlex::Reactive.reset_stream_builder! }
+
+    it "merges the actor options over its process defaults, without rebuilding" do
+      context = Phlex::Reactive.off_request_view_context
+      default_url = context.url_for(controller: "demos", action: "counter", only_path: false)
+
+      Phlex::Reactive.with_url_options({ protocol: "http://", host: "yoga.test", port: 1120 }) do
+        expect(Phlex::Reactive.off_request_view_context).to be(context)
+        expect(context.url_for(controller: "demos", action: "counter", only_path: false))
+          .to eq("http://yoga.test:1120/counter")
+      end
+
+      # Cleared afterwards — the same memoized context is back on defaults.
+      expect(context.url_for(controller: "demos", action: "counter", only_path: false)).to eq(default_url)
+    end
+  end
+end

--- a/spec/requests/reply_url_options_spec.rb
+++ b/spec/requests/reply_url_options_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "turbo/broadcastable/test_helper"
+
+# Issue #232: components rendered in an ACTOR REPLY go through the memoized
+# off-request view context, whose url_options are process defaults — so any
+# absolute URL helper (image_tag on an Active Storage attachment being the
+# everyday case) renders the WRONG host on a multi-host app. The fix threads
+# the request's protocol/host/port into the reply render (the
+# ActiveStorage::SetCurrent move). Broadcasts stay on process defaults — there
+# is no request, and subscribers can be on different hosts.
+RSpec.describe "Reply url_options (issue #232)", type: :request do
+  include Turbo::Broadcastable::TestHelper
+
+  def reply_link_href
+    response.body[/data-testid="abs-link"[^>]*href="([^"]+)"/, 1] ||
+      response.body[/href="([^"]+)"[^>]*data-testid="abs-link"/, 1]
+  end
+
+  describe "the actor reply (POST action_path)" do
+    it "renders absolute URLs with the REQUEST's host, not the process default" do
+      host! "yoga.test"
+      post_action(SettingsLinkComponent, payload: { "s" => { "saved" => false } }, act: "save")
+
+      expect(response).to have_http_status(:ok)
+      expect(reply_link_href).to eq("http://yoga.test/counter")
+    end
+
+    it "carries the request's port and protocol" do
+      token = token_for(SettingsLinkComponent, { "s" => { "saved" => false } })
+      post Phlex::Reactive.action_path,
+        params: { token:, act: "save", params: {} }.to_json,
+        headers: { "Content-Type" => "application/json",
+                   "Accept" => "text/vnd.turbo-stream.html",
+                   "Host" => "yoga.local:1120" }
+
+      expect(response).to have_http_status(:ok)
+      expect(reply_link_href).to eq("http://yoga.local:1120/counter")
+    end
+  end
+
+  describe "a broadcast fired INSIDE the action" do
+    it "keeps the process-default url_options (never the actor's host)" do
+      host! "yoga.test"
+      broadcasts = capture_turbo_stream_broadcasts("settings") do
+        post_action(SettingsLinkComponent, payload: { "s" => { "saved" => false } }, act: "save_and_broadcast")
+      end
+
+      expect(response).to have_http_status(:ok)
+      # The actor's own reply carries the actor host…
+      expect(reply_link_href).to eq("http://yoga.test/counter")
+
+      # …but the broadcast render must NOT: subscribers can be on other hosts.
+      broadcast_href = broadcasts.sole.to_html[/href="([^"]+)"/, 1]
+      expect(broadcast_href).to start_with("http://example.org")
+      expect(broadcast_href).not_to include("yoga.test")
+    end
+  end
+
+  describe "the defer pull endpoint (POST defer_path)" do
+    it "renders the deferred segment with the request's host (it IS an actor request)" do
+      host! "yoga.test"
+      token = Phlex::Reactive.sign_defer({ "c" => "SettingsLinkComponent", "s" => { "saved" => true } })
+      post Phlex::Reactive.defer_path,
+        params: { token: }.to_json,
+        headers: { "Content-Type" => "application/json", "Accept" => "text/vnd.turbo-stream.html" }
+
+      expect(response).to have_http_status(:ok)
+      expect(reply_link_href).to eq("http://yoga.test/counter")
+    end
+  end
+
+  describe "off-request renders (no actor)" do
+    it "keeps process-default url_options for a plain broadcast" do
+      broadcasts = capture_turbo_stream_broadcasts("settings") do
+        SettingsLinkComponent.broadcast_to("settings", replace: SettingsLinkComponent.new(saved: true))
+      end
+
+      expect(broadcasts.sole.to_html[/href="([^"]+)"/, 1]).to start_with("http://example.org")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #232.

## Summary

Components rendered in an **actor reply** (`reply.replace`, `reply.streams(Component.replace(...))`, the implicit replace) go through the memoized off-request view context, whose `url_options` are process defaults — so any absolute URL helper (`image_tag` on an Active Storage attachment being the everyday case) rendered the wrong host on a multi-host app: a broken image after every save, healed by the next full page load.

The key asymmetry from the issue: **actor replies happen during a request** — the endpoint holds `request` at exactly the moment the reply renders. This PR threads the request's `protocol`/`host`/`port` into that render (the `ActiveStorage::SetCurrent` move):

- `Phlex::Reactive.with_url_options` / `.current_url_options` / `.url_options_for(request)` — a thread-local mirroring `with_connection_id`.
- The endpoint wraps `create` **and** `deferred` (the defer *pull* is an actor request too) in `with_url_options(url_options_for(request))`.
- `request_bound_view_context` gives the memoized renderer instance a singleton `url_options` that merges the thread-local over `super` per call. View contexts delegate `url_options` to their controller (`ActionView::RoutingUrlFor`), and phlex-rails `Helpers::Routes` delegates the same way — so one override covers every helper spelling. Off-request (thread-local nil) it returns `super`'s frozen memo untouched: zero-alloc, byte-identical URLs.
- **Broadcasts stay as they are, enforced**: `Streamable.broadcast_component` clears the actor options around its render, so a `broadcast_to` fired *inside* an action never inherits the actor's host — subscribers can be on different hosts. The "URLs in broadcast-rendered components must be host-relative" contract is now a section in the Broadcasting guide.

The memoized view context is **never rebuilt** — the render memoization win is untouched. The `port` in the trio is `optional_port` and is included even when nil, so a default-port request *clears* a configured default port instead of inheriting it.

## Test plan

- `spec/requests/reply_url_options_spec.rb` (new fixture `SettingsLinkComponent` renders `counter_url` — the same url_options path `image_tag(attachment)` takes via `polymorphic_url`):
  - reply carries the request host (`yoga.test`), and port/protocol (`yoga.local:1120`) — RED before: both rendered `http://example.org/counter`
  - a broadcast fired **inside** the action keeps process defaults while the same action's reply carries the actor host
  - the defer pull endpoint renders with the request host
  - a plain off-request broadcast is unchanged
- `spec/phlex/reactive/url_options_spec.rb`: thread-local restore/raise/nil-clears-nesting; `url_options_for` extraction incl. nil `optional_port`; the memoized context merges without rebuilding and reverts after the block.
- Full fast suite: 1454 examples, 0 failures. RuboCop clean.

## Performance

Hot paths touched: broadcast render (a `with_url_options(nil)` guard — two thread-local writes per broadcast call) and one wrapper per action request. Paired same-machine `benchmark/micro/{broadcast,render}.rb` vs `main` (worktree):

| bench | main | branch |
|---|---|---|
| broadcast replace (1 key) | ~22k i/s | ~22k i/s (flat within noise; one interleaved run swung 9.7k→22k on identical code — noisy machine) |
| broadcast allocations (loop 10 keys / each: 10 keys) | 1450 / 163 obj | 1450 / 163 obj (identical, 0 retained) |
| render_component | 22.5k i/s, 136 obj | 24.1k i/s, 136 obj |

Method-level framing: no measurable delta; allocations byte-identical, 0 retained. No representative numbers moved, so the performance page is unchanged.

## Deviations & judgment calls

- Discovery: BOTH memoized off-request contexts (Streamable's per-class `thread_view_context_cache` AND the module-level `off_request_view_context`) are built by `Phlex::Reactive.request_bound_view_context` — so the override lives there once and covers component renders, flashes, and `reply.with` content.
- Discovery: view contexts delegate `url_options` to `controller.url_options` (actionview `routing_url_for.rb:124`), and phlex-rails' `Helpers::Routes` delegates the same way — so a singleton `url_options` override on the memoized renderer controller instance covers every URL helper spelling.
- Judgment call: applied the fix to the DEFER pull endpoint too (the issue says "actor path only" — the defer fetch IS an actor request with a real host). The push lane (job → SSE) has no request and stays on defaults.
- Judgment call: broadcasts fired INSIDE an action must not inherit the actor's host (subscribers can be on other hosts) — `broadcast_component` clears the thread-local around its render. This is the "broadcasts stay as they are" contract from the issue, enforced rather than assumed.
- Judgment call: did NOT set `ActiveStorage::Current.url_options` — the reported failure (`image_tag` on an attachment) goes through route URL generation (`polymorphic_url` → controller url_options), which this fixes. `blob.url` (service URLs) is out of scope and stays app-managed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures actor replies generate absolute URLs with the requesting host by threading the request’s protocol/host/port into reply renders; broadcasts remain on process defaults. Previously, replies used process-default `url_options`, producing wrong hosts on multi-host apps.

- Wraps action and defer endpoints in `Phlex::Reactive.with_url_options(Phlex::Reactive.url_options_for(request))`.
- Adds `Phlex::Reactive.current_url_options` thread-local; `request_bound_view_context` merges it via a singleton `url_options` override without rebuilding the memoized context.
- Guards broadcasts by clearing actor options around their render, so broadcasted components never inherit the actor host; Broadcasting guide clarifies “use host‑relative URLs in broadcasts.”
- Includes `optional_port` (even when nil) to clear any configured default port on default‑port requests.
- No migration required; verify broadcasted components use host‑relative URLs if they emitted absolute URLs before.

**Testing and performance**
- New request specs cover reply host/port/protocol, in‑action broadcast guard, defer pull behavior, and off‑request broadcasts.
- Unit specs cover thread‑local semantics and `url_options_for` extraction.
- Benchmarks show no measurable change; allocations remain byte‑identical.

<sup>Written for commit 0cc625efa2fa5d813f54e728b5b687a898912be2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/phlex-reactive/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

