### PR TITLE
chore(docs): bump docs-kit to 1.1.1 and repoint cross-links at zoolutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ hand-picking Turbo Stream targets.
 
 - **Ruby**: >= 3.4 | **Rails**: >= 7.1
 - **Rendering**: phlex-rails (Phlex 2)
-- **Transport**: turbo-rails (Turbo Streams); [pgbus](https://github.com/mhenrixon/pgbus) optional for Postgres SSE
+- **Transport**: turbo-rails (Turbo Streams); [pgbus](https://github.com/zoolutions/pgbus) optional for Postgres SSE
 - **Client**: one generic Stimulus controller (no per-feature JS)
 - **Autoloading**: zeitwerk
 - **Testing**: RSpec + Capybara/Playwright (via `spec/dummy`)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ follows* — and implements it the Rails way:
 - **One tiny client runtime.** A single generic Stimulus controller, registered
   once, handles every reactive component. You don't write per-feature JS.
 
-Pair it with [**pgbus**](https://github.com/mhenrixon/pgbus) and your live
+Pair it with [**pgbus**](https://github.com/zoolutions/pgbus) and your live
 updates become *transactional* (no broadcast for a rolled-back change) and
 *reconnect-safe* (missed messages replay) over Postgres SSE — **no Action Cable,
 no Redis.**
@@ -2786,7 +2786,7 @@ end
 
 ## Live updates with pgbus (recommended)
 
-[pgbus](https://github.com/mhenrixon/pgbus) replaces Action Cable's transport
+[pgbus](https://github.com/zoolutions/pgbus) replaces Action Cable's transport
 with Postgres SSE and fixes its reliability gaps. With it installed,
 `broadcast_to` and `turbo_stream_from` route over pgbus automatically:
 
@@ -3004,7 +3004,7 @@ The mental model is stolen, gratefully, from
 [Laravel Livewire](https://livewire.laravel.com) (public method = action) and
 [Phoenix LiveView](https://www.phoenixframework.org) (a component is a re-render
 unit). The transport and reliability come from
-[pgbus](https://github.com/mhenrixon/pgbus). The rendering is all
+[pgbus](https://github.com/zoolutions/pgbus). The rendering is all
 [Phlex](https://www.phlex.fun).
 
 ## License

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -29,14 +29,14 @@ gem "phlex-rails"
 
 # Docs UI: daisyUI Phlex components for chrome (sidebar, drawer, tabs, cards).
 # The reactive demo components themselves stay framework-agnostic.
-gem "daisyui", github: "mhenrixon/daisyui", require: "daisy_ui"
+gem "daisyui", github: "zoolutions/daisyui", require: "daisy_ui"
 
 # Shared docs-site chrome (Shell/Sidebar/Code/Page/...) — the single place the
 # layout/design lives, shared with the daisyUI docs site. Configured per-site via
 # DocsKit.configure (see config/initializers/docs_kit.rb). Pulled from RubyGems
 # now the gem is released there — the old GitHub ref (needed while the sibling
 # repo sat outside the Docker build context) is obsolete.
-gem "docs-kit", "~> 1.0.8", require: "docs_kit"
+gem "docs-kit", "~> 1.1", ">= 1.1.1", require: "docs_kit"
 
 # MCP — docs-kit's optional Model Context Protocol server (read-only, stateless).
 # Not a docs-kit gemspec dependency; present here so the /mcp endpoint (routes in

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/mhenrixon/daisyui.git
-  revision: 1fc5a896fec0bc227ff8f15bbb00c4bc53512e77
+  remote: https://github.com/zoolutions/daisyui.git
+  revision: d8e8821e62408ecdbb03034a21d235e683f3e51a
   specs:
     daisyui (1.2.1)
       phlex (~> 2.0, >= 2.0.0)
@@ -147,13 +147,15 @@ GEM
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)
-    commonmarker (2.9.0-aarch64-linux)
-    commonmarker (2.9.0-aarch64-linux-musl)
-    commonmarker (2.9.0-arm-linux)
-    commonmarker (2.9.0-arm64-darwin)
-    commonmarker (2.9.0-x86_64-darwin)
-    commonmarker (2.9.0-x86_64-linux)
-    commonmarker (2.9.0-x86_64-linux-musl)
+    commonmarker (2.10.0)
+      rb_sys (~> 0.9)
+    commonmarker (2.10.0-aarch64-linux)
+    commonmarker (2.10.0-aarch64-linux-musl)
+    commonmarker (2.10.0-arm-linux-gnu)
+    commonmarker (2.10.0-arm64-darwin)
+    commonmarker (2.10.0-x86_64-darwin)
+    commonmarker (2.10.0-x86_64-linux)
+    commonmarker (2.10.0-x86_64-linux-musl)
     concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     console (1.36.0)
@@ -166,7 +168,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
-    docs-kit (1.0.8)
+    docs-kit (1.1.1)
       commonmarker (~> 2.0)
       daisyui (>= 1.2, < 2)
       nokogiri (>= 1.15, < 2)
@@ -259,7 +261,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol
@@ -384,7 +386,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.3)
+    rake-compiler-dock (1.12.0)
+    rb_sys (0.9.130)
+      rake-compiler-dock (= 1.12.0)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -522,7 +527,7 @@ DEPENDENCIES
   capybara-playwright-driver
   daisyui!
   debug
-  docs-kit (~> 1.0.8)
+  docs-kit (~> 1.1, >= 1.1.1)
   falcon
   importmap-rails
   mcp
@@ -584,13 +589,14 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-playwright-driver (0.5.9) sha256=4c17fed20817b7e1bde2cfc8186e7bf5cd72017ce1aa695e35130f8e600e7282
-  commonmarker (2.9.0-aarch64-linux) sha256=e2b4aadb9a2cfa4e206582641ce3a49465549ac1ed4c289fdd63b78d8f24579c
-  commonmarker (2.9.0-aarch64-linux-musl) sha256=1cf4d2821f2a7e64945f1ed7c4eeced586fdb27ea7fe7337788802cf8f57cfca
-  commonmarker (2.9.0-arm-linux) sha256=290a000947cf9d154d0480c33c0a36bcef49ce4c2e74bb75e9d06f5afe93f670
-  commonmarker (2.9.0-arm64-darwin) sha256=1748dbfa4f5813b0d2a14bb4bbfa65a4ec293aa1c825016d60029ee0e132b046
-  commonmarker (2.9.0-x86_64-darwin) sha256=0a9914ccfd2f5d2a59c7bd0dda4fe90eb084cf513b477e499008e09ec9d6edd6
-  commonmarker (2.9.0-x86_64-linux) sha256=8cfe92970eef585a19ddf6613224b91cab64d6029834661bda801f877c9c7f43
-  commonmarker (2.9.0-x86_64-linux-musl) sha256=293921398b839f79ceaf55010e061357e34f053822c3b003cd0be6686176335e
+  commonmarker (2.10.0) sha256=1884529957bf59bcd4f19fcc29e931f2042760ced273353e8010a20fe4ae68cb
+  commonmarker (2.10.0-aarch64-linux) sha256=eeb167dea203dee066eb0dd99b3fd2deb526c8b5e7297ad385f7a5d60f869478
+  commonmarker (2.10.0-aarch64-linux-musl) sha256=e95d9e87ea6306e21ffa11855a7bb55518538143b23a227fe3bb00b41873ce25
+  commonmarker (2.10.0-arm-linux-gnu) sha256=2165642969df6816625c5fa4470a8959345d715daf96dd063fc56913fdbb1b90
+  commonmarker (2.10.0-arm64-darwin) sha256=39ecc891d1e4308b5233cc28b40383de854a2bfbefe17d68e49174347a8aa79e
+  commonmarker (2.10.0-x86_64-darwin) sha256=01e0830ed0319825ecdc16411c90acd3f661d1568dfc178731b3f64d0ce2363d
+  commonmarker (2.10.0-x86_64-linux) sha256=945c510c0bfca9022245928e2248468fe3ddad58c939be0c37b20082cc392880
+  commonmarker (2.10.0-x86_64-linux-musl) sha256=288cd4fb9f17eed2ffa73551ef241dcf594e0f484b2aee2a0999540333c0618e
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   console (1.36.0) sha256=45599ea906cf80a73d8941f03abf873fe66a6a954e0bac5bc1c01e2cdc406f07
@@ -599,7 +605,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docs-kit (1.0.8) sha256=a4ae96211888b55f17139474003be9d86bd39a1d5a70ac6b14bd0faa8eb63e8e
+  docs-kit (1.1.1) sha256=4eea89a9361101b85534274031369bd51731660b68cf255a0df94076c4dd6a37
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
@@ -639,7 +645,7 @@ CHECKSUMS
   msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   net-imap (0.6.6) sha256=96aa4ee50df3060203e649efc341f53480b791d49e150f2fdebf68beb141a8df
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
-  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-protocol (0.3.0) sha256=ba310c3d4f1cad46bb1ab20336b06669b1ff8f7c568d9cb9342b32a718547472
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
   nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
@@ -692,7 +698,9 @@ CHECKSUMS
   railties (8.1.3.1) sha256=2388a232579a00cefea4487de66c8553c3408c1300abdc6cf1799d86ffb04487
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rake-compiler-dock (1.12.0) sha256=f13205c2738f3d2053afcd03491a9e4541b22a59a0bfc53fc8bc883bd8188023
+  rb_sys (0.9.130) sha256=7d486d99c1da02635515deaf9860fc5aea90bb4ab2589b2deec7fdc7d3548615
+  rbs (4.2.0) sha256=51f7b886dcc05bc09e10b901daa6a81829f6adc03101d6ca9ea4aac6103e0674
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb


### PR DESCRIPTION
## Summary
- `docs/Gemfile`: `docs-kit "~> 1.1", ">= 1.1.1"` (was `~> 1.0.8`, which excluded 1.1.x) + relock. 1.1 scaffolds the dash 4 deploy; 1.1.1 adds a public `max-age` on `/llms.txt` so the dash-proxy cache enabled in the last PR actually stores it
- Remaining `mhenrixon/*` links to sibling gems (daisyui, phlex-reactive, phlex-forms, pgbus) → `zoolutions/*`; where that's a Gemfile `github:` source the lock is re-resolved against the new remote. Changelog / upgrade history untouched
- Local machine paths (`~/Code/mhenrixon/...`, tailwind `@source`) left alone — not links

## Test plan
- [ ] CI green (docs site build + specs validate the new lock)
- [ ] After merge: **Deploy docs** → `curl -I https://phlex-reactive.zoolutions.llc/llms.txt` shows `cache-control: max-age=300, public`; a second request shows `x-cache: HIT`

https://claude.ai/code/session_01SdEc37DFCkYzwpQpadu9My


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `docs-kit` from `~> 1.0.8` to `~> 1.1`, `>= 1.1.1` and repoints cross-links to sibling gems at the `zoolutions` org.

**Changes**

- `docs-kit` 1.1 scaffolds the dash 4 deploy; 1.1.1 adds a public `max-age` on `/llms.txt` so the dash-proxy cache stores it.
- Repoints `Gemfile` sources and README/CLAUDE links from `mhenrixon/*` to `zoolutions/*`.
- Re-resolves `Gemfile.lock` against the new remote; transitive bumps (commonmarker, net-protocol, etc.) included.

**Rollout**

- After merge, deploy the docs and verify `curl -I https://phlex-reactive.zoolutions.llc/llms.txt` returns `cache-control: max-age=300, public` and a second request shows `x-cache: HIT`.

<sup>Written for commit c493baa9248af243b36d86103dd9104b19f4f300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/phlex-reactive/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

