### PR TITLE
chore(deploy): require dash 4.0.7 for the docs deploy

### DIFF
--- a/docs/config/deploy.yml
+++ b/docs/config/deploy.yml
@@ -9,7 +9,7 @@ image: zoolutions/phlex-reactive
 
 # dash 4 renamed the on-host proxy (kamal-proxy → dash-proxy) and migrates a
 # host in place; an older CLI must not deploy this config.
-minimum_version: 4.0.0
+minimum_version: 4.0.7
 
 # A stateless docs site never rolls back far — keep the host tidy.
 retain_containers: 2


### PR DESCRIPTION
## Summary

dash [v4.0.7](https://github.com/zoolutions/dash/releases/tag/v4.0.7) is out with two deploy-path fixes (doctor passes a stale proxy the next deploy reboots automatically; registry login fails fast on a blank credential). Raise this docs site's dash floor to match: `minimum_version: 4.0.7` in `docs/config/deploy.yml`.

The shared deploy workflow (zoolutions/docs-kit#79) now installs `dash ~> 4.0.7`; this makes the site's own config state the same floor.

## Test plan

Config-only change — the docs redeploy after merge is the proof.

https://claude.ai/code/session_01KsqvKPn1c1hWu6NSEQHy1W


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the docs deploy's dash minimum version from 4.0.0 to 4.0.7 to match the floor set by the shared deploy workflow.

Dash v4.0.7 includes two deploy-path fixes: a stale proxy that previously caused the next deploy to reboot automatically, and a registry login that fails fast on blank credentials. This is a config-only change; the docs redeploy after merge is the proof.

<sup>Written for commit 56a05e33c658e9add513c695f2e5fb11d8306aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/phlex-reactive/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

